### PR TITLE
test(server): migrate first server test batch to JUnit 5

### DIFF
--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQArraysTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQArraysTest.java
@@ -26,6 +26,7 @@ import org.apache.druid.data.input.impl.JsonInputFormat;
 import org.apache.druid.data.input.impl.LocalInputSource;
 import org.apache.druid.data.input.impl.systemfield.SystemFields;
 import org.apache.druid.error.DruidException;
+import org.apache.druid.error.ThrowableMatcher;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.msq.indexing.LegacyMSQSpec;
@@ -135,9 +136,8 @@ public class MSQArraysTest extends MSQTestBase
             + "PARTITIONED BY ALL TIME"
         )
         .setQueryContext(adjustedContext)
-        .setExpectedExecutionErrorMatcher(exceptionAssertion(
-            DruidException.class,
-            message -> message.startsWith(
+        .setExpectedExecutionErrorMatcher(ThrowableMatcher.of(DruidException.class)
+            .expectMessage(message -> message.startsWith(
                 "Cannot write into field[dim3] using type[VARCHAR ARRAY] and arrayIngestMode[array], "
                 + "since the existing type is[VARCHAR]"
             )
@@ -163,9 +163,8 @@ public class MSQArraysTest extends MSQTestBase
             + "PARTITIONED BY ALL TIME"
         )
         .setQueryContext(adjustedContext)
-        .setExpectedExecutionErrorMatcher(exceptionAssertion(
-            DruidException.class,
-            message -> message.startsWith(
+        .setExpectedExecutionErrorMatcher(ThrowableMatcher.of(DruidException.class)
+            .expectMessage(message -> message.startsWith(
                 "Cannot write into field[arrayString] using type[VARCHAR] and arrayIngestMode[array], since the "
                 + "existing type is[VARCHAR ARRAY]. Try adjusting your query to make this column an ARRAY instead "
                 + "of VARCHAR."
@@ -192,9 +191,8 @@ public class MSQArraysTest extends MSQTestBase
             + "PARTITIONED BY ALL TIME"
         )
         .setQueryContext(adjustedContext)
-        .setExpectedExecutionErrorMatcher(exceptionAssertion(
-            DruidException.class,
-            message -> message.startsWith(
+        .setExpectedExecutionErrorMatcher(ThrowableMatcher.of(DruidException.class)
+            .expectMessage(message -> message.startsWith(
                 "Cannot write into field[arrayString] using type[VARCHAR] and arrayIngestMode[mvd], since the "
                 + "existing type is[VARCHAR ARRAY]. Try setting arrayIngestMode to[array] and adjusting your query to "
                 + "make this column an ARRAY instead of VARCHAR."
@@ -393,7 +391,7 @@ public class MSQArraysTest extends MSQTestBase
                              + ") PARTITIONED BY ALL")
                      .setQueryContext(adjustedContext)
                      .setExpectedExecutionErrorMatcher(
-                         exceptionAssertion(ISE.class, message -> message.contains("Numeric arrays can only be ingested when"))
+                         ThrowableMatcher.of(ISE.class).expectMessageContains("Numeric arrays can only be ingested when")
                      )
                      .verifyExecutionError();
   }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQArraysTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQArraysTest.java
@@ -47,8 +47,6 @@ import org.apache.druid.sql.calcite.planner.ColumnMapping;
 import org.apache.druid.sql.calcite.planner.ColumnMappings;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.utils.CompressionUtils;
-import org.hamcrest.CoreMatchers;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -137,11 +135,12 @@ public class MSQArraysTest extends MSQTestBase
             + "PARTITIONED BY ALL TIME"
         )
         .setQueryContext(adjustedContext)
-        .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
-            CoreMatchers.instanceOf(DruidException.class),
-            ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith(
+        .setExpectedExecutionErrorMatcher(exceptionAssertion(
+            DruidException.class,
+            message -> message.startsWith(
                 "Cannot write into field[dim3] using type[VARCHAR ARRAY] and arrayIngestMode[array], "
-                + "since the existing type is[VARCHAR]"))
+                + "since the existing type is[VARCHAR]"
+            )
         ))
         .verifyExecutionError();
   }
@@ -164,12 +163,13 @@ public class MSQArraysTest extends MSQTestBase
             + "PARTITIONED BY ALL TIME"
         )
         .setQueryContext(adjustedContext)
-        .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
-            CoreMatchers.instanceOf(DruidException.class),
-            ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith(
+        .setExpectedExecutionErrorMatcher(exceptionAssertion(
+            DruidException.class,
+            message -> message.startsWith(
                 "Cannot write into field[arrayString] using type[VARCHAR] and arrayIngestMode[array], since the "
                 + "existing type is[VARCHAR ARRAY]. Try adjusting your query to make this column an ARRAY instead "
-                + "of VARCHAR."))
+                + "of VARCHAR."
+            )
         ))
         .verifyExecutionError();
   }
@@ -192,12 +192,13 @@ public class MSQArraysTest extends MSQTestBase
             + "PARTITIONED BY ALL TIME"
         )
         .setQueryContext(adjustedContext)
-        .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
-            CoreMatchers.instanceOf(DruidException.class),
-            ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith(
+        .setExpectedExecutionErrorMatcher(exceptionAssertion(
+            DruidException.class,
+            message -> message.startsWith(
                 "Cannot write into field[arrayString] using type[VARCHAR] and arrayIngestMode[mvd], since the "
                 + "existing type is[VARCHAR ARRAY]. Try setting arrayIngestMode to[array] and adjusting your query to "
-                + "make this column an ARRAY instead of VARCHAR."))
+                + "make this column an ARRAY instead of VARCHAR."
+            )
         ))
         .verifyExecutionError();
   }
@@ -391,11 +392,9 @@ public class MSQArraysTest extends MSQTestBase
                              + "  )\n"
                              + ") PARTITIONED BY ALL")
                      .setQueryContext(adjustedContext)
-                     .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
-                         CoreMatchers.instanceOf(ISE.class),
-                         ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
-                             "Numeric arrays can only be ingested when"))
-                     ))
+                     .setExpectedExecutionErrorMatcher(
+                         exceptionAssertion(ISE.class, message -> message.contains("Numeric arrays can only be ingested when"))
+                     )
                      .verifyExecutionError();
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQFaultsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQFaultsTest.java
@@ -54,8 +54,6 @@ import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.DimensionRangeShardSpec;
 import org.apache.druid.timeline.partition.LinearShardSpec;
-import org.hamcrest.CoreMatchers;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.ArgumentMatchers;
@@ -653,14 +651,10 @@ public class MSQFaultsTest extends MSQTestBase
                      .setExpectedDataSource("foo1")
                      .setExpectedRowSignature(rowSignature)
                      .setExpectedShardSpec(DimensionRangeShardSpec.class)
-                     .setExpectedExecutionErrorMatcher(
-                         CoreMatchers.allOf(
-                             CoreMatchers.instanceOf(ISE.class),
-                             ThrowableMessageMatcher.hasMessage(
-                                 CoreMatchers.containsString(expectedError)
-                             )
-                         )
-                     )
+                     .setExpectedExecutionErrorMatcher(exceptionAssertion(
+                         ISE.class,
+                         message -> message.contains(expectedError)
+                     ))
                      .verifyExecutionError();
   }
 
@@ -701,14 +695,10 @@ public class MSQFaultsTest extends MSQTestBase
                      .setExpectedDataSource("foo1")
                      .setExpectedRowSignature(rowSignature)
                      .setExpectedShardSpec(DimensionRangeShardSpec.class)
-                     .setExpectedExecutionErrorMatcher(
-                         CoreMatchers.allOf(
-                             CoreMatchers.instanceOf(ISE.class),
-                             ThrowableMessageMatcher.hasMessage(
-                                 CoreMatchers.containsString(expectedError)
-                             )
-                         )
-                     )
+                     .setExpectedExecutionErrorMatcher(exceptionAssertion(
+                         ISE.class,
+                         message -> message.contains(expectedError)
+                     ))
                      .verifyExecutionError();
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQFaultsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQFaultsTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.DruidExceptionMatcher;
+import org.apache.druid.error.ThrowableMatcher;
 import org.apache.druid.indexing.common.TaskLockType;
 import org.apache.druid.indexing.common.actions.RetrieveUsedSegmentsAction;
 import org.apache.druid.indexing.common.actions.SegmentAllocateAction;
@@ -651,10 +652,9 @@ public class MSQFaultsTest extends MSQTestBase
                      .setExpectedDataSource("foo1")
                      .setExpectedRowSignature(rowSignature)
                      .setExpectedShardSpec(DimensionRangeShardSpec.class)
-                     .setExpectedExecutionErrorMatcher(exceptionAssertion(
-                         ISE.class,
-                         message -> message.contains(expectedError)
-                     ))
+                     .setExpectedExecutionErrorMatcher(
+                         ThrowableMatcher.of(ISE.class).expectMessageContains(expectedError)
+                     )
                      .verifyExecutionError();
   }
 
@@ -695,10 +695,9 @@ public class MSQFaultsTest extends MSQTestBase
                      .setExpectedDataSource("foo1")
                      .setExpectedRowSignature(rowSignature)
                      .setExpectedShardSpec(DimensionRangeShardSpec.class)
-                     .setExpectedExecutionErrorMatcher(exceptionAssertion(
-                         ISE.class,
-                         message -> message.contains(expectedError)
-                     ))
+                     .setExpectedExecutionErrorMatcher(
+                         ThrowableMatcher.of(ISE.class).expectMessageContains(expectedError)
+                     )
                      .verifyExecutionError();
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQInsertTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQInsertTest.java
@@ -38,6 +38,7 @@ import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.DruidExceptionMatcher;
+import org.apache.druid.error.ThrowableMatcher;
 import org.apache.druid.hll.HyperLogLogCollector;
 import org.apache.druid.indexing.common.TaskLockType;
 import org.apache.druid.indexing.common.task.Tasks;
@@ -745,11 +746,8 @@ public class MSQInsertTest extends MSQTestBase
                              + "  )\n"
                              + ") PARTITIONED by day")
                      .setExpectedExecutionErrorMatcher(
-                         exceptionAssertion(
-                             ISE.class,
-                             message -> message.contains(
-                                 "projection[channel_delta_daily] contains aggregator[sum_delta] that is missing required field[delta] in base table"
-                             )
+                         ThrowableMatcher.of(ISE.class).expectMessageContains(
+                             "projection[channel_delta_daily] contains aggregator[sum_delta] that is missing required field[delta] in base table"
                          )
                      )
                      .verifyExecutionError();
@@ -1415,12 +1413,11 @@ public class MSQInsertTest extends MSQTestBase
     testIngestQuery().setSql(
                          "INSERT INTO foo1 SELECT dim3, count(*) AS cnt1 FROM foo GROUP BY dim3 PARTITIONED BY ALL TIME")
                      .setQueryContext(localContext)
-                     .setExpectedExecutionErrorMatcher(exceptionAssertion(
-                         ISE.class,
-                         message -> message.contains(
+                     .setExpectedExecutionErrorMatcher(
+                         ThrowableMatcher.of(ISE.class).expectMessageContains(
                              "Column [dim3] is a multi-value string. Please wrap the column using MV_TO_ARRAY() to proceed further."
                          )
-                     ))
+                     )
                      .verifyExecutionError();
   }
 
@@ -1431,12 +1428,11 @@ public class MSQInsertTest extends MSQTestBase
     testIngestQuery().setSql(
                          "SET groupByEnableMultiValueUnnesting = false; INSERT INTO foo1 SELECT dim3, count(*) AS cnt1 FROM foo GROUP BY dim3 PARTITIONED BY ALL TIME")
                      .setQueryContext(context)
-                     .setExpectedExecutionErrorMatcher(exceptionAssertion(
-                         ISE.class,
-                         message -> message.contains(
+                     .setExpectedExecutionErrorMatcher(
+                         ThrowableMatcher.of(ISE.class).expectMessageContains(
                              "Column [dim3] is a multi-value string. Please wrap the column using MV_TO_ARRAY() to proceed further."
                          )
-                     ))
+                     )
                      .verifyExecutionError();
   }
 
@@ -1912,10 +1908,9 @@ public class MSQInsertTest extends MSQTestBase
                      .setExpectedDataSource("foo")
                      .setQueryContext(context)
                      .setExpectedMSQFault(new RowTooLargeFault(500))
-                     .setExpectedExecutionErrorMatcher(exceptionAssertion(
-                         ISE.class,
-                         message -> message.contains("Row too large to add to frame")
-                     ))
+                     .setExpectedExecutionErrorMatcher(
+                         ThrowableMatcher.of(ISE.class).expectMessageContains("Row too large to add to frame")
+                     )
                      .verifyExecutionError();
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQInsertTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQInsertTest.java
@@ -82,8 +82,6 @@ import org.apache.druid.sql.calcite.util.CalciteTests;
 import org.apache.druid.timeline.ClusterGroupTuples;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.hamcrest.CoreMatchers;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -747,10 +745,10 @@ public class MSQInsertTest extends MSQTestBase
                              + "  )\n"
                              + ") PARTITIONED by day")
                      .setExpectedExecutionErrorMatcher(
-                         CoreMatchers.allOf(
-                             CoreMatchers.instanceOf(ISE.class),
-                             ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
-                                 "projection[channel_delta_daily] contains aggregator[sum_delta] that is missing required field[delta] in base table")
+                         exceptionAssertion(
+                             ISE.class,
+                             message -> message.contains(
+                                 "projection[channel_delta_daily] contains aggregator[sum_delta] that is missing required field[delta] in base table"
                              )
                          )
                      )
@@ -1417,10 +1415,10 @@ public class MSQInsertTest extends MSQTestBase
     testIngestQuery().setSql(
                          "INSERT INTO foo1 SELECT dim3, count(*) AS cnt1 FROM foo GROUP BY dim3 PARTITIONED BY ALL TIME")
                      .setQueryContext(localContext)
-                     .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
-                         CoreMatchers.instanceOf(ISE.class),
-                         ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
-                             "Column [dim3] is a multi-value string. Please wrap the column using MV_TO_ARRAY() to proceed further.")
+                     .setExpectedExecutionErrorMatcher(exceptionAssertion(
+                         ISE.class,
+                         message -> message.contains(
+                             "Column [dim3] is a multi-value string. Please wrap the column using MV_TO_ARRAY() to proceed further."
                          )
                      ))
                      .verifyExecutionError();
@@ -1433,10 +1431,10 @@ public class MSQInsertTest extends MSQTestBase
     testIngestQuery().setSql(
                          "SET groupByEnableMultiValueUnnesting = false; INSERT INTO foo1 SELECT dim3, count(*) AS cnt1 FROM foo GROUP BY dim3 PARTITIONED BY ALL TIME")
                      .setQueryContext(context)
-                     .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
-                         CoreMatchers.instanceOf(ISE.class),
-                         ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
-                             "Column [dim3] is a multi-value string. Please wrap the column using MV_TO_ARRAY() to proceed further.")
+                     .setExpectedExecutionErrorMatcher(exceptionAssertion(
+                         ISE.class,
+                         message -> message.contains(
+                             "Column [dim3] is a multi-value string. Please wrap the column using MV_TO_ARRAY() to proceed further."
                          )
                      ))
                      .verifyExecutionError();
@@ -1914,10 +1912,9 @@ public class MSQInsertTest extends MSQTestBase
                      .setExpectedDataSource("foo")
                      .setQueryContext(context)
                      .setExpectedMSQFault(new RowTooLargeFault(500))
-                     .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
-                         CoreMatchers.instanceOf(ISE.class),
-                         ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
-                             "Row too large to add to frame"))
+                     .setExpectedExecutionErrorMatcher(exceptionAssertion(
+                         ISE.class,
+                         message -> message.contains("Row too large to add to frame")
                      ))
                      .verifyExecutionError();
   }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQLoadedSegmentTests.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQLoadedSegmentTests.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import org.apache.druid.client.ImmutableSegmentLoadInfo;
+import org.apache.druid.error.ThrowableMatcher;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -390,7 +391,7 @@ public class MSQLoadedSegmentTests extends MSQTestBase
         )
         .setQueryContext(REALTIME_QUERY_CTX)
         .setExpectedRowSignature(rowSignature)
-        .setExpectedExecutionErrorMatcher(exceptionAssertion(ISE.class))
+        .setExpectedExecutionErrorMatcher(ThrowableMatcher.of(ISE.class))
         .verifyExecutionError();
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQLoadedSegmentTests.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQLoadedSegmentTests.java
@@ -51,7 +51,6 @@ import org.apache.druid.sql.calcite.planner.ColumnMappings;
 import org.apache.druid.sql.calcite.util.CalciteTests;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.LinearShardSpec;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -391,7 +390,7 @@ public class MSQLoadedSegmentTests extends MSQTestBase
         )
         .setQueryContext(REALTIME_QUERY_CTX)
         .setExpectedRowSignature(rowSignature)
-        .setExpectedExecutionErrorMatcher(CoreMatchers.instanceOf(ISE.class))
+        .setExpectedExecutionErrorMatcher(exceptionAssertion(ISE.class))
         .verifyExecutionError();
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.data.input.impl.LocalInputSource;
 import org.apache.druid.data.input.impl.systemfield.SystemFields;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.DruidExceptionMatcher;
+import org.apache.druid.error.ThrowableMatcher;
 import org.apache.druid.frame.util.DurableStorageUtils;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.ISE;
@@ -2192,12 +2193,11 @@ public class MSQSelectTest extends MSQTestBase
     testSelectQuery()
         .setSql("select dim3, count(*) as cnt1 from foo group by dim3")
         .setQueryContext(localContext)
-        .setExpectedExecutionErrorMatcher(exceptionAssertion(
-            ISE.class,
-            message -> message.contains(
+        .setExpectedExecutionErrorMatcher(ThrowableMatcher.of(ISE.class)
+            .expectMessageContains(
                 "Column [dim3] is a multi-value string. Please wrap the column using MV_TO_ARRAY() to proceed further."
             )
-        ))
+        )
         .verifyExecutionError();
   }
 
@@ -2375,12 +2375,11 @@ public class MSQSelectTest extends MSQTestBase
     testSelectQuery()
         .setSql("select MV_TO_ARRAY(dim3), count(*) as cnt1 from foo group by dim3")
         .setQueryContext(localContext)
-        .setExpectedExecutionErrorMatcher(exceptionAssertion(
-            ISE.class,
-            message -> message.contains(
+        .setExpectedExecutionErrorMatcher(ThrowableMatcher.of(ISE.class)
+            .expectMessageContains(
                 "Encountered multi-value dimension [dim3] that cannot be processed with 'groupByEnableMultiValueUnnesting' set to false."
             )
-        ))
+        )
         .setExpectedMetricDimensions(
             Map.of(
                 DruidMetrics.DATASOURCE, "foo",
@@ -2398,12 +2397,11 @@ public class MSQSelectTest extends MSQTestBase
     testSelectQuery()
         .setSql("select unique_dim1 from foo2 group by unique_dim1")
         .setQueryContext(context)
-        .setExpectedExecutionErrorMatcher(exceptionAssertion(
-            DruidException.class,
-            message -> message.contains(
+        .setExpectedExecutionErrorMatcher(ThrowableMatcher.of(DruidException.class)
+            .expectMessageContains(
                 "SQL requires a group-by on a column with type [COMPLEX<hyperUnique>] that is unsupported."
             )
-        ))
+        )
         .verifyExecutionError();
   }
 
@@ -2804,10 +2802,9 @@ public class MSQSelectTest extends MSQTestBase
         .setExpectedRowSignature(resultSignature)
         .setQueryContext(timeoutContext)
         .setExpectedMSQFault(CanceledFault.timeout())
-        .setExpectedExecutionErrorMatcher(exceptionAssertion(
-            ISE.class,
-            message -> message.contains("Query timed out")
-        ))
+        .setExpectedExecutionErrorMatcher(
+            ThrowableMatcher.of(ISE.class).expectMessageContains("Query timed out")
+        )
         .verifyExecutionError();
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
@@ -90,9 +90,7 @@ import org.apache.druid.sql.calcite.planner.ColumnMapping;
 import org.apache.druid.sql.calcite.planner.ColumnMappings;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.apache.druid.sql.calcite.util.CalciteTests;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -2194,10 +2192,10 @@ public class MSQSelectTest extends MSQTestBase
     testSelectQuery()
         .setSql("select dim3, count(*) as cnt1 from foo group by dim3")
         .setQueryContext(localContext)
-        .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
-            CoreMatchers.instanceOf(ISE.class),
-            ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
-                "Column [dim3] is a multi-value string. Please wrap the column using MV_TO_ARRAY() to proceed further.")
+        .setExpectedExecutionErrorMatcher(exceptionAssertion(
+            ISE.class,
+            message -> message.contains(
+                "Column [dim3] is a multi-value string. Please wrap the column using MV_TO_ARRAY() to proceed further."
             )
         ))
         .verifyExecutionError();
@@ -2377,11 +2375,10 @@ public class MSQSelectTest extends MSQTestBase
     testSelectQuery()
         .setSql("select MV_TO_ARRAY(dim3), count(*) as cnt1 from foo group by dim3")
         .setQueryContext(localContext)
-        .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
-            CoreMatchers.instanceOf(ISE.class),
-            ThrowableMessageMatcher.hasMessage(
-                CoreMatchers.containsString(
-                    "Encountered multi-value dimension [dim3] that cannot be processed with 'groupByEnableMultiValueUnnesting' set to false.")
+        .setExpectedExecutionErrorMatcher(exceptionAssertion(
+            ISE.class,
+            message -> message.contains(
+                "Encountered multi-value dimension [dim3] that cannot be processed with 'groupByEnableMultiValueUnnesting' set to false."
             )
         ))
         .setExpectedMetricDimensions(
@@ -2401,10 +2398,11 @@ public class MSQSelectTest extends MSQTestBase
     testSelectQuery()
         .setSql("select unique_dim1 from foo2 group by unique_dim1")
         .setQueryContext(context)
-        .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
-            CoreMatchers.instanceOf(DruidException.class),
-            ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
-                "SQL requires a group-by on a column with type [COMPLEX<hyperUnique>] that is unsupported."))
+        .setExpectedExecutionErrorMatcher(exceptionAssertion(
+            DruidException.class,
+            message -> message.contains(
+                "SQL requires a group-by on a column with type [COMPLEX<hyperUnique>] that is unsupported."
+            )
         ))
         .verifyExecutionError();
   }
@@ -2806,9 +2804,9 @@ public class MSQSelectTest extends MSQTestBase
         .setExpectedRowSignature(resultSignature)
         .setQueryContext(timeoutContext)
         .setExpectedMSQFault(CanceledFault.timeout())
-        .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
-            CoreMatchers.instanceOf(ISE.class),
-            ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("Query timed out"))
+        .setExpectedExecutionErrorMatcher(exceptionAssertion(
+            ISE.class,
+            message -> message.contains("Query timed out")
         ))
         .verifyExecutionError();
   }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQWindowTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQWindowTest.java
@@ -63,8 +63,6 @@ import org.apache.druid.sql.calcite.planner.ColumnMapping;
 import org.apache.druid.sql.calcite.planner.ColumnMappings;
 import org.apache.druid.sql.calcite.util.CalciteTests;
 import org.apache.druid.timeline.SegmentId;
-import org.hamcrest.CoreMatchers;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -2233,10 +2231,11 @@ public class MSQWindowTest extends MSQTestBase
                 + "where countryName in ('Austria', 'Republic of Korea') and cityName is not null\n"
                 + "order by 1, 2, 3")
         .setQueryContext(DEFAULT_MSQ_CONTEXT)
-        .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
-            CoreMatchers.instanceOf(ISE.class),
-            ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
-                "Encountered a multi value column. Window processing does not support MVDs. Consider using UNNEST or MV_TO_ARRAY."))
+        .setExpectedExecutionErrorMatcher(exceptionAssertion(
+            ISE.class,
+            message -> message.contains(
+                "Encountered a multi value column. Window processing does not support MVDs. Consider using UNNEST or MV_TO_ARRAY."
+            )
         ))
         .verifyExecutionError();
   }
@@ -2252,10 +2251,11 @@ public class MSQWindowTest extends MSQTestBase
                 + "where countryName in ('Austria', 'Republic of Korea') and cityName is not null\n"
                 + "order by 1, 2, 3")
         .setQueryContext(DEFAULT_MSQ_CONTEXT)
-        .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
-            CoreMatchers.instanceOf(ISE.class),
-            ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
-                "Encountered a multi value column. Window processing does not support MVDs. Consider using UNNEST or MV_TO_ARRAY."))
+        .setExpectedExecutionErrorMatcher(exceptionAssertion(
+            ISE.class,
+            message -> message.contains(
+                "Encountered a multi value column. Window processing does not support MVDs. Consider using UNNEST or MV_TO_ARRAY."
+            )
         ))
         .verifyExecutionError();
   }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQWindowTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQWindowTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.msq.exec;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.apache.druid.error.ThrowableMatcher;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -2231,12 +2232,11 @@ public class MSQWindowTest extends MSQTestBase
                 + "where countryName in ('Austria', 'Republic of Korea') and cityName is not null\n"
                 + "order by 1, 2, 3")
         .setQueryContext(DEFAULT_MSQ_CONTEXT)
-        .setExpectedExecutionErrorMatcher(exceptionAssertion(
-            ISE.class,
-            message -> message.contains(
+        .setExpectedExecutionErrorMatcher(ThrowableMatcher.of(ISE.class)
+            .expectMessageContains(
                 "Encountered a multi value column. Window processing does not support MVDs. Consider using UNNEST or MV_TO_ARRAY."
             )
-        ))
+        )
         .verifyExecutionError();
   }
 
@@ -2251,12 +2251,11 @@ public class MSQWindowTest extends MSQTestBase
                 + "where countryName in ('Austria', 'Republic of Korea') and cityName is not null\n"
                 + "order by 1, 2, 3")
         .setQueryContext(DEFAULT_MSQ_CONTEXT)
-        .setExpectedExecutionErrorMatcher(exceptionAssertion(
-            ISE.class,
-            message -> message.contains(
+        .setExpectedExecutionErrorMatcher(ThrowableMatcher.of(ISE.class)
+            .expectMessageContains(
                 "Encountered a multi value column. Window processing does not support MVDs. Consider using UNNEST or MV_TO_ARRAY."
             )
-        ))
+        )
         .verifyExecutionError();
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
@@ -111,7 +111,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SqlStatementResourceTest extends MSQTestBase
 {
@@ -1299,7 +1298,7 @@ public class SqlStatementResourceTest extends MSQTestBase
 
   private void assertInvalidFileName(String filename, String errorMessage)
   {
-    assertThat(
+    DruidExceptionMatcher.assertThat(
         Assert.assertThrows(DruidException.class, () -> SqlStatementResource.validateFilename(filename)),
         DruidExceptionMatcher.invalidInput().expectMessageIs(errorMessage)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -45,6 +45,7 @@ import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.frame.Frame;
 import org.apache.druid.frame.FrameType;
 import org.apache.druid.frame.channel.FrameChannelSequence;
@@ -227,6 +228,7 @@ import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
 import org.hamcrest.Matcher;
+import org.hamcrest.MatcherAssert;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
@@ -250,6 +252,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -260,7 +263,6 @@ import static org.apache.druid.sql.calcite.util.CalciteTests.RESTRICTED_DATASOUR
 import static org.apache.druid.sql.calcite.util.CalciteTests.WIKIPEDIA;
 import static org.apache.druid.sql.calcite.util.TestDataBuilder.ROWS1;
 import static org.apache.druid.sql.calcite.util.TestDataBuilder.ROWS2;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -1003,9 +1005,9 @@ public class MSQTestBase extends BaseCalciteQueryTest
     protected Set<Interval> expectedTombstoneIntervals = null;
     protected List<Object[]> expectedResultRows = null;
     protected LookupLoadingSpec expectedLookupLoadingSpec = LookupLoadingSpec.NONE;
-    protected Matcher<Throwable> expectedValidationErrorMatcher = null;
+    protected Consumer<Throwable> expectedValidationErrorAssertion = null;
     protected List<Pair<Predicate<MSQTaskReportPayload>, String>> adhocReportAssertionAndReasons = new ArrayList<>();
-    protected Matcher<Throwable> expectedExecutionErrorMatcher = null;
+    protected Consumer<Throwable> expectedExecutionErrorAssertion = null;
     protected MSQFault expectedMSQFault = null;
     protected Class<? extends MSQFault> expectedMSQFaultClass = null;
     protected MSQSegmentReport expectedSegmentReport = null;
@@ -1101,15 +1103,27 @@ public class MSQTestBase extends BaseCalciteQueryTest
       return asBuilder();
     }
 
-    public Builder setExpectedValidationErrorMatcher(Matcher<Throwable> expectedValidationErrorMatcher)
+    public Builder setExpectedValidationErrorMatcher(final DruidExceptionMatcher expectedValidationErrorMatcher)
     {
-      this.expectedValidationErrorMatcher = expectedValidationErrorMatcher;
+      this.expectedValidationErrorAssertion = e -> DruidExceptionMatcher.assertThat(e, expectedValidationErrorMatcher);
       return asBuilder();
     }
 
-    public Builder setExpectedExecutionErrorMatcher(Matcher<Throwable> expectedExecutionErrorMatcher)
+    public Builder setExpectedValidationErrorMatcher(final Matcher<Throwable> expectedValidationErrorMatcher)
     {
-      this.expectedExecutionErrorMatcher = expectedExecutionErrorMatcher;
+      this.expectedValidationErrorAssertion = e -> MatcherAssert.assertThat(e, expectedValidationErrorMatcher);
+      return asBuilder();
+    }
+
+    public Builder setExpectedExecutionErrorMatcher(final DruidExceptionMatcher expectedExecutionErrorMatcher)
+    {
+      this.expectedExecutionErrorAssertion = e -> DruidExceptionMatcher.assertThat(e, expectedExecutionErrorMatcher);
+      return asBuilder();
+    }
+
+    public Builder setExpectedExecutionErrorMatcher(final Matcher<Throwable> expectedExecutionErrorMatcher)
+    {
+      this.expectedExecutionErrorAssertion = e -> MatcherAssert.assertThat(e, expectedExecutionErrorMatcher);
       return asBuilder();
     }
 
@@ -1176,7 +1190,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
 
     public void verifyPlanningErrors()
     {
-      Preconditions.checkArgument(expectedValidationErrorMatcher != null, "Validation error matcher cannot be null");
+      Preconditions.checkArgument(expectedValidationErrorAssertion != null, "Validation error matcher cannot be null");
       Preconditions.checkArgument(sql != null, "Sql cannot be null");
       readyToRun();
 
@@ -1185,7 +1199,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
           () -> runMultiStageQuery(sql, queryContext, authenticationResult, dynamicParameters)
       );
 
-      assertThat(e, expectedValidationErrorMatcher);
+      expectedValidationErrorAssertion.accept(e);
     }
 
     protected void verifyMetrics()
@@ -1598,7 +1612,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
           "sql and taskSpec both cannot be provided in the same test"
       );
       Preconditions.checkArgument(sql == null || queryContext != null, "queryContext cannot be null");
-      Preconditions.checkArgument(expectedExecutionErrorMatcher != null, "Execution error matcher cannot be null");
+      Preconditions.checkArgument(expectedExecutionErrorAssertion != null, "Execution error matcher cannot be null");
       readyToRun();
       try {
         String controllerId;
@@ -1613,13 +1627,22 @@ public class MSQTestBase extends BaseCalciteQueryTest
         Assert.fail(StringUtils.format("Query did not throw an exception (sql = [%s])", sql));
       }
       catch (Exception e) {
-        assertThat(
+        assertExpectedExecutionError(
             StringUtils.format("Query error did not match expectations (sql = [%s])", sql),
-            e,
-            expectedExecutionErrorMatcher
+            e
         );
       }
       verifyMetrics();
+    }
+
+    private void assertExpectedExecutionError(final String reason, final Throwable e)
+    {
+      try {
+        expectedExecutionErrorAssertion.accept(e);
+      }
+      catch (AssertionError assertionError) {
+        throw new AssertionError(reason + ": " + assertionError.getMessage(), assertionError);
+      }
     }
   }
 
@@ -1753,10 +1776,10 @@ public class MSQTestBase extends BaseCalciteQueryTest
         throw new RuntimeException(ex);
       }
       catch (Exception e) {
-        if (expectedExecutionErrorMatcher == null) {
+        if (expectedExecutionErrorAssertion == null) {
           throw new ISE(e, "Query %s failed", sql != null ? sql : taskSpec);
         }
-        assertThat(e, expectedExecutionErrorMatcher);
+        expectedExecutionErrorAssertion.accept(e);
         return null;
       }
     }
@@ -1782,7 +1805,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
 
     public void verifyExecutionError()
     {
-      Preconditions.checkArgument(expectedExecutionErrorMatcher != null, "Execution error matcher cannot be null");
+      Preconditions.checkArgument(expectedExecutionErrorAssertion != null, "Execution error matcher cannot be null");
       if (runQueryWithResult() != null) {
         throw new ISE("Query %s did not throw an exception", sql != null ? sql : taskSpec);
       }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -46,6 +46,7 @@ import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.error.DruidExceptionMatcher;
+import org.apache.druid.error.ThrowableMatcher;
 import org.apache.druid.frame.Frame;
 import org.apache.druid.frame.FrameType;
 import org.apache.druid.frame.channel.FrameChannelSequence;
@@ -230,7 +231,6 @@ import org.apache.druid.timeline.partition.TombstoneShardSpec;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 
@@ -989,24 +989,6 @@ public class MSQTestBase extends BaseCalciteQueryTest
     }
   }
 
-  protected static Consumer<Throwable> exceptionAssertion(final Class<? extends Throwable> expectedType)
-  {
-    return exception -> Assertions.assertInstanceOf(expectedType, exception);
-  }
-
-  protected static Consumer<Throwable> exceptionAssertion(
-      final Class<? extends Throwable> expectedType,
-      final Predicate<String> messagePredicate
-  )
-  {
-    return exception -> {
-      final Throwable typedException = Assertions.assertInstanceOf(expectedType, exception);
-      final String message = typedException.getMessage();
-      Assertions.assertNotNull(message);
-      Assertions.assertTrue(messagePredicate.test(message));
-    };
-  }
-
   public abstract class MSQTester<Builder extends MSQTester<Builder>>
   {
     protected String sql = null;
@@ -1126,6 +1108,12 @@ public class MSQTestBase extends BaseCalciteQueryTest
       return asBuilder();
     }
 
+    public Builder setExpectedValidationErrorMatcher(final ThrowableMatcher expectedValidationErrorMatcher)
+    {
+      this.expectedValidationErrorAssertion = expectedValidationErrorMatcher::assertThat;
+      return asBuilder();
+    }
+
     public Builder setExpectedValidationErrorMatcher(final Consumer<Throwable> expectedValidationErrorAssertion)
     {
       this.expectedValidationErrorAssertion = expectedValidationErrorAssertion;
@@ -1135,6 +1123,12 @@ public class MSQTestBase extends BaseCalciteQueryTest
     public Builder setExpectedExecutionErrorMatcher(final DruidExceptionMatcher expectedExecutionErrorMatcher)
     {
       this.expectedExecutionErrorAssertion = e -> DruidExceptionMatcher.assertThat(e, expectedExecutionErrorMatcher);
+      return asBuilder();
+    }
+
+    public Builder setExpectedExecutionErrorMatcher(final ThrowableMatcher expectedExecutionErrorMatcher)
+    {
+      this.expectedExecutionErrorAssertion = expectedExecutionErrorMatcher::assertThat;
       return asBuilder();
     }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -227,11 +227,10 @@ import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
-import org.hamcrest.Matcher;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 
@@ -990,6 +989,24 @@ public class MSQTestBase extends BaseCalciteQueryTest
     }
   }
 
+  protected static Consumer<Throwable> exceptionAssertion(final Class<? extends Throwable> expectedType)
+  {
+    return exception -> Assertions.assertInstanceOf(expectedType, exception);
+  }
+
+  protected static Consumer<Throwable> exceptionAssertion(
+      final Class<? extends Throwable> expectedType,
+      final Predicate<String> messagePredicate
+  )
+  {
+    return exception -> {
+      final Throwable typedException = Assertions.assertInstanceOf(expectedType, exception);
+      final String message = typedException.getMessage();
+      Assertions.assertNotNull(message);
+      Assertions.assertTrue(messagePredicate.test(message));
+    };
+  }
+
   public abstract class MSQTester<Builder extends MSQTester<Builder>>
   {
     protected String sql = null;
@@ -1109,9 +1126,9 @@ public class MSQTestBase extends BaseCalciteQueryTest
       return asBuilder();
     }
 
-    public Builder setExpectedValidationErrorMatcher(final Matcher<Throwable> expectedValidationErrorMatcher)
+    public Builder setExpectedValidationErrorMatcher(final Consumer<Throwable> expectedValidationErrorAssertion)
     {
-      this.expectedValidationErrorAssertion = e -> MatcherAssert.assertThat(e, expectedValidationErrorMatcher);
+      this.expectedValidationErrorAssertion = expectedValidationErrorAssertion;
       return asBuilder();
     }
 
@@ -1121,9 +1138,9 @@ public class MSQTestBase extends BaseCalciteQueryTest
       return asBuilder();
     }
 
-    public Builder setExpectedExecutionErrorMatcher(final Matcher<Throwable> expectedExecutionErrorMatcher)
+    public Builder setExpectedExecutionErrorMatcher(final Consumer<Throwable> expectedExecutionErrorAssertion)
     {
-      this.expectedExecutionErrorAssertion = e -> MatcherAssert.assertThat(e, expectedExecutionErrorMatcher);
+      this.expectedExecutionErrorAssertion = expectedExecutionErrorAssertion;
       return asBuilder();
     }
 

--- a/processing/src/test/java/org/apache/druid/common/exception/PersonaBasedErrorTransformStrategyTest.java
+++ b/processing/src/test/java/org/apache/druid/common/exception/PersonaBasedErrorTransformStrategyTest.java
@@ -22,7 +22,6 @@ package org.apache.druid.common.exception;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.DruidExceptionMatcher;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,7 +52,7 @@ public class PersonaBasedErrorTransformStrategyTest
   {
     DruidException druidException = DruidException.defensive().build("Test Defensive exception");
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         target.maybeTransform(druidException, Optional.of("the-error")).get(),
         new DruidExceptionMatcher(
             DruidException.Persona.USER,
@@ -70,7 +69,7 @@ public class PersonaBasedErrorTransformStrategyTest
   {
     DruidException druidException = DruidException.defensive().build("Test Defensive exception");
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         target.maybeTransform(druidException, Optional.empty()).get(),
         new DruidExceptionMatcher(
             DruidException.Persona.USER,

--- a/processing/src/test/java/org/apache/druid/error/DruidExceptionMatcher.java
+++ b/processing/src/test/java/org/apache/druid/error/DruidExceptionMatcher.java
@@ -19,17 +19,15 @@
 
 package org.apache.druid.error;
 
-import org.apache.druid.matchers.DruidMatchers;
-import org.hamcrest.Description;
-import org.hamcrest.DiagnosingMatcher;
-import org.hamcrest.Matcher;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.hamcrest.core.AllOf;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
-public class DruidExceptionMatcher extends DiagnosingMatcher<Throwable>
+public class DruidExceptionMatcher
 {
   public static DruidExceptionMatcher invalidInput()
   {
@@ -95,78 +93,81 @@ public class DruidExceptionMatcher extends DiagnosingMatcher<Throwable>
     );
   }
 
-  private final AllOf<DruidException> delegate;
-  private final ArrayList<Matcher<? super DruidException>> matcherList;
+  private final List<Consumer<DruidException>> assertions;
 
   public DruidExceptionMatcher(
-      DruidException.Persona targetPersona,
-      DruidException.Category category,
-      String errorCode
+      final DruidException.Persona targetPersona,
+      final DruidException.Category category,
+      final String errorCode
   )
   {
-    matcherList = new ArrayList<>();
-    matcherList.add(DruidMatchers.fn("targetPersona", DruidException::getTargetPersona, Matchers.is(targetPersona)));
-    matcherList.add(DruidMatchers.fn("category", DruidException::getCategory, Matchers.is(category)));
-    matcherList.add(DruidMatchers.fn("errorCode", DruidException::getErrorCode, Matchers.is(errorCode)));
-
-    delegate = new AllOf<>(matcherList);
+    assertions = new ArrayList<>();
+    assertions.add(exception -> Assertions.assertEquals(targetPersona, exception.getTargetPersona()));
+    assertions.add(exception -> Assertions.assertEquals(category, exception.getCategory()));
+    assertions.add(exception -> Assertions.assertEquals(errorCode, exception.getErrorCode()));
   }
 
-  public DruidExceptionMatcher expectContext(String key, String value)
+  public DruidExceptionMatcher expectContext(final String key, final String value)
   {
-    matcherList.add(0, DruidMatchers.fn("context", DruidException::getContext, Matchers.hasEntry(key, value)));
+    assertions.add(exception -> {
+      final Map<String, String> context = exception.getContext();
+      Assertions.assertTrue(context.containsKey(key));
+      Assertions.assertEquals(value, context.get(key));
+    });
     return this;
   }
 
-  public DruidExceptionMatcher expectMessageIs(String s)
+  public DruidExceptionMatcher expectMessageIs(final String s)
   {
-    return expectMessage(Matchers.equalTo(s));
-  }
-
-  public DruidExceptionMatcher expectMessageContains(String contains)
-  {
-    return expectMessage(Matchers.containsString(contains));
-  }
-
-  public DruidExceptionMatcher expectMessage(Matcher<String> messageMatcher)
-  {
-    matcherList.add(0, DruidMatchers.fn("message", DruidException::getMessage, messageMatcher));
+    assertions.add(exception -> Assertions.assertEquals(s, exception.getMessage()));
     return this;
   }
 
-  public DruidExceptionMatcher expectException(Matcher<Throwable> causeMatcher)
+  public DruidExceptionMatcher expectMessageContains(final String contains)
   {
-    matcherList.add(0, DruidMatchers.fn("cause", DruidException::getCause, causeMatcher));
+    assertions.add(exception -> {
+      Assertions.assertNotNull(exception.getMessage());
+      Assertions.assertTrue(exception.getMessage().contains(contains));
+    });
     return this;
   }
 
-  @Override
-  protected boolean matches(Object item, Description mismatchDescription)
+  public DruidExceptionMatcher expectMessage(final Predicate<String> messageMatcher)
   {
-    return delegate.matches(item, mismatchDescription);
+    assertions.add(exception -> Assertions.assertTrue(messageMatcher.test(exception.getMessage())));
+    return this;
   }
 
-  @Override
-  public void describeTo(Description description)
+  public DruidExceptionMatcher expectException(final Predicate<Throwable> causeMatcher)
   {
-    delegate.describeTo(description);
+    assertions.add(exception -> Assertions.assertTrue(causeMatcher.test(exception.getCause())));
+    return this;
   }
 
-  public <T> void assertThrowsAndMatches(ThrowingSupplier fn)
+  public static void assertThat(final Throwable actual, final DruidExceptionMatcher expected)
   {
-    boolean thrown = false;
+    final DruidException exception = Assertions.assertInstanceOf(DruidException.class, actual);
+    expected.assertions.forEach(assertion -> assertion.accept(exception));
+  }
+
+  public static void assertThat(
+      final String reason,
+      final Throwable actual,
+      final DruidExceptionMatcher expected
+  )
+  {
     try {
-      fn.get();
+      assertThat(actual, expected);
     }
-    catch (Throwable e) {
-      if (e instanceof DruidException) {
-        MatcherAssert.assertThat(e, this);
-        thrown = true;
-      } else {
-        throw new RuntimeException(e);
-      }
+    catch (AssertionError e) {
+      throw new AssertionError(reason + ": " + e.getMessage(), e);
     }
-    MatcherAssert.assertThat(thrown, Matchers.is(true));
+  }
+
+  public void assertThrowsAndMatches(final ThrowingSupplier fn)
+  {
+    final DruidException exception = Assertions.assertThrows(DruidException.class, fn::get);
+    assertThat(exception, this);
   }
 
   public interface ThrowingSupplier

--- a/processing/src/test/java/org/apache/druid/error/ErrorResponseTest.java
+++ b/processing/src/test/java/org/apache/druid/error/ErrorResponseTest.java
@@ -51,7 +51,7 @@ public class ErrorResponseTest
 
     ErrorResponse recomposed = ErrorResponse.fromMap(asMap);
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         recomposed.getUnderlyingException(),
         DruidExceptionMatcher.invalidSqlInput().expectMessageIs("bad sql!")
     );
@@ -101,7 +101,7 @@ public class ErrorResponseTest
 
     ErrorResponse recomposed = ErrorResponse.fromMap(asMap);
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         recomposed.getUnderlyingException(),
         new DruidExceptionMatcher(DruidException.Persona.OPERATOR, DruidException.Category.TIMEOUT, "legacyQueryException")
             .expectMessageIs("Query did not complete within configured timeout period. You can increase query timeout or tune the performance of query.")

--- a/processing/src/test/java/org/apache/druid/error/ForbiddenTest.java
+++ b/processing/src/test/java/org/apache/druid/error/ForbiddenTest.java
@@ -47,7 +47,7 @@ public class ForbiddenTest
 
     ErrorResponse recomposed = ErrorResponse.fromMap(asMap);
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         recomposed.getUnderlyingException(),
         new DruidExceptionMatcher(
             DruidException.Persona.USER,

--- a/processing/src/test/java/org/apache/druid/error/InternalServerErrorTest.java
+++ b/processing/src/test/java/org/apache/druid/error/InternalServerErrorTest.java
@@ -47,7 +47,7 @@ public class InternalServerErrorTest
 
     ErrorResponse recomposed = ErrorResponse.fromMap(asMap);
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         recomposed.getUnderlyingException(),
         new DruidExceptionMatcher(
             DruidException.Persona.OPERATOR,

--- a/processing/src/test/java/org/apache/druid/error/NotFoundTest.java
+++ b/processing/src/test/java/org/apache/druid/error/NotFoundTest.java
@@ -49,7 +49,7 @@ public class NotFoundTest
 
     ErrorResponse recomposed = ErrorResponse.fromMap(asMap);
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         recomposed.getUnderlyingException(),
         new DruidExceptionMatcher(
             DruidException.Persona.USER,

--- a/processing/src/test/java/org/apache/druid/error/ThrowableMatcher.java
+++ b/processing/src/test/java/org/apache/druid/error/ThrowableMatcher.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.error;
+
+import org.junit.jupiter.api.Assertions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+public class ThrowableMatcher
+{
+  public static ThrowableMatcher of(final Class<? extends Throwable> expectedType)
+  {
+    return new ThrowableMatcher(expectedType);
+  }
+
+  private final Class<? extends Throwable> expectedType;
+  private final List<Consumer<Throwable>> assertions;
+
+  public ThrowableMatcher(final Class<? extends Throwable> expectedType)
+  {
+    this.expectedType = expectedType;
+    assertions = new ArrayList<>();
+  }
+
+  public ThrowableMatcher expectMessageIs(final String message)
+  {
+    assertions.add(exception -> Assertions.assertEquals(message, exception.getMessage()));
+    return this;
+  }
+
+  public ThrowableMatcher expectMessageContains(final String contains)
+  {
+    assertions.add(exception -> {
+      Assertions.assertNotNull(exception.getMessage());
+      Assertions.assertTrue(exception.getMessage().contains(contains));
+    });
+    return this;
+  }
+
+  public ThrowableMatcher expectMessage(final Predicate<String> messageMatcher)
+  {
+    assertions.add(exception -> {
+      final String message = exception.getMessage();
+      Assertions.assertNotNull(message);
+      Assertions.assertTrue(messageMatcher.test(message));
+    });
+    return this;
+  }
+
+  public ThrowableMatcher expectCause(final Predicate<Throwable> causeMatcher)
+  {
+    assertions.add(exception -> Assertions.assertTrue(causeMatcher.test(exception.getCause())));
+    return this;
+  }
+
+  public static void assertThat(final Throwable actual, final ThrowableMatcher expected)
+  {
+    final Throwable exception = Assertions.assertInstanceOf(expected.expectedType, actual);
+    expected.assertions.forEach(assertion -> assertion.accept(exception));
+  }
+
+  public void assertThat(final Throwable actual)
+  {
+    assertThat(actual, this);
+  }
+
+  public void assertThrowsAndMatches(final ThrowingSupplier fn)
+  {
+    final Throwable exception = Assertions.assertThrows(expectedType, fn::get);
+    assertThat(exception, this);
+  }
+
+  public interface ThrowingSupplier
+  {
+    void get() throws Throwable;
+  }
+}

--- a/processing/src/test/java/org/apache/druid/error/ThrowableMatcherTest.java
+++ b/processing/src/test/java/org/apache/druid/error/ThrowableMatcherTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.error;
+
+import org.junit.jupiter.api.Test;
+
+public class ThrowableMatcherTest
+{
+  @Test
+  public void testAssertThrowsAndMatches()
+  {
+    ThrowableMatcher.of(IllegalStateException.class)
+                    .expectMessage(message -> message.startsWith("bad state"))
+                    .expectCause(cause -> cause instanceof IllegalArgumentException)
+                    .assertThrowsAndMatches(
+                        () -> {
+                          throw new IllegalStateException("bad state", new IllegalArgumentException());
+                        }
+      );
+  }
+}

--- a/processing/src/test/java/org/apache/druid/java/util/common/io/smoosh/SmooshedFileMapperTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/io/smoosh/SmooshedFileMapperTest.java
@@ -27,7 +27,6 @@ import org.apache.druid.java.util.common.BufferUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.file.SegmentFileChannel;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -90,7 +89,7 @@ public class SmooshedFileMapperTest
     File baseDir = new File(folder, "base");
     baseDir.mkdir();
     try (FileSmoosher smoosher = new FileSmoosher(baseDir, 5)) {
-      MatcherAssert.assertThat(
+      DruidExceptionMatcher.assertThat(
           Assertions.assertThrows(
               DruidException.class,
               () -> smoosher.addWithChannel("foo", 10)

--- a/processing/src/test/java/org/apache/druid/query/QueriesTest.java
+++ b/processing/src/test/java/org/apache/druid/query/QueriesTest.java
@@ -44,7 +44,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -519,7 +518,7 @@ public class QueriesTest
             new TableDataSource("foo")
         )
     );
-    assertThat(
+    DruidExceptionMatcher.assertThat(
         e,
         DruidExceptionMatcher.defensive()
             .expectMessageContains("Its unsafe to replace the BaseDataSource of a non-processable query")

--- a/processing/src/test/java/org/apache/druid/query/expression/RegexpExtractExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/RegexpExtractExprMacroTest.java
@@ -24,7 +24,6 @@ import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.InputBindings;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -58,7 +57,7 @@ public class RegexpExtractExprMacroTest extends MacroTestBase
   @Test
   public void testInvalidRegexpExtractPattern()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(DruidException.class, () ->
             eval(
                 "regexp_extract('pod-1234-node', '[ab-0-9]')",

--- a/processing/src/test/java/org/apache/druid/query/expression/RegexpLikeExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/RegexpLikeExprMacroTest.java
@@ -24,7 +24,6 @@ import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.InputBindings;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -58,7 +57,7 @@ public class RegexpLikeExprMacroTest extends MacroTestBase
   @Test
   public void testInvalidRegexpLikePattern()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> eval("regexp_like('a', '[Ab-C]')", InputBindings.nilBindings())),

--- a/processing/src/test/java/org/apache/druid/query/expression/RegexpReplaceExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/RegexpReplaceExprMacroTest.java
@@ -25,7 +25,6 @@ import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.InputBindings;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -49,7 +48,7 @@ public class RegexpReplaceExprMacroTest extends MacroTestBase
   @Test
   public void testInvalidRegexpReplacePattern()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> eval("regexp_replace(a, '[Ab-cd-0]', 'xyz')", InputBindings.nilBindings())),

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTestHelper.java
@@ -175,25 +175,35 @@ public class GroupByQueryRunnerTestHelper
       final TestGroupByBuffers bufferPools
   )
   {
-    if (bufferPools.getBufferSize() != DEFAULT_PROCESSING_CONFIG.intermediateComputeSizeBytes()) {
+    return makeQueryRunnerFactory(mapper, config, bufferPools, DEFAULT_PROCESSING_CONFIG);
+  }
+
+  public static GroupByQueryRunnerFactory makeQueryRunnerFactory(
+      final ObjectMapper mapper,
+      final GroupByQueryConfig config,
+      final TestGroupByBuffers bufferPools,
+      final DruidProcessingConfig processingConfig
+  )
+  {
+    if (bufferPools.getBufferSize() != processingConfig.intermediateComputeSizeBytes()) {
       throw new ISE(
           "Provided buffer size [%,d] does not match configured size [%,d]",
           bufferPools.getBufferSize(),
-          DEFAULT_PROCESSING_CONFIG.intermediateComputeSizeBytes()
+          processingConfig.intermediateComputeSizeBytes()
       );
     }
-    if (bufferPools.getNumMergeBuffers() != DEFAULT_PROCESSING_CONFIG.getNumMergeBuffers()) {
+    if (bufferPools.getNumMergeBuffers() != processingConfig.getNumMergeBuffers()) {
       throw new ISE(
           "Provided merge buffer count [%,d] does not match configured count [%,d]",
           bufferPools.getNumMergeBuffers(),
-          DEFAULT_PROCESSING_CONFIG.getNumMergeBuffers()
+          processingConfig.getNumMergeBuffers()
       );
     }
     final GroupByStatsProvider statsProvider = new GroupByStatsProvider();
     final GroupByResourcesReservationPool groupByResourcesReservationPool =
         new GroupByResourcesReservationPool(bufferPools.getMergePool(), config);
     final GroupingEngine groupingEngine = new GroupingEngine(
-        DEFAULT_PROCESSING_CONFIG,
+        processingConfig,
         Suppliers.ofInstance(config),
         groupByResourcesReservationPool,
         mapper,

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTestHelper.java
@@ -38,6 +38,7 @@ import org.apache.druid.query.QueryRunner;
 import org.apache.druid.query.QueryRunnerFactory;
 import org.apache.druid.query.QueryRunnerTestHelper;
 import org.apache.druid.query.QueryToolChest;
+import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
@@ -166,6 +167,15 @@ public class GroupByQueryRunnerTestHelper
         V2_SMALL_BUFFER_CONFIG,
         V2_SMALL_DICTIONARY_CONFIG,
         V2_PARALLEL_COMBINE_CONFIG
+    );
+  }
+
+  public static GroupByQueryRunnerFactory makeQueryRunnerFactory(final GroupByQueryConfig config)
+  {
+    return makeQueryRunnerFactory(
+        TestHelper.makeSmileMapper(),
+        config,
+        TestGroupByBuffers.createDefault()
     );
   }
 

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
@@ -48,7 +48,6 @@ import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.projections.AggregateProjectionSchema;
 import org.apache.druid.timeline.LogicalSegment;
 import org.apache.druid.timeline.SegmentId;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.Interval;
 import org.joda.time.Period;
 import org.junit.jupiter.api.Assertions;
@@ -518,7 +517,7 @@ public class SegmentMetadataQueryQueryToolChestTest
     final SegmentAnalysis analysis1 = new SegmentAnalysis.Builder(TEST_SEGMENT_ID1).build();
     final SegmentAnalysis analysis2 = new SegmentAnalysis.Builder(TEST_SEGMENT_ID2).build();
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> SegmentMetadataQueryQueryToolChest.mergeAnalyses(
@@ -531,7 +530,7 @@ public class SegmentMetadataQueryQueryToolChestTest
         DruidExceptionMatcher.defensive().expectMessageIs("SegementMetadata queries require at least one datasource.")
     );
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> SegmentMetadataQueryQueryToolChest.mergeAnalyses(

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -77,7 +77,6 @@ import org.apache.druid.segment.projections.AggregateProjectionSchema;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.LogicalSegment;
 import org.apache.druid.timeline.SegmentId;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.Interval;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -1606,7 +1605,7 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
   @Test
   public void testSegmentMetadataQueryWithInvalidDatasourceTypes()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new SegmentMetadataQuery(
@@ -1629,7 +1628,7 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
             .expectMessageIs("You do not have permission to run a segmentMetadata query on table[testDatasource].")
     );
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new SegmentMetadataQuery(
@@ -1656,7 +1655,7 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
             .expectMessageIs("You do not have permission to run a segmentMetadata query on table[testDatasource].")
     );
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new SegmentMetadataQuery(
@@ -1684,7 +1683,7 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
                 "Invalid dataSource type [InlineDataSource{signature={column:STRING}}]. SegmentMetadataQuery only supports table or union datasources.")
     );
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new SegmentMetadataQuery(
@@ -1708,7 +1707,7 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
                 "Invalid dataSource type [InlineDataSource{signature={column:STRING}}]. SegmentMetadataQuery only supports table or union datasources.")
     );
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new SegmentMetadataQuery(
@@ -1729,7 +1728,7 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
                 "Invalid dataSource type [LookupDataSource{lookupName='lookyloo'}]. SegmentMetadataQuery only supports table or union datasources.")
     );
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new SegmentMetadataQuery(
@@ -1867,7 +1866,7 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
   @Test
   public void testSegmentMetadataQueryWithBothDeprecatedAndNewParameter()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new SegmentMetadataQuery(
@@ -1888,7 +1887,7 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
                                  + " Consider using aggregatorMergeStrategy since lenientAggregatorMerge is deprecated.")
     );
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new SegmentMetadataQuery(
@@ -1909,7 +1908,7 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
                                  + " Consider using aggregatorMergeStrategy since lenientAggregatorMerge is deprecated.")
     );
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new SegmentMetadataQuery(

--- a/processing/src/test/java/org/apache/druid/timeline/ClusterGroupTuplesTest.java
+++ b/processing/src/test/java/org/apache/druid/timeline/ClusterGroupTuplesTest.java
@@ -30,7 +30,6 @@ import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -68,7 +67,7 @@ class ClusterGroupTuplesTest
   @Test
   void testConstructorRejectsNullClusteringColumns()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new ClusterGroupTuples(null, List.of(List.of("acme", "us-east-1")))
@@ -80,7 +79,7 @@ class ClusterGroupTuplesTest
   @Test
   void testConstructorRejectsEmptyClusteringColumns()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new ClusterGroupTuples(RowSignature.empty(), List.of())
@@ -106,7 +105,7 @@ class ClusterGroupTuplesTest
   @Test
   void testConstructorRejectsTupleLengthMismatch()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new ClusterGroupTuples(tenantRegion(), List.of(List.of("acme")))
@@ -119,7 +118,7 @@ class ClusterGroupTuplesTest
   @Test
   void testConstructorRejectsNullTuple()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new ClusterGroupTuples(tenantRegion(), Arrays.asList(Arrays.asList("acme", "us-east-1"), null))
@@ -133,7 +132,7 @@ class ClusterGroupTuplesTest
   void testConstructorRejectsUntypedClusteringColumn()
   {
     final RowSignature untyped = RowSignature.builder().add("tenant", null).build();
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new ClusterGroupTuples(untyped, List.of(List.of("acme")))
@@ -146,7 +145,7 @@ class ClusterGroupTuplesTest
   void testConstructorRejectsUnsupportedColumnType()
   {
     final RowSignature arraySig = RowSignature.builder().add("arr", ColumnType.STRING_ARRAY).build();
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new ClusterGroupTuples(arraySig, List.of(List.of(List.of("a"))))
@@ -204,7 +203,7 @@ class ClusterGroupTuplesTest
   {
     // Coercion is intentionally narrow: only Number-family inputs are normalized. A String numeric value is rejected
     // rather than parsed, so operator typos don't silently broaden the matched set in future rule consumers.
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new ClusterGroupTuples(tenantPriority(), List.of(List.of("acme", "42")))
@@ -227,7 +226,7 @@ class ClusterGroupTuplesTest
   void testCoercionStringRejectedForDouble()
   {
     final RowSignature sig = RowSignature.builder().add("v", ColumnType.DOUBLE).build();
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new ClusterGroupTuples(sig, List.of(List.of("3.14")))
@@ -240,7 +239,7 @@ class ClusterGroupTuplesTest
   @Test
   void testCoercionBooleanRejectedForLong()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new ClusterGroupTuples(tenantPriority(), List.of(List.of("acme", (Object) Boolean.TRUE)))

--- a/server/src/test/java/org/apache/druid/client/BrokerSegmentWatcherConfigTest.java
+++ b/server/src/test/java/org/apache/druid/client/BrokerSegmentWatcherConfigTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  */
@@ -44,9 +44,9 @@ public class BrokerSegmentWatcherConfigTest
         BrokerSegmentWatcherConfig.class
     );
 
-    Assert.assertNull(config.getWatchedTiers());
-    Assert.assertTrue(config.isWatchRealtimeTasks());
-    Assert.assertNull(config.getIgnoredTiers());
+    Assertions.assertNull(config.getWatchedTiers());
+    Assertions.assertTrue(config.isWatchRealtimeTasks());
+    Assertions.assertNull(config.getIgnoredTiers());
 
     //non-defaults
     json = "{ \"watchedTiers\": [\"t1\", \"t2\"], \"watchedDataSources\": [\"ds1\", \"ds2\"], \"watchRealtimeTasks\": false }";
@@ -58,10 +58,10 @@ public class BrokerSegmentWatcherConfigTest
         BrokerSegmentWatcherConfig.class
     );
 
-    Assert.assertEquals(ImmutableSet.of("t1", "t2"), config.getWatchedTiers());
-    Assert.assertNull(config.getIgnoredTiers());
-    Assert.assertEquals(ImmutableSet.of("ds1", "ds2"), config.getWatchedDataSources());
-    Assert.assertFalse(config.isWatchRealtimeTasks());
+    Assertions.assertEquals(ImmutableSet.of("t1", "t2"), config.getWatchedTiers());
+    Assertions.assertNull(config.getIgnoredTiers());
+    Assertions.assertEquals(ImmutableSet.of("ds1", "ds2"), config.getWatchedDataSources());
+    Assertions.assertFalse(config.isWatchRealtimeTasks());
 
     // json with ignoredTiers
     json = "{ \"ignoredTiers\": [\"t3\", \"t4\"], \"watchedDataSources\": [\"ds1\", \"ds2\"] }";
@@ -73,9 +73,9 @@ public class BrokerSegmentWatcherConfigTest
         BrokerSegmentWatcherConfig.class
     );
 
-    Assert.assertNull(config.getWatchedTiers());
-    Assert.assertEquals(ImmutableSet.of("t3", "t4"), config.getIgnoredTiers());
-    Assert.assertEquals(ImmutableSet.of("ds1", "ds2"), config.getWatchedDataSources());
-    Assert.assertTrue(config.isWatchRealtimeTasks());
+    Assertions.assertNull(config.getWatchedTiers());
+    Assertions.assertEquals(ImmutableSet.of("t3", "t4"), config.getIgnoredTiers());
+    Assertions.assertEquals(ImmutableSet.of("ds1", "ds2"), config.getWatchedDataSources());
+    Assertions.assertTrue(config.isWatchRealtimeTasks());
   }
 }

--- a/server/src/test/java/org/apache/druid/client/BrokerServerViewTest.java
+++ b/server/src/test/java/org/apache/druid/client/BrokerServerViewTest.java
@@ -55,10 +55,10 @@ import org.apache.druid.timeline.partition.PartitionHolder;
 import org.apache.druid.timeline.partition.SingleElementPartitionChunk;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -68,6 +68,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
 
 public class BrokerServerViewTest
 {
@@ -87,7 +88,7 @@ public class BrokerServerViewTest
     brokerViewOfCoordinatorConfig = new BrokerViewOfCoordinatorConfig(new TestCoordinatorClient());
   }
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     brokerViewOfCoordinatorConfig.start();
@@ -107,37 +108,37 @@ public class BrokerServerViewTest
     final int partition = segment.getShardSpec().getPartitionNum();
     final Interval intervals = Intervals.of("2014-10-20T00:00:00Z/P1D");
     baseView.addSegment(druidServer, segment);
-    Assert.assertTrue(awaitLatch(segmentViewInitLatch));
-    Assert.assertTrue(awaitLatch(segmentAddedLatch));
+    Assertions.assertTrue(awaitLatch(segmentViewInitLatch));
+    Assertions.assertTrue(awaitLatch(segmentAddedLatch));
 
     TimelineLookup<String, ServerSelector> timeline = brokerServerView.getTimeline(
         new TableDataSource("test_broker_server_view")
     ).get();
     List<TimelineObjectHolder<String, ServerSelector>> serverLookupRes = timeline.lookup(intervals);
-    Assert.assertEquals(1, serverLookupRes.size());
+    Assertions.assertEquals(1, serverLookupRes.size());
 
     TimelineObjectHolder<String, ServerSelector> actualTimelineObjectHolder = serverLookupRes.get(0);
-    Assert.assertEquals(intervals, actualTimelineObjectHolder.getInterval());
-    Assert.assertEquals("v1", actualTimelineObjectHolder.getVersion());
+    Assertions.assertEquals(intervals, actualTimelineObjectHolder.getInterval());
+    Assertions.assertEquals("v1", actualTimelineObjectHolder.getVersion());
 
     PartitionHolder<ServerSelector> actualPartitionHolder = actualTimelineObjectHolder.getObject();
-    Assert.assertTrue(actualPartitionHolder.isComplete());
-    Assert.assertEquals(1, Iterables.size(actualPartitionHolder));
+    Assertions.assertTrue(actualPartitionHolder.isComplete());
+    Assertions.assertEquals(1, Iterables.size(actualPartitionHolder));
 
     ServerSelector selector = (actualPartitionHolder.iterator().next()).getObject();
-    Assert.assertFalse(selector.isEmpty());
-    Assert.assertEquals(segment, selector.getSegment());
-    Assert.assertEquals(druidServer, selector.pick(null, CloneQueryMode.EXCLUDECLONES).getServer());
-    Assert.assertNotNull(timeline.findChunk(intervals, "v1", partition));
+    Assertions.assertFalse(selector.isEmpty());
+    Assertions.assertEquals(segment, selector.getSegment());
+    Assertions.assertEquals(druidServer, selector.pick(null, CloneQueryMode.EXCLUDECLONES).getServer());
+    Assertions.assertNotNull(timeline.findChunk(intervals, "v1", partition));
 
     baseView.removeSegment(druidServer, segment);
-    Assert.assertTrue(awaitLatch(segmentRemovedLatch));
+    Assertions.assertTrue(awaitLatch(segmentRemovedLatch));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         timeline.lookup(intervals).size()
     );
-    Assert.assertNull(timeline.findChunk(intervals, "v1", partition));
+    Assertions.assertNull(timeline.findChunk(intervals, "v1", partition));
   }
 
   @Test
@@ -169,8 +170,8 @@ public class BrokerServerViewTest
     for (int i = 0; i < 5; ++i) {
       baseView.addSegment(druidServers.get(i), segments.get(i));
     }
-    Assert.assertTrue(awaitLatch(segmentViewInitLatch));
-    Assert.assertTrue(awaitLatch(segmentAddedLatch));
+    Assertions.assertTrue(awaitLatch(segmentViewInitLatch));
+    Assertions.assertTrue(awaitLatch(segmentAddedLatch));
 
     TimelineLookup timeline = brokerServerView.getTimeline(
         new TableDataSource("test_broker_server_view")
@@ -190,7 +191,7 @@ public class BrokerServerViewTest
 
     // unannounce the segment created by dataSegmentWithIntervalAndVersion("2011-04-01/2011-04-09", "v2")
     baseView.removeSegment(druidServers.get(2), segments.get(2));
-    Assert.assertTrue(awaitLatch(segmentRemovedLatch));
+    Assertions.assertTrue(awaitLatch(segmentRemovedLatch));
 
     // renew segmentRemovedLatch since we still have 4 segments to unannounce
     segmentRemovedLatch = new CountDownLatch(4);
@@ -219,9 +220,9 @@ public class BrokerServerViewTest
         baseView.removeSegment(druidServers.get(i), segments.get(i));
       }
     }
-    Assert.assertTrue(awaitLatch(segmentRemovedLatch));
+    Assertions.assertTrue(awaitLatch(segmentRemovedLatch));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         ((List<TimelineObjectHolder>) timeline.lookup(Intervals.of("2011-04-01/2011-04-09"))).size()
     );
@@ -261,11 +262,11 @@ public class BrokerServerViewTest
 
     baseView.addServer(druidBroker);
 
-    Assert.assertTrue(awaitLatch(segmentViewInitLatch));
-    Assert.assertTrue(awaitLatch(serverAddedLatch));
+    Assertions.assertTrue(awaitLatch(segmentViewInitLatch));
+    Assertions.assertTrue(awaitLatch(serverAddedLatch));
 
     // check server metadatas
-    Assert.assertEquals(
+    Assertions.assertEquals(
         druidServers.stream().map(DruidServer::getMetadata).collect(Collectors.toSet()),
         ImmutableSet.copyOf(brokerServerView.getDruidServerMetadatas())
     );
@@ -286,7 +287,7 @@ public class BrokerServerViewTest
     for (int i = 0; i < 5; ++i) {
       baseView.addSegment(druidServers.get(i), segments.get(i));
     }
-    Assert.assertTrue(awaitLatch(segmentAddedLatch));
+    Assertions.assertTrue(awaitLatch(segmentAddedLatch));
 
     TimelineLookup timeline = brokerServerView.getTimeline(
         new TableDataSource("test_broker_server_view")
@@ -307,7 +308,7 @@ public class BrokerServerViewTest
 
     // unannounce the broker segment should do nothing to announcements
     baseView.removeSegment(druidBroker, brokerSegment);
-    Assert.assertTrue(awaitLatch(segmentRemovedLatch));
+    Assertions.assertTrue(awaitLatch(segmentRemovedLatch));
 
     // renew segmentRemovedLatch since we still have 5 segments to unannounce
     segmentRemovedLatch = new CountDownLatch(5);
@@ -334,7 +335,7 @@ public class BrokerServerViewTest
     for (int i = 0; i < 5; ++i) {
       baseView.removeSegment(druidServers.get(i), segments.get(i));
     }
-    Assert.assertTrue(awaitLatch(segmentRemovedLatch));
+    Assertions.assertTrue(awaitLatch(segmentRemovedLatch));
   }
 
   @Test
@@ -364,8 +365,8 @@ public class BrokerServerViewTest
     baseView.addSegment(server21, segment3);
 
     // Wait for the segments to be added
-    Assert.assertTrue(awaitLatch(segmentViewInitLatch));
-    Assert.assertTrue(awaitLatch(segmentAddedLatch));
+    Assertions.assertTrue(awaitLatch(segmentViewInitLatch));
+    Assertions.assertTrue(awaitLatch(segmentAddedLatch));
 
     // Get the timeline for the datasource
     TimelineLookup<String, ServerSelector> timeline = brokerServerView.getTimeline(
@@ -373,30 +374,30 @@ public class BrokerServerViewTest
     ).get();
 
     // Verify that the timeline has no entry for the interval of segment 1
-    Assert.assertTrue(timeline.lookup(segment1.getInterval()).isEmpty());
+    Assertions.assertTrue(timeline.lookup(segment1.getInterval()).isEmpty());
 
     // Verify that there is one entry for the interval of segment 2
     List<TimelineObjectHolder<String, ServerSelector>> timelineHolders =
         timeline.lookup(segment2.getInterval());
-    Assert.assertEquals(1, timelineHolders.size());
+    Assertions.assertEquals(1, timelineHolders.size());
 
     TimelineObjectHolder<String, ServerSelector> timelineHolder = timelineHolders.get(0);
-    Assert.assertEquals(segment2.getInterval(), timelineHolder.getInterval());
-    Assert.assertEquals(segment2.getVersion(), timelineHolder.getVersion());
+    Assertions.assertEquals(segment2.getInterval(), timelineHolder.getInterval());
+    Assertions.assertEquals(segment2.getVersion(), timelineHolder.getVersion());
 
     PartitionHolder<ServerSelector> partitionHolder = timelineHolder.getObject();
-    Assert.assertTrue(partitionHolder.isComplete());
-    Assert.assertEquals(1, Iterables.size(partitionHolder));
+    Assertions.assertTrue(partitionHolder.isComplete());
+    Assertions.assertEquals(1, Iterables.size(partitionHolder));
 
     ServerSelector selector = (partitionHolder.iterator().next()).getObject();
-    Assert.assertFalse(selector.isEmpty());
-    Assert.assertEquals(segment2, selector.getSegment());
+    Assertions.assertFalse(selector.isEmpty());
+    Assertions.assertEquals(segment2, selector.getSegment());
 
     // Verify that the ServerSelector always picks Tier 1
     for (int i = 0; i < 5; ++i) {
-      Assert.assertEquals(server21, selector.pick(null, CloneQueryMode.EXCLUDECLONES).getServer());
+      Assertions.assertEquals(server21, selector.pick(null, CloneQueryMode.EXCLUDECLONES).getServer());
     }
-    Assert.assertEquals(Collections.singletonList(server21.getMetadata()), selector.getCandidates(2, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(Collections.singletonList(server21.getMetadata()), selector.getCandidates(2, CloneQueryMode.EXCLUDECLONES));
   }
 
   @Test
@@ -424,8 +425,8 @@ public class BrokerServerViewTest
     baseView.addSegment(historicalServer, segment3);
 
     // Wait for the segments to be added
-    Assert.assertTrue(awaitLatch(segmentViewInitLatch));
-    Assert.assertTrue(awaitLatch(segmentAddedLatch));
+    Assertions.assertTrue(awaitLatch(segmentViewInitLatch));
+    Assertions.assertTrue(awaitLatch(segmentAddedLatch));
 
     // Get the timeline for the datasource
     TimelineLookup<String, ServerSelector> timeline = brokerServerView.getTimeline(
@@ -433,30 +434,30 @@ public class BrokerServerViewTest
     ).get();
 
     // Verify that the timeline has no entry for the interval of segment 1
-    Assert.assertTrue(timeline.lookup(segment1.getInterval()).isEmpty());
+    Assertions.assertTrue(timeline.lookup(segment1.getInterval()).isEmpty());
 
     // Verify that there is one entry for the interval of segment 2
     List<TimelineObjectHolder<String, ServerSelector>> timelineHolders =
         timeline.lookup(segment2.getInterval());
-    Assert.assertEquals(1, timelineHolders.size());
+    Assertions.assertEquals(1, timelineHolders.size());
 
     TimelineObjectHolder<String, ServerSelector> timelineHolder = timelineHolders.get(0);
-    Assert.assertEquals(segment2.getInterval(), timelineHolder.getInterval());
-    Assert.assertEquals(segment2.getVersion(), timelineHolder.getVersion());
+    Assertions.assertEquals(segment2.getInterval(), timelineHolder.getInterval());
+    Assertions.assertEquals(segment2.getVersion(), timelineHolder.getVersion());
 
     PartitionHolder<ServerSelector> partitionHolder = timelineHolder.getObject();
-    Assert.assertTrue(partitionHolder.isComplete());
-    Assert.assertEquals(1, Iterables.size(partitionHolder));
+    Assertions.assertTrue(partitionHolder.isComplete());
+    Assertions.assertEquals(1, Iterables.size(partitionHolder));
 
     ServerSelector selector = (partitionHolder.iterator().next()).getObject();
-    Assert.assertFalse(selector.isEmpty());
-    Assert.assertEquals(segment2, selector.getSegment());
+    Assertions.assertFalse(selector.isEmpty());
+    Assertions.assertEquals(segment2, selector.getSegment());
 
     // Verify that the ServerSelector always picks the Historical server
     for (int i = 0; i < 5; ++i) {
-      Assert.assertEquals(historicalServer, selector.pick(null, CloneQueryMode.EXCLUDECLONES).getServer());
+      Assertions.assertEquals(historicalServer, selector.pick(null, CloneQueryMode.EXCLUDECLONES).getServer());
     }
-    Assert.assertEquals(Collections.singletonList(historicalServer.getMetadata()), selector.getCandidates(2, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(Collections.singletonList(historicalServer.getMetadata()), selector.getCandidates(2, CloneQueryMode.EXCLUDECLONES));
   }
 
   @Test
@@ -486,8 +487,8 @@ public class BrokerServerViewTest
     baseView.addSegment(server21, segment3);
 
     // Wait for the segments to be added
-    Assert.assertTrue(awaitLatch(segmentViewInitLatch));
-    Assert.assertTrue(awaitLatch(segmentAddedLatch));
+    Assertions.assertTrue(awaitLatch(segmentViewInitLatch));
+    Assertions.assertTrue(awaitLatch(segmentAddedLatch));
 
     // Get the timeline for the datasource
     TimelineLookup<String, ServerSelector> timeline = brokerServerView.getTimeline(
@@ -495,51 +496,55 @@ public class BrokerServerViewTest
     ).get();
 
     // Verify that the timeline has no entry for the interval of segment 1
-    Assert.assertTrue(timeline.lookup(segment1.getInterval()).isEmpty());
+    Assertions.assertTrue(timeline.lookup(segment1.getInterval()).isEmpty());
 
     // Verify that there is one entry for the interval of segment 2
     List<TimelineObjectHolder<String, ServerSelector>> timelineHolders =
         timeline.lookup(segment2.getInterval());
-    Assert.assertEquals(1, timelineHolders.size());
+    Assertions.assertEquals(1, timelineHolders.size());
 
     TimelineObjectHolder<String, ServerSelector> timelineHolder = timelineHolders.get(0);
-    Assert.assertEquals(segment2.getInterval(), timelineHolder.getInterval());
-    Assert.assertEquals(segment2.getVersion(), timelineHolder.getVersion());
+    Assertions.assertEquals(segment2.getInterval(), timelineHolder.getInterval());
+    Assertions.assertEquals(segment2.getVersion(), timelineHolder.getVersion());
 
     PartitionHolder<ServerSelector> partitionHolder = timelineHolder.getObject();
-    Assert.assertTrue(partitionHolder.isComplete());
-    Assert.assertEquals(1, Iterables.size(partitionHolder));
+    Assertions.assertTrue(partitionHolder.isComplete());
+    Assertions.assertEquals(1, Iterables.size(partitionHolder));
 
     ServerSelector selector = (partitionHolder.iterator().next()).getObject();
-    Assert.assertFalse(selector.isEmpty());
-    Assert.assertEquals(segment2, selector.getSegment());
+    Assertions.assertFalse(selector.isEmpty());
+    Assertions.assertEquals(segment2, selector.getSegment());
 
     // Verify that the ServerSelector always picks Tier 1
     for (int i = 0; i < 5; ++i) {
-      Assert.assertEquals(server21, selector.pick(null, CloneQueryMode.EXCLUDECLONES).getServer());
+      Assertions.assertEquals(server21, selector.pick(null, CloneQueryMode.EXCLUDECLONES).getServer());
     }
-    Assert.assertEquals(Collections.singletonList(server21.getMetadata()), selector.getCandidates(2, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(Collections.singletonList(server21.getMetadata()), selector.getCandidates(2, CloneQueryMode.EXCLUDECLONES));
   }
 
-  @Test(expected = ISE.class)
-  public void testInvalidWatchedTiersConfig() throws Exception
+  @Test
+  public void testInvalidWatchedTiersConfig()
   {
-    // Verify that specifying both ignoredTiers and watchedTiers fails startup
-    final String tier1 = "tier1";
-    final String tier2 = "tier2";
-    setupViews(Sets.newHashSet(tier2), Sets.newHashSet(tier1), true);
+    org.junit.jupiter.api.Assertions.assertThrows(ISE.class, () -> {
+      // Verify that specifying both ignoredTiers and watchedTiers fails startup
+      final String tier1 = "tier1";
+      final String tier2 = "tier2";
+      setupViews(Sets.newHashSet(tier2), Sets.newHashSet(tier1), true);
+    });
   }
 
-  @Test(expected = ISE.class)
-  public void testEmptyWatchedTiersConfig() throws Exception
+  @Test
+  public void testEmptyWatchedTiersConfig()
   {
-    setupViews(Collections.emptySet(), null, true);
+    org.junit.jupiter.api.Assertions.assertThrows(ISE.class, () ->
+      setupViews(Collections.emptySet(), null, true));
   }
 
-  @Test(expected = ISE.class)
-  public void testEmptyIgnoredTiersConfig() throws Exception
+  @Test
+  public void testEmptyIgnoredTiersConfig()
   {
-    setupViews(null, Collections.emptySet(), true);
+    org.junit.jupiter.api.Assertions.assertThrows(ISE.class, () ->
+      setupViews(null, Collections.emptySet(), true));
   }
 
   @Test
@@ -578,8 +583,8 @@ public class BrokerServerViewTest
     baseView.addSegment(realtimeHighPriority, segment3);
 
     // Wait for the segments to be added
-    Assert.assertTrue(awaitLatch(segmentViewInitLatch));
-    Assert.assertTrue(awaitLatch(segmentAddedLatch));
+    Assertions.assertTrue(awaitLatch(segmentViewInitLatch));
+    Assertions.assertTrue(awaitLatch(segmentAddedLatch));
 
     // Get the timeline for the datasource
     TimelineLookup<String, ServerSelector> timeline = brokerServerView.getTimeline(
@@ -588,37 +593,37 @@ public class BrokerServerViewTest
 
     // Test segment 1: should pick the lowest priority historical (priority 0)
     List<TimelineObjectHolder<String, ServerSelector>> holders1 = timeline.lookup(segment1.getInterval());
-    Assert.assertEquals(1, holders1.size());
+    Assertions.assertEquals(1, holders1.size());
     ServerSelector selector1 = holders1.get(0).getObject().iterator().next().getObject();
-    Assert.assertEquals(segment1, selector1.getSegment());
+    Assertions.assertEquals(segment1, selector1.getSegment());
 
     // Historical LowestPriorityTierSelectorStrategy should pick the historical servers low and high in order
-    Assert.assertEquals(historicalLowPriority, selector1.pick(null, CloneQueryMode.EXCLUDECLONES).getServer());
-    Assert.assertEquals(List.of(historicalLowPriority.getMetadata()), selector1.getCandidates(1, CloneQueryMode.EXCLUDECLONES));
-    Assert.assertEquals(List.of(historicalLowPriority.getMetadata(), historicalHighPriority.getMetadata()), selector1.getAllServers(CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(historicalLowPriority, selector1.pick(null, CloneQueryMode.EXCLUDECLONES).getServer());
+    Assertions.assertEquals(List.of(historicalLowPriority.getMetadata()), selector1.getCandidates(1, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(List.of(historicalLowPriority.getMetadata(), historicalHighPriority.getMetadata()), selector1.getAllServers(CloneQueryMode.EXCLUDECLONES));
 
     // Test segment 2: should pick the highest priority realtime (priority 10)
     List<TimelineObjectHolder<String, ServerSelector>> holders2 = timeline.lookup(segment2.getInterval());
-    Assert.assertEquals(1, holders2.size());
+    Assertions.assertEquals(1, holders2.size());
     ServerSelector selector2 = holders2.get(0).getObject().iterator().next().getObject();
-    Assert.assertEquals(segment2, selector2.getSegment());
+    Assertions.assertEquals(segment2, selector2.getSegment());
 
     // Realtime HighestPriorityTierSelectorStrategy for realtime should pick the realtime servers high and low in order
-    Assert.assertEquals(realtimeHighPriority, selector2.pick(null, CloneQueryMode.EXCLUDECLONES).getServer());
-    Assert.assertEquals(List.of(realtimeHighPriority.getMetadata()), selector2.getCandidates(1, CloneQueryMode.EXCLUDECLONES));
-    Assert.assertEquals(List.of(realtimeHighPriority.getMetadata(), realtimeLowPriority.getMetadata()), selector2.getAllServers(CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(realtimeHighPriority, selector2.pick(null, CloneQueryMode.EXCLUDECLONES).getServer());
+    Assertions.assertEquals(List.of(realtimeHighPriority.getMetadata()), selector2.getCandidates(1, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(List.of(realtimeHighPriority.getMetadata(), realtimeLowPriority.getMetadata()), selector2.getAllServers(CloneQueryMode.EXCLUDECLONES));
 
     // Test segment 3: when both historical and realtime exist, historical is preferred
     // and should pick based on historical strategy (lowest priority = 10)
     List<TimelineObjectHolder<String, ServerSelector>> holders3 = timeline.lookup(segment3.getInterval());
-    Assert.assertEquals(1, holders3.size());
+    Assertions.assertEquals(1, holders3.size());
     ServerSelector selector3 = holders3.get(0).getObject().iterator().next().getObject();
-    Assert.assertEquals(segment3, selector3.getSegment());
+    Assertions.assertEquals(segment3, selector3.getSegment());
 
     // Should prefer historical over realtime servers and in order
-    Assert.assertEquals(historicalHighPriority, selector3.pick(null, CloneQueryMode.EXCLUDECLONES).getServer());
-    Assert.assertEquals(List.of(historicalHighPriority.getMetadata()), selector3.getCandidates(1, CloneQueryMode.EXCLUDECLONES));
-    Assert.assertEquals(
+    Assertions.assertEquals(historicalHighPriority, selector3.pick(null, CloneQueryMode.EXCLUDECLONES).getServer());
+    Assertions.assertEquals(List.of(historicalHighPriority.getMetadata()), selector3.getCandidates(1, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(
         List.of(historicalHighPriority.getMetadata(), realtimeHighPriority.getMetadata(), realtimeLowPriority.getMetadata()),
         selector3.getAllServers(CloneQueryMode.EXCLUDECLONES)
     );
@@ -670,24 +675,24 @@ public class BrokerServerViewTest
       List<Pair<Interval, Pair<String, Pair<DruidServer, DataSegment>>>> expected, List<TimelineObjectHolder> actual
   )
   {
-    Assert.assertEquals(expected.size(), actual.size());
+    Assertions.assertEquals(expected.size(), actual.size());
 
     for (int i = 0; i < expected.size(); ++i) {
       Pair<Interval, Pair<String, Pair<DruidServer, DataSegment>>> expectedPair = expected.get(i);
       TimelineObjectHolder<String, ServerSelector> actualTimelineObjectHolder = actual.get(i);
 
-      Assert.assertEquals(expectedPair.lhs, actualTimelineObjectHolder.getInterval());
-      Assert.assertEquals(expectedPair.rhs.lhs, actualTimelineObjectHolder.getVersion());
+      Assertions.assertEquals(expectedPair.lhs, actualTimelineObjectHolder.getInterval());
+      Assertions.assertEquals(expectedPair.rhs.lhs, actualTimelineObjectHolder.getVersion());
 
       PartitionHolder<ServerSelector> actualPartitionHolder = actualTimelineObjectHolder.getObject();
-      Assert.assertTrue(actualPartitionHolder.isComplete());
-      Assert.assertEquals(1, Iterables.size(actualPartitionHolder));
+      Assertions.assertTrue(actualPartitionHolder.isComplete());
+      Assertions.assertEquals(1, Iterables.size(actualPartitionHolder));
 
       ServerSelector selector = ((SingleElementPartitionChunk<ServerSelector>) actualPartitionHolder.iterator()
                                                                                                     .next()).getObject();
-      Assert.assertFalse(selector.isEmpty());
-      Assert.assertEquals(expectedPair.rhs.rhs.lhs, selector.pick(null, CloneQueryMode.EXCLUDECLONES).getServer());
-      Assert.assertEquals(expectedPair.rhs.rhs.rhs, selector.getSegment());
+      Assertions.assertFalse(selector.isEmpty());
+      Assertions.assertEquals(expectedPair.rhs.rhs.lhs, selector.pick(null, CloneQueryMode.EXCLUDECLONES).getServer());
+      Assertions.assertEquals(expectedPair.rhs.rhs.rhs, selector.getSegment());
     }
   }
 
@@ -855,7 +860,7 @@ public class BrokerServerViewTest
     return retVal;
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     if (baseView != null) {

--- a/server/src/test/java/org/apache/druid/client/BrokerServerViewTest.java
+++ b/server/src/test/java/org/apache/druid/client/BrokerServerViewTest.java
@@ -525,7 +525,7 @@ public class BrokerServerViewTest
   @Test
   public void testInvalidWatchedTiersConfig()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(ISE.class, () -> {
+    Assertions.assertThrows(ISE.class, () -> {
       // Verify that specifying both ignoredTiers and watchedTiers fails startup
       final String tier1 = "tier1";
       final String tier2 = "tier2";
@@ -536,14 +536,14 @@ public class BrokerServerViewTest
   @Test
   public void testEmptyWatchedTiersConfig()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(ISE.class, () ->
+    Assertions.assertThrows(ISE.class, () ->
       setupViews(Collections.emptySet(), null, true));
   }
 
   @Test
   public void testEmptyIgnoredTiersConfig()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(ISE.class, () ->
+    Assertions.assertThrows(ISE.class, () ->
       setupViews(null, Collections.emptySet(), true));
   }
 

--- a/server/src/test/java/org/apache/druid/client/BrokerViewOfBrokerConfigTest.java
+++ b/server/src/test/java/org/apache/druid/client/BrokerViewOfBrokerConfigTest.java
@@ -29,9 +29,9 @@ import org.apache.druid.query.QueryContext;
 import org.apache.druid.server.DefaultQueryBlocklistRule;
 import org.apache.druid.server.broker.BrokerDynamicConfig;
 import org.apache.druid.server.broker.QueryConfigSnapshot;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Map;
@@ -45,7 +45,7 @@ public class BrokerViewOfBrokerConfigTest
   private DefaultQueryConfig defaultQueryConfig;
 
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     config = BrokerDynamicConfig.builder().build();
@@ -60,7 +60,7 @@ public class BrokerViewOfBrokerConfigTest
   {
     target.start();
     Mockito.verify(coordinatorClient, Mockito.times(1)).getBrokerDynamicConfig();
-    Assert.assertEquals(config, target.getDynamicConfig());
+    Assertions.assertEquals(config, target.getDynamicConfig());
   }
 
   @Test
@@ -75,24 +75,24 @@ public class BrokerViewOfBrokerConfigTest
     target.setDynamicConfig(dynamicConfig);
 
     final Map<String, Object> resolved = target.getContext();
-    Assert.assertEquals(30000, resolved.get("timeout"));
-    Assert.assertEquals(false, resolved.get("useCache"));
-    Assert.assertEquals(5, resolved.get("priority"));
+    Assertions.assertEquals(30000, resolved.get("timeout"));
+    Assertions.assertEquals(false, resolved.get("useCache"));
+    Assertions.assertEquals(5, resolved.get("priority"));
   }
 
   @Test
   public void testResolvedContextEqualsStaticDefaultsWhenDynamicContextIsEmpty()
   {
     target.setDynamicConfig(BrokerDynamicConfig.builder().build());
-    Assert.assertEquals(defaultQueryConfig.getContext(), target.getContext());
+    Assertions.assertEquals(defaultQueryConfig.getContext(), target.getContext());
   }
 
   @Test
   public void testSnapshotBeforeFirstSyncHasStaticDefaultsAndNoDynamicConfig()
   {
     final QueryConfigSnapshot snapshot = target.snapshotForQuery();
-    Assert.assertEquals(defaultQueryConfig.getContext(), snapshot.getResolvedDefaultQueryContext());
-    Assert.assertTrue(snapshot.getQueryBlocklist().isEmpty());
+    Assertions.assertEquals(defaultQueryConfig.getContext(), snapshot.getResolvedDefaultQueryContext());
+    Assertions.assertTrue(snapshot.getQueryBlocklist().isEmpty());
   }
 
   @Test
@@ -108,10 +108,10 @@ public class BrokerViewOfBrokerConfigTest
     target.setDynamicConfig(dynamicConfig);
 
     final QueryConfigSnapshot snapshot = target.snapshotForQuery();
-    Assert.assertSame(target.getContext(), snapshot.getResolvedDefaultQueryContext());
-    Assert.assertEquals(dynamicConfig.getQueryBlocklist(), snapshot.getQueryBlocklist());
-    Assert.assertEquals(5, snapshot.getResolvedDefaultQueryContext().get("priority"));
-    Assert.assertSame(snapshot.getDynamicConfig(), target.getDynamicConfig());
+    Assertions.assertSame(target.getContext(), snapshot.getResolvedDefaultQueryContext());
+    Assertions.assertEquals(dynamicConfig.getQueryBlocklist(), snapshot.getQueryBlocklist());
+    Assertions.assertEquals(5, snapshot.getResolvedDefaultQueryContext().get("priority"));
+    Assertions.assertSame(snapshot.getDynamicConfig(), target.getDynamicConfig());
   }
 
   @Test
@@ -131,7 +131,7 @@ public class BrokerViewOfBrokerConfigTest
                            .build()
     );
 
-    Assert.assertEquals(5, snapshot.getResolvedDefaultQueryContext().get("priority"));
-    Assert.assertEquals(9, target.getContext().get("priority"));
+    Assertions.assertEquals(5, snapshot.getResolvedDefaultQueryContext().get("priority"));
+    Assertions.assertEquals(9, target.getContext().get("priority"));
   }
 }

--- a/server/src/test/java/org/apache/druid/client/BrokerViewOfCoordinatorConfigTest.java
+++ b/server/src/test/java/org/apache/druid/client/BrokerViewOfCoordinatorConfigTest.java
@@ -26,9 +26,9 @@ import org.apache.druid.query.CloneQueryMode;
 import org.apache.druid.query.QueryRunner;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.HashSet;
@@ -43,7 +43,7 @@ public class BrokerViewOfCoordinatorConfigTest
   private CoordinatorDynamicConfig config;
 
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     config = CoordinatorDynamicConfig.builder()
@@ -59,7 +59,7 @@ public class BrokerViewOfCoordinatorConfigTest
   {
     target.start();
     Mockito.verify(coordinatorClient, Mockito.times(1)).getCoordinatorDynamicConfig();
-    Assert.assertEquals(config, target.getDynamicConfig());
+    Assertions.assertEquals(config, target.getDynamicConfig());
   }
 
   @Test
@@ -72,9 +72,9 @@ public class BrokerViewOfCoordinatorConfigTest
         target.getQueryableServers(servers, CloneQueryMode.EXCLUDECLONES);
 
     Set<String> hosts = extractHosts(result);
-    Assert.assertFalse("target clone server host1 should be filtered", hosts.contains("host1"));
-    Assert.assertTrue("source clone server host2 should remain", hosts.contains("host2"));
-    Assert.assertTrue("non-clone server host3 should remain", hosts.contains("host3"));
+    Assertions.assertFalse(hosts.contains("host1"), "target clone server host1 should be filtered");
+    Assertions.assertTrue(hosts.contains("host2"), "source clone server host2 should remain");
+    Assertions.assertTrue(hosts.contains("host3"), "non-clone server host3 should remain");
   }
 
   @Test
@@ -87,9 +87,9 @@ public class BrokerViewOfCoordinatorConfigTest
         target.getQueryableServers(servers, CloneQueryMode.PREFERCLONES);
 
     Set<String> hosts = extractHosts(result);
-    Assert.assertTrue("target clone server host1 should remain", hosts.contains("host1"));
-    Assert.assertFalse("source clone server host2 should be filtered", hosts.contains("host2"));
-    Assert.assertTrue("non-clone server host3 should remain", hosts.contains("host3"));
+    Assertions.assertTrue(hosts.contains("host1"), "target clone server host1 should remain");
+    Assertions.assertFalse(hosts.contains("host2"), "source clone server host2 should be filtered");
+    Assertions.assertTrue(hosts.contains("host3"), "non-clone server host3 should remain");
   }
 
   @Test
@@ -101,7 +101,7 @@ public class BrokerViewOfCoordinatorConfigTest
     Int2ObjectRBTreeMap<Set<QueryableDruidServer>> result =
         target.getQueryableServers(servers, CloneQueryMode.INCLUDECLONES);
 
-    Assert.assertSame("INCLUDECLONES should return the original map", servers, result);
+    Assertions.assertSame(servers, result, "INCLUDECLONES should return the original map");
   }
 
   @Test
@@ -120,9 +120,9 @@ public class BrokerViewOfCoordinatorConfigTest
         target.getQueryableServers(servers, CloneQueryMode.EXCLUDECLONES);
 
     Set<String> hosts = extractHosts(result);
-    Assert.assertFalse("new target clone host3 should be filtered", hosts.contains("host3"));
-    Assert.assertTrue("host1 is now source, should remain", hosts.contains("host1"));
-    Assert.assertTrue("host2 is unrelated, should remain", hosts.contains("host2"));
+    Assertions.assertFalse(hosts.contains("host3"), "new target clone host3 should be filtered");
+    Assertions.assertTrue(hosts.contains("host1"), "host1 is now source, should remain");
+    Assertions.assertTrue(hosts.contains("host2"), "host2 is unrelated, should remain");
   }
 
   /**

--- a/server/src/test/java/org/apache/druid/client/CacheUtilTest.java
+++ b/server/src/test/java/org/apache/druid/client/CacheUtilTest.java
@@ -32,8 +32,8 @@ import org.apache.druid.query.LookupDataSource;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -49,7 +49,7 @@ public class CacheUtilTest
   @Test
   public void test_isQueryCacheable_cacheableOnBroker()
   {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         CacheUtil.isQueryCacheable(
             timeseriesQuery,
             new DummyCacheStrategy<>(true, true),
@@ -63,7 +63,7 @@ public class CacheUtilTest
   @Test
   public void test_isQueryCacheable_cacheableOnDataServer()
   {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         CacheUtil.isQueryCacheable(
             timeseriesQuery,
             new DummyCacheStrategy<>(true, true),
@@ -77,7 +77,7 @@ public class CacheUtilTest
   @Test
   public void test_isQueryCacheable_unCacheableOnBroker()
   {
-    Assert.assertFalse(
+    Assertions.assertFalse(
         CacheUtil.isQueryCacheable(
             timeseriesQuery,
             new DummyCacheStrategy<>(false, true),
@@ -91,7 +91,7 @@ public class CacheUtilTest
   @Test
   public void test_isQueryCacheable_unCacheableOnDataServer()
   {
-    Assert.assertFalse(
+    Assertions.assertFalse(
         CacheUtil.isQueryCacheable(
             timeseriesQuery,
             new DummyCacheStrategy<>(true, false),
@@ -105,7 +105,7 @@ public class CacheUtilTest
   @Test
   public void test_isQueryCacheable_unCacheableType()
   {
-    Assert.assertFalse(
+    Assertions.assertFalse(
         CacheUtil.isQueryCacheable(
             timeseriesQuery,
             new DummyCacheStrategy<>(true, false),
@@ -119,7 +119,7 @@ public class CacheUtilTest
   @Test
   public void test_isQueryCacheable_unCacheableDataSourceOnBroker()
   {
-    Assert.assertFalse(
+    Assertions.assertFalse(
         CacheUtil.isQueryCacheable(
             timeseriesQuery.withDataSource(new GlobalTableDataSource("global")),
             new DummyCacheStrategy<>(true, true),
@@ -133,7 +133,7 @@ public class CacheUtilTest
   @Test
   public void test_isQueryCacheable_unCacheableDataSourceOnDataServer()
   {
-    Assert.assertFalse(
+    Assertions.assertFalse(
         CacheUtil.isQueryCacheable(
             timeseriesQuery.withDataSource(new LookupDataSource("lookyloo")),
             new DummyCacheStrategy<>(true, true),
@@ -147,7 +147,7 @@ public class CacheUtilTest
   @Test
   public void test_isQueryCacheable_nullCacheStrategy()
   {
-    Assert.assertFalse(
+    Assertions.assertFalse(
         CacheUtil.isQueryCacheable(
             timeseriesQuery,
             null,

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientCacheKeyManagerTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientCacheKeyManagerTest.java
@@ -34,14 +34,14 @@ import org.apache.druid.segment.join.NoopDataSource;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.easymock.EasyMockRunner;
+import org.easymock.EasyMockExtension;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Set;
 
@@ -49,7 +49,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 
-@RunWith(EasyMockRunner.class)
+@ExtendWith(EasyMockExtension.class)
 public class CachingClusteredClientCacheKeyManagerTest extends EasyMockSupport
 {
   @Mock
@@ -65,14 +65,14 @@ public class CachingClusteredClientCacheKeyManagerTest extends EasyMockSupport
   private static final byte[] JOIN_KEY = new byte[]{4, 5};
   private static final byte[] FULL_QUERY_CACHE_KEY = new byte[]{DataSource.NOOP_CACHE_ID, 1, 2, 3};
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     expect(strategy.computeCacheKey(query)).andReturn(QUERY_CACHE_KEY).anyTimes();
     expect(query.context()).andReturn(QueryContext.of(ImmutableMap.of(QueryContexts.BY_SEGMENT_KEY, false))).anyTimes();
   }
 
-  @After
+  @AfterEach
   public void teardown()
   {
     verifyAllUnexpectedCalls();
@@ -88,7 +88,7 @@ public class CachingClusteredClientCacheKeyManagerTest extends EasyMockSupport
         makeRealtimeServerSelector(1)
     );
     String actual = keyManager.computeResultLevelCachingEtag(selectors, CloneQueryMode.EXCLUDECLONES, QUERY_CACHE_KEY);
-    Assert.assertNull(actual);
+    Assertions.assertNull(actual);
   }
 
   @Test
@@ -101,23 +101,23 @@ public class CachingClusteredClientCacheKeyManagerTest extends EasyMockSupport
         makeHistoricalServerSelector(1)
     );
     String actual1 = keyManager.computeResultLevelCachingEtag(selectors, CloneQueryMode.EXCLUDECLONES, QUERY_CACHE_KEY);
-    Assert.assertNotNull(actual1);
+    Assertions.assertNotNull(actual1);
 
     selectors = ImmutableSet.of(
         makeHistoricalServerSelector(1),
         makeHistoricalServerSelector(1)
     );
     String actual2 = keyManager.computeResultLevelCachingEtag(selectors, CloneQueryMode.EXCLUDECLONES, QUERY_CACHE_KEY);
-    Assert.assertNotNull(actual2);
-    Assert.assertEquals("cache key should not change for same server selectors", actual1, actual2);
+    Assertions.assertNotNull(actual2);
+    Assertions.assertEquals(actual1, actual2, "cache key should not change for same server selectors");
 
     selectors = ImmutableSet.of(
         makeHistoricalServerSelector(2),
         makeHistoricalServerSelector(1)
     );
     String actual3 = keyManager.computeResultLevelCachingEtag(selectors, CloneQueryMode.EXCLUDECLONES, QUERY_CACHE_KEY);
-    Assert.assertNotNull(actual3);
-    Assert.assertNotEquals(actual1, actual3);
+    Assertions.assertNotNull(actual3);
+    Assertions.assertNotEquals(actual1, actual3);
   }
 
   @Test
@@ -130,11 +130,11 @@ public class CachingClusteredClientCacheKeyManagerTest extends EasyMockSupport
         makeHistoricalServerSelector(1)
     );
     String actual1 = keyManager.computeResultLevelCachingEtag(selectors, CloneQueryMode.EXCLUDECLONES, new byte[]{1, 2});
-    Assert.assertNotNull(actual1);
+    Assertions.assertNotNull(actual1);
 
     String actual2 = keyManager.computeResultLevelCachingEtag(selectors, CloneQueryMode.EXCLUDECLONES, new byte[]{3, 4});
-    Assert.assertNotNull(actual2);
-    Assert.assertNotEquals(actual1, actual2);
+    Assertions.assertNotNull(actual2);
+    Assertions.assertNotEquals(actual1, actual2);
   }
 
   @Test
@@ -148,15 +148,15 @@ public class CachingClusteredClientCacheKeyManagerTest extends EasyMockSupport
         makeHistoricalServerSelector(1)
     );
     String actual1 = keyManager.computeResultLevelCachingEtag(selectors, CloneQueryMode.EXCLUDECLONES, FULL_QUERY_CACHE_KEY);
-    Assert.assertNotNull(actual1);
+    Assertions.assertNotNull(actual1);
 
     selectors = ImmutableSet.of(
         makeHistoricalServerSelector(1),
         makeHistoricalServerSelector(1)
     );
     String actual2 = keyManager.computeResultLevelCachingEtag(selectors, CloneQueryMode.EXCLUDECLONES, null);
-    Assert.assertNotNull(actual2);
-    Assert.assertEquals(actual1, actual2);
+    Assertions.assertNotNull(actual2);
+    Assertions.assertEquals(actual1, actual2);
   }
 
   @Test
@@ -171,7 +171,7 @@ public class CachingClusteredClientCacheKeyManagerTest extends EasyMockSupport
         makeHistoricalServerSelector(1)
     );
     String actual = keyManager.computeResultLevelCachingEtag(selectors, CloneQueryMode.EXCLUDECLONES, null);
-    Assert.assertNull(actual);
+    Assertions.assertNull(actual);
   }
 
   @Test
@@ -189,7 +189,7 @@ public class CachingClusteredClientCacheKeyManagerTest extends EasyMockSupport
         makeHistoricalServerSelector(1)
     );
     String actual = keyManager.computeResultLevelCachingEtag(selectors, CloneQueryMode.EXCLUDECLONES, null);
-    Assert.assertNotNull(actual);
+    Assertions.assertNotNull(actual);
   }
 
   @Test
@@ -208,7 +208,7 @@ public class CachingClusteredClientCacheKeyManagerTest extends EasyMockSupport
         makeHistoricalServerSelector(1)
     );
     String actual = keyManager.computeResultLevelCachingEtag(selectors, CloneQueryMode.EXCLUDECLONES, null);
-    Assert.assertNotNull(actual);
+    Assertions.assertNotNull(actual);
   }
 
   @Test
@@ -218,7 +218,7 @@ public class CachingClusteredClientCacheKeyManagerTest extends EasyMockSupport
     replayAll();
     CachingClusteredClient.CacheKeyManager<Object> keyManager = makeKeyManager();
     byte[] cacheKey = keyManager.computeSegmentLevelQueryCacheKey();
-    Assert.assertArrayEquals(FULL_QUERY_CACHE_KEY, cacheKey);
+    Assertions.assertArrayEquals(FULL_QUERY_CACHE_KEY, cacheKey);
   }
 
   @Test
@@ -228,7 +228,7 @@ public class CachingClusteredClientCacheKeyManagerTest extends EasyMockSupport
     replayAll();
     CachingClusteredClient.CacheKeyManager<Object> keyManager = makeKeyManager();
     byte[] cacheKey = keyManager.computeSegmentLevelQueryCacheKey();
-    Assert.assertNotNull(cacheKey);
+    Assertions.assertNotNull(cacheKey);
   }
 
   @Test
@@ -239,7 +239,7 @@ public class CachingClusteredClientCacheKeyManagerTest extends EasyMockSupport
     replayAll();
     CachingClusteredClient.CacheKeyManager<Object> keyManager = makeKeyManager();
     byte[] cacheKey = keyManager.computeSegmentLevelQueryCacheKey();
-    Assert.assertArrayEquals(Bytes.concat(JOIN_KEY, QUERY_CACHE_KEY), cacheKey);
+    Assertions.assertArrayEquals(Bytes.concat(JOIN_KEY, QUERY_CACHE_KEY), cacheKey);
   }
 
   @Test
@@ -249,14 +249,14 @@ public class CachingClusteredClientCacheKeyManagerTest extends EasyMockSupport
     expect(query.context()).andReturn(QueryContext.of(ImmutableMap.of(QueryContexts.BY_SEGMENT_KEY, true))).anyTimes();
     replayAll();
     byte[] cacheKey = makeKeyManager().computeSegmentLevelQueryCacheKey();
-    Assert.assertNull(cacheKey);
+    Assertions.assertNull(cacheKey);
   }
 
   @Test
   public void testSegmentQueryCacheKey_useAndPopulateCacheFalse()
   {
     replayAll();
-    Assert.assertNull(new CachingClusteredClient.CacheKeyManager<>(
+    Assertions.assertNull(new CachingClusteredClient.CacheKeyManager<>(
         query,
         strategy,
         false,

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientPerfTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientPerfTest.java
@@ -59,8 +59,9 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -69,6 +70,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
 
@@ -79,7 +81,8 @@ import static org.mockito.ArgumentMatchers.any;
 public class CachingClusteredClientPerfTest
 {
 
-  @Test(timeout = 10_000)
+  @Test
+  @Timeout(value = 10_000, unit = TimeUnit.MILLISECONDS)
   public void testGetQueryRunnerForSegments_singleIntervalLargeSegments()
   {
     final int segmentCount = 30_000;
@@ -153,7 +156,7 @@ public class CachingClusteredClientPerfTest
         segmentDescriptors
     );
     Sequence<SegmentDescriptor> sequence = queryRunner.run(QueryPlus.wrap(fakeQuery));
-    Assert.assertEquals(segmentDescriptors, sequence.toList());
+    Assertions.assertEquals(segmentDescriptors, sequence.toList());
   }
 
   private Query<SegmentDescriptor> makeFakeQuery(Interval interval)

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
@@ -138,8 +138,10 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.joda.time.Period;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
@@ -165,6 +167,8 @@ import java.util.stream.IntStream;
 /**
  *
  */
+@ParameterizedClass(name = "{0}")
+@MethodSource("constructorFeeder")
 public class CachingClusteredClientTest
 {
   private static final ImmutableMap<String, Object> CONTEXT = ImmutableMap.of(
@@ -252,6 +256,7 @@ public class CachingClusteredClientTest
   @RegisterExtension
   public static QueryStackTests.ConglomerateExtension conglomerateRule = new QueryStackTests.ConglomerateExtension();
 
+  private final int randomSeed;
   private Random random;
 
   private CachingClusteredClient client;
@@ -261,10 +266,9 @@ public class CachingClusteredClientTest
   private Cache cache;
   private DruidServer[] servers;
 
-  public void initCachingClusteredClientTest(int randomSeed)
+  public CachingClusteredClientTest(int randomSeed)
   {
-    this.random = new Random(randomSeed);
-    setUp();
+    this.randomSeed = randomSeed;
   }
 
   public static Iterable<Object[]> constructorFeeder()
@@ -282,8 +286,10 @@ public class CachingClusteredClientTest
     );
   }
 
+  @BeforeEach
   public void setUp()
   {
+    this.random = new Random(randomSeed);
     timeline = new VersionedIntervalTimeline<>(Ordering.natural());
     serverView = EasyMock.createNiceMock(TimelineServerView.class);
     cache = MapCache.create(100000);
@@ -298,11 +304,9 @@ public class CachingClusteredClientTest
     };
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testOutOfOrderBackgroundCachePopulation(int randomSeed)
+  @Test
+  public void testOutOfOrderBackgroundCachePopulation()
   {
-    initCachingClusteredClientTest(randomSeed);
     // This test is a bit whacky, but I couldn't find a better way to do it in the current framework.
 
     // The purpose of this special executor is to randomize execution of tasks on purpose.
@@ -449,12 +453,10 @@ public class CachingClusteredClientTest
     );
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
+  @Test
   @SuppressWarnings("unchecked")
-  public void testTimeseriesCaching(int randomSeed)
+  public void testTimeseriesCaching()
   {
-    initCachingClusteredClientTest(randomSeed);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -519,12 +521,10 @@ public class CachingClusteredClientTest
   }
 
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
+  @Test
   @SuppressWarnings("unchecked")
-  public void testCachingOverBulkLimitEnforcesLimit(int randomSeed)
+  public void testCachingOverBulkLimitEnforcesLimit()
   {
-    initCachingClusteredClientTest(randomSeed);
     final int limit = 10;
     final Interval interval = Intervals.of("2011-01-01/2011-01-02");
     final TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
@@ -579,11 +579,9 @@ public class CachingClusteredClientTest
     Assertions.assertTrue(ImmutableList.copyOf(cacheKeyCapture.getValue()).isEmpty(), "Cache Keys empty");
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testTimeseriesMergingOutOfOrderPartitions(int randomSeed)
+  @Test
+  public void testTimeseriesMergingOutOfOrderPartitions()
   {
-    initCachingClusteredClientTest(randomSeed);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -639,12 +637,10 @@ public class CachingClusteredClientTest
     );
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
+  @Test
   @SuppressWarnings("unchecked")
-  public void testTimeseriesCachingTimeZone(int randomSeed)
+  public void testTimeseriesCachingTimeZone()
   {
-    initCachingClusteredClientTest(randomSeed);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -684,11 +680,9 @@ public class CachingClusteredClientTest
     );
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testDisableUseCache(int randomSeed)
+  @Test
+  public void testDisableUseCache()
   {
-    initCachingClusteredClientTest(randomSeed);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -754,12 +748,10 @@ public class CachingClusteredClientTest
     Assertions.assertEquals(1, cache.getStats().getNumMisses());
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
+  @Test
   @SuppressWarnings("unchecked")
-  public void testTopNCaching(int randomSeed)
+  public void testTopNCaching()
   {
-    initCachingClusteredClientTest(randomSeed);
     final TopNQueryBuilder builder = new TopNQueryBuilder()
         .dataSource(DATA_SOURCE)
         .dimension(TOP_DIM)
@@ -827,12 +819,10 @@ public class CachingClusteredClientTest
     );
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
+  @Test
   @SuppressWarnings("unchecked")
-  public void testTopNCachingTimeZone(int randomSeed)
+  public void testTopNCachingTimeZone()
   {
-    initCachingClusteredClientTest(randomSeed);
     final TopNQueryBuilder builder = new TopNQueryBuilder()
         .dataSource(DATA_SOURCE)
         .dimension(TOP_DIM)
@@ -876,11 +866,9 @@ public class CachingClusteredClientTest
     );
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testOutOfOrderSequenceMerging(int randomSeed)
+  @Test
+  public void testOutOfOrderSequenceMerging()
   {
-    initCachingClusteredClientTest(randomSeed);
     List<Sequence<Result<TopNResultValue>>> sequences =
         ImmutableList.of(
             Sequences.simple(
@@ -931,12 +919,10 @@ public class CachingClusteredClientTest
   }
 
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
+  @Test
   @SuppressWarnings("unchecked")
-  public void testTopNCachingEmptyResults(int randomSeed)
+  public void testTopNCachingEmptyResults()
   {
-    initCachingClusteredClientTest(randomSeed);
     final TopNQueryBuilder builder = new TopNQueryBuilder()
         .dataSource(DATA_SOURCE)
         .dimension(TOP_DIM)
@@ -1003,11 +989,9 @@ public class CachingClusteredClientTest
     );
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testTopNOnPostAggMetricCaching(int randomSeed)
+  @Test
+  public void testTopNOnPostAggMetricCaching()
   {
-    initCachingClusteredClientTest(randomSeed);
     final TopNQueryBuilder builder = new TopNQueryBuilder()
         .dataSource(DATA_SOURCE)
         .dimension(TOP_DIM)
@@ -1084,11 +1068,9 @@ public class CachingClusteredClientTest
         .applyPostMergeDecoration();
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testSearchCaching(int randomSeed)
+  @Test
+  public void testSearchCaching()
   {
-    initCachingClusteredClientTest(randomSeed);
     final Druids.SearchQueryBuilder builder = Druids.newSearchQueryBuilder()
                                                     .dataSource(DATA_SOURCE)
                                                     .filters(DIM_FILTER)
@@ -1154,11 +1136,9 @@ public class CachingClusteredClientTest
     );
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testSearchCachingRenamedOutput(int randomSeed)
+  @Test
+  public void testSearchCachingRenamedOutput()
   {
-    initCachingClusteredClientTest(randomSeed);
     final Druids.SearchQueryBuilder builder = Druids.newSearchQueryBuilder()
                                                     .dataSource(DATA_SOURCE)
                                                     .filters(DIM_FILTER)
@@ -1248,11 +1228,9 @@ public class CachingClusteredClientTest
     );
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testTimeBoundaryCaching(int randomSeed)
+  @Test
+  public void testTimeBoundaryCaching()
   {
-    initCachingClusteredClientTest(randomSeed);
     testQueryCaching(
         getDefaultQueryRunner(),
         Druids.newTimeBoundaryQueryBuilder()
@@ -1316,11 +1294,9 @@ public class CachingClusteredClientTest
     );
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testTimeSeriesWithFilter(int randomSeed)
+  @Test
+  public void testTimeSeriesWithFilter()
   {
-    initCachingClusteredClientTest(randomSeed);
     DimFilter filter = new AndDimFilter(
         new OrDimFilter(
             new SelectorDimFilter("dim0", "1", null),
@@ -1380,11 +1356,9 @@ public class CachingClusteredClientTest
 
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testSingleDimensionPruning(int randomSeed)
+  @Test
+  public void testSingleDimensionPruning()
   {
-    initCachingClusteredClientTest(randomSeed);
     DimFilter filter = new AndDimFilter(
         new OrDimFilter(
             new SelectorDimFilter("dim1", "a", null),
@@ -1455,11 +1429,9 @@ public class CachingClusteredClientTest
     Assertions.assertEquals(expected, ((TimeseriesQuery) capture.getValue().getQuery()).getQuerySegmentSpec());
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testHashBasedPruningQueryContextEnabledWithPartitionFunctionAndPartitionDimensionsDoSegmentPruning(int randomSeed)
+  @Test
+  public void testHashBasedPruningQueryContextEnabledWithPartitionFunctionAndPartitionDimensionsDoSegmentPruning()
   {
-    initCachingClusteredClientTest(randomSeed);
     DimFilter filter = new AndDimFilter(
         new SelectorDimFilter("dim1", "a", null),
         new BoundDimFilter("dim2", "e", "zzz", true, true, false, null, StringComparators.LEXICOGRAPHIC),
@@ -1632,27 +1604,21 @@ public class CachingClusteredClientTest
     Assertions.assertEquals(expected, ((TimeseriesQuery) capture.getValue().getQuery()).getQuerySegmentSpec());
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testHashBasedPruningQueryContextDisabledNoSegmentPruning(int randomSeed)
+  @Test
+  public void testHashBasedPruningQueryContextDisabledNoSegmentPruning()
   {
-    initCachingClusteredClientTest(randomSeed);
     testNoSegmentPruningForHashPartitionedSegments(false, HashPartitionFunction.MURMUR3_32_ABS, false);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testHashBasedPruningWithoutPartitionFunctionNoSegmentPruning(int randomSeed)
+  @Test
+  public void testHashBasedPruningWithoutPartitionFunctionNoSegmentPruning()
   {
-    initCachingClusteredClientTest(randomSeed);
     testNoSegmentPruningForHashPartitionedSegments(true, null, false);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testHashBasedPruningWithEmptyPartitionDimensionsNoSegmentPruning(int randomSeed)
+  @Test
+  public void testHashBasedPruningWithEmptyPartitionDimensionsNoSegmentPruning()
   {
-    initCachingClusteredClientTest(randomSeed);
     testNoSegmentPruningForHashPartitionedSegments(true, HashPartitionFunction.MURMUR3_32_ABS, true);
   }
 
@@ -2984,11 +2950,9 @@ public class CachingClusteredClientTest
     }
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testTimeBoundaryCachingWhenTimeIsInteger(int randomSeed)
+  @Test
+  public void testTimeBoundaryCachingWhenTimeIsInteger()
   {
-    initCachingClusteredClientTest(randomSeed);
     testQueryCaching(
         getDefaultQueryRunner(),
         Druids.newTimeBoundaryQueryBuilder()
@@ -3052,11 +3016,9 @@ public class CachingClusteredClientTest
     );
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testIfNoneMatch(int randomSeed)
+  @Test
+  public void testIfNoneMatch()
   {
-    initCachingClusteredClientTest(randomSeed);
     Interval interval = Intervals.of("2016/2017");
     final DataSegment dataSegment = new DataSegment(
         "dataSource",
@@ -3094,11 +3056,9 @@ public class CachingClusteredClientTest
     Assertions.assertEquals("RsQmZHYstvXNeGf86z3pgpk+Wsg=", responseContext.getEntityTag());
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testEtagforDifferentQueryInterval(int randomSeed)
+  @Test
+  public void testEtagforDifferentQueryInterval()
   {
-    initCachingClusteredClientTest(randomSeed);
     final Interval interval = Intervals.of("2016-01-01/2016-01-02");
     final Interval queryInterval = Intervals.of("2016-01-01T14:00:00/2016-01-02T14:00:00");
     final Interval queryInterval2 = Intervals.of("2016-01-01T18:00:00/2016-01-02T18:00:00");
@@ -3148,11 +3108,9 @@ public class CachingClusteredClientTest
     Assertions.assertNotEquals(etag1, etag2);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testRealtimeSegmentsQueryContext(int randomSeed)
+  @Test
+  public void testRealtimeSegmentsQueryContext()
   {
-    initCachingClusteredClientTest(randomSeed);
     final Interval interval = Intervals.of("2016-01-01/2016-01-02");
     final Interval queryInterval = Intervals.of("2016-01-01T14:00:00/2016-01-02T14:00:00");
     final DataSegment dataSegment = new DataSegment(
@@ -3213,11 +3171,9 @@ public class CachingClusteredClientTest
     Assertions.assertEquals(0, remainingResponseMap.get(queryLegacyTrue.getId()).intValue());
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "{0}")
-  public void testRealtimeSegmentsModeExclude(int randomSeed)
+  @Test
+  public void testRealtimeSegmentsModeExclude()
   {
-    initCachingClusteredClientTest(randomSeed);
     final Interval interval = Intervals.of("2016-01-01/2016-01-02");
     final Interval queryInterval = Intervals.of("2016-01-01T14:00:00/2016-01-02T14:00:00");
     final DataSegment dataSegment = new DataSegment(

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
@@ -138,10 +138,8 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.joda.time.Period;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
@@ -167,8 +165,6 @@ import java.util.stream.IntStream;
 /**
  *
  */
-@ParameterizedClass(name = "{0}")
-@MethodSource("constructorFeeder")
 public class CachingClusteredClientTest
 {
   private static final ImmutableMap<String, Object> CONTEXT = ImmutableMap.of(
@@ -256,7 +252,6 @@ public class CachingClusteredClientTest
   @RegisterExtension
   public static QueryStackTests.ConglomerateExtension conglomerateRule = new QueryStackTests.ConglomerateExtension();
 
-  private final int randomSeed;
   private Random random;
 
   private CachingClusteredClient client;
@@ -266,9 +261,10 @@ public class CachingClusteredClientTest
   private Cache cache;
   private DruidServer[] servers;
 
-  public CachingClusteredClientTest(int randomSeed)
+  public void initCachingClusteredClientTest(int randomSeed)
   {
-    this.randomSeed = randomSeed;
+    this.random = new Random(randomSeed);
+    setUp();
   }
 
   public static Iterable<Object[]> constructorFeeder()
@@ -286,10 +282,8 @@ public class CachingClusteredClientTest
     );
   }
 
-  @BeforeEach
   public void setUp()
   {
-    this.random = new Random(randomSeed);
     timeline = new VersionedIntervalTimeline<>(Ordering.natural());
     serverView = EasyMock.createNiceMock(TimelineServerView.class);
     cache = MapCache.create(100000);
@@ -304,9 +298,11 @@ public class CachingClusteredClientTest
     };
   }
 
-  @Test
-  public void testOutOfOrderBackgroundCachePopulation()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testOutOfOrderBackgroundCachePopulation(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     // This test is a bit whacky, but I couldn't find a better way to do it in the current framework.
 
     // The purpose of this special executor is to randomize execution of tasks on purpose.
@@ -453,10 +449,12 @@ public class CachingClusteredClientTest
     );
   }
 
-  @Test
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
   @SuppressWarnings("unchecked")
-  public void testTimeseriesCaching()
+  public void testTimeseriesCaching(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -521,10 +519,12 @@ public class CachingClusteredClientTest
   }
 
 
-  @Test
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
   @SuppressWarnings("unchecked")
-  public void testCachingOverBulkLimitEnforcesLimit()
+  public void testCachingOverBulkLimitEnforcesLimit(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     final int limit = 10;
     final Interval interval = Intervals.of("2011-01-01/2011-01-02");
     final TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
@@ -579,9 +579,11 @@ public class CachingClusteredClientTest
     Assertions.assertTrue(ImmutableList.copyOf(cacheKeyCapture.getValue()).isEmpty(), "Cache Keys empty");
   }
 
-  @Test
-  public void testTimeseriesMergingOutOfOrderPartitions()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testTimeseriesMergingOutOfOrderPartitions(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -637,10 +639,12 @@ public class CachingClusteredClientTest
     );
   }
 
-  @Test
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
   @SuppressWarnings("unchecked")
-  public void testTimeseriesCachingTimeZone()
+  public void testTimeseriesCachingTimeZone(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -680,9 +684,11 @@ public class CachingClusteredClientTest
     );
   }
 
-  @Test
-  public void testDisableUseCache()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testDisableUseCache(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     final Druids.TimeseriesQueryBuilder builder = Druids.newTimeseriesQueryBuilder()
                                                         .dataSource(DATA_SOURCE)
                                                         .intervals(SEG_SPEC)
@@ -748,10 +754,12 @@ public class CachingClusteredClientTest
     Assertions.assertEquals(1, cache.getStats().getNumMisses());
   }
 
-  @Test
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
   @SuppressWarnings("unchecked")
-  public void testTopNCaching()
+  public void testTopNCaching(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     final TopNQueryBuilder builder = new TopNQueryBuilder()
         .dataSource(DATA_SOURCE)
         .dimension(TOP_DIM)
@@ -819,10 +827,12 @@ public class CachingClusteredClientTest
     );
   }
 
-  @Test
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
   @SuppressWarnings("unchecked")
-  public void testTopNCachingTimeZone()
+  public void testTopNCachingTimeZone(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     final TopNQueryBuilder builder = new TopNQueryBuilder()
         .dataSource(DATA_SOURCE)
         .dimension(TOP_DIM)
@@ -866,9 +876,11 @@ public class CachingClusteredClientTest
     );
   }
 
-  @Test
-  public void testOutOfOrderSequenceMerging()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testOutOfOrderSequenceMerging(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     List<Sequence<Result<TopNResultValue>>> sequences =
         ImmutableList.of(
             Sequences.simple(
@@ -919,10 +931,12 @@ public class CachingClusteredClientTest
   }
 
 
-  @Test
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
   @SuppressWarnings("unchecked")
-  public void testTopNCachingEmptyResults()
+  public void testTopNCachingEmptyResults(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     final TopNQueryBuilder builder = new TopNQueryBuilder()
         .dataSource(DATA_SOURCE)
         .dimension(TOP_DIM)
@@ -989,9 +1003,11 @@ public class CachingClusteredClientTest
     );
   }
 
-  @Test
-  public void testTopNOnPostAggMetricCaching()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testTopNOnPostAggMetricCaching(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     final TopNQueryBuilder builder = new TopNQueryBuilder()
         .dataSource(DATA_SOURCE)
         .dimension(TOP_DIM)
@@ -1068,9 +1084,11 @@ public class CachingClusteredClientTest
         .applyPostMergeDecoration();
   }
 
-  @Test
-  public void testSearchCaching()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testSearchCaching(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     final Druids.SearchQueryBuilder builder = Druids.newSearchQueryBuilder()
                                                     .dataSource(DATA_SOURCE)
                                                     .filters(DIM_FILTER)
@@ -1136,9 +1154,11 @@ public class CachingClusteredClientTest
     );
   }
 
-  @Test
-  public void testSearchCachingRenamedOutput()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testSearchCachingRenamedOutput(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     final Druids.SearchQueryBuilder builder = Druids.newSearchQueryBuilder()
                                                     .dataSource(DATA_SOURCE)
                                                     .filters(DIM_FILTER)
@@ -1228,9 +1248,11 @@ public class CachingClusteredClientTest
     );
   }
 
-  @Test
-  public void testTimeBoundaryCaching()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testTimeBoundaryCaching(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     testQueryCaching(
         getDefaultQueryRunner(),
         Druids.newTimeBoundaryQueryBuilder()
@@ -1294,9 +1316,11 @@ public class CachingClusteredClientTest
     );
   }
 
-  @Test
-  public void testTimeSeriesWithFilter()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testTimeSeriesWithFilter(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     DimFilter filter = new AndDimFilter(
         new OrDimFilter(
             new SelectorDimFilter("dim0", "1", null),
@@ -1356,9 +1380,11 @@ public class CachingClusteredClientTest
 
   }
 
-  @Test
-  public void testSingleDimensionPruning()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testSingleDimensionPruning(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     DimFilter filter = new AndDimFilter(
         new OrDimFilter(
             new SelectorDimFilter("dim1", "a", null),
@@ -1429,9 +1455,11 @@ public class CachingClusteredClientTest
     Assertions.assertEquals(expected, ((TimeseriesQuery) capture.getValue().getQuery()).getQuerySegmentSpec());
   }
 
-  @Test
-  public void testHashBasedPruningQueryContextEnabledWithPartitionFunctionAndPartitionDimensionsDoSegmentPruning()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testHashBasedPruningQueryContextEnabledWithPartitionFunctionAndPartitionDimensionsDoSegmentPruning(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     DimFilter filter = new AndDimFilter(
         new SelectorDimFilter("dim1", "a", null),
         new BoundDimFilter("dim2", "e", "zzz", true, true, false, null, StringComparators.LEXICOGRAPHIC),
@@ -1604,21 +1632,27 @@ public class CachingClusteredClientTest
     Assertions.assertEquals(expected, ((TimeseriesQuery) capture.getValue().getQuery()).getQuerySegmentSpec());
   }
 
-  @Test
-  public void testHashBasedPruningQueryContextDisabledNoSegmentPruning()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testHashBasedPruningQueryContextDisabledNoSegmentPruning(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     testNoSegmentPruningForHashPartitionedSegments(false, HashPartitionFunction.MURMUR3_32_ABS, false);
   }
 
-  @Test
-  public void testHashBasedPruningWithoutPartitionFunctionNoSegmentPruning()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testHashBasedPruningWithoutPartitionFunctionNoSegmentPruning(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     testNoSegmentPruningForHashPartitionedSegments(true, null, false);
   }
 
-  @Test
-  public void testHashBasedPruningWithEmptyPartitionDimensionsNoSegmentPruning()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testHashBasedPruningWithEmptyPartitionDimensionsNoSegmentPruning(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     testNoSegmentPruningForHashPartitionedSegments(true, HashPartitionFunction.MURMUR3_32_ABS, true);
   }
 
@@ -2950,9 +2984,11 @@ public class CachingClusteredClientTest
     }
   }
 
-  @Test
-  public void testTimeBoundaryCachingWhenTimeIsInteger()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testTimeBoundaryCachingWhenTimeIsInteger(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     testQueryCaching(
         getDefaultQueryRunner(),
         Druids.newTimeBoundaryQueryBuilder()
@@ -3016,9 +3052,11 @@ public class CachingClusteredClientTest
     );
   }
 
-  @Test
-  public void testIfNoneMatch()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testIfNoneMatch(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     Interval interval = Intervals.of("2016/2017");
     final DataSegment dataSegment = new DataSegment(
         "dataSource",
@@ -3056,9 +3094,11 @@ public class CachingClusteredClientTest
     Assertions.assertEquals("RsQmZHYstvXNeGf86z3pgpk+Wsg=", responseContext.getEntityTag());
   }
 
-  @Test
-  public void testEtagforDifferentQueryInterval()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testEtagforDifferentQueryInterval(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     final Interval interval = Intervals.of("2016-01-01/2016-01-02");
     final Interval queryInterval = Intervals.of("2016-01-01T14:00:00/2016-01-02T14:00:00");
     final Interval queryInterval2 = Intervals.of("2016-01-01T18:00:00/2016-01-02T18:00:00");
@@ -3108,9 +3148,11 @@ public class CachingClusteredClientTest
     Assertions.assertNotEquals(etag1, etag2);
   }
 
-  @Test
-  public void testRealtimeSegmentsQueryContext()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testRealtimeSegmentsQueryContext(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     final Interval interval = Intervals.of("2016-01-01/2016-01-02");
     final Interval queryInterval = Intervals.of("2016-01-01T14:00:00/2016-01-02T14:00:00");
     final DataSegment dataSegment = new DataSegment(
@@ -3171,9 +3213,11 @@ public class CachingClusteredClientTest
     Assertions.assertEquals(0, remainingResponseMap.get(queryLegacyTrue.getId()).intValue());
   }
 
-  @Test
-  public void testRealtimeSegmentsModeExclude()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testRealtimeSegmentsModeExclude(int randomSeed)
   {
+    initCachingClusteredClientTest(randomSeed);
     final Interval interval = Intervals.of("2016-01-01/2016-01-02");
     final Interval queryInterval = Intervals.of("2016-01-01T14:00:00/2016-01-02T14:00:00");
     final DataSegment dataSegment = new DataSegment(

--- a/server/src/test/java/org/apache/druid/client/CachingQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingQueryRunnerTest.java
@@ -71,10 +71,9 @@ import org.apache.druid.query.topn.TopNResultValue;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
@@ -90,10 +89,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-@RunWith(Parameterized.class)
 public class CachingQueryRunnerTest extends InitializedNullHandlingTest
 {
-  @Parameterized.Parameters(name = "numBackgroundThreads={0}")
   public static Iterable<Object[]> constructorFeeder()
   {
     return QueryRunnerTestHelper.cartesian(Arrays.asList(5, 1, 0));
@@ -122,7 +119,7 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
   private ObjectMapper objectMapper;
   private CachePopulator cachePopulator;
 
-  public CachingQueryRunnerTest(int numBackgroundThreads)
+  public void initCachingQueryRunnerTest(int numBackgroundThreads)
   {
     objectMapper = new DefaultObjectMapper();
 
@@ -138,9 +135,11 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
     }
   }
 
-  @Test
-  public void testCloseAndPopulate() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "numBackgroundThreads={0}")
+  public void testCloseAndPopulate(int numBackgroundThreads) throws Exception
   {
+    initCachingQueryRunnerTest(numBackgroundThreads);
     List<Result> expectedRes = makeTopNResults(false, OBJECTS);
     List<Result> expectedCacheRes = makeTopNResults(true, OBJECTS);
 
@@ -159,9 +158,11 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
     testUseCache(expectedCacheRes, builder.build(), toolchest);
   }
 
-  @Test
-  public void testTimeseries() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "numBackgroundThreads={0}")
+  public void testTimeseries(int numBackgroundThreads) throws Exception
   {
+    initCachingQueryRunnerTest(numBackgroundThreads);
     for (boolean descending : new boolean[]{false, true}) {
       TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
                                     .dataSource(QueryRunnerTestHelper.DATA_SOURCE)
@@ -206,9 +207,11 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
     }
   }
 
-  @Test
-  public void testNullCacheKeyPrefix()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "numBackgroundThreads={0}")
+  public void testNullCacheKeyPrefix(int numBackgroundThreads)
   {
+    initCachingQueryRunnerTest(numBackgroundThreads);
     Query query = new TopNQueryBuilder()
         .dataSource("ds")
         .dimension("top_dim")
@@ -223,15 +226,17 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
     Cache cache = EasyMock.mock(Cache.class);
     EasyMock.replay(cache);
     CachingQueryRunner queryRunner = makeCachingQueryRunner(null, cache, toolchest, Sequences.empty());
-    Assert.assertFalse(queryRunner.canPopulateCache(query, toolchest.getCacheStrategy(query, null)));
-    Assert.assertFalse(queryRunner.canUseCache(query, toolchest.getCacheStrategy(query, null)));
+    Assertions.assertFalse(queryRunner.canPopulateCache(query, toolchest.getCacheStrategy(query, null)));
+    Assertions.assertFalse(queryRunner.canUseCache(query, toolchest.getCacheStrategy(query, null)));
     queryRunner.run(QueryPlus.wrap(query));
     EasyMock.verifyUnexpectedCalls(cache);
   }
 
-  @Test
-  public void testNullStrategy()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "numBackgroundThreads={0}")
+  public void testNullStrategy(int numBackgroundThreads)
   {
+    initCachingQueryRunnerTest(numBackgroundThreads);
     Query query = new TopNQueryBuilder()
         .dataSource("ds")
         .dimension("top_dim")
@@ -247,8 +252,8 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
     EasyMock.expect(toolchest.getCacheStrategy(EasyMock.eq(query), EasyMock.anyObject())).andReturn(null);
     EasyMock.replay(cache, toolchest);
     CachingQueryRunner queryRunner = makeCachingQueryRunner(new byte[0], cache, toolchest, Sequences.empty());
-    Assert.assertFalse(queryRunner.canPopulateCache(query, null));
-    Assert.assertFalse(queryRunner.canUseCache(query, null));
+    Assertions.assertFalse(queryRunner.canPopulateCache(query, null));
+    Assertions.assertFalse(queryRunner.canUseCache(query, null));
     queryRunner.run(QueryPlus.wrap(query));
     EasyMock.verifyUnexpectedCalls(cache);
   }
@@ -269,7 +274,7 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
           @Override
           public void before()
           {
-            Assert.assertFalse(closable.isClosed());
+            Assertions.assertFalse(closable.isClosed());
           }
 
           @Override
@@ -346,21 +351,21 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
         SEGMENT_DESCRIPTOR,
         Bytes.concat(keyPrefix, cacheStrategy.computeCacheKey(query))
     );
-    Assert.assertTrue(runner.canPopulateCache(query, cacheStrategy));
+    Assertions.assertTrue(runner.canPopulateCache(query, cacheStrategy));
     Sequence res = runner.run(QueryPlus.wrap(query));
     // base sequence is not closed yet
-    Assert.assertFalse("sequence must not be closed", closable.isClosed());
-    Assert.assertNull("cache must be empty", cache.get(cacheKey));
+    Assertions.assertFalse(closable.isClosed(), "sequence must not be closed");
+    Assertions.assertNull(cache.get(cacheKey), "cache must be empty");
 
     List results = res.toList();
-    Assert.assertTrue(closable.isClosed());
-    Assert.assertEquals(expectedRes.toString(), results.toString());
+    Assertions.assertTrue(closable.isClosed());
+    Assertions.assertEquals(expectedRes.toString(), results.toString());
 
     // wait for background caching finish
     // wait at most 10 seconds to fail the test to avoid block overall tests
-    Assert.assertTrue("cache must be populated", cacheMustBePutOnce.await(10, TimeUnit.SECONDS));
+    Assertions.assertTrue(cacheMustBePutOnce.await(10, TimeUnit.SECONDS), "cache must be populated");
     byte[] cacheValue = cache.get(cacheKey);
-    Assert.assertNotNull(cacheValue);
+    Assertions.assertNotNull(cacheValue);
 
     Function<Object, Result> fn = cacheStrategy.pullFromSegmentLevelCache();
     List<Result> cacheResults = Lists.newArrayList(
@@ -372,7 +377,7 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
             fn
         )
     );
-    Assert.assertEquals(expectedCacheRes.toString(), cacheResults.toString());
+    Assertions.assertEquals(expectedCacheRes.toString(), cacheResults.toString());
   }
 
   private void testUseCache(
@@ -400,9 +405,9 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
         toolchest,
         Sequences.empty()
     );
-    Assert.assertTrue(runner.canUseCache(query, toolchest.getCacheStrategy(query, null)));
+    Assertions.assertTrue(runner.canUseCache(query, toolchest.getCacheStrategy(query, null)));
     List<Result> results = runner.run(QueryPlus.wrap(query)).toList();
-    Assert.assertEquals(expectedResults.toString(), results.toString());
+    Assertions.assertEquals(expectedResults.toString(), results.toString());
   }
 
   private CachingQueryRunner makeCachingQueryRunner(
@@ -515,8 +520,8 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
     @Override
     public void close()
     {
-      Assert.assertFalse(closed.get());
-      Assert.assertTrue(closed.compareAndSet(false, true));
+      Assertions.assertFalse(closed.get());
+      Assertions.assertTrue(closed.compareAndSet(false, true));
     }
 
     public boolean isClosed()

--- a/server/src/test/java/org/apache/druid/client/CachingQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingQueryRunnerTest.java
@@ -72,6 +72,7 @@ import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -119,10 +120,17 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
   );
   private static final String CACHE_ID = "segment";
 
+  private final int numBackgroundThreads;
   private ObjectMapper objectMapper;
   private CachePopulator cachePopulator;
 
-  public CachingQueryRunnerTest(int numBackgroundThreads)
+  public CachingQueryRunnerTest(final int numBackgroundThreads)
+  {
+    this.numBackgroundThreads = numBackgroundThreads;
+  }
+
+  @BeforeEach
+  public void setUp()
   {
     objectMapper = new DefaultObjectMapper();
 

--- a/server/src/test/java/org/apache/druid/client/CachingQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingQueryRunnerTest.java
@@ -72,7 +72,8 @@ import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayOutputStream;
@@ -89,6 +90,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+@ParameterizedClass(name = "numBackgroundThreads={0}")
+@MethodSource("constructorFeeder")
 public class CachingQueryRunnerTest extends InitializedNullHandlingTest
 {
   public static Iterable<Object[]> constructorFeeder()
@@ -119,7 +122,7 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
   private ObjectMapper objectMapper;
   private CachePopulator cachePopulator;
 
-  public void initCachingQueryRunnerTest(int numBackgroundThreads)
+  public CachingQueryRunnerTest(int numBackgroundThreads)
   {
     objectMapper = new DefaultObjectMapper();
 
@@ -135,11 +138,9 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
     }
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "numBackgroundThreads={0}")
-  public void testCloseAndPopulate(int numBackgroundThreads) throws Exception
+  @Test
+  public void testCloseAndPopulate() throws Exception
   {
-    initCachingQueryRunnerTest(numBackgroundThreads);
     List<Result> expectedRes = makeTopNResults(false, OBJECTS);
     List<Result> expectedCacheRes = makeTopNResults(true, OBJECTS);
 
@@ -158,11 +159,9 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
     testUseCache(expectedCacheRes, builder.build(), toolchest);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "numBackgroundThreads={0}")
-  public void testTimeseries(int numBackgroundThreads) throws Exception
+  @Test
+  public void testTimeseries() throws Exception
   {
-    initCachingQueryRunnerTest(numBackgroundThreads);
     for (boolean descending : new boolean[]{false, true}) {
       TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
                                     .dataSource(QueryRunnerTestHelper.DATA_SOURCE)
@@ -207,11 +206,9 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
     }
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "numBackgroundThreads={0}")
-  public void testNullCacheKeyPrefix(int numBackgroundThreads)
+  @Test
+  public void testNullCacheKeyPrefix()
   {
-    initCachingQueryRunnerTest(numBackgroundThreads);
     Query query = new TopNQueryBuilder()
         .dataSource("ds")
         .dimension("top_dim")
@@ -232,11 +229,9 @@ public class CachingQueryRunnerTest extends InitializedNullHandlingTest
     EasyMock.verifyUnexpectedCalls(cache);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "numBackgroundThreads={0}")
-  public void testNullStrategy(int numBackgroundThreads)
+  @Test
+  public void testNullStrategy()
   {
-    initCachingQueryRunnerTest(numBackgroundThreads);
     Query query = new TopNQueryBuilder()
         .dataSource("ds")
         .dimension("top_dim")

--- a/server/src/test/java/org/apache/druid/client/CoordinatorServerViewTest.java
+++ b/server/src/test/java/org/apache/druid/client/CoordinatorServerViewTest.java
@@ -38,12 +38,11 @@ import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.apache.druid.timeline.partition.PartitionHolder;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.List;
@@ -52,7 +51,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
-@RunWith(Parameterized.class)
 public class CoordinatorServerViewTest
 {
   private static final long AWAIT_SECONDS = 10;
@@ -72,26 +70,27 @@ public class CoordinatorServerViewTest
 
   private boolean setDruidClientFactory;
 
-  @Parameterized.Parameters
   public static Object[] data()
   {
     return new Object[]{true, false};
   }
 
-  public CoordinatorServerViewTest(boolean setDruidClientFactory)
+  public void initCoordinatorServerViewTest(boolean setDruidClientFactory)
   {
     this.setDruidClientFactory = setDruidClientFactory;
   }
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     callbackExec = Execs.singleThreaded("CoordinatorServerViewTest-%s");
   }
 
-  @Test
-  public void testSingleServerAddedRemovedSegment() throws Exception
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testSingleServerAddedRemovedSegment(boolean setDruidClientFactory) throws Exception
   {
+    initCoordinatorServerViewTest(setDruidClientFactory);
     segmentViewInitLatch = new CountDownLatch(1);
     segmentAddedLatch = new CountDownLatch(1);
     segmentRemovedLatch = new CountDownLatch(1);
@@ -120,55 +119,57 @@ public class CoordinatorServerViewTest
     final int partition = segment.getShardSpec().getPartitionNum();
     final Interval intervals = Intervals.of("2014-10-20T00:00:00Z/P1D");
     baseView.addSegment(druidServer, segment);
-    Assert.assertTrue(awaitLatch(segmentViewInitLatch));
-    Assert.assertTrue(awaitLatch(segmentAddedLatch));
+    Assertions.assertTrue(awaitLatch(segmentViewInitLatch));
+    Assertions.assertTrue(awaitLatch(segmentAddedLatch));
 
-    Assert.assertTrue(awaitLatch(callbackSegmentViewInitLatch));
-    Assert.assertTrue(awaitLatch(callbackSegmentAddedLatch));
+    Assertions.assertTrue(awaitLatch(callbackSegmentViewInitLatch));
+    Assertions.assertTrue(awaitLatch(callbackSegmentAddedLatch));
 
     if (setDruidClientFactory) {
-      Assert.assertNotNull(coordinatorServerView.getQueryRunner(druidServer.getName()));
+      Assertions.assertNotNull(coordinatorServerView.getQueryRunner(druidServer.getName()));
     } else {
-      Assert.assertNull(coordinatorServerView.getQueryRunner(druidServer.getName()));
+      Assertions.assertNull(coordinatorServerView.getQueryRunner(druidServer.getName()));
     }
 
     TimelineLookup timeline = coordinatorServerView.getTimeline(new TableDataSource("test_overlord_server_view"));
     List<TimelineObjectHolder> serverLookupRes = (List<TimelineObjectHolder>) timeline.lookup(
         intervals
     );
-    Assert.assertEquals(1, serverLookupRes.size());
+    Assertions.assertEquals(1, serverLookupRes.size());
 
     TimelineObjectHolder<String, SegmentLoadInfo> actualTimelineObjectHolder = serverLookupRes.get(0);
-    Assert.assertEquals(intervals, actualTimelineObjectHolder.getInterval());
-    Assert.assertEquals("v1", actualTimelineObjectHolder.getVersion());
+    Assertions.assertEquals(intervals, actualTimelineObjectHolder.getInterval());
+    Assertions.assertEquals("v1", actualTimelineObjectHolder.getVersion());
 
     PartitionHolder<SegmentLoadInfo> actualPartitionHolder = actualTimelineObjectHolder.getObject();
-    Assert.assertTrue(actualPartitionHolder.isComplete());
-    Assert.assertEquals(1, Iterables.size(actualPartitionHolder));
+    Assertions.assertTrue(actualPartitionHolder.isComplete());
+    Assertions.assertEquals(1, Iterables.size(actualPartitionHolder));
 
     SegmentLoadInfo segmentLoadInfo = actualPartitionHolder.iterator().next().getObject();
-    Assert.assertFalse(segmentLoadInfo.isEmpty());
-    Assert.assertEquals(
+    Assertions.assertFalse(segmentLoadInfo.isEmpty());
+    Assertions.assertEquals(
         druidServer.getMetadata(),
         Iterables.getOnlyElement(segmentLoadInfo.toImmutableSegmentLoadInfo().getServers())
     );
-    Assert.assertNotNull(timeline.findChunk(intervals, "v1", partition));
+    Assertions.assertNotNull(timeline.findChunk(intervals, "v1", partition));
 
     baseView.removeSegment(druidServer, segment);
-    Assert.assertTrue(awaitLatch(segmentRemovedLatch));
-    Assert.assertTrue(awaitLatch(callbackServerSegmentRemovedLatch));
-    Assert.assertTrue(awaitLatch(callbackSegmentRemovedLatch));
+    Assertions.assertTrue(awaitLatch(segmentRemovedLatch));
+    Assertions.assertTrue(awaitLatch(callbackServerSegmentRemovedLatch));
+    Assertions.assertTrue(awaitLatch(callbackSegmentRemovedLatch));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         ((List<TimelineObjectHolder>) timeline.lookup(Intervals.of("2014-10-20T00:00:00Z/P1D"))).size()
     );
-    Assert.assertNull(timeline.findChunk(intervals, "v1", partition));
+    Assertions.assertNull(timeline.findChunk(intervals, "v1", partition));
   }
 
-  @Test
-  public void testMultipleServerAddedRemovedSegment() throws Exception
+  @MethodSource("data")
+  @ParameterizedTest
+  public void testMultipleServerAddedRemovedSegment(boolean setDruidClientFactory) throws Exception
   {
+    initCoordinatorServerViewTest(setDruidClientFactory);
     segmentViewInitLatch = new CountDownLatch(1);
     segmentAddedLatch = new CountDownLatch(5);
 
@@ -215,16 +216,16 @@ public class CoordinatorServerViewTest
     for (int i = 0; i < 5; ++i) {
       baseView.addSegment(druidServers.get(i), segments.get(i));
     }
-    Assert.assertTrue(awaitLatch(segmentViewInitLatch));
-    Assert.assertTrue(awaitLatch(segmentAddedLatch));
-    Assert.assertTrue(awaitLatch(callbackSegmentViewInitLatch));
-    Assert.assertTrue(awaitLatch(callbackSegmentAddedLatch));
+    Assertions.assertTrue(awaitLatch(segmentViewInitLatch));
+    Assertions.assertTrue(awaitLatch(segmentAddedLatch));
+    Assertions.assertTrue(awaitLatch(callbackSegmentViewInitLatch));
+    Assertions.assertTrue(awaitLatch(callbackSegmentAddedLatch));
 
     for (int i = 0; i < 5; ++i) {
       if (setDruidClientFactory) {
-        Assert.assertNotNull(coordinatorServerView.getQueryRunner(druidServers.get(i).getName()));
+        Assertions.assertNotNull(coordinatorServerView.getQueryRunner(druidServers.get(i).getName()));
       } else {
-        Assert.assertNull(coordinatorServerView.getQueryRunner(druidServers.get(i).getName()));
+        Assertions.assertNull(coordinatorServerView.getQueryRunner(druidServers.get(i).getName()));
       }
     }
 
@@ -244,9 +245,9 @@ public class CoordinatorServerViewTest
 
     // unannounce the segment created by dataSegmentWithIntervalAndVersion("2011-04-01/2011-04-09", "v2")
     baseView.removeSegment(druidServers.get(2), segments.get(2));
-    Assert.assertTrue(awaitLatch(segmentRemovedLatch));
-    Assert.assertTrue(awaitLatch(callbackSegmentRemovedLatch));
-    Assert.assertTrue(awaitLatch(callbackServerSegmentRemovedLatch));
+    Assertions.assertTrue(awaitLatch(segmentRemovedLatch));
+    Assertions.assertTrue(awaitLatch(callbackSegmentRemovedLatch));
+    Assertions.assertTrue(awaitLatch(callbackServerSegmentRemovedLatch));
 
     // renew segmentRemovedLatch since we still have 4 segments to unannounce
     segmentRemovedLatch = new CountDownLatch(4);
@@ -271,11 +272,11 @@ public class CoordinatorServerViewTest
         baseView.removeSegment(druidServers.get(i), segments.get(i));
       }
     }
-    Assert.assertTrue(awaitLatch(segmentRemovedLatch));
-    Assert.assertTrue(awaitLatch(callbackSegmentRemovedLatch));
-    Assert.assertTrue(awaitLatch(callbackServerSegmentRemovedLatch));
+    Assertions.assertTrue(awaitLatch(segmentRemovedLatch));
+    Assertions.assertTrue(awaitLatch(callbackSegmentRemovedLatch));
+    Assertions.assertTrue(awaitLatch(callbackServerSegmentRemovedLatch));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         ((List<TimelineObjectHolder>) timeline.lookup(Intervals.of("2011-04-01/2011-04-09"))).size()
     );
@@ -300,24 +301,24 @@ public class CoordinatorServerViewTest
       List<Pair<Interval, Pair<String, Pair<DruidServer, DataSegment>>>> expected, List<TimelineObjectHolder> actual
   )
   {
-    Assert.assertEquals(expected.size(), actual.size());
+    Assertions.assertEquals(expected.size(), actual.size());
 
     for (int i = 0; i < expected.size(); ++i) {
       Pair<Interval, Pair<String, Pair<DruidServer, DataSegment>>> expectedPair = expected.get(i);
       TimelineObjectHolder<String, SegmentLoadInfo> actualTimelineObjectHolder = actual.get(i);
 
-      Assert.assertEquals(expectedPair.lhs, actualTimelineObjectHolder.getInterval());
-      Assert.assertEquals(expectedPair.rhs.lhs, actualTimelineObjectHolder.getVersion());
+      Assertions.assertEquals(expectedPair.lhs, actualTimelineObjectHolder.getInterval());
+      Assertions.assertEquals(expectedPair.rhs.lhs, actualTimelineObjectHolder.getVersion());
 
       PartitionHolder<SegmentLoadInfo> actualPartitionHolder = actualTimelineObjectHolder.getObject();
-      Assert.assertTrue(actualPartitionHolder.isComplete());
-      Assert.assertEquals(1, Iterables.size(actualPartitionHolder));
+      Assertions.assertTrue(actualPartitionHolder.isComplete());
+      Assertions.assertEquals(1, Iterables.size(actualPartitionHolder));
 
       SegmentLoadInfo segmentLoadInfo = actualPartitionHolder.iterator().next().getObject();
-      Assert.assertFalse(segmentLoadInfo.isEmpty());
-      Assert.assertEquals(expectedPair.rhs.rhs.lhs.getMetadata(),
+      Assertions.assertFalse(segmentLoadInfo.isEmpty());
+      Assertions.assertEquals(expectedPair.rhs.rhs.lhs.getMetadata(),
                           Iterables.getOnlyElement(segmentLoadInfo.toImmutableSegmentLoadInfo().getServers()));
-      Assert.assertEquals(expectedPair.rhs.rhs.lhs.getMetadata(), segmentLoadInfo.pickOne());
+      Assertions.assertEquals(expectedPair.rhs.rhs.lhs.getMetadata(), segmentLoadInfo.pickOne());
     }
   }
 
@@ -459,7 +460,7 @@ public class CoordinatorServerViewTest
                       .build();
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     if (baseView != null) {

--- a/server/src/test/java/org/apache/druid/client/CoordinatorServerViewTest.java
+++ b/server/src/test/java/org/apache/druid/client/CoordinatorServerViewTest.java
@@ -41,7 +41,8 @@ import org.joda.time.Interval;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
@@ -51,6 +52,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+@ParameterizedClass
+@MethodSource("data")
 public class CoordinatorServerViewTest
 {
   private static final long AWAIT_SECONDS = 10;
@@ -68,14 +71,14 @@ public class CoordinatorServerViewTest
   private CoordinatorServerView coordinatorServerView;
   private ExecutorService callbackExec;
 
-  private boolean setDruidClientFactory;
+  private final boolean setDruidClientFactory;
 
   public static Object[] data()
   {
     return new Object[]{true, false};
   }
 
-  public void initCoordinatorServerViewTest(boolean setDruidClientFactory)
+  public CoordinatorServerViewTest(boolean setDruidClientFactory)
   {
     this.setDruidClientFactory = setDruidClientFactory;
   }
@@ -86,11 +89,9 @@ public class CoordinatorServerViewTest
     callbackExec = Execs.singleThreaded("CoordinatorServerViewTest-%s");
   }
 
-  @MethodSource("data")
-  @ParameterizedTest
-  public void testSingleServerAddedRemovedSegment(boolean setDruidClientFactory) throws Exception
+  @Test
+  public void testSingleServerAddedRemovedSegment() throws Exception
   {
-    initCoordinatorServerViewTest(setDruidClientFactory);
     segmentViewInitLatch = new CountDownLatch(1);
     segmentAddedLatch = new CountDownLatch(1);
     segmentRemovedLatch = new CountDownLatch(1);
@@ -165,11 +166,9 @@ public class CoordinatorServerViewTest
     Assertions.assertNull(timeline.findChunk(intervals, "v1", partition));
   }
 
-  @MethodSource("data")
-  @ParameterizedTest
-  public void testMultipleServerAddedRemovedSegment(boolean setDruidClientFactory) throws Exception
+  @Test
+  public void testMultipleServerAddedRemovedSegment() throws Exception
   {
-    initCoordinatorServerViewTest(setDruidClientFactory);
     segmentViewInitLatch = new CountDownLatch(1);
     segmentAddedLatch = new CountDownLatch(5);
 

--- a/server/src/test/java/org/apache/druid/client/DataSourcesSnapshotTest.java
+++ b/server/src/test/java/org/apache/druid/client/DataSourcesSnapshotTest.java
@@ -24,8 +24,8 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.server.coordinator.CreateDataSegments;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -76,9 +76,9 @@ public class DataSourcesSnapshotTest
         SNAPSHOT_TIME
     );
 
-    Assert.assertSame(previous.getDataSource(DS2), updated.getDataSource(DS2));
-    Assert.assertNotSame(previous.getDataSource(DS1), updated.getDataSource(DS1));
-    Assert.assertEquals(
+    Assertions.assertSame(previous.getDataSource(DS2), updated.getDataSource(DS2));
+    Assertions.assertNotSame(previous.getDataSource(DS1), updated.getDataSource(DS1));
+    Assertions.assertEquals(
         newDs1.stream().map(s -> s.getId().toString()).collect(Collectors.toSet()),
         idsOf(updated, DS1)
     );
@@ -103,9 +103,9 @@ public class DataSourcesSnapshotTest
     finalState.put(DS2, baseDs2);
     final DataSourcesSnapshot fullRebuild = DataSourcesSnapshot.fromUsedSegments(finalState, SNAPSHOT_TIME);
 
-    Assert.assertEquals(idsOf(fullRebuild, DS1), idsOf(incremental, DS1));
-    Assert.assertEquals(idsOf(fullRebuild, DS2), idsOf(incremental, DS2));
-    Assert.assertEquals(fullRebuild.getOvershadowedSegments(), incremental.getOvershadowedSegments());
+    Assertions.assertEquals(idsOf(fullRebuild, DS1), idsOf(incremental, DS1));
+    Assertions.assertEquals(idsOf(fullRebuild, DS2), idsOf(incremental, DS2));
+    Assertions.assertEquals(fullRebuild.getOvershadowedSegments(), incremental.getOvershadowedSegments());
   }
 
   @Test
@@ -119,7 +119,7 @@ public class DataSourcesSnapshotTest
         SNAPSHOT_TIME
     );
 
-    Assert.assertNull(updated.getDataSource(DS2));
-    Assert.assertNotNull(updated.getDataSource(DS1));
+    Assertions.assertNull(updated.getDataSource(DS2));
+    Assertions.assertNotNull(updated.getDataSource(DS1));
   }
 }

--- a/server/src/test/java/org/apache/druid/client/DirectDruidClientAbortHttpTest.java
+++ b/server/src/test/java/org/apache/druid/client/DirectDruidClientAbortHttpTest.java
@@ -52,6 +52,7 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;

--- a/server/src/test/java/org/apache/druid/client/DirectDruidClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/DirectDruidClientTest.java
@@ -53,6 +53,7 @@ import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.simulate.BlockingExecutorService;
 import org.apache.druid.server.coordinator.simulate.WrappingScheduledExecutorService;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.jboss.netty.handler.codec.http.HttpMethod;
@@ -62,10 +63,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PipedInputStream;
@@ -82,8 +81,8 @@ public class DirectDruidClientTest
   @RegisterExtension
   public static QueryStackTests.ConglomerateExtension conglomerateRule = new QueryStackTests.ConglomerateExtension();
 
-  @TempDir
-  public File temporaryFolder;
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   private final String hostName = "localhost:8080";
   private final ObjectMapper objectMapper = new DefaultObjectMapper();
@@ -451,7 +450,7 @@ public class DirectDruidClientTest
   {
     try {
       return IndexBuilder.create()
-                         .tmpDir(newFolder(temporaryFolder, "junit"))
+                         .tmpDir(temporaryFolder.newFolder())
                          .segmentWriteOutMediumFactory(OffHeapMemorySegmentWriteOutMediumFactory.instance())
                          .schema(
                              new IncrementalIndexSchema.Builder()
@@ -465,7 +464,7 @@ public class DirectDruidClientTest
                              )
                          )
                          .inputFormat(TestIndex.DEFAULT_JSON_INPUT_FORMAT)
-                         .inputTmpDir(newFolder(temporaryFolder, "junit"))
+                         .inputTmpDir(temporaryFolder.newFolder())
                          .buildMMappedIndex();
     }
     catch (IOException e) {
@@ -483,14 +482,4 @@ public class DirectDruidClientTest
     return QueryPlus.wrap(Druids.newTimeBoundaryQueryBuilder().dataSource("test").context(context).randomQueryId().build());
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException
-  {
-    if (subDirs.length == 0 || (subDirs.length == 1 && "junit".equals(subDirs[0]))) {
-      return org.apache.druid.java.util.common.FileUtils.createTempDirInLocation(root.toPath(), "junit");
-    }
-    String subFolder = String.join("/", subDirs);
-    File result = new File(root, subFolder);
-    org.apache.druid.java.util.common.FileUtils.mkdirp(result);
-    return result;
-  }
 }

--- a/server/src/test/java/org/apache/druid/client/DruidServerConfigTest.java
+++ b/server/src/test/java/org/apache/druid/client/DruidServerConfigTest.java
@@ -31,12 +31,12 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.segment.loading.SegmentLoaderConfig;
 import org.apache.druid.segment.loading.StorageLocationConfig;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.utils.RuntimeInfo;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -47,8 +47,8 @@ public class DruidServerConfigTest
   private File testSegmentCacheDir1;
   private File testSegmentCacheDir2;
 
-  @Rule
-  public final TemporaryFolder tmpFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   public ObjectMapper mapper = new DefaultObjectMapper();
 
@@ -58,11 +58,11 @@ public class DruidServerConfigTest
     binder.bindConstant().annotatedWith(Names.named("tlsServicePort")).to(-1);
   };
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
-    testSegmentCacheDir1 = tmpFolder.newFolder("segment_cache_folder1");
-    testSegmentCacheDir2 = tmpFolder.newFolder("segment_cache_folder2");
+    testSegmentCacheDir1 = temporaryFolder.newFolder("segment_cache_folder1");
+    testSegmentCacheDir2 = temporaryFolder.newFolder("segment_cache_folder2");
   }
 
   @Test
@@ -73,8 +73,8 @@ public class DruidServerConfigTest
     );
     final DruidServerConfig druidServerConfig = injector.getInstance(DruidServerConfig.class);
 
-    Assert.assertNotNull(druidServerConfig);
-    Assert.assertEquals(DruidServerConfig.class, druidServerConfig.getClass());
+    Assertions.assertNotNull(druidServerConfig);
+    Assertions.assertEquals(DruidServerConfig.class, druidServerConfig.getClass());
   }
 
   @Test
@@ -89,7 +89,7 @@ public class DruidServerConfigTest
         new RuntimeInfo(),
         SegmentLoaderConfig.builder().locations(locations).build()
     );
-    Assert.assertEquals(30000000000L, druidServerConfig.getMaxSize());
+    Assertions.assertEquals(30000000000L, druidServerConfig.getMaxSize());
   }
 
   @Test
@@ -105,7 +105,7 @@ public class DruidServerConfigTest
     };
     SegmentLoaderConfig segmentLoaderConfig = SegmentLoaderConfig.builder().virtualStorage(true).build();
     DruidServerConfig druidServerConfig = new DruidServerConfig(runtimeInfo, segmentLoaderConfig);
-    Assert.assertEquals(HumanReadableBytes.parse("45TiB"), druidServerConfig.getMaxSize());
+    Assertions.assertEquals(HumanReadableBytes.parse("45TiB"), druidServerConfig.getMaxSize());
   }
 
   @Test
@@ -143,8 +143,7 @@ public class DruidServerConfigTest
         DruidServerConfig.class
     );
 
-    Assert.assertEquals(serverConfigWithDefaultSize.getMaxSize(), 10000000000L);
-    Assert.assertEquals(serverConfigWithNonDefaultSize.getMaxSize(), 123456L);
+    Assertions.assertEquals(serverConfigWithDefaultSize.getMaxSize(), 10000000000L);
+    Assertions.assertEquals(serverConfigWithNonDefaultSize.getMaxSize(), 123456L);
   }
 }
-

--- a/server/src/test/java/org/apache/druid/client/HttpServerInventoryViewConfigTest.java
+++ b/server/src/test/java/org/apache/druid/client/HttpServerInventoryViewConfigTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.client;
 
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
@@ -36,9 +36,9 @@ public class HttpServerInventoryViewConfigTest
 
     HttpServerInventoryViewConfig config = TestHelper.makeJsonMapper().readValue(json, HttpServerInventoryViewConfig.class);
 
-    Assert.assertEquals(TimeUnit.MINUTES.toMillis(4), config.getServerTimeout());
-    Assert.assertEquals(TimeUnit.MINUTES.toMillis(1), config.getServerUnstabilityTimeout());
-    Assert.assertEquals(5, config.getNumThreads());
+    Assertions.assertEquals(TimeUnit.MINUTES.toMillis(4), config.getServerTimeout());
+    Assertions.assertEquals(TimeUnit.MINUTES.toMillis(1), config.getServerUnstabilityTimeout());
+    Assertions.assertEquals(5, config.getNumThreads());
   }
 
   @Test
@@ -52,8 +52,8 @@ public class HttpServerInventoryViewConfigTest
 
     HttpServerInventoryViewConfig config = TestHelper.makeJsonMapper().readValue(json, HttpServerInventoryViewConfig.class);
 
-    Assert.assertEquals(TimeUnit.MINUTES.toMillis(2), config.getServerTimeout());
-    Assert.assertEquals(TimeUnit.MINUTES.toMillis(3), config.getServerUnstabilityTimeout());
-    Assert.assertEquals(7, config.getNumThreads());
+    Assertions.assertEquals(TimeUnit.MINUTES.toMillis(2), config.getServerTimeout());
+    Assertions.assertEquals(TimeUnit.MINUTES.toMillis(3), config.getServerUnstabilityTimeout());
+    Assertions.assertEquals(7, config.getNumThreads());
   }
 }

--- a/server/src/test/java/org/apache/druid/client/HttpServerInventoryViewTest.java
+++ b/server/src/test/java/org/apache/druid/client/HttpServerInventoryViewTest.java
@@ -53,10 +53,11 @@ import org.apache.druid.server.coordinator.simulate.WrappingScheduledExecutorSer
 import org.apache.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -68,6 +69,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class HttpServerInventoryViewTest
@@ -97,7 +99,7 @@ public class HttpServerInventoryViewTest
 
   private AtomicBoolean inventoryInitialized;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     serviceEmitter = new StubServiceEmitter("test", "localhost");
@@ -123,7 +125,7 @@ public class HttpServerInventoryViewTest
     );
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     EasyMock.verify(druidNodeDiscoveryProvider);
@@ -136,14 +138,14 @@ public class HttpServerInventoryViewTest
   public void testInitHappensAfterNodeViewInit()
   {
     httpServerInventoryView.start();
-    Assert.assertTrue(httpServerInventoryView.isStarted());
-    Assert.assertFalse(inventoryInitialized.get());
+    Assertions.assertTrue(httpServerInventoryView.isStarted());
+    Assertions.assertFalse(inventoryInitialized.get());
 
     druidNodeDiscovery.markNodeViewInitialized();
-    Assert.assertFalse(inventoryInitialized.get());
+    Assertions.assertFalse(inventoryInitialized.get());
 
     execHelper.finishInventoryInitialization();
-    Assert.assertTrue(inventoryInitialized.get());
+    Assertions.assertTrue(inventoryInitialized.get());
 
     httpServerInventoryView.stop();
   }
@@ -152,10 +154,10 @@ public class HttpServerInventoryViewTest
   public void testStopShutsDownExecutors()
   {
     httpServerInventoryView.start();
-    Assert.assertFalse(execHelper.syncExecutor.isShutdown());
+    Assertions.assertFalse(execHelper.syncExecutor.isShutdown());
 
     httpServerInventoryView.stop();
-    Assert.assertTrue(execHelper.syncExecutor.isShutdown());
+    Assertions.assertTrue(execHelper.syncExecutor.isShutdown());
   }
 
   @Test
@@ -170,9 +172,9 @@ public class HttpServerInventoryViewTest
     final DruidServer server = druidNode.toDruidServer();
 
     Collection<DruidServer> inventory = httpServerInventoryView.getInventory();
-    Assert.assertEquals(1, inventory.size());
-    Assert.assertTrue(inventory.contains(server));
-    Assert.assertTrue(addedServers.contains(server.getMetadata()));
+    Assertions.assertEquals(1, inventory.size());
+    Assertions.assertTrue(inventory.contains(server));
+    Assertions.assertTrue(addedServers.contains(server.getMetadata()));
 
     execHelper.emitMetrics();
     serviceEmitter.verifyValue(METRIC_SUCCESS, 1);
@@ -185,9 +187,9 @@ public class HttpServerInventoryViewTest
     execHelper.sendSyncRequestAndHandleResponse();
 
     DruidServer inventoryValue = httpServerInventoryView.getInventoryValue(server.getName());
-    Assert.assertNotNull(inventoryValue);
-    Assert.assertEquals(1, inventoryValue.getTotalSegments());
-    Assert.assertNotNull(inventoryValue.getSegment(segment.getId()));
+    Assertions.assertNotNull(inventoryValue);
+    Assertions.assertEquals(1, inventoryValue.getTotalSegments());
+    Assertions.assertNotNull(inventoryValue.getSegment(segment.getId()));
 
     httpServerInventoryView.stop();
   }
@@ -205,7 +207,7 @@ public class HttpServerInventoryViewTest
 
     druidNodeDiscovery.removeNodesAndNotifyListeners(druidNode);
 
-    Assert.assertNull(httpServerInventoryView.getInventoryValue(server.getName()));
+    Assertions.assertNull(httpServerInventoryView.getInventoryValue(server.getName()));
 
     execHelper.emitMetrics();
     serviceEmitter.verifyNotEmitted(METRIC_SUCCESS);
@@ -225,12 +227,13 @@ public class HttpServerInventoryViewTest
         .addNodeAndNotifyListeners("localhost");
     final DruidServer server = druidNode.toDruidServer();
 
-    Assert.assertTrue(addedServers.contains(server.getMetadata()));
+    Assertions.assertTrue(addedServers.contains(server.getMetadata()));
 
     httpServerInventoryView.stop();
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testSyncSegmentLoadAndDrop()
   {
     httpServerInventoryView.start();
@@ -241,7 +244,7 @@ public class HttpServerInventoryViewTest
         .addNodeAndNotifyListeners("localhost");
     final DruidServer server = druidNode.toDruidServer();
 
-    Assert.assertTrue(addedServers.contains(server.getMetadata()));
+    Assertions.assertTrue(addedServers.contains(server.getMetadata()));
 
     final DataSegment[] segments =
         CreateDataSegments.ofDatasource("wiki")
@@ -254,7 +257,7 @@ public class HttpServerInventoryViewTest
         snapshotOf(new SegmentChangeRequestLoad(segments[0]))
     );
     execHelper.sendSyncRequestAndHandleResponse();
-    Assert.assertTrue(isAddedToView(server, segments[0]));
+    Assertions.assertTrue(isAddedToView(server, segments[0]));
 
     // Request 2: Drop S1, Load S2, S3
     resetForNextSyncRequest();
@@ -266,9 +269,9 @@ public class HttpServerInventoryViewTest
         )
     );
     execHelper.sendSyncRequestAndHandleResponse();
-    Assert.assertTrue(isRemovedFromView(server, segments[0]));
-    Assert.assertTrue(isAddedToView(server, segments[1]));
-    Assert.assertTrue(isAddedToView(server, segments[2]));
+    Assertions.assertTrue(isRemovedFromView(server, segments[0]));
+    Assertions.assertTrue(isAddedToView(server, segments[1]));
+    Assertions.assertTrue(isAddedToView(server, segments[2]));
 
     // Request 3: reset the counter
     resetForNextSyncRequest();
@@ -281,8 +284,8 @@ public class HttpServerInventoryViewTest
         )
     );
     execHelper.sendSyncRequestAndHandleResponse();
-    Assert.assertTrue(segmentsAddedToView.isEmpty());
-    Assert.assertTrue(segmentsRemovedFromView.isEmpty());
+    Assertions.assertTrue(segmentsAddedToView.isEmpty());
+    Assertions.assertTrue(segmentsRemovedFromView.isEmpty());
 
     // Request 4: Load S3, S4
     resetForNextSyncRequest();
@@ -293,14 +296,14 @@ public class HttpServerInventoryViewTest
         )
     );
     execHelper.sendSyncRequestAndHandleResponse();
-    Assert.assertTrue(isRemovedFromView(server, segments[1]));
-    Assert.assertTrue(isAddedToView(server, segments[3]));
+    Assertions.assertTrue(isRemovedFromView(server, segments[1]));
+    Assertions.assertTrue(isAddedToView(server, segments[3]));
 
     DruidServer inventoryValue = httpServerInventoryView.getInventoryValue(server.getName());
-    Assert.assertNotNull(inventoryValue);
-    Assert.assertEquals(2, inventoryValue.getTotalSegments());
-    Assert.assertNotNull(inventoryValue.getSegment(segments[2].getId()));
-    Assert.assertNotNull(inventoryValue.getSegment(segments[3].getId()));
+    Assertions.assertNotNull(inventoryValue);
+    Assertions.assertEquals(2, inventoryValue.getTotalSegments());
+    Assertions.assertNotNull(inventoryValue.getSegment(segments[2].getId()));
+    Assertions.assertNotNull(inventoryValue.getSegment(segments[3].getId()));
 
     // Verify node removal
     druidNodeDiscovery.removeNodesAndNotifyListeners(druidNode);
@@ -326,8 +329,8 @@ public class HttpServerInventoryViewTest
         )
     );
 
-    Assert.assertTrue(removedServers.contains(server.getMetadata()));
-    Assert.assertNull(httpServerInventoryView.getInventoryValue(server.getName()));
+    Assertions.assertTrue(removedServers.contains(server.getMetadata()));
+    Assertions.assertNull(httpServerInventoryView.getInventoryValue(server.getName()));
 
     httpServerInventoryView.stop();
   }
@@ -340,7 +343,7 @@ public class HttpServerInventoryViewTest
     execHelper.finishInventoryInitialization();
 
     final DiscoveryDruidNode druidNode = druidNodeDiscovery.addNodeAndNotifyListeners("localhost");
-    Assert.assertTrue(addedServers.contains(druidNode.toDruidServer().getMetadata()));
+    Assertions.assertTrue(addedServers.contains(druidNode.toDruidServer().getMetadata()));
 
     httpClient.failToSendNextRequestWith(new ISE("Could not send request to server"));
     execHelper.sendSyncRequest();
@@ -384,16 +387,16 @@ public class HttpServerInventoryViewTest
     execHelper.finishInventoryInitialization();
 
     final DiscoveryDruidNode druidNode = druidNodeDiscovery.addNodeAndNotifyListeners("localhost");
-    Assert.assertTrue(addedServers.contains(druidNode.toDruidServer().getMetadata()));
+    Assertions.assertTrue(addedServers.contains(druidNode.toDruidServer().getMetadata()));
 
     serviceEmitter.flush();
     httpClient.completeNextRequestWith(InvalidInput.exception("failure on server"));
     execHelper.sendSyncRequestAndHandleResponse();
 
     List<AlertEvent> alerts = serviceEmitter.getAlerts();
-    Assert.assertEquals(1, alerts.size());
+    Assertions.assertEquals(1, alerts.size());
     AlertEvent alert = alerts.get(0);
-    Assert.assertTrue(alert.getDescription().contains("Sync failed for server"));
+    Assertions.assertTrue(alert.getDescription().contains("Sync failed for server"));
 
     serviceEmitter.flush();
     execHelper.emitMetrics();
@@ -402,7 +405,8 @@ public class HttpServerInventoryViewTest
     httpServerInventoryView.stop();
   }
 
-  @Test(timeout = 60_000)
+  @Test
+  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS)
   public void testInitWaitsForServerToSync()
   {
     httpServerInventoryView.start();
@@ -410,7 +414,7 @@ public class HttpServerInventoryViewTest
     final DiscoveryDruidNode druidNode = druidNodeDiscovery.addNodeAndNotifyListeners("localhost");
     final DruidServer server = druidNode.toDruidServer();
 
-    Assert.assertTrue(addedServers.contains(server.getMetadata()));
+    Assertions.assertTrue(addedServers.contains(server.getMetadata()));
 
     ExecutorService initExecutor = Execs.singleThreaded(EXEC_NAME_PREFIX + "-init");
 
@@ -419,7 +423,7 @@ public class HttpServerInventoryViewTest
 
       // Wait to ensure that init thread is in progress and waiting
       Thread.sleep(1000);
-      Assert.assertFalse(inventoryInitialized.get());
+      Assertions.assertFalse(inventoryInitialized.get());
 
       // Finish sync of server
       httpClient.completeNextRequestWith(snapshotOf());
@@ -427,7 +431,7 @@ public class HttpServerInventoryViewTest
 
       // Wait for 10 seconds to ensure that init thread knows about server sync
       Thread.sleep(10_000);
-      Assert.assertTrue(inventoryInitialized.get());
+      Assertions.assertTrue(inventoryInitialized.get());
     }
     catch (InterruptedException e) {
       throw new ISE(e, "Interrupted");
@@ -437,13 +441,14 @@ public class HttpServerInventoryViewTest
     }
   }
 
-  @Test(timeout = 60_000)
+  @Test
+  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS)
   public void testInitDoesNotWaitForRemovedServerToSync()
   {
     httpServerInventoryView.start();
     druidNodeDiscovery.markNodeViewInitialized();
     DiscoveryDruidNode node = druidNodeDiscovery.addNodeAndNotifyListeners("localhost");
-    Assert.assertTrue(addedServers.contains(node.toDruidServer().getMetadata()));
+    Assertions.assertTrue(addedServers.contains(node.toDruidServer().getMetadata()));
 
     ExecutorService initExecutor = Execs.singleThreaded(EXEC_NAME_PREFIX + "-init");
 
@@ -452,14 +457,14 @@ public class HttpServerInventoryViewTest
 
       // Wait to ensure that init thread is in progress and waiting
       Thread.sleep(1000);
-      Assert.assertFalse(inventoryInitialized.get());
+      Assertions.assertFalse(inventoryInitialized.get());
 
       // Remove the node from discovery
       druidNodeDiscovery.removeNodesAndNotifyListeners(node);
 
       // Wait for 10 seconds to ensure that init thread knows about server removal
       Thread.sleep(10_000);
-      Assert.assertTrue(inventoryInitialized.get());
+      Assertions.assertTrue(inventoryInitialized.get());
     }
     catch (InterruptedException e) {
       throw new ISE(e, "Interrupted");

--- a/server/src/test/java/org/apache/druid/client/ImmutableDruidDataSourceTest.java
+++ b/server/src/test/java/org/apache/druid/client/ImmutableDruidDataSourceTest.java
@@ -30,10 +30,8 @@ import org.apache.druid.test.utils.ImmutableDruidDataSourceTestUtils;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.DataSegment.PruneSpecsHolder;
 import org.apache.druid.timeline.SegmentId;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -51,9 +49,6 @@ public class ImmutableDruidDataSourceTest
                                                              .binaryVersion(1)
                                                              .size(100L)
                                                              .build();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws IOException
@@ -76,10 +71,10 @@ public class ImmutableDruidDataSourceTest
 
     final ImmutableDruidDataSource dataSource2 = getImmutableDruidDataSource(TEST_SEGMENT);
 
-    Assert.assertThrows(
-        "ImmutableDruidDataSource shouldn't be used as the key in containers",
+    Assertions.assertThrows(
         UnsupportedOperationException.class,
-        () -> dataSource1.equals(dataSource2)
+        () -> dataSource1.equals(dataSource2),
+        "ImmutableDruidDataSource shouldn't be used as the key in containers"
     );
   }
 
@@ -98,10 +93,10 @@ public class ImmutableDruidDataSourceTest
   {
     final ImmutableDruidDataSource dataSource = getImmutableDruidDataSource(TEST_SEGMENT);
 
-    Assert.assertThrows(
-        "ImmutableDruidDataSource shouldn't be used as the key in containers",
+    Assertions.assertThrows(
         UnsupportedOperationException.class,
-        dataSource::hashCode
+        dataSource::hashCode,
+        "ImmutableDruidDataSource shouldn't be used as the key in containers"
     );
   }
 }

--- a/server/src/test/java/org/apache/druid/client/InternalQueryConfigTest.java
+++ b/server/src/test/java/org/apache/druid/client/InternalQueryConfigTest.java
@@ -33,11 +33,12 @@ import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+
 
 public class InternalQueryConfigTest
 {
@@ -56,7 +57,7 @@ public class InternalQueryConfigTest
         InternalQueryConfig.class
     );
 
-    Assert.assertEquals(ImmutableMap.of(), config.getContext());
+    Assertions.assertEquals(ImmutableMap.of(), config.getContext());
 
     //non-defaults
     json = "{ \"context\": {\"priority\": 5}}";
@@ -70,7 +71,7 @@ public class InternalQueryConfigTest
 
     Map<String, Object> expected = new HashMap<>();
     expected.put("priority", 5);
-    Assert.assertEquals(expected, config.getContext());
+    Assertions.assertEquals(expected, config.getContext());
   }
 
   /**
@@ -78,16 +79,18 @@ public class InternalQueryConfigTest
    *
    * @throws Exception
    */
-  @Test(expected = JsonEOFException.class)
-  public void testMalfomattedContext() throws Exception
+  @Test
+  public void testMalfomattedContext()
   {
-    String malformedJson = "{\"priority: 5}";
-    MAPPER.readValue(
-        MAPPER.writeValueAsString(
-            MAPPER.readValue(malformedJson, InternalQueryConfig.class)
-        ),
-        InternalQueryConfig.class
-    );
+    org.junit.jupiter.api.Assertions.assertThrows(JsonEOFException.class, () -> {
+      String malformedJson = "{\"priority: 5}";
+      MAPPER.readValue(
+          MAPPER.writeValueAsString(
+              MAPPER.readValue(malformedJson, InternalQueryConfig.class)
+          ),
+          InternalQueryConfig.class
+      );
+    });
   }
 
   /**
@@ -116,6 +119,6 @@ public class InternalQueryConfigTest
         }
     );
     InternalQueryConfig config = injector.getInstance(InternalQueryConfig.class);
-    Assert.assertEquals(ImmutableMap.of(), config.getContext());
+    Assertions.assertEquals(ImmutableMap.of(), config.getContext());
   }
 }

--- a/server/src/test/java/org/apache/druid/client/InternalQueryConfigTest.java
+++ b/server/src/test/java/org/apache/druid/client/InternalQueryConfigTest.java
@@ -82,7 +82,7 @@ public class InternalQueryConfigTest
   @Test
   public void testMalfomattedContext()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(JsonEOFException.class, () -> {
+    Assertions.assertThrows(JsonEOFException.class, () -> {
       String malformedJson = "{\"priority: 5}";
       MAPPER.readValue(
           MAPPER.writeValueAsString(

--- a/server/src/test/java/org/apache/druid/client/JsonParserIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/client/JsonParserIteratorTest.java
@@ -37,12 +37,9 @@ import org.apache.druid.query.QueryInterruptedException;
 import org.apache.druid.query.QueryTimeoutException;
 import org.apache.druid.query.QueryUnsupportedException;
 import org.apache.druid.query.ResourceLimitExceededException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -52,6 +49,8 @@ import java.io.InputStream;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JsonParserIteratorTest
 {
@@ -63,93 +62,93 @@ public class JsonParserIteratorTest
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public static class FutureExceptionTest
   {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testConvertFutureTimeoutToQueryTimeoutException()
     {
-      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
-          JAVA_TYPE,
-          Futures.immediateFailedFuture(
-              new QueryException(
-                  QueryException.QUERY_TIMEOUT_ERROR_CODE,
-                  "timeout exception conversion test",
-                  null,
-                  HOST
-              )
-          ),
-          URL,
-          null,
-          HOST,
-          OBJECT_MAPPER
-      );
-      expectedException.expect(QueryTimeoutException.class);
-      expectedException.expectMessage("timeout exception conversion test");
-      iterator.hasNext();
+      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryTimeoutException.class, () -> {
+        JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+            JAVA_TYPE,
+            Futures.immediateFailedFuture(
+                new QueryException(
+                    QueryException.QUERY_TIMEOUT_ERROR_CODE,
+                    "timeout exception conversion test",
+                    null,
+                    HOST
+                )
+            ),
+            URL,
+            null,
+            HOST,
+            OBJECT_MAPPER
+        );
+        iterator.hasNext();
+      });
+      assertTrue(exception.getMessage().contains("timeout exception conversion test"));
     }
 
     @Test
     public void testConvertFutureCancellationToQueryInterruptedException()
     {
-      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
-          JAVA_TYPE,
-          Futures.immediateCancelledFuture(),
-          URL,
-          null,
-          HOST,
-          OBJECT_MAPPER
-      );
-      expectedException.expect(QueryInterruptedException.class);
-      expectedException.expectMessage("Task was cancelled.");
-      iterator.hasNext();
+      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryInterruptedException.class, () -> {
+        JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+            JAVA_TYPE,
+            Futures.immediateCancelledFuture(),
+            URL,
+            null,
+            HOST,
+            OBJECT_MAPPER
+        );
+        iterator.hasNext();
+      });
+      assertTrue(exception.getMessage().contains("Task was cancelled."));
     }
 
     @Test
     public void testConvertFutureInterruptedToQueryInterruptedException()
     {
-      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
-          JAVA_TYPE,
-          Futures.immediateFailedFuture(new InterruptedException("interrupted future")),
-          URL,
-          null,
-          HOST,
-          OBJECT_MAPPER
-      );
-      expectedException.expect(QueryInterruptedException.class);
-      expectedException.expectMessage("interrupted future");
-      iterator.hasNext();
+      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryInterruptedException.class, () -> {
+        JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+            JAVA_TYPE,
+            Futures.immediateFailedFuture(new InterruptedException("interrupted future")),
+            URL,
+            null,
+            HOST,
+            OBJECT_MAPPER
+        );
+        iterator.hasNext();
+      });
+      assertTrue(exception.getMessage().contains("interrupted future"));
     }
 
     @Test
-    public void testConvertIOExceptionToQueryInterruptedException() throws IOException
+    public void testConvertIOExceptionToQueryInterruptedException()
     {
-      InputStream exceptionThrowingStream = Mockito.mock(InputStream.class);
-      IOException ioException = new IOException("ioexception test");
-      Mockito.when(exceptionThrowingStream.read()).thenThrow(ioException);
-      Mockito.when(exceptionThrowingStream.read(ArgumentMatchers.any())).thenThrow(ioException);
-      Mockito.when(
-          exceptionThrowingStream.read(ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
-      ).thenThrow(ioException);
-      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
-          JAVA_TYPE,
-          Futures.immediateFuture(exceptionThrowingStream),
-          URL,
-          null,
-          HOST,
-          OBJECT_MAPPER
-      );
-      expectedException.expect(QueryInterruptedException.class);
-      expectedException.expectMessage("ioexception test");
-      iterator.hasNext();
+      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryInterruptedException.class, () -> {
+        InputStream exceptionThrowingStream = Mockito.mock(InputStream.class);
+        IOException ioException = new IOException("ioexception test");
+        Mockito.when(exceptionThrowingStream.read()).thenThrow(ioException);
+        Mockito.when(exceptionThrowingStream.read(ArgumentMatchers.any())).thenThrow(ioException);
+        Mockito.when(
+            exceptionThrowingStream.read(ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
+        ).thenThrow(ioException);
+        JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+            JAVA_TYPE,
+            Futures.immediateFuture(exceptionThrowingStream),
+            URL,
+            null,
+            HOST,
+            OBJECT_MAPPER
+        );
+        iterator.hasNext();
+      });
+      assertTrue(exception.getMessage().contains("ioexception test"));
     }
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
-  @RunWith(Parameterized.class)
   public static class NonQueryInterruptedExceptionRestoreTest
   {
-    @Parameters(name = "{0}")
     public static Iterable<Object[]> constructorFeeder()
     {
       return ImmutableList.of(
@@ -162,145 +161,145 @@ public class JsonParserIteratorTest
       );
     }
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+    private Exception exception;
 
-    private final Exception exception;
-
-    public NonQueryInterruptedExceptionRestoreTest(Exception exception)
+    public void initNonQueryInterruptedExceptionRestoreTest(Exception exception)
     {
       this.exception = exception;
     }
 
-    @Test
-    public void testRestoreException() throws JsonProcessingException
+    @MethodSource("constructorFeeder")
+    @ParameterizedTest(name = "{0}")
+    public void testRestoreException(Exception exception)
     {
-      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
-          JAVA_TYPE,
-          Futures.immediateFuture(mockErrorResponse(exception)),
-          URL,
-          null,
-          HOST,
-          OBJECT_MAPPER
-      );
-      expectedException.expect(exception.getClass());
-      expectedException.expectMessage(exception.getMessage());
-      iterator.hasNext();
+      Throwable thrown = org.junit.jupiter.api.Assertions.assertThrows(exception.getClass(), () -> {
+        initNonQueryInterruptedExceptionRestoreTest(exception);
+        JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+            JAVA_TYPE,
+            Futures.immediateFuture(mockErrorResponse(exception)),
+            URL,
+            null,
+            HOST,
+            OBJECT_MAPPER
+        );
+        iterator.hasNext();
+      });
+      assertTrue(thrown.getMessage().contains(exception.getMessage()));
     }
   }
 
   public static class QueryInterruptedExceptionConversionTest
   {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
-    public void testConvertQueryExceptionWithNullErrorCodeToQueryInterruptedException() throws JsonProcessingException
+    public void testConvertQueryExceptionWithNullErrorCodeToQueryInterruptedException()
     {
-      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
-          JAVA_TYPE,
-          Futures.immediateFuture(mockErrorResponse(new QueryException(null, "query exception test", null, null))),
-          URL,
-          null,
-          HOST,
-          OBJECT_MAPPER
-      );
-      expectedException.expect(QueryInterruptedException.class);
-      expectedException.expectMessage("query exception test");
-      iterator.hasNext();
+      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryInterruptedException.class, () -> {
+        JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+            JAVA_TYPE,
+            Futures.immediateFuture(mockErrorResponse(new QueryException(null, "query exception test", null, null))),
+            URL,
+            null,
+            HOST,
+            OBJECT_MAPPER
+        );
+        iterator.hasNext();
+      });
+      assertTrue(exception.getMessage().contains("query exception test"));
     }
 
     @Test
     public void testConvertQueryExceptionWithNonNullErrorCodeToQueryInterruptedException()
-        throws JsonProcessingException
     {
-      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
-          JAVA_TYPE,
-          Futures.immediateFuture(
-              mockErrorResponse(new QueryException("test error", "query exception test", null, null))
-          ),
-          URL,
-          null,
-          HOST,
-          OBJECT_MAPPER
-      );
-      expectedException.expect(QueryInterruptedException.class);
-      expectedException.expectMessage("query exception test");
-      iterator.hasNext();
+      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryInterruptedException.class, () -> {
+        JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+            JAVA_TYPE,
+            Futures.immediateFuture(
+                mockErrorResponse(new QueryException("test error", "query exception test", null, null))
+            ),
+            URL,
+            null,
+            HOST,
+            OBJECT_MAPPER
+        );
+        iterator.hasNext();
+      });
+      assertTrue(exception.getMessage().contains("query exception test"));
     }
   }
 
   public static class TimeoutExceptionConversionTest
   {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testTimeoutBeforeCallingFuture()
     {
-      JsonParserIterator<?> iterator = new JsonParserIterator<>(
-          JAVA_TYPE,
-          Mockito.mock(Future.class),
-          URL,
-          mockQuery("qid", 0L), // should always timeout
-          HOST,
-          OBJECT_MAPPER
-      );
-      expectedException.expect(QueryTimeoutException.class);
-      expectedException.expectMessage(StringUtils.format("url[%s] timed out", URL));
-      iterator.hasNext();
+      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryTimeoutException.class, () -> {
+        JsonParserIterator<?> iterator = new JsonParserIterator<>(
+            JAVA_TYPE,
+            Mockito.mock(Future.class),
+            URL,
+            mockQuery("qid", 0L), // should always timeout
+            HOST,
+            OBJECT_MAPPER
+        );
+        iterator.hasNext();
+      });
+      assertTrue(exception.getMessage().contains(StringUtils.format("url[%s] timed out", URL)));
     }
 
     @Test
     public void testTimeoutWhileCallingFuture()
     {
-      Future<InputStream> future = new AbstractFuture<>()
-      {
-        @Override
-        public InputStream get(long timeout, TimeUnit unit)
-            throws InterruptedException
+      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryTimeoutException.class, () -> {
+        Future<InputStream> future = new AbstractFuture<>()
         {
-          Thread.sleep(2000); // Sleep longer than timeout
-          return null; // should return null so that JsonParserIterator checks timeout
-        }
-      };
-      JsonParserIterator<?> iterator = new JsonParserIterator<>(
-          JAVA_TYPE,
-          future,
-          URL,
-          mockQuery("qid", System.currentTimeMillis() + 500L), // timeout in 500 ms
-          HOST,
-          OBJECT_MAPPER
-      );
-      expectedException.expect(QueryTimeoutException.class);
-      expectedException.expectMessage(StringUtils.format("url[%s] timed out", URL));
-      iterator.hasNext();
-    }
-
-    @Test
-    public void testTimeoutAfterCallingFuture()
-    {
-      ExecutorService service = Execs.singleThreaded("timeout-test");
-      try {
+          @Override
+          public InputStream get(long timeout, TimeUnit unit)
+              throws InterruptedException
+          {
+            Thread.sleep(2000); // Sleep longer than timeout
+            return null; // should return null so that JsonParserIterator checks timeout
+          }
+        };
         JsonParserIterator<?> iterator = new JsonParserIterator<>(
             JAVA_TYPE,
-            service.submit(() -> {
-              Thread.sleep(2000); // Sleep longer than timeout
-              return null;
-            }),
+            future,
             URL,
             mockQuery("qid", System.currentTimeMillis() + 500L), // timeout in 500 ms
             HOST,
             OBJECT_MAPPER
         );
-        expectedException.expect(QueryTimeoutException.class);
-        expectedException.expectMessage("Query [qid] timed out");
         iterator.hasNext();
+      });
+      assertTrue(exception.getMessage().contains(StringUtils.format("url[%s] timed out", URL)));
+    }
 
-      }
-      finally {
-        service.shutdownNow();
-      }
+    @Test
+    public void testTimeoutAfterCallingFuture()
+    {
+      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryTimeoutException.class, () -> {
+        ExecutorService service = Execs.singleThreaded("timeout-test");
+        try {
+          JsonParserIterator<?> iterator = new JsonParserIterator<>(
+              JAVA_TYPE,
+              service.submit(() -> {
+                Thread.sleep(2000); // Sleep longer than timeout
+                return null;
+              }),
+              URL,
+              mockQuery("qid", System.currentTimeMillis() + 500L), // timeout in 500 ms
+              HOST,
+              OBJECT_MAPPER
+          );
+          iterator.hasNext();
+
+        }
+        finally {
+          service.shutdownNow();
+        }
+      });
+      assertTrue(exception.getMessage().contains("Query [qid] timed out"));
     }
 
     private Query<?> mockQuery(String queryId, long timeoutAt)
@@ -316,48 +315,46 @@ public class JsonParserIteratorTest
 
   public static class IAEExceptionConversionTest
   {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     private String errorMessage = "pstream connect error or disconnect/reset before header";
     private String nullErrMsg = null;
 
     @Test
-    public void testNullErrorMsg() throws JsonProcessingException
+    public void testNullErrorMsg()
     {
-      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
-          JAVA_TYPE,
-          Futures.immediateFuture(
-              mockErrorResponse(nullErrMsg)
-          ),
-          URL,
-          null,
-          HOST,
-          OBJECT_MAPPER
-      );
-
-      expectedException.expect(QueryInterruptedException.class);
-      expectedException.expectMessage("");
-      iterator.hasNext();
+      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryInterruptedException.class, () -> {
+        JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+            JAVA_TYPE,
+            Futures.immediateFuture(
+                mockErrorResponse(nullErrMsg)
+            ),
+            URL,
+            null,
+            HOST,
+            OBJECT_MAPPER
+        );
+        iterator.hasNext();
+      });
+      assertTrue(exception.getMessage().contains(""));
     }
 
     @Test
-    public void testParsingError() throws JsonProcessingException
+    public void testParsingError()
     {
-      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
-          JAVA_TYPE,
-          Futures.immediateFuture(
-              mockErrorResponse(errorMessage)
-          ),
-          URL,
-          null,
-          HOST,
-          OBJECT_MAPPER
-      );
-
-      expectedException.expect(QueryInterruptedException.class);
-      expectedException.expectMessage(errorMessage);
-      iterator.hasNext();
+      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryInterruptedException.class, () -> {
+        JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+            JAVA_TYPE,
+            Futures.immediateFuture(
+                mockErrorResponse(errorMessage)
+            ),
+            URL,
+            null,
+            HOST,
+            OBJECT_MAPPER
+        );
+        iterator.hasNext();
+      });
+      assertTrue(exception.getMessage().contains(errorMessage));
     }
   }
 

--- a/server/src/test/java/org/apache/druid/client/JsonParserIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/client/JsonParserIteratorTest.java
@@ -39,7 +39,7 @@ import org.apache.druid.query.QueryUnsupportedException;
 import org.apache.druid.query.ResourceLimitExceededException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -146,6 +146,8 @@ public class JsonParserIteratorTest
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
+  @ParameterizedClass(name = "{0}")
+  @MethodSource("constructorFeeder")
   public static class NonQueryInterruptedExceptionRestoreTest
   {
     public static Iterable<Object[]> constructorFeeder()
@@ -160,19 +162,17 @@ public class JsonParserIteratorTest
       );
     }
 
-    private Exception exception;
+    private final Exception exception;
 
-    public void initNonQueryInterruptedExceptionRestoreTest(Exception exception)
+    public NonQueryInterruptedExceptionRestoreTest(Exception exception)
     {
       this.exception = exception;
     }
 
-    @MethodSource("constructorFeeder")
-    @ParameterizedTest(name = "{0}")
-    public void testRestoreException(Exception exception)
+    @Test
+    public void testRestoreException()
     {
       Throwable thrown = org.junit.jupiter.api.Assertions.assertThrows(exception.getClass(), () -> {
-        initNonQueryInterruptedExceptionRestoreTest(exception);
         JsonParserIterator<Object> iterator = new JsonParserIterator<>(
             JAVA_TYPE,
             Futures.immediateFuture(mockErrorResponse(exception)),

--- a/server/src/test/java/org/apache/druid/client/JsonParserIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/client/JsonParserIteratorTest.java
@@ -65,7 +65,7 @@ public class JsonParserIteratorTest
     @Test
     public void testConvertFutureTimeoutToQueryTimeoutException()
     {
-      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryTimeoutException.class, () -> {
+      Throwable exception = Assertions.assertThrows(QueryTimeoutException.class, () -> {
         JsonParserIterator<Object> iterator = new JsonParserIterator<>(
             JAVA_TYPE,
             Futures.immediateFailedFuture(
@@ -89,7 +89,7 @@ public class JsonParserIteratorTest
     @Test
     public void testConvertFutureCancellationToQueryInterruptedException()
     {
-      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryInterruptedException.class, () -> {
+      Throwable exception = Assertions.assertThrows(QueryInterruptedException.class, () -> {
         JsonParserIterator<Object> iterator = new JsonParserIterator<>(
             JAVA_TYPE,
             Futures.immediateCancelledFuture(),
@@ -106,7 +106,7 @@ public class JsonParserIteratorTest
     @Test
     public void testConvertFutureInterruptedToQueryInterruptedException()
     {
-      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryInterruptedException.class, () -> {
+      Throwable exception = Assertions.assertThrows(QueryInterruptedException.class, () -> {
         JsonParserIterator<Object> iterator = new JsonParserIterator<>(
             JAVA_TYPE,
             Futures.immediateFailedFuture(new InterruptedException("interrupted future")),
@@ -123,7 +123,7 @@ public class JsonParserIteratorTest
     @Test
     public void testConvertIOExceptionToQueryInterruptedException()
     {
-      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryInterruptedException.class, () -> {
+      Throwable exception = Assertions.assertThrows(QueryInterruptedException.class, () -> {
         InputStream exceptionThrowingStream = Mockito.mock(InputStream.class);
         IOException ioException = new IOException("ioexception test");
         Mockito.when(exceptionThrowingStream.read()).thenThrow(ioException);
@@ -172,7 +172,7 @@ public class JsonParserIteratorTest
     @Test
     public void testRestoreException()
     {
-      Throwable thrown = org.junit.jupiter.api.Assertions.assertThrows(exception.getClass(), () -> {
+      Throwable thrown = Assertions.assertThrows(exception.getClass(), () -> {
         JsonParserIterator<Object> iterator = new JsonParserIterator<>(
             JAVA_TYPE,
             Futures.immediateFuture(mockErrorResponse(exception)),
@@ -193,7 +193,7 @@ public class JsonParserIteratorTest
     @Test
     public void testConvertQueryExceptionWithNullErrorCodeToQueryInterruptedException()
     {
-      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryInterruptedException.class, () -> {
+      Throwable exception = Assertions.assertThrows(QueryInterruptedException.class, () -> {
         JsonParserIterator<Object> iterator = new JsonParserIterator<>(
             JAVA_TYPE,
             Futures.immediateFuture(mockErrorResponse(new QueryException(null, "query exception test", null, null))),
@@ -210,7 +210,7 @@ public class JsonParserIteratorTest
     @Test
     public void testConvertQueryExceptionWithNonNullErrorCodeToQueryInterruptedException()
     {
-      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryInterruptedException.class, () -> {
+      Throwable exception = Assertions.assertThrows(QueryInterruptedException.class, () -> {
         JsonParserIterator<Object> iterator = new JsonParserIterator<>(
             JAVA_TYPE,
             Futures.immediateFuture(
@@ -233,7 +233,7 @@ public class JsonParserIteratorTest
     @Test
     public void testTimeoutBeforeCallingFuture()
     {
-      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryTimeoutException.class, () -> {
+      Throwable exception = Assertions.assertThrows(QueryTimeoutException.class, () -> {
         JsonParserIterator<?> iterator = new JsonParserIterator<>(
             JAVA_TYPE,
             Mockito.mock(Future.class),
@@ -250,7 +250,7 @@ public class JsonParserIteratorTest
     @Test
     public void testTimeoutWhileCallingFuture()
     {
-      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryTimeoutException.class, () -> {
+      Throwable exception = Assertions.assertThrows(QueryTimeoutException.class, () -> {
         Future<InputStream> future = new AbstractFuture<>()
         {
           @Override
@@ -277,7 +277,7 @@ public class JsonParserIteratorTest
     @Test
     public void testTimeoutAfterCallingFuture()
     {
-      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryTimeoutException.class, () -> {
+      Throwable exception = Assertions.assertThrows(QueryTimeoutException.class, () -> {
         ExecutorService service = Execs.singleThreaded("timeout-test");
         try {
           JsonParserIterator<?> iterator = new JsonParserIterator<>(
@@ -321,7 +321,7 @@ public class JsonParserIteratorTest
     @Test
     public void testNullErrorMsg()
     {
-      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryInterruptedException.class, () -> {
+      Throwable exception = Assertions.assertThrows(QueryInterruptedException.class, () -> {
         JsonParserIterator<Object> iterator = new JsonParserIterator<>(
             JAVA_TYPE,
             Futures.immediateFuture(
@@ -340,7 +340,7 @@ public class JsonParserIteratorTest
     @Test
     public void testParsingError()
     {
-      Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(QueryInterruptedException.class, () -> {
+      Throwable exception = Assertions.assertThrows(QueryInterruptedException.class, () -> {
         JsonParserIterator<Object> iterator = new JsonParserIterator<>(
             JAVA_TYPE,
             Futures.immediateFuture(

--- a/server/src/test/java/org/apache/druid/client/JsonParserIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/client/JsonParserIteratorTest.java
@@ -37,6 +37,7 @@ import org.apache.druid.query.QueryInterruptedException;
 import org.apache.druid.query.QueryTimeoutException;
 import org.apache.druid.query.QueryUnsupportedException;
 import org.apache.druid.query.ResourceLimitExceededException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -49,8 +50,6 @@ import java.io.InputStream;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JsonParserIteratorTest
 {
@@ -84,7 +83,7 @@ public class JsonParserIteratorTest
         );
         iterator.hasNext();
       });
-      assertTrue(exception.getMessage().contains("timeout exception conversion test"));
+      Assertions.assertTrue(exception.getMessage().contains("timeout exception conversion test"));
     }
 
     @Test
@@ -101,7 +100,7 @@ public class JsonParserIteratorTest
         );
         iterator.hasNext();
       });
-      assertTrue(exception.getMessage().contains("Task was cancelled."));
+      Assertions.assertTrue(exception.getMessage().contains("Task was cancelled."));
     }
 
     @Test
@@ -118,7 +117,7 @@ public class JsonParserIteratorTest
         );
         iterator.hasNext();
       });
-      assertTrue(exception.getMessage().contains("interrupted future"));
+      Assertions.assertTrue(exception.getMessage().contains("interrupted future"));
     }
 
     @Test
@@ -142,7 +141,7 @@ public class JsonParserIteratorTest
         );
         iterator.hasNext();
       });
-      assertTrue(exception.getMessage().contains("ioexception test"));
+      Assertions.assertTrue(exception.getMessage().contains("ioexception test"));
     }
   }
 
@@ -184,7 +183,7 @@ public class JsonParserIteratorTest
         );
         iterator.hasNext();
       });
-      assertTrue(thrown.getMessage().contains(exception.getMessage()));
+      Assertions.assertTrue(thrown.getMessage().contains(exception.getMessage()));
     }
   }
 
@@ -205,7 +204,7 @@ public class JsonParserIteratorTest
         );
         iterator.hasNext();
       });
-      assertTrue(exception.getMessage().contains("query exception test"));
+      Assertions.assertTrue(exception.getMessage().contains("query exception test"));
     }
 
     @Test
@@ -224,7 +223,7 @@ public class JsonParserIteratorTest
         );
         iterator.hasNext();
       });
-      assertTrue(exception.getMessage().contains("query exception test"));
+      Assertions.assertTrue(exception.getMessage().contains("query exception test"));
     }
   }
 
@@ -245,7 +244,7 @@ public class JsonParserIteratorTest
         );
         iterator.hasNext();
       });
-      assertTrue(exception.getMessage().contains(StringUtils.format("url[%s] timed out", URL)));
+      Assertions.assertTrue(exception.getMessage().contains(StringUtils.format("url[%s] timed out", URL)));
     }
 
     @Test
@@ -272,7 +271,7 @@ public class JsonParserIteratorTest
         );
         iterator.hasNext();
       });
-      assertTrue(exception.getMessage().contains(StringUtils.format("url[%s] timed out", URL)));
+      Assertions.assertTrue(exception.getMessage().contains(StringUtils.format("url[%s] timed out", URL)));
     }
 
     @Test
@@ -299,7 +298,7 @@ public class JsonParserIteratorTest
           service.shutdownNow();
         }
       });
-      assertTrue(exception.getMessage().contains("Query [qid] timed out"));
+      Assertions.assertTrue(exception.getMessage().contains("Query [qid] timed out"));
     }
 
     private Query<?> mockQuery(String queryId, long timeoutAt)
@@ -335,7 +334,7 @@ public class JsonParserIteratorTest
         );
         iterator.hasNext();
       });
-      assertTrue(exception.getMessage().contains(""));
+      Assertions.assertTrue(exception.getMessage().contains(""));
     }
 
     @Test
@@ -354,7 +353,7 @@ public class JsonParserIteratorTest
         );
         iterator.hasNext();
       });
-      assertTrue(exception.getMessage().contains(errorMessage));
+      Assertions.assertTrue(exception.getMessage().contains(errorMessage));
     }
   }
 

--- a/server/src/test/java/org/apache/druid/client/TestHttpClient.java
+++ b/server/src/test/java/org/apache/druid/client/TestHttpClient.java
@@ -49,6 +49,7 @@ import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.joda.time.Duration;
 
 import javax.annotation.Nullable;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;

--- a/server/src/test/java/org/apache/druid/client/broker/BrokerClientImplTest.java
+++ b/server/src/test/java/org/apache/druid/client/broker/BrokerClientImplTest.java
@@ -39,16 +39,17 @@ import org.apache.druid.server.broker.BrokerDynamicConfig;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BrokerClientImplTest
 {
@@ -56,7 +57,7 @@ public class BrokerClientImplTest
   private MockServiceClient serviceClient;
   private BrokerClient brokerClient;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     jsonMapper = new DefaultObjectMapper();
@@ -64,7 +65,7 @@ public class BrokerClientImplTest
     brokerClient = new BrokerClientImpl(serviceClient, jsonMapper);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     serviceClient.verify();

--- a/server/src/test/java/org/apache/druid/client/broker/BrokerClientImplTest.java
+++ b/server/src/test/java/org/apache/druid/client/broker/BrokerClientImplTest.java
@@ -40,6 +40,7 @@ import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -48,8 +49,6 @@ import javax.ws.rs.core.MediaType;
 
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BrokerClientImplTest
 {
@@ -90,7 +89,7 @@ public class BrokerClientImplTest
         jsonMapper.writeValueAsBytes(response)
     );
 
-    assertEquals(
+    Assertions.assertEquals(
         jsonMapper.writeValueAsString(response),
         brokerClient.submitNativeQuery(scanQuery).get()
     );
@@ -118,7 +117,7 @@ public class BrokerClientImplTest
         jsonMapper.writeValueAsBytes(taskStatus)
     );
 
-    assertEquals(taskStatus, brokerClient.submitSqlTask(query).get());
+    Assertions.assertEquals(taskStatus, brokerClient.submitSqlTask(query).get());
   }
 
   @Test
@@ -166,7 +165,7 @@ public class BrokerClientImplTest
         jsonMapper.writeValueAsBytes(givenPlans)
     );
 
-    assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(new ExplainPlan(plan, resources, attributes)),
         brokerClient.fetchExplainPlan(query).get()
     );
@@ -185,7 +184,7 @@ public class BrokerClientImplTest
         new byte[0]
     );
 
-    assertEquals(true, brokerClient.updateCoordinatorDynamicConfig(config).get());
+    Assertions.assertEquals(true, brokerClient.updateCoordinatorDynamicConfig(config).get());
   }
 
   @Test
@@ -201,6 +200,6 @@ public class BrokerClientImplTest
         new byte[0]
     );
 
-    assertEquals(true, brokerClient.updateBrokerDynamicConfig(config).get());
+    Assertions.assertEquals(true, brokerClient.updateBrokerDynamicConfig(config).get());
   }
 }

--- a/server/src/test/java/org/apache/druid/client/cache/BackgroundCachePopulatorTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/BackgroundCachePopulatorTest.java
@@ -48,9 +48,9 @@ import org.apache.druid.query.topn.TopNQueryConfig;
 import org.apache.druid.query.topn.TopNQueryQueryToolChest;
 import org.apache.druid.query.topn.TopNResultValue;
 import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -83,7 +83,7 @@ public class BackgroundCachePopulatorTest
   private QueryRunner baseRunner;
   private AssertingClosable closable;
 
-  @Before
+  @BeforeEach
   public void before()
   {
     this.backgroundCachePopulator = new BackgroundCachePopulator(
@@ -115,7 +115,7 @@ public class BackgroundCachePopulatorTest
           @Override
           public void before()
           {
-            Assert.assertFalse(closable.isClosed());
+            Assertions.assertFalse(closable.isClosed());
           }
 
           @Override
@@ -199,14 +199,14 @@ public class BackgroundCachePopulatorTest
 
     Sequence res = this.backgroundCachePopulator.wrap(this.baseRunner.run(QueryPlus.wrap(query), ResponseContext.createEmpty()),
         (value) -> cacheStrategy.prepareForSegmentLevelCache().apply(value), cache, cacheKey);
-    Assert.assertFalse("sequence must not be closed", closable.isClosed());
-    Assert.assertNull("cache must be empty", cache.get(cacheKey));
+    Assertions.assertFalse(closable.isClosed(), "sequence must not be closed");
+    Assertions.assertNull(cache.get(cacheKey), "cache must be empty");
 
     List results = res.toList();
-    Assert.assertTrue(closable.isClosed());
+    Assertions.assertTrue(closable.isClosed());
     List<Result> expectedRes = makeTopNResults(false, OBJECTS);
-    Assert.assertEquals(expectedRes.toString(), results.toString());
-    Assert.assertEquals(5, results.size());
+    Assertions.assertEquals(expectedRes.toString(), results.toString());
+    Assertions.assertEquals(5, results.size());
   }
 
   @Test
@@ -227,14 +227,14 @@ public class BackgroundCachePopulatorTest
         (value) -> {
         throw new RuntimeException("Error");
       }, cache, cacheKey);
-    Assert.assertFalse("sequence must not be closed", closable.isClosed());
-    Assert.assertNull("cache must be empty", cache.get(cacheKey));
+    Assertions.assertFalse(closable.isClosed(), "sequence must not be closed");
+    Assertions.assertNull(cache.get(cacheKey), "cache must be empty");
 
     List results = res.toList();
-    Assert.assertTrue(closable.isClosed());
+    Assertions.assertTrue(closable.isClosed());
     List<Result> expectedRes = makeTopNResults(false, OBJECTS);
-    Assert.assertEquals(expectedRes.toString(), results.toString());
-    Assert.assertEquals(5, results.size());
+    Assertions.assertEquals(expectedRes.toString(), results.toString());
+    Assertions.assertEquals(5, results.size());
   }
 
 
@@ -291,8 +291,8 @@ public class BackgroundCachePopulatorTest
     @Override
     public void close()
     {
-      Assert.assertFalse(closed.get());
-      Assert.assertTrue(closed.compareAndSet(false, true));
+      Assertions.assertFalse(closed.get());
+      Assertions.assertTrue(closed.compareAndSet(false, true));
     }
 
     public boolean isClosed()

--- a/server/src/test/java/org/apache/druid/client/cache/ByteCountingLRUMapTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/ByteCountingLRUMapTest.java
@@ -19,9 +19,9 @@
 
 package org.apache.druid.client.cache;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -34,7 +34,7 @@ public class ByteCountingLRUMapTest
 {
   private ByteCountingLRUMap map;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     map = new ByteCountingLRUMap(100);
@@ -52,22 +52,22 @@ public class ByteCountingLRUMapTest
     assertMapValues(0, 0, 0);
     map.put(tenKey, eightNineNineVal);
     assertMapValues(1, 99, 0);
-    Assert.assertEquals(ByteBuffer.wrap(eightNineNineVal), ByteBuffer.wrap(map.get(tenKey)));
+    Assertions.assertEquals(ByteBuffer.wrap(eightNineNineVal), ByteBuffer.wrap(map.get(tenKey)));
 
     map.put(oneByte, oneByte.array());
     assertMapValues(1, 2, 1);
-    Assert.assertNull(map.get(tenKey));
-    Assert.assertEquals(oneByte, ByteBuffer.wrap(map.get(oneByte)));
+    Assertions.assertNull(map.get(tenKey));
+    Assertions.assertEquals(oneByte, ByteBuffer.wrap(map.get(oneByte)));
 
     map.put(tenKey, eightyEightVal);
     assertMapValues(2, 100, 1);
-    Assert.assertEquals(oneByte, ByteBuffer.wrap(map.get(oneByte)));
-    Assert.assertEquals(ByteBuffer.wrap(eightyEightVal), ByteBuffer.wrap(map.get(tenKey)));
+    Assertions.assertEquals(oneByte, ByteBuffer.wrap(map.get(oneByte)));
+    Assertions.assertEquals(ByteBuffer.wrap(eightyEightVal), ByteBuffer.wrap(map.get(tenKey)));
 
     map.put(twoByte, oneByte.array());
     assertMapValues(1, 3, 3);
-    Assert.assertEquals(null, map.get(tenKey));
-    Assert.assertEquals(oneByte, ByteBuffer.wrap(map.get(twoByte)));
+    Assertions.assertEquals(null, map.get(tenKey));
+    Assertions.assertEquals(oneByte, ByteBuffer.wrap(map.get(twoByte)));
 
     Iterator<ByteBuffer> it = map.keySet().iterator();
     List<ByteBuffer> toRemove = new ArrayList<>();
@@ -101,8 +101,8 @@ public class ByteCountingLRUMapTest
 
   private void assertMapValues(final int size, final int numBytes, final int evictionCount)
   {
-    Assert.assertEquals(size, map.size());
-    Assert.assertEquals(numBytes, map.getNumBytes());
-    Assert.assertEquals(evictionCount, map.getEvictionCount());
+    Assertions.assertEquals(size, map.size());
+    Assertions.assertEquals(numBytes, map.getNumBytes());
+    Assertions.assertEquals(evictionCount, map.getEvictionCount());
   }
 }

--- a/server/src/test/java/org/apache/druid/client/cache/BytesBoundedLinkedQueueTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/BytesBoundedLinkedQueueTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.client.cache;
 
 
 import org.apache.druid.java.util.common.ISE;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,11 +60,11 @@ public class BytesBoundedLinkedQueueTest
   {
     final BlockingQueue q = getQueue(10);
     long startTime = System.nanoTime();
-    Assert.assertNull(q.poll(delayMS, TimeUnit.MILLISECONDS));
-    Assert.assertTrue(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) >= delayMS);
+    Assertions.assertNull(q.poll(delayMS, TimeUnit.MILLISECONDS));
+    Assertions.assertTrue(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) >= delayMS);
     TestObject obj = new TestObject(2);
-    Assert.assertTrue(q.offer(obj, delayMS, TimeUnit.MILLISECONDS));
-    Assert.assertSame(obj, q.poll(delayMS, TimeUnit.MILLISECONDS));
+    Assertions.assertTrue(q.offer(obj, delayMS, TimeUnit.MILLISECONDS));
+    Assertions.assertSame(obj, q.poll(delayMS, TimeUnit.MILLISECONDS));
 
     Thread.currentThread().interrupt();
     try {
@@ -73,7 +73,7 @@ public class BytesBoundedLinkedQueueTest
     }
     catch (InterruptedException success) {
     }
-    Assert.assertFalse(Thread.interrupted());
+    Assertions.assertFalse(Thread.interrupted());
   }
 
   @Test
@@ -83,7 +83,7 @@ public class BytesBoundedLinkedQueueTest
     Thread.currentThread().interrupt();
     try {
       q.take();
-      Assert.fail();
+      Assertions.fail();
     }
     catch (InterruptedException success) {
       //
@@ -106,14 +106,14 @@ public class BytesBoundedLinkedQueueTest
     // test take blocks on empty queue
     try {
       future.get(delayMS, TimeUnit.MILLISECONDS);
-      Assert.fail();
+      Assertions.fail();
     }
     catch (TimeoutException success) {
 
     }
 
     q.offer(object);
-    Assert.assertEquals(object, future.get());
+    Assertions.assertEquals(object, future.get());
   }
 
   @Test
@@ -122,7 +122,7 @@ public class BytesBoundedLinkedQueueTest
     final BlockingQueue<TestObject> q = getQueue(10);
     try {
       q.offer(null);
-      Assert.fail();
+      Assertions.fail();
     }
     catch (NullPointerException success) {
 
@@ -130,12 +130,12 @@ public class BytesBoundedLinkedQueueTest
 
     final TestObject obj = new TestObject(2);
     while (q.remainingCapacity() > 0) {
-      Assert.assertTrue(q.offer(obj, delayMS, TimeUnit.MILLISECONDS));
+      Assertions.assertTrue(q.offer(obj, delayMS, TimeUnit.MILLISECONDS));
     }
     // queue full
-    Assert.assertEquals(0, q.remainingCapacity());
-    Assert.assertFalse(q.offer(obj, delayMS, TimeUnit.MILLISECONDS));
-    Assert.assertFalse(q.offer(obj));
+    Assertions.assertEquals(0, q.remainingCapacity());
+    Assertions.assertFalse(q.offer(obj, delayMS, TimeUnit.MILLISECONDS));
+    Assertions.assertFalse(q.offer(obj));
     final CyclicBarrier barrier = new CyclicBarrier(2);
 
     Future<Boolean> future = exec.submit(
@@ -145,8 +145,8 @@ public class BytesBoundedLinkedQueueTest
           public Boolean call() throws Exception
           {
             barrier.await();
-            Assert.assertTrue(q.offer(obj, delayMS, TimeUnit.MILLISECONDS));
-            Assert.assertEquals(q.remainingCapacity(), 0);
+            Assertions.assertTrue(q.offer(obj, delayMS, TimeUnit.MILLISECONDS));
+            Assertions.assertEquals(q.remainingCapacity(), 0);
             barrier.await();
             q.put(obj);
             return true;
@@ -157,7 +157,7 @@ public class BytesBoundedLinkedQueueTest
     q.take();
     barrier.await();
     q.take();
-    Assert.assertTrue(future.get());
+    Assertions.assertTrue(future.get());
 
   }
 
@@ -167,7 +167,7 @@ public class BytesBoundedLinkedQueueTest
     BlockingQueue<TestObject> q = getQueue(5);
     try {
       q.offer(new TestObject(10));
-      Assert.fail();
+      Assertions.fail();
     }
     catch (IllegalArgumentException success) {
 
@@ -178,9 +178,9 @@ public class BytesBoundedLinkedQueueTest
   public void testAddedObjectExceedsCapacity() throws Exception
   {
     BlockingQueue<TestObject> q = getQueue(4);
-    Assert.assertTrue(q.offer(new TestObject(3)));
-    Assert.assertFalse(q.offer(new TestObject(2)));
-    Assert.assertFalse(q.offer(new TestObject(2), delayMS, TimeUnit.MILLISECONDS));
+    Assertions.assertTrue(q.offer(new TestObject(3)));
+    Assertions.assertFalse(q.offer(new TestObject(2)));
+    Assertions.assertFalse(q.offer(new TestObject(2), delayMS, TimeUnit.MILLISECONDS));
   }
 
   @Test
@@ -251,7 +251,7 @@ public class BytesBoundedLinkedQueueTest
     Thread.sleep(duration);
     stopTest.set(true);
     for (Future<Boolean> future : futures) {
-      Assert.assertTrue(future.get());
+      Assertions.assertTrue(future.get());
     }
   }
 

--- a/server/src/test/java/org/apache/druid/client/cache/CacheConfigTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/CacheConfigTest.java
@@ -30,13 +30,14 @@ import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.JsonConfigurator;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.query.Query;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Properties;
+
 
 /**
  *
@@ -48,7 +49,7 @@ public class CacheConfigTest
   JsonConfigProvider<CacheConfig> configProvider;
   private static final String PROPERTY_PREFIX = "org.apache.druid.collections.test.cache";
 
-  @BeforeClass
+  @BeforeAll
   public static void populateStatics()
   {
     injector = GuiceInjectors.makeStartupInjectorWithModules(ImmutableList.<com.google.inject.Module>of(new CacheConfigTestModule()));
@@ -73,7 +74,7 @@ public class CacheConfigTest
 
   private Properties properties = new Properties();
 
-  @Before
+  @BeforeEach
   public void setupTest()
   {
     properties.clear();
@@ -92,9 +93,9 @@ public class CacheConfigTest
     CacheConfig config = configProvider.get();
 
     injector.injectMembers(config);
-    Assert.assertEquals(5, config.getNumBackgroundThreads());
-    Assert.assertEquals(true, config.isPopulateCache());
-    Assert.assertEquals(true, config.isUseCache());
+    Assertions.assertEquals(5, config.getNumBackgroundThreads());
+    Assertions.assertEquals(true, config.isPopulateCache());
+    Assertions.assertEquals(true, config.isUseCache());
   }
 
   @Test
@@ -107,29 +108,33 @@ public class CacheConfigTest
     configProvider.inject(properties, configurator);
     CacheConfig config = configProvider.get();
 
-    Assert.assertEquals(99, config.getNumBackgroundThreads());
-    Assert.assertEquals(false, config.isPopulateCache());
-    Assert.assertEquals(false, config.isUseCache());
+    Assertions.assertEquals(99, config.getNumBackgroundThreads());
+    Assertions.assertEquals(false, config.isPopulateCache());
+    Assertions.assertEquals(false, config.isUseCache());
   }
 
-  @Test(expected = ProvisionException.class)
+  @Test
   public void testValidationError()
   {
-    properties.put(PROPERTY_PREFIX + ".numBackgroundThreads", "-1");
+    org.junit.jupiter.api.Assertions.assertThrows(ProvisionException.class, () -> {
+      properties.put(PROPERTY_PREFIX + ".numBackgroundThreads", "-1");
 
-    configProvider.inject(properties, configurator);
-    CacheConfig config = configProvider.get();
-    Assert.assertNotEquals(-1, config.getNumBackgroundThreads());
+      configProvider.inject(properties, configurator);
+      CacheConfig config = configProvider.get();
+      Assertions.assertNotEquals(-1, config.getNumBackgroundThreads());
+    });
   }
 
 
-  @Test(expected = ProvisionException.class)
+  @Test
   public void testValidationInsaneError()
   {
-    properties.put(PROPERTY_PREFIX + ".numBackgroundThreads", "BABBA YAGA");
-    configProvider.inject(properties, configurator);
-    CacheConfig config = configProvider.get();
-    throw new IllegalStateException("Should have already failed");
+    org.junit.jupiter.api.Assertions.assertThrows(ProvisionException.class, () -> {
+      properties.put(PROPERTY_PREFIX + ".numBackgroundThreads", "BABBA YAGA");
+      configProvider.inject(properties, configurator);
+      CacheConfig config = configProvider.get();
+      throw new IllegalStateException("Should have already failed");
+    });
   }
 
   @Test
@@ -138,7 +143,7 @@ public class CacheConfigTest
     properties.put(PROPERTY_PREFIX + ".populateCache", "TRUE");
     configProvider.inject(properties, configurator);
     CacheConfig config = configProvider.get();
-    Assert.assertTrue(config.isPopulateCache());
+    Assertions.assertTrue(config.isPopulateCache());
   }
 
   @Test
@@ -147,17 +152,19 @@ public class CacheConfigTest
     properties.put(PROPERTY_PREFIX + ".populateCache", "FALSE");
     configProvider.inject(properties, configurator);
     CacheConfig config = configProvider.get();
-    Assert.assertFalse(config.isPopulateCache());
+    Assertions.assertFalse(config.isPopulateCache());
   }
 
 
-  @Test(expected = ProvisionException.class)
+  @Test
   public void testMixedCaseFalseIsRejected()
   {
-    properties.put(PROPERTY_PREFIX + ".populateCache", "FaLse");
-    configProvider.inject(properties, configurator);
-    CacheConfig config = configProvider.get();
-    throw new IllegalStateException("Should have already failed");
+    org.junit.jupiter.api.Assertions.assertThrows(ProvisionException.class, () -> {
+      properties.put(PROPERTY_PREFIX + ".populateCache", "FaLse");
+      configProvider.inject(properties, configurator);
+      CacheConfig config = configProvider.get();
+      throw new IllegalStateException("Should have already failed");
+    });
   }
 
   @Test
@@ -167,7 +174,7 @@ public class CacheConfigTest
     CacheConfig config = configProvider.get();
     injector.injectMembers(config);
 
-    Assert.assertFalse(config.isQueryCacheable(Query.SCAN));
+    Assertions.assertFalse(config.isQueryCacheable(Query.SCAN));
 
     properties.clear();
     configProvider = JsonConfigProvider.of(PROPERTY_PREFIX, CacheConfig.class);
@@ -176,6 +183,6 @@ public class CacheConfigTest
     configProvider.inject(properties, configurator);
     CacheConfig config2 = configProvider.get();
     injector.injectMembers(config2);
-    Assert.assertTrue(config2.isQueryCacheable(Query.SCAN));
+    Assertions.assertTrue(config2.isQueryCacheable(Query.SCAN));
   }
 }

--- a/server/src/test/java/org/apache/druid/client/cache/CacheConfigTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/CacheConfigTest.java
@@ -116,7 +116,7 @@ public class CacheConfigTest
   @Test
   public void testValidationError()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(ProvisionException.class, () -> {
+    Assertions.assertThrows(ProvisionException.class, () -> {
       properties.put(PROPERTY_PREFIX + ".numBackgroundThreads", "-1");
 
       configProvider.inject(properties, configurator);
@@ -129,7 +129,7 @@ public class CacheConfigTest
   @Test
   public void testValidationInsaneError()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(ProvisionException.class, () -> {
+    Assertions.assertThrows(ProvisionException.class, () -> {
       properties.put(PROPERTY_PREFIX + ".numBackgroundThreads", "BABBA YAGA");
       configProvider.inject(properties, configurator);
       CacheConfig config = configProvider.get();
@@ -159,7 +159,7 @@ public class CacheConfigTest
   @Test
   public void testMixedCaseFalseIsRejected()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(ProvisionException.class, () -> {
+    Assertions.assertThrows(ProvisionException.class, () -> {
       properties.put(PROPERTY_PREFIX + ".populateCache", "FaLse");
       configProvider.inject(properties, configurator);
       CacheConfig config = configProvider.get();

--- a/server/src/test/java/org/apache/druid/client/cache/CacheDistributionTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/CacheDistributionTest.java
@@ -29,11 +29,10 @@ import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.util.DefaultKetamaNodeLocatorConfiguration;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.easymock.EasyMock;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -45,12 +44,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
-@RunWith(Parameterized.class)
 public class CacheDistributionTest
 {
   public static final int KEY_COUNT = 1_000_000;
 
-  @Parameterized.Parameters(name = "repetitions={0}, hash={1}")
   public static Iterable<Object[]> data()
   {
     List<HashAlgorithm> hash = ImmutableList.of(
@@ -67,10 +64,10 @@ public class CacheDistributionTest
     return Iterables.transform(values, List::toArray);
   }
 
-  final HashAlgorithm hash;
-  final int reps;
+  HashAlgorithm hash;
+  int reps;
 
-  @BeforeClass
+  @BeforeAll
   public static void header()
   {
     System.out.printf(
@@ -80,7 +77,7 @@ public class CacheDistributionTest
     );
   }
 
-  public CacheDistributionTest(final HashAlgorithm hash, final int reps)
+  public void initCacheDistributionTest(final HashAlgorithm hash, final int reps)
   {
     this.hash = hash;
     this.reps = reps;
@@ -89,10 +86,12 @@ public class CacheDistributionTest
   // Run to get a sense of cache key distribution for different ketama reps / hash functions
   // This test is disabled by default because it's a qualitative test not an unit test and thus it have a meaning only
   // when being run and checked by humans.
-  @Ignore
-  @Test
-  public void testDistribution()
+  @Disabled
+  @MethodSource("data")
+  @ParameterizedTest(name = "repetitions={0}, hash={1}")
+  public void testDistribution(final HashAlgorithm hash, final int reps)
   {
+    initCacheDistributionTest(hash, reps);
     KetamaNodeLocator locator = new KetamaNodeLocator(
         ImmutableList.of(
             dummyNode("druid-cache.0001", 11211),

--- a/server/src/test/java/org/apache/druid/client/cache/CacheDistributionTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/CacheDistributionTest.java
@@ -31,7 +31,8 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.InetSocketAddress;
@@ -44,6 +45,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
+@ParameterizedClass(name = "repetitions={0}, hash={1}")
+@MethodSource("data")
 public class CacheDistributionTest
 {
   public static final int KEY_COUNT = 1_000_000;
@@ -64,8 +67,14 @@ public class CacheDistributionTest
     return Iterables.transform(values, List::toArray);
   }
 
-  HashAlgorithm hash;
-  int reps;
+  private final HashAlgorithm hash;
+  private final int reps;
+
+  public CacheDistributionTest(HashAlgorithm hash, int reps)
+  {
+    this.hash = hash;
+    this.reps = reps;
+  }
 
   @BeforeAll
   public static void header()
@@ -77,21 +86,13 @@ public class CacheDistributionTest
     );
   }
 
-  public void initCacheDistributionTest(final HashAlgorithm hash, final int reps)
-  {
-    this.hash = hash;
-    this.reps = reps;
-  }
-
   // Run to get a sense of cache key distribution for different ketama reps / hash functions
   // This test is disabled by default because it's a qualitative test not an unit test and thus it have a meaning only
   // when being run and checked by humans.
   @Disabled
-  @MethodSource("data")
-  @ParameterizedTest(name = "repetitions={0}, hash={1}")
-  public void testDistribution(final HashAlgorithm hash, final int reps)
+  @Test
+  public void testDistribution()
   {
-    initCacheDistributionTest(hash, reps);
     KetamaNodeLocator locator = new KetamaNodeLocator(
         ImmutableList.of(
             dummyNode("druid-cache.0001", 11211),

--- a/server/src/test/java/org/apache/druid/client/cache/CacheMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/CacheMonitorTest.java
@@ -29,8 +29,8 @@ import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.initialization.Initialization;
 import org.apache.druid.server.DruidNode;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CacheMonitorTest
 {
@@ -52,7 +52,7 @@ public class CacheMonitorTest
     ));
 
     CacheMonitor monitor = injector.getInstance(CacheMonitor.class);
-    Assert.assertNull(monitor.cache);
+    Assertions.assertNull(monitor.cache);
   }
 
   @Test
@@ -74,6 +74,6 @@ public class CacheMonitorTest
     ));
 
     CacheMonitor monitor = injector.getInstance(CacheMonitor.class);
-    Assert.assertNotNull(monitor.cache);
+    Assertions.assertNotNull(monitor.cache);
   }
 }

--- a/server/src/test/java/org/apache/druid/client/cache/CacheTestBase.java
+++ b/server/src/test/java/org/apache/druid/client/cache/CacheTestBase.java
@@ -21,9 +21,9 @@ package org.apache.druid.client.cache;
 
 import org.apache.druid.client.CacheUtil;
 import org.apache.druid.client.cache.Cache.NamedKey;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public abstract class CacheTestBase<T extends Cache>
 {

--- a/server/src/test/java/org/apache/druid/client/cache/CacheTestBase.java
+++ b/server/src/test/java/org/apache/druid/client/cache/CacheTestBase.java
@@ -21,9 +21,8 @@ package org.apache.druid.client.cache;
 
 import org.apache.druid.client.CacheUtil;
 import org.apache.druid.client.cache.Cache.NamedKey;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public abstract class CacheTestBase<T extends Cache>
 {
@@ -35,6 +34,6 @@ public abstract class CacheTestBase<T extends Cache>
     byte[] value = new byte[] {1, 0, -10, -55, 111};
     NamedKey key = CacheUtil.computeResultLevelCacheKey(new byte[] {1, 0, -10, 0});
     cache.put(key, value);
-    assertArrayEquals(value, cache.get(key));
+    Assertions.assertArrayEquals(value, cache.get(key));
   }
 }

--- a/server/src/test/java/org/apache/druid/client/cache/CaffeineCacheTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/CaffeineCacheTest.java
@@ -32,9 +32,9 @@ import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.initialization.Initialization;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,7 +58,7 @@ public class CaffeineCacheTest extends CacheTestBase<CaffeineCache>
     }
   };
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     cache = CaffeineCache.create(cacheConfig);
@@ -84,7 +84,7 @@ public class CaffeineCacheTest extends CacheTestBase<CaffeineCache>
     lifecycle.start();
     try {
       Cache cache = injector.getInstance(Cache.class);
-      Assert.assertEquals(CaffeineCache.class, cache.getClass());
+      Assertions.assertEquals(CaffeineCache.class, cache.getClass());
     }
     finally {
       lifecycle.stop();
@@ -109,43 +109,43 @@ public class CaffeineCacheTest extends CacheTestBase<CaffeineCache>
         )
     );
     final CacheProvider cacheProvider = injector.getInstance(CacheProvider.class);
-    Assert.assertNotNull(cacheProvider);
-    Assert.assertEquals(CaffeineCacheProvider.class, cacheProvider.getClass());
+    Assertions.assertNotNull(cacheProvider);
+    Assertions.assertEquals(CaffeineCacheProvider.class, cacheProvider.getClass());
   }
 
   @Test
   public void testBaseOps()
   {
     final Cache.NamedKey aKey = new Cache.NamedKey("a", HI);
-    Assert.assertNull(cache.get(aKey));
+    Assertions.assertNull(cache.get(aKey));
     put(cache, aKey, 1);
-    Assert.assertEquals(1, get(cache, aKey));
+    Assertions.assertEquals(1, get(cache, aKey));
 
     cache.close("a");
-    Assert.assertNull(cache.get(aKey));
+    Assertions.assertNull(cache.get(aKey));
 
     final Cache.NamedKey hiKey = new Cache.NamedKey("the", HI);
     final Cache.NamedKey hoKey = new Cache.NamedKey("the", HO);
     put(cache, hiKey, 10);
     put(cache, hoKey, 20);
-    Assert.assertEquals(10, get(cache, hiKey));
-    Assert.assertEquals(20, get(cache, hoKey));
+    Assertions.assertEquals(10, get(cache, hiKey));
+    Assertions.assertEquals(20, get(cache, hoKey));
     cache.close("the");
 
-    Assert.assertNull(cache.get(hiKey));
-    Assert.assertNull(cache.get(hoKey));
+    Assertions.assertNull(cache.get(hiKey));
+    Assertions.assertNull(cache.get(hoKey));
 
-    Assert.assertNull(cache.get(new Cache.NamedKey("miss", HI)));
+    Assertions.assertNull(cache.get(new Cache.NamedKey("miss", HI)));
 
     final CacheStats stats = cache.getStats();
-    Assert.assertEquals(3, stats.getNumHits());
-    Assert.assertEquals(5, stats.getNumMisses());
+    Assertions.assertEquals(3, stats.getNumHits());
+    Assertions.assertEquals(5, stats.getNumMisses());
   }
 
   @Test
   public void testGetBulk()
   {
-    Assert.assertNull(cache.get(new Cache.NamedKey("the", HI)));
+    Assertions.assertNull(cache.get(new Cache.NamedKey("the", HI)));
 
     Cache.NamedKey key1 = new Cache.NamedKey("the", HI);
     put(cache, key1, 2);
@@ -160,15 +160,15 @@ public class CaffeineCacheTest extends CacheTestBase<CaffeineCache>
         )
     );
 
-    Assert.assertEquals(2, Ints.fromByteArray(result.get(key1)));
-    Assert.assertEquals(10, Ints.fromByteArray(result.get(key2)));
+    Assertions.assertEquals(2, Ints.fromByteArray(result.get(key1)));
+    Assertions.assertEquals(10, Ints.fromByteArray(result.get(key2)));
 
     Cache.NamedKey missingKey = new Cache.NamedKey("missing", HI);
     result = cache.getBulk(Collections.singletonList(missingKey));
-    Assert.assertEquals(result.size(), 0);
+    Assertions.assertEquals(result.size(), 0);
 
     result = cache.getBulk(new ArrayList<>());
-    Assert.assertEquals(result.size(), 0);
+    Assertions.assertEquals(result.size(), 0);
   }
 
   @Test
@@ -191,7 +191,7 @@ public class CaffeineCacheTest extends CacheTestBase<CaffeineCache>
     final Cache.NamedKey key2 = new Cache.NamedKey("the", s2);
     final CaffeineCache cache = CaffeineCache.create(config, Runnable::run);
 
-    Assert.assertEquals(0, cache.getCache().stats().evictionWeight());
+    Assertions.assertEquals(0, cache.getCache().stats().evictionWeight());
 
     // Two entries with combined weight exceeding the 40-byte maximum. Caffeine 3's W-TinyLFU
     // admission policy chooses which to keep based on frequency; we don't assert on identity,
@@ -200,12 +200,12 @@ public class CaffeineCacheTest extends CacheTestBase<CaffeineCache>
     cache.put(key2, val2);
     cache.getCache().cleanUp();
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
+        cache.getCache().stats().evictionWeight() > 0,
         "Expected eviction weight > 0 after exceeding max size, got "
-        + cache.getCache().stats().evictionWeight(),
-        cache.getCache().stats().evictionWeight() > 0
+        + cache.getCache().stats().evictionWeight()
     );
-    Assert.assertEquals(1, cache.getCache().asMap().size());
+    Assertions.assertEquals(1, cache.getCache().asMap().size());
   }
 
   @Test
@@ -229,20 +229,20 @@ public class CaffeineCacheTest extends CacheTestBase<CaffeineCache>
     final Cache cache = CaffeineCache.create(config, Runnable::run);
 
     CacheStats stats = cache.getStats();
-    Assert.assertEquals(0L, stats.getNumEntries());
-    Assert.assertEquals(0L, stats.getSizeInBytes());
+    Assertions.assertEquals(0L, stats.getNumEntries());
+    Assertions.assertEquals(0L, stats.getSizeInBytes());
 
     cache.put(key1, val1);
 
     stats = cache.getStats();
-    Assert.assertEquals(1L, stats.getNumEntries());
-    Assert.assertEquals(34L, stats.getSizeInBytes());
+    Assertions.assertEquals(1L, stats.getNumEntries());
+    Assertions.assertEquals(34L, stats.getSizeInBytes());
 
     cache.put(key2, val2);
 
     stats = cache.getStats();
-    Assert.assertEquals(1L, stats.getNumEntries());
-    Assert.assertEquals(34L, stats.getSizeInBytes());
+    Assertions.assertEquals(1L, stats.getNumEntries());
+    Assertions.assertEquals(34L, stats.getSizeInBytes());
   }
 
   @Test
@@ -274,25 +274,25 @@ public class CaffeineCacheTest extends CacheTestBase<CaffeineCache>
     final Cache cache = CaffeineCache.create(config, Runnable::run);
 
     CacheStats stats = cache.getStats();
-    Assert.assertEquals(0L, stats.getNumEntries());
-    Assert.assertEquals(0L, stats.getSizeInBytes());
+    Assertions.assertEquals(0L, stats.getNumEntries());
+    Assertions.assertEquals(0L, stats.getSizeInBytes());
 
     cache.put(key1, val1);
 
     stats = cache.getStats();
-    Assert.assertEquals(1L, stats.getNumEntries());
-    Assert.assertEquals(34L, stats.getSizeInBytes());
+    Assertions.assertEquals(1L, stats.getNumEntries());
+    Assertions.assertEquals(34L, stats.getSizeInBytes());
 
     cache.put(key2, val2);
 
     stats = cache.getStats();
-    Assert.assertEquals(2L, stats.getNumEntries());
-    Assert.assertEquals(68L, stats.getSizeInBytes());
+    Assertions.assertEquals(2L, stats.getNumEntries());
+    Assertions.assertEquals(68L, stats.getSizeInBytes());
 
     cache.close(namespace);
     stats = cache.getStats();
-    Assert.assertEquals(0, stats.getNumEntries());
-    Assert.assertEquals(0, stats.getSizeInBytes());
+    Assertions.assertEquals(0, stats.getNumEntries());
+    Assertions.assertEquals(0, stats.getSizeInBytes());
   }
 
 
@@ -317,20 +317,20 @@ public class CaffeineCacheTest extends CacheTestBase<CaffeineCache>
     final Cache cache = CaffeineCache.create(config, Runnable::run);
 
     CacheStats stats = cache.getStats();
-    Assert.assertEquals(0L, stats.getNumEntries());
-    Assert.assertEquals(0L, stats.getSizeInBytes());
+    Assertions.assertEquals(0L, stats.getNumEntries());
+    Assertions.assertEquals(0L, stats.getSizeInBytes());
 
     cache.put(key1, val1);
 
     stats = cache.getStats();
-    Assert.assertEquals(1L, stats.getNumEntries());
-    Assert.assertEquals(34L, stats.getSizeInBytes());
+    Assertions.assertEquals(1L, stats.getNumEntries());
+    Assertions.assertEquals(34L, stats.getSizeInBytes());
 
     cache.put(key2, val2);
 
     stats = cache.getStats();
-    Assert.assertEquals(2L, stats.getNumEntries());
-    Assert.assertEquals(68L, stats.getSizeInBytes());
+    Assertions.assertEquals(2L, stats.getNumEntries());
+    Assertions.assertEquals(68L, stats.getSizeInBytes());
   }
 
   @Test
@@ -354,20 +354,20 @@ public class CaffeineCacheTest extends CacheTestBase<CaffeineCache>
     final CaffeineCache cache = CaffeineCache.create(config, Runnable::run);
 
     CacheStats stats = cache.getStats();
-    Assert.assertEquals(0L, stats.getNumEntries());
-    Assert.assertEquals(0L, stats.getSizeInBytes());
+    Assertions.assertEquals(0L, stats.getNumEntries());
+    Assertions.assertEquals(0L, stats.getSizeInBytes());
 
     cache.put(key1, val1);
 
     stats = cache.getStats();
-    Assert.assertEquals(1L, stats.getNumEntries());
-    Assert.assertEquals(34L, stats.getSizeInBytes());
+    Assertions.assertEquals(1L, stats.getNumEntries());
+    Assertions.assertEquals(34L, stats.getSizeInBytes());
 
     cache.put(key2, val2);
 
     stats = cache.getStats();
-    Assert.assertEquals(2L, stats.getNumEntries());
-    Assert.assertEquals(68L, stats.getSizeInBytes());
+    Assertions.assertEquals(2L, stats.getNumEntries());
+    Assertions.assertEquals(68L, stats.getSizeInBytes());
   }
 
   @Test
@@ -396,9 +396,9 @@ public class CaffeineCacheTest extends CacheTestBase<CaffeineCache>
     );
     caffeineCacheConfigJsonConfigProvider.inject(properties, configurator);
     final CaffeineCacheConfig config = caffeineCacheConfigJsonConfigProvider.get();
-    Assert.assertEquals(10, config.getExpireAfter());
-    Assert.assertEquals(100, config.getSizeInBytes());
-    Assert.assertNotNull(config.createExecutor());
+    Assertions.assertEquals(10, config.getExpireAfter());
+    Assertions.assertEquals(100, config.getSizeInBytes());
+    Assertions.assertNotNull(config.createExecutor());
   }
 
   @Test
@@ -427,9 +427,9 @@ public class CaffeineCacheTest extends CacheTestBase<CaffeineCache>
     );
     caffeineCacheConfigJsonConfigProvider.inject(properties, configurator);
     final CaffeineCacheConfig config = caffeineCacheConfigJsonConfigProvider.get();
-    Assert.assertEquals(10, config.getExpireAfter());
-    Assert.assertEquals(100, config.getSizeInBytes());
-    Assert.assertEquals(ForkJoinPool.commonPool(), config.createExecutor());
+    Assertions.assertEquals(10, config.getExpireAfter());
+    Assertions.assertEquals(100, config.getSizeInBytes());
+    Assertions.assertEquals(ForkJoinPool.commonPool(), config.createExecutor());
   }
 
   @Test
@@ -455,9 +455,9 @@ public class CaffeineCacheTest extends CacheTestBase<CaffeineCache>
     );
     caffeineCacheConfigJsonConfigProvider.inject(properties, configurator);
     final CaffeineCacheConfig config = caffeineCacheConfigJsonConfigProvider.get();
-    Assert.assertEquals(-1, config.getExpireAfter());
-    Assert.assertEquals(-1L, config.getSizeInBytes());
-    Assert.assertEquals(ForkJoinPool.commonPool(), config.createExecutor());
+    Assertions.assertEquals(-1, config.getExpireAfter());
+    Assertions.assertEquals(-1L, config.getSizeInBytes());
+    Assertions.assertEquals(ForkJoinPool.commonPool(), config.createExecutor());
   }
 
   public int get(Cache cache, Cache.NamedKey key)

--- a/server/src/test/java/org/apache/druid/client/cache/HybridCacheTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/HybridCacheTest.java
@@ -32,8 +32,8 @@ import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.guice.annotations.Global;
 import org.apache.druid.initialization.Initialization;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -69,17 +69,17 @@ public class HybridCacheTest
         )
     );
     final CacheProvider cacheProvider = injector.getInstance(Key.get(CacheProvider.class, Global.class));
-    Assert.assertNotNull(cacheProvider);
-    Assert.assertEquals(HybridCacheProvider.class, cacheProvider.getClass());
+    Assertions.assertNotNull(cacheProvider);
+    Assertions.assertEquals(HybridCacheProvider.class, cacheProvider.getClass());
 
     final Cache cache = cacheProvider.get();
-    Assert.assertNotNull(cache);
+    Assertions.assertNotNull(cache);
 
-    Assert.assertFalse(cache.isLocal());
-    Assert.assertFalse(((HybridCacheProvider) cacheProvider).getUseL2());
-    Assert.assertTrue(((HybridCacheProvider) cacheProvider).getPopulateL2());
-    Assert.assertEquals(LocalCacheProvider.class, ((HybridCacheProvider) cacheProvider).level1.getClass());
-    Assert.assertEquals(MemcachedCacheProvider.class, ((HybridCacheProvider) cacheProvider).level2.getClass());
+    Assertions.assertFalse(cache.isLocal());
+    Assertions.assertFalse(((HybridCacheProvider) cacheProvider).getUseL2());
+    Assertions.assertTrue(((HybridCacheProvider) cacheProvider).getPopulateL2());
+    Assertions.assertEquals(LocalCacheProvider.class, ((HybridCacheProvider) cacheProvider).level1.getClass());
+    Assertions.assertEquals(MemcachedCacheProvider.class, ((HybridCacheProvider) cacheProvider).level2.getClass());
   }
 
   @Test
@@ -104,84 +104,84 @@ public class HybridCacheTest
 
     // test put puts to both
     cache.put(key1, value1);
-    Assert.assertEquals(value1, l1.get(key1));
-    Assert.assertEquals(value1, l2.get(key1));
-    Assert.assertEquals(value1, cache.get(key1));
+    Assertions.assertEquals(value1, l1.get(key1));
+    Assertions.assertEquals(value1, l2.get(key1));
+    Assertions.assertEquals(value1, cache.get(key1));
 
     int hits = 0;
-    Assert.assertEquals(0, cache.getStats().getNumMisses());
-    Assert.assertEquals(++hits, cache.getStats().getNumHits());
+    Assertions.assertEquals(0, cache.getStats().getNumMisses());
+    Assertions.assertEquals(++hits, cache.getStats().getNumHits());
 
     // test l1
     l1.put(key2, value2);
-    Assert.assertEquals(value2, cache.get(key2));
-    Assert.assertEquals(0, cache.getStats().getNumMisses());
-    Assert.assertEquals(++hits, cache.getStats().getNumHits());
+    Assertions.assertEquals(value2, cache.get(key2));
+    Assertions.assertEquals(0, cache.getStats().getNumMisses());
+    Assertions.assertEquals(++hits, cache.getStats().getNumHits());
 
     // test l2
     l2.put(key3, value3);
-    Assert.assertEquals(value3, cache.get(key3));
-    Assert.assertEquals(0, cache.getStats().getNumMisses());
-    Assert.assertEquals(++hits, cache.getStats().getNumHits());
+    Assertions.assertEquals(value3, cache.get(key3));
+    Assertions.assertEquals(0, cache.getStats().getNumMisses());
+    Assertions.assertEquals(++hits, cache.getStats().getNumHits());
 
 
     // test bulk get with l1 and l2
     {
       final HashSet<Cache.NamedKey> keys = Sets.newHashSet(key1, key2, key3);
       Map<Cache.NamedKey, byte[]> res = cache.getBulk(keys);
-      Assert.assertNotNull(res);
-      Assert.assertEquals(keys, res.keySet());
-      Assert.assertArrayEquals(value1, res.get(key1));
-      Assert.assertArrayEquals(value2, res.get(key2));
-      Assert.assertArrayEquals(value3, res.get(key3));
+      Assertions.assertNotNull(res);
+      Assertions.assertEquals(keys, res.keySet());
+      Assertions.assertArrayEquals(value1, res.get(key1));
+      Assertions.assertArrayEquals(value2, res.get(key2));
+      Assertions.assertArrayEquals(value3, res.get(key3));
 
       hits += 3;
-      Assert.assertEquals(0, cache.getStats().getNumMisses());
-      Assert.assertEquals(hits, cache.getStats().getNumHits());
+      Assertions.assertEquals(0, cache.getStats().getNumMisses());
+      Assertions.assertEquals(hits, cache.getStats().getNumHits());
     }
 
     // test bulk get with l1 entries only
     {
       final HashSet<Cache.NamedKey> keys = Sets.newHashSet(key1, key2);
       Map<Cache.NamedKey, byte[]> res = cache.getBulk(keys);
-      Assert.assertNotNull(res);
-      Assert.assertEquals(keys, res.keySet());
-      Assert.assertArrayEquals(value1, res.get(key1));
-      Assert.assertArrayEquals(value2, res.get(key2));
+      Assertions.assertNotNull(res);
+      Assertions.assertEquals(keys, res.keySet());
+      Assertions.assertArrayEquals(value1, res.get(key1));
+      Assertions.assertArrayEquals(value2, res.get(key2));
 
       hits += 2;
-      Assert.assertEquals(0, cache.getStats().getNumMisses());
-      Assert.assertEquals(hits, cache.getStats().getNumHits());
+      Assertions.assertEquals(0, cache.getStats().getNumMisses());
+      Assertions.assertEquals(hits, cache.getStats().getNumHits());
     }
 
     int misses = 0;
-    Assert.assertNull(cache.get(key4));
-    Assert.assertEquals(++misses, cache.getStats().getNumMisses());
+    Assertions.assertNull(cache.get(key4));
+    Assertions.assertEquals(++misses, cache.getStats().getNumMisses());
 
-    Assert.assertTrue(cache.getBulk(Sets.newHashSet(key4)).isEmpty());
-    Assert.assertEquals(++misses, cache.getStats().getNumMisses());
+    Assertions.assertTrue(cache.getBulk(Sets.newHashSet(key4)).isEmpty());
+    Assertions.assertEquals(++misses, cache.getStats().getNumMisses());
 
     {
       final Map<Cache.NamedKey, byte[]> res = cache.getBulk(Sets.newHashSet(key1, key4));
-      Assert.assertEquals(Sets.newHashSet(key1), res.keySet());
-      Assert.assertArrayEquals(value1, res.get(key1));
+      Assertions.assertEquals(Sets.newHashSet(key1), res.keySet());
+      Assertions.assertArrayEquals(value1, res.get(key1));
 
-      Assert.assertEquals(++hits, cache.getStats().getNumHits());
-      Assert.assertEquals(++misses, cache.getStats().getNumMisses());
+      Assertions.assertEquals(++hits, cache.getStats().getNumHits());
+      Assertions.assertEquals(++misses, cache.getStats().getNumMisses());
     }
 
     {
       final Map<Cache.NamedKey, byte[]> res = cache.getBulk(Sets.newHashSet(key3, key4));
-      Assert.assertEquals(Sets.newHashSet(key3), res.keySet());
-      Assert.assertArrayEquals(value3, res.get(key3));
+      Assertions.assertEquals(Sets.newHashSet(key3), res.keySet());
+      Assertions.assertArrayEquals(value3, res.get(key3));
 
-      Assert.assertEquals(hits + 1, cache.getStats().getNumHits());
-      Assert.assertEquals(misses + 1, cache.getStats().getNumMisses());
+      Assertions.assertEquals(hits + 1, cache.getStats().getNumHits());
+      Assertions.assertEquals(misses + 1, cache.getStats().getNumMisses());
     }
 
     // test close
     cache.close();
-    Assert.assertEquals("l1 size after close()", 0, l1Map.size());
-    Assert.assertEquals("l2 size after close()", 0, l2Map.size());
+    Assertions.assertEquals(0, l1Map.size(), "l1 size after close()");
+    Assertions.assertEquals(0, l2Map.size(), "l2 size after close()");
   }
 }

--- a/server/src/test/java/org/apache/druid/client/cache/MapCacheTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/MapCacheTest.java
@@ -21,9 +21,9 @@ package org.apache.druid.client.cache;
 
 import com.google.common.primitives.Ints;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  */
@@ -33,7 +33,7 @@ public class MapCacheTest extends CacheTestBase<MapCache>
   private static final byte[] HO = StringUtils.toUtf8("ho");
   private ByteCountingLRUMap baseMap;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     baseMap = new ByteCountingLRUMap(1024 * 1024);
@@ -43,32 +43,32 @@ public class MapCacheTest extends CacheTestBase<MapCache>
   @Test
   public void testSanity()
   {
-    Assert.assertNull(cache.get(new Cache.NamedKey("a", HI)));
-    Assert.assertEquals(0, baseMap.size());
+    Assertions.assertNull(cache.get(new Cache.NamedKey("a", HI)));
+    Assertions.assertEquals(0, baseMap.size());
     put(cache, "a", HI, 1);
-    Assert.assertEquals(1, baseMap.size());
-    Assert.assertEquals(1, get(cache, "a", HI));
-    Assert.assertNull(cache.get(new Cache.NamedKey("the", HI)));
+    Assertions.assertEquals(1, baseMap.size());
+    Assertions.assertEquals(1, get(cache, "a", HI));
+    Assertions.assertNull(cache.get(new Cache.NamedKey("the", HI)));
 
     put(cache, "the", HI, 2);
-    Assert.assertEquals(2, baseMap.size());
-    Assert.assertEquals(1, get(cache, "a", HI));
-    Assert.assertEquals(2, get(cache, "the", HI));
+    Assertions.assertEquals(2, baseMap.size());
+    Assertions.assertEquals(1, get(cache, "a", HI));
+    Assertions.assertEquals(2, get(cache, "the", HI));
 
     put(cache, "the", HO, 10);
-    Assert.assertEquals(3, baseMap.size());
-    Assert.assertEquals(1, get(cache, "a", HI));
-    Assert.assertNull(cache.get(new Cache.NamedKey("a", HO)));
-    Assert.assertEquals(2, get(cache, "the", HI));
-    Assert.assertEquals(10, get(cache, "the", HO));
+    Assertions.assertEquals(3, baseMap.size());
+    Assertions.assertEquals(1, get(cache, "a", HI));
+    Assertions.assertNull(cache.get(new Cache.NamedKey("a", HO)));
+    Assertions.assertEquals(2, get(cache, "the", HI));
+    Assertions.assertEquals(10, get(cache, "the", HO));
 
     cache.close("the");
-    Assert.assertEquals(1, baseMap.size());
-    Assert.assertEquals(1, get(cache, "a", HI));
-    Assert.assertNull(cache.get(new Cache.NamedKey("a", HO)));
+    Assertions.assertEquals(1, baseMap.size());
+    Assertions.assertEquals(1, get(cache, "a", HI));
+    Assertions.assertNull(cache.get(new Cache.NamedKey("a", HO)));
 
     cache.close("a");
-    Assert.assertEquals(0, baseMap.size());
+    Assertions.assertEquals(0, baseMap.size());
   }
 
   public void put(Cache cache, String namespace, byte[] key, Integer value)

--- a/server/src/test/java/org/apache/druid/client/cache/MemcacheClientPoolTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/MemcacheClientPoolTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.client.cache;
 
 import com.google.common.base.Suppliers;
 import net.spy.memcached.MemcachedClientIF;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class MemcacheClientPoolTest
 {
@@ -33,20 +33,20 @@ public class MemcacheClientPoolTest
     MemcacheClientPool pool = new MemcacheClientPool(3, Suppliers.ofInstance((MemcachedClientIF) null));
     // First round
     MemcacheClientPool.IdempotentCloseableHolder first = pool.get();
-    Assert.assertEquals(1, first.count());
+    Assertions.assertEquals(1, first.count());
     MemcacheClientPool.IdempotentCloseableHolder second = pool.get();
-    Assert.assertEquals(1, second.count());
+    Assertions.assertEquals(1, second.count());
     MemcacheClientPool.IdempotentCloseableHolder third = pool.get();
-    Assert.assertEquals(1, third.count());
+    Assertions.assertEquals(1, third.count());
     // Second round
     MemcacheClientPool.IdempotentCloseableHolder firstClientSecondRound = pool.get();
-    Assert.assertEquals(2, firstClientSecondRound.count());
+    Assertions.assertEquals(2, firstClientSecondRound.count());
     MemcacheClientPool.IdempotentCloseableHolder secondClientSecondRound = pool.get();
-    Assert.assertEquals(2, secondClientSecondRound.count());
+    Assertions.assertEquals(2, secondClientSecondRound.count());
     first.close();
     firstClientSecondRound.close();
     MemcacheClientPool.IdempotentCloseableHolder firstAgain = pool.get();
-    Assert.assertEquals(1, firstAgain.count());
+    Assertions.assertEquals(1, firstAgain.count());
     
     firstAgain.close();
     second.close();
@@ -65,7 +65,7 @@ public class MemcacheClientPoolTest
       byte[] garbage = new byte[10_000_000];
       Thread.sleep(10);
     }
-    Assert.assertEquals(initialLeakedClients + 1, MemcacheClientPool.leakedClients());
+    Assertions.assertEquals(initialLeakedClients + 1, MemcacheClientPool.leakedClients());
   }
 
   private void createDanglingClient()

--- a/server/src/test/java/org/apache/druid/client/cache/MemcachedCacheTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/MemcachedCacheTest.java
@@ -56,9 +56,9 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.metrics.AbstractMonitor;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.SocketAddress;
 import java.security.KeyManagementException;
@@ -119,7 +119,7 @@ public class MemcachedCacheTest extends CacheTestBase<MemcachedCache>
     }
   };
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     cache = new MemcachedCache(
@@ -163,7 +163,7 @@ public class MemcachedCacheTest extends CacheTestBase<MemcachedCache>
     lifecycle.start();
     try {
       Cache cache = injector.getInstance(Cache.class);
-      Assert.assertEquals(MemcachedCache.class, cache.getClass());
+      Assertions.assertEquals(MemcachedCache.class, cache.getClass());
     }
     finally {
       lifecycle.stop();
@@ -194,8 +194,8 @@ public class MemcachedCacheTest extends CacheTestBase<MemcachedCache>
         )
     );
     final CacheProvider memcachedCacheProvider = injector.getInstance(CacheProvider.class);
-    Assert.assertNotNull(memcachedCacheProvider);
-    Assert.assertEquals(MemcachedCacheProvider.class, memcachedCacheProvider.getClass());
+    Assertions.assertNotNull(memcachedCacheProvider);
+    Assertions.assertEquals(MemcachedCacheProvider.class, memcachedCacheProvider.getClass());
   }
 
   @Test
@@ -209,8 +209,8 @@ public class MemcachedCacheTest extends CacheTestBase<MemcachedCache>
       cache.doMonitor(serviceEmitter);
     }
 
-    Assert.assertTrue(serviceEmitter.getNumEmittedEvents() > 0);
-    Assert.assertFalse(serviceEmitter.getMetricEvents("query/cache/memcached/total").isEmpty());
+    Assertions.assertTrue(serviceEmitter.getNumEmittedEvents() > 0);
+    Assertions.assertFalse(serviceEmitter.getMetricEvents("query/cache/memcached/total").isEmpty());
   }
 
   @Test
@@ -218,8 +218,8 @@ public class MemcachedCacheTest extends CacheTestBase<MemcachedCache>
   {
     ConnectionFactory connectionFactory = MemcachedCache.createConnectionFactory(memcachedCacheConfig, null, null, null);
     // Ensure that clientMode is set to Static by default
-    Assert.assertEquals(connectionFactory.getClientMode(), ClientMode.Static);
-    Assert.assertNull(connectionFactory.getSSLContext());
+    Assertions.assertEquals(connectionFactory.getClientMode(), ClientMode.Static);
+    Assertions.assertNull(connectionFactory.getSSLContext());
   }
   @Test
   public void testConnectionFactory() throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException
@@ -246,11 +246,11 @@ public class MemcachedCacheTest extends CacheTestBase<MemcachedCache>
     // Dynamic mode
     ConnectionFactory connectionFactoryDynamic = MemcachedCache.createConnectionFactory(config, null, null, null);
     // Ensure client mode is set to the value passed in config.
-    Assert.assertEquals(connectionFactoryDynamic.getClientMode(), ClientMode.Dynamic);
+    Assertions.assertEquals(connectionFactoryDynamic.getClientMode(), ClientMode.Dynamic);
     //enableTls is true so sslContext is not null
-    Assert.assertNotNull(connectionFactoryDynamic.getSSLContext());
+    Assertions.assertNotNull(connectionFactoryDynamic.getSSLContext());
     // Ensure Protocol is TLSv1.2
-    Assert.assertEquals("TLSv1.2", connectionFactoryDynamic.getSSLContext().getProtocol());
+    Assertions.assertEquals("TLSv1.2", connectionFactoryDynamic.getSSLContext().getProtocol());
   }
 
   @Test
@@ -265,32 +265,31 @@ public class MemcachedCacheTest extends CacheTestBase<MemcachedCache>
         return "invalid-name";
       }
     };
-    RuntimeException exception = Assert.assertThrows(RuntimeException.class, () -> {
-      MemcachedCache.createConnectionFactory(config, null, null, null);
-    });
-    Assert.assertEquals(exception.getMessage(), "Invalid value provided for `druid.cache.clientMode`. Value must be 'static' or 'dynamic'.");
+    RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () ->
+      MemcachedCache.createConnectionFactory(config, null, null, null));
+    Assertions.assertEquals(exception.getMessage(), "Invalid value provided for `druid.cache.clientMode`. Value must be 'static' or 'dynamic'.");
   }
   @Test
   public void testSanity()
   {
-    Assert.assertNull(cache.get(new Cache.NamedKey("a", HI)));
+    Assertions.assertNull(cache.get(new Cache.NamedKey("a", HI)));
     put(cache, "a", HI, 1);
-    Assert.assertEquals(1, get(cache, "a", HI));
-    Assert.assertNull(cache.get(new Cache.NamedKey("the", HI)));
+    Assertions.assertEquals(1, get(cache, "a", HI));
+    Assertions.assertNull(cache.get(new Cache.NamedKey("the", HI)));
 
     put(cache, "the", HI, 2);
-    Assert.assertEquals(1, get(cache, "a", HI));
-    Assert.assertEquals(2, get(cache, "the", HI));
+    Assertions.assertEquals(1, get(cache, "a", HI));
+    Assertions.assertEquals(2, get(cache, "the", HI));
 
     put(cache, "the", HO, 10);
-    Assert.assertEquals(1, get(cache, "a", HI));
-    Assert.assertNull(cache.get(new Cache.NamedKey("a", HO)));
-    Assert.assertEquals(2, get(cache, "the", HI));
-    Assert.assertEquals(10, get(cache, "the", HO));
+    Assertions.assertEquals(1, get(cache, "a", HI));
+    Assertions.assertNull(cache.get(new Cache.NamedKey("a", HO)));
+    Assertions.assertEquals(2, get(cache, "the", HI));
+    Assertions.assertEquals(10, get(cache, "the", HO));
 
     cache.close("the");
-    Assert.assertEquals(1, get(cache, "a", HI));
-    Assert.assertNull(cache.get(new Cache.NamedKey("a", HO)));
+    Assertions.assertEquals(1, get(cache, "a", HI));
+    Assertions.assertNull(cache.get(new Cache.NamedKey("a", HO)));
 
     cache.close("a");
   }
@@ -298,7 +297,7 @@ public class MemcachedCacheTest extends CacheTestBase<MemcachedCache>
   @Test
   public void testGetBulk()
   {
-    Assert.assertNull(cache.get(new Cache.NamedKey("the", HI)));
+    Assertions.assertNull(cache.get(new Cache.NamedKey("the", HI)));
 
     put(cache, "the", HI, 2);
     put(cache, "the", HO, 10);
@@ -313,8 +312,8 @@ public class MemcachedCacheTest extends CacheTestBase<MemcachedCache>
         )
     );
 
-    Assert.assertEquals(2, Ints.fromByteArray(result.get(key1)));
-    Assert.assertEquals(10, Ints.fromByteArray(result.get(key2)));
+    Assertions.assertEquals(2, Ints.fromByteArray(result.get(key1)));
+    Assertions.assertEquals(10, Ints.fromByteArray(result.get(key2)));
   }
 
   public void put(Cache cache, String namespace, byte[] key, Integer value)

--- a/server/src/test/java/org/apache/druid/client/client/ImmutableSegmentLoadInfoTest.java
+++ b/server/src/test/java/org/apache/druid/client/client/ImmutableSegmentLoadInfoTest.java
@@ -21,7 +21,6 @@ package org.apache.druid.client.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
-import junit.framework.Assert;
 import org.apache.druid.client.ImmutableSegmentLoadInfo;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.segment.TestHelper;
@@ -29,7 +28,8 @@ import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -58,7 +58,7 @@ public class ImmutableSegmentLoadInfoTest
         ImmutableSegmentLoadInfo.class
     );
 
-    Assert.assertEquals(segmentLoadInfo, serde);
+    Assertions.assertEquals(segmentLoadInfo, serde);
   }
 
 }

--- a/server/src/test/java/org/apache/druid/client/coordinator/CoordinatorClientImplTest.java
+++ b/server/src/test/java/org/apache/druid/client/coordinator/CoordinatorClientImplTest.java
@@ -67,13 +67,14 @@ import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -117,7 +118,7 @@ public class CoordinatorClientImplTest
                                                          .size(1)
                                                          .build();
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     jsonMapper = new DefaultObjectMapper();
@@ -132,7 +133,7 @@ public class CoordinatorClientImplTest
     coordinatorClient = new CoordinatorClientImpl(serviceClient, jsonMapper);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     serviceClient.verify();
@@ -154,7 +155,7 @@ public class CoordinatorClientImplTest
         StringUtils.toUtf8("true")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         true,
         coordinatorClient.isHandoffComplete(
             "xyz",
@@ -185,7 +186,7 @@ public class CoordinatorClientImplTest
         jsonMapper.writeValueAsBytes(segment)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         segment,
         coordinatorClient.fetchSegment("xyz", "def", false).get()
     );
@@ -213,7 +214,7 @@ public class CoordinatorClientImplTest
         jsonMapper.writeValueAsBytes(segment)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         segment,
         coordinatorClient.fetchSegment("xyz", "def", true).get()
     );
@@ -240,7 +241,7 @@ public class CoordinatorClientImplTest
         jsonMapper.writeValueAsBytes(Collections.singletonList(segment))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singletonList(segment),
         coordinatorClient.fetchUsedSegments("xyz", intervals).get()
     );
@@ -259,11 +260,11 @@ public class CoordinatorClientImplTest
     );
 
     final ListenableFuture<BootstrapSegmentsResponse> response = coordinatorClient.fetchBootstrapSegments();
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     final ImmutableList<DataSegment> observedDataSegments = ImmutableList.copyOf(response.get().getIterator());
     for (int idx = 0; idx < expectedSegments.size(); idx++) {
-      Assert.assertEquals(expectedSegments.get(idx).getLoadSpec(), observedDataSegments.get(idx).getLoadSpec());
+      Assertions.assertEquals(expectedSegments.get(idx).getLoadSpec(), observedDataSegments.get(idx).getLoadSpec());
     }
   }
 
@@ -292,12 +293,12 @@ public class CoordinatorClientImplTest
     );
 
     final ListenableFuture<BootstrapSegmentsResponse> response = coordinatorClient.fetchBootstrapSegments();
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
     final ImmutableList<DataSegment> observedDataSegments = ImmutableList.copyOf(response.get().getIterator());
-    Assert.assertEquals(expectedSegments, observedDataSegments);
+    Assertions.assertEquals(expectedSegments, observedDataSegments);
     for (int idx = 0; idx < expectedSegments.size(); idx++) {
-      Assert.assertEquals(expectedSegments.get(idx).getLoadSpec(), observedDataSegments.get(idx).getLoadSpec());
+      Assertions.assertEquals(expectedSegments.get(idx).getLoadSpec(), observedDataSegments.get(idx).getLoadSpec());
     }
   }
 
@@ -314,9 +315,9 @@ public class CoordinatorClientImplTest
     );
 
     final ListenableFuture<BootstrapSegmentsResponse> response = coordinatorClient.fetchBootstrapSegments();
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         segments,
         ImmutableList.copyOf(response.get().getIterator())
     );
@@ -343,7 +344,7 @@ public class CoordinatorClientImplTest
         jsonMapper.writeValueAsBytes(Collections.singletonList(fooInfo))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singletonList(fooInfo),
         coordinatorClient.fetchDataSourceInformation(Collections.singleton(foo)).get()
     );
@@ -417,7 +418,7 @@ public class CoordinatorClientImplTest
     List<ImmutableSegmentLoadInfo> segmentLoadInfoList =
         ImmutableList.of(immutableSegmentLoadInfo1, immutableSegmentLoadInfo2);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         segmentLoadInfoList,
         coordinatorClient.fetchServerViewSegments("xyz", intervals)
     );
@@ -442,7 +443,7 @@ public class CoordinatorClientImplTest
         DefaultObjectMapper.INSTANCE.writeValueAsBytes(new CompactionStatusResponse(compactionSnapshots))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new CompactionStatusResponse(compactionSnapshots),
         coordinatorClient.getCompactionSnapshots(null).get()
     );
@@ -461,7 +462,7 @@ public class CoordinatorClientImplTest
         DefaultObjectMapper.INSTANCE.writeValueAsBytes(new CompactionStatusResponse(compactionSnapshots))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new CompactionStatusResponse(compactionSnapshots),
         coordinatorClient.getCompactionSnapshots("ds1").get()
     );
@@ -487,7 +488,7 @@ public class CoordinatorClientImplTest
         DefaultObjectMapper.INSTANCE.writeValueAsBytes(config)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         config,
         coordinatorClient.getCoordinatorDynamicConfig().get()
     );
@@ -511,7 +512,7 @@ public class CoordinatorClientImplTest
         DefaultObjectMapper.INSTANCE.writeValueAsBytes(null)
     );
 
-    Assert.assertNull(coordinatorClient.updateCoordinatorDynamicConfig(config).get());
+    Assertions.assertNull(coordinatorClient.updateCoordinatorDynamicConfig(config).get());
   }
 
   @Test
@@ -525,7 +526,7 @@ public class CoordinatorClientImplTest
         DefaultObjectMapper.INSTANCE.writeValueAsBytes(null)
     );
 
-    Assert.assertNull(coordinatorClient.updateAllLookups(Map.of()).get());
+    Assertions.assertNull(coordinatorClient.updateAllLookups(Map.of()).get());
   }
 
   @Test
@@ -553,7 +554,7 @@ public class CoordinatorClientImplTest
         DefaultObjectMapper.INSTANCE.writeValueAsBytes(lookups)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         lookups,
         coordinatorClient.fetchLookupsForTierSync("default_tier")
     );
@@ -582,7 +583,7 @@ public class CoordinatorClientImplTest
     while (iterator.hasNext()) {
       actualSegments.add(iterator.next());
     }
-    Assert.assertEquals(
+    Assertions.assertEquals(
         segments,
         actualSegments.stream()
                       .map(SegmentStatusInCluster::getDataSegment)
@@ -613,7 +614,7 @@ public class CoordinatorClientImplTest
     while (iterator.hasNext()) {
       actualSegments.add(iterator.next());
     }
-    Assert.assertEquals(
+    Assertions.assertEquals(
         segments,
         actualSegments.stream()
                       .map(SegmentStatusInCluster::getDataSegment)
@@ -643,7 +644,7 @@ public class CoordinatorClientImplTest
     while (iterator.hasNext()) {
       actualSegments.add(iterator.next());
     }
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(SEGMENT3),
         actualSegments.stream()
                       .map(SegmentStatusInCluster::getDataSegment)
@@ -674,7 +675,7 @@ public class CoordinatorClientImplTest
     while (iterator.hasNext()) {
       actualSegments.add(iterator.next());
     }
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(SEGMENT1, SEGMENT2, SEGMENT3),
         actualSegments.stream()
                       .map(SegmentStatusInCluster::getDataSegment)
@@ -704,7 +705,7 @@ public class CoordinatorClientImplTest
     while (iterator.hasNext()) {
       actualSegments.add(iterator.next());
     }
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(SEGMENT3),
         actualSegments.stream()
                       .map(SegmentStatusInCluster::getDataSegment)
@@ -738,7 +739,7 @@ public class CoordinatorClientImplTest
         jsonMapper.writeValueAsBytes(rules)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         rules,
         coordinatorClient.getRulesForAllDatasources().get()
     );
@@ -755,7 +756,7 @@ public class CoordinatorClientImplTest
         StringUtils.toUtf8(leaderUrl)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         leaderUrl,
         FutureUtils.getUnchecked(coordinatorClient.findCurrentLeader(), true).toString()
     );
@@ -771,7 +772,7 @@ public class CoordinatorClientImplTest
         ImmutableMap.of(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN),
         StringUtils.toUtf8(invalidLeaderUrl)
     );
-    Assert.assertThrows(
+    Assertions.assertThrows(
         RuntimeException.class,
         () -> FutureUtils.getUnchecked(coordinatorClient.findCurrentLeader(), true)
     );
@@ -785,7 +786,7 @@ public class CoordinatorClientImplTest
         new RuntimeException("Simulated runtime error")
     );
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         RuntimeException.class,
         () -> FutureUtils.getUnchecked(coordinatorClient.findCurrentLeader(), true)
     );
@@ -809,7 +810,7 @@ public class CoordinatorClientImplTest
     }
     catch (Exception e) {
       Throwable throwable = Throwables.getRootCause(e);
-      Assert.assertTrue(throwable instanceof HttpResponseException);
+      Assertions.assertTrue(throwable instanceof HttpResponseException);
     }
   }
 
@@ -832,7 +833,7 @@ public class CoordinatorClientImplTest
         jsonMapper.writeValueAsBytes(null)
     );
 
-    Assert.assertNull(coordinatorClient.updateRulesForDatasource("xyz", rules).get());
+    Assertions.assertNull(coordinatorClient.updateRulesForDatasource("xyz", rules).get());
   }
 
   @Test
@@ -850,7 +851,7 @@ public class CoordinatorClientImplTest
         ImmutableMap.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON),
         jsonMapper.writeValueAsBytes(brokerDynamicConfig)
     );
-    Assert.assertEquals(brokerDynamicConfig, coordinatorClient.getBrokerDynamicConfig().get());
+    Assertions.assertEquals(brokerDynamicConfig, coordinatorClient.getBrokerDynamicConfig().get());
   }
 
   @Test
@@ -865,6 +866,6 @@ public class CoordinatorClientImplTest
             )
         )
     );
-    Assert.assertEquals(BrokerDynamicConfig.builder().build(), coordinatorClient.getBrokerDynamicConfig().get());
+    Assertions.assertEquals(BrokerDynamicConfig.builder().build(), coordinatorClient.getBrokerDynamicConfig().get());
   }
 }

--- a/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionIntervalSpecTest.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionIntervalSpecTest.java
@@ -33,8 +33,8 @@ import org.apache.druid.server.compaction.CompactionStatus;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -81,7 +81,7 @@ public class ClientCompactionIntervalSpecTest
   {
     // The umbrella interval of segments is 2015-02-12/2015-04-14
     CompactionCandidate actual = CompactionCandidate.from(ImmutableList.of(dataSegment1, dataSegment2, dataSegment3), null, CompactionStatus.running(""));
-    Assert.assertEquals(Intervals.of("2015-02-12/2015-04-14"), actual.getCompactionInterval());
+    Assertions.assertEquals(Intervals.of("2015-02-12/2015-04-14"), actual.getCompactionInterval());
   }
 
   @Test
@@ -89,7 +89,7 @@ public class ClientCompactionIntervalSpecTest
   {
     // The umbrella interval of segments is 2015-04-11/2015-04-12
     CompactionCandidate actual = CompactionCandidate.from(ImmutableList.of(dataSegment1), Granularities.DAY, CompactionStatus.running(""));
-    Assert.assertEquals(Intervals.of("2015-04-11/2015-04-12"), actual.getCompactionInterval());
+    Assertions.assertEquals(Intervals.of("2015-04-11/2015-04-12"), actual.getCompactionInterval());
   }
 
   @Test
@@ -98,7 +98,7 @@ public class ClientCompactionIntervalSpecTest
     // The umbrella interval of segments is 2015-02-12/2015-04-14
     CompactionCandidate actual = CompactionCandidate.from(ImmutableList.of(dataSegment1, dataSegment2, dataSegment3), Granularities.YEAR, CompactionStatus.running(""));
     // The compaction interval should be expanded to start of the year and end of the year to cover the segmentGranularity
-    Assert.assertEquals(Intervals.of("2015-01-01/2016-01-01"), actual.getCompactionInterval());
+    Assertions.assertEquals(Intervals.of("2015-01-01/2016-01-01"), actual.getCompactionInterval());
   }
 
   @Test
@@ -107,7 +107,7 @@ public class ClientCompactionIntervalSpecTest
     // The umbrella interval of segments is 2015-02-12/2015-04-14
     CompactionCandidate actual = CompactionCandidate.from(ImmutableList.of(dataSegment1, dataSegment2, dataSegment3), Granularities.DAY, CompactionStatus.running(""));
     // The segmentGranularity of DAY align with the umbrella interval (umbrella interval can be evenly divide into the segmentGranularity)
-    Assert.assertEquals(Intervals.of("2015-02-12/2015-04-14"), actual.getCompactionInterval());
+    Assertions.assertEquals(Intervals.of("2015-02-12/2015-04-14"), actual.getCompactionInterval());
   }
 
   @Test
@@ -117,14 +117,14 @@ public class ClientCompactionIntervalSpecTest
     CompactionCandidate actual = CompactionCandidate.from(ImmutableList.of(dataSegment1, dataSegment2, dataSegment3), Granularities.WEEK, CompactionStatus.running(""));
     // The segmentGranularity of WEEK does not align with the umbrella interval (umbrella interval cannot be evenly divide into the segmentGranularity)
     // Hence the compaction interval is modified to aling with the segmentGranularity
-    Assert.assertEquals(Intervals.of("2015-02-09/2015-04-20"), actual.getCompactionInterval());
+    Assertions.assertEquals(Intervals.of("2015-02-09/2015-04-20"), actual.getCompactionInterval());
   }
 
   @Test
   public void testClientMinorCompactionInputSpec_throwsException_whenEmptySegmentsList()
   {
     Interval interval = Intervals.of("2015-04-11/2015-04-12");
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> new ClientMinorCompactionInputSpec(interval, null)
     );
@@ -140,7 +140,7 @@ public class ClientCompactionIntervalSpecTest
     ClientCompactionIntervalSpec withoutSegments = new ClientCompactionIntervalSpec(interval, null);
     String json2 = mapper.writeValueAsString(withoutSegments);
     ClientCompactionIntervalSpec deserialized2 = mapper.readValue(json2, ClientCompactionIntervalSpec.class);
-    Assert.assertEquals(withoutSegments, deserialized2);
+    Assertions.assertEquals(withoutSegments, deserialized2);
   }
 
   @Test
@@ -156,8 +156,8 @@ public class ClientCompactionIntervalSpecTest
     ClientCompactionInputSpec withSegments = new ClientMinorCompactionInputSpec(interval, segments);
     String json1 = mapper.writeValueAsString(withSegments);
     ClientCompactionInputSpec deserialized1 = mapper.readValue(json1, ClientCompactionIntervalSpec.class);
-    Assert.assertTrue(deserialized1 instanceof ClientMinorCompactionInputSpec);
-    Assert.assertEquals(withSegments, deserialized1);
-    Assert.assertEquals(segments, ((ClientMinorCompactionInputSpec) deserialized1).getSegments());
+    Assertions.assertTrue(deserialized1 instanceof ClientMinorCompactionInputSpec);
+    Assertions.assertEquals(withSegments, deserialized1);
+    Assertions.assertEquals(segments, ((ClientMinorCompactionInputSpec) deserialized1).getSegments());
   }
 }

--- a/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionRunnerInfoTest.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionRunnerInfoTest.java
@@ -46,10 +46,11 @@ import org.apache.druid.server.coordinator.UserCompactionTaskGranularityConfig;
 import org.apache.druid.server.coordinator.UserCompactionTaskQueryTuningConfig;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -70,8 +71,8 @@ public class ClientCompactionRunnerInfoTest
         compactionConfig,
         CompactionEngine.NATIVE
     );
-    Assert.assertFalse(validationResult.isValid());
-    Assert.assertEquals(
+    Assertions.assertFalse(validationResult.isValid());
+    Assertions.assertEquals(
         "MSQ: Invalid partitioning type[HashedPartitionsSpec]. Must be either 'dynamic' or 'range'",
         validationResult.getReason()
     );
@@ -91,8 +92,8 @@ public class ClientCompactionRunnerInfoTest
         compactionConfig,
         CompactionEngine.NATIVE
     );
-    Assert.assertFalse(validationResult.isValid());
-    Assert.assertEquals(
+    Assertions.assertFalse(validationResult.isValid());
+    Assertions.assertEquals(
         "MSQ: 'maxTotalRows' not supported with 'dynamic' partitioning",
         validationResult.getReason()
     );
@@ -112,8 +113,8 @@ public class ClientCompactionRunnerInfoTest
         compactionConfig,
         CompactionEngine.NATIVE
     );
-    Assert.assertFalse(validationResult.isValid());
-    Assert.assertEquals(
+    Assertions.assertFalse(validationResult.isValid());
+    Assertions.assertEquals(
         "MSQ: tuningConfig.partitionsSpec must be specified",
         validationResult.getReason()
     );
@@ -129,7 +130,7 @@ public class ClientCompactionRunnerInfoTest
         null,
         null
     );
-    Assert.assertTrue(ClientCompactionRunnerInfo.validateCompactionConfig(compactionConfig, CompactionEngine.NATIVE)
+    Assertions.assertTrue(ClientCompactionRunnerInfo.validateCompactionConfig(compactionConfig, CompactionEngine.NATIVE)
                                          .isValid());
   }
 
@@ -143,7 +144,7 @@ public class ClientCompactionRunnerInfoTest
         null,
         null
     );
-    Assert.assertTrue(ClientCompactionRunnerInfo.validateCompactionConfig(compactionConfig, CompactionEngine.NATIVE)
+    Assertions.assertTrue(ClientCompactionRunnerInfo.validateCompactionConfig(compactionConfig, CompactionEngine.NATIVE)
                                          .isValid());
   }
 
@@ -161,8 +162,8 @@ public class ClientCompactionRunnerInfoTest
         compactionConfig,
         CompactionEngine.NATIVE
     );
-    Assert.assertFalse(validationResult.isValid());
-    Assert.assertEquals(
+    Assertions.assertFalse(validationResult.isValid());
+    Assertions.assertEquals(
         "MSQ: Non-string partition dimension[partitionDim] of type[LONG] not supported with 'range' partition spec",
         validationResult.getReason()
     );
@@ -178,7 +179,7 @@ public class ClientCompactionRunnerInfoTest
         null,
         null
     );
-    Assert.assertTrue(ClientCompactionRunnerInfo.validateCompactionConfig(compactionConfig, CompactionEngine.NATIVE)
+    Assertions.assertTrue(ClientCompactionRunnerInfo.validateCompactionConfig(compactionConfig, CompactionEngine.NATIVE)
                                           .isValid());
   }
 
@@ -196,8 +197,8 @@ public class ClientCompactionRunnerInfoTest
         compactionConfig,
         CompactionEngine.NATIVE
     );
-    Assert.assertFalse(validationResult.isValid());
-    Assert.assertEquals(
+    Assertions.assertFalse(validationResult.isValid());
+    Assertions.assertEquals(
         "MSQ: 'granularitySpec.rollup' must be true if and only if 'metricsSpec' is specified",
         validationResult.getReason()
     );
@@ -217,8 +218,8 @@ public class ClientCompactionRunnerInfoTest
         compactionConfig,
         CompactionEngine.NATIVE
     );
-    Assert.assertFalse(validationResult.isValid());
-    Assert.assertEquals(
+    Assertions.assertFalse(validationResult.isValid());
+    Assertions.assertEquals(
         "MSQ: 'granularitySpec.rollup' must be true if and only if 'metricsSpec' is specified",
         validationResult.getReason()
     );
@@ -241,8 +242,8 @@ public class ClientCompactionRunnerInfoTest
         compactionConfig,
         CompactionEngine.NATIVE
     );
-    Assert.assertFalse(validationResult.isValid());
-    Assert.assertEquals(
+    Assertions.assertFalse(validationResult.isValid());
+    Assertions.assertEquals(
         "MSQ: Aggregator[sum_added] not supported in 'metricsSpec'",
         validationResult.getReason()
     );
@@ -262,8 +263,8 @@ public class ClientCompactionRunnerInfoTest
         compactionConfig,
         CompactionEngine.NATIVE
     );
-    Assert.assertFalse(validationResult.isValid());
-    Assert.assertEquals(
+    Assertions.assertFalse(validationResult.isValid());
+    Assertions.assertEquals(
         "MSQ: 'granularitySpec.rollup' must be true if and only if 'metricsSpec' is specified",
         validationResult.getReason()
     );
@@ -273,7 +274,7 @@ public class ClientCompactionRunnerInfoTest
   public void testMSQEngineWithBaseTableIsValid()
   {
     DataSourceCompactionConfig compactionConfig = createBaseTableCompactionConfig(CompactionEngine.MSQ);
-    Assert.assertTrue(
+    Assertions.assertTrue(
         ClientCompactionRunnerInfo.validateCompactionConfig(compactionConfig, CompactionEngine.NATIVE).isValid()
     );
   }
@@ -286,8 +287,8 @@ public class ClientCompactionRunnerInfoTest
         compactionConfig,
         CompactionEngine.MSQ
     );
-    Assert.assertFalse(validationResult.isValid());
-    Assert.assertEquals(
+    Assertions.assertFalse(validationResult.isValid());
+    Assertions.assertEquals(
         "Compaction engine[native] does not support 'baseTable'; use the MSQ compaction engine.",
         validationResult.getReason()
     );
@@ -309,7 +310,7 @@ public class ClientCompactionRunnerInfoTest
         new DimensionRangePartitionsSpec(100, null, ImmutableList.of("tenant"), false),
         baseTable
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         ClientCompactionRunnerInfo.validateCompactionConfig(compactionConfig, CompactionEngine.NATIVE).isValid()
     );
   }
@@ -335,8 +336,8 @@ public class ClientCompactionRunnerInfoTest
     );
     final CompactionConfigValidationResult validationResult =
         ClientCompactionRunnerInfo.validateCompactionConfig(compactionConfig, CompactionEngine.NATIVE);
-    Assert.assertFalse(validationResult.isValid());
-    Assert.assertEquals(
+    Assertions.assertFalse(validationResult.isValid());
+    Assertions.assertEquals(
         "MSQ: Non-string partition dimension[region_id] of type[LONG] not supported with 'range' partition spec",
         validationResult.getReason()
     );

--- a/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionTaskDimensionsSpecTest.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionTaskDimensionsSpecTest.java
@@ -26,10 +26,11 @@ import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+
 
 public class ClientCompactionTaskDimensionsSpecTest
 {
@@ -58,14 +59,16 @@ public class ClientCompactionTaskDimensionsSpecTest
         json,
         ClientCompactionTaskDimensionsSpec.class
     );
-    Assert.assertEquals(expected, fromJson);
+    Assertions.assertEquals(expected, fromJson);
   }
 
-  @Test(expected = ParseException.class)
+  @Test
   public void testInvalidDimensionsField()
   {
-    final ClientCompactionTaskDimensionsSpec expected = new ClientCompactionTaskDimensionsSpec(
-        DimensionsSpec.getDefaultSchemas(ImmutableList.of("ts", "dim", "dim"))
-    );
+    org.junit.jupiter.api.Assertions.assertThrows(ParseException.class, () -> {
+      final ClientCompactionTaskDimensionsSpec expected = new ClientCompactionTaskDimensionsSpec(
+          DimensionsSpec.getDefaultSchemas(ImmutableList.of("ts", "dim", "dim"))
+      );
+    });
   }
 }

--- a/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionTaskDimensionsSpecTest.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionTaskDimensionsSpecTest.java
@@ -65,7 +65,7 @@ public class ClientCompactionTaskDimensionsSpecTest
   @Test
   public void testInvalidDimensionsField()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(ParseException.class, () -> {
+    Assertions.assertThrows(ParseException.class, () -> {
       final ClientCompactionTaskDimensionsSpec expected = new ClientCompactionTaskDimensionsSpec(
           DimensionsSpec.getDefaultSchemas(ImmutableList.of("ts", "dim", "dim"))
       );

--- a/server/src/test/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsTaskQueryTest.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsTaskQueryTest.java
@@ -23,10 +23,10 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.DateTimes;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ClientKillUnusedSegmentsTaskQueryTest
 {
@@ -38,7 +38,7 @@ public class ClientKillUnusedSegmentsTaskQueryTest
 
   ClientKillUnusedSegmentsTaskQuery clientKillUnusedSegmentsQuery;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     clientKillUnusedSegmentsQuery = new ClientKillUnusedSegmentsTaskQuery(
@@ -52,7 +52,7 @@ public class ClientKillUnusedSegmentsTaskQueryTest
     );
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     clientKillUnusedSegmentsQuery = null;
@@ -61,31 +61,31 @@ public class ClientKillUnusedSegmentsTaskQueryTest
   @Test
   public void testGetType()
   {
-    Assert.assertEquals("kill", clientKillUnusedSegmentsQuery.getType());
+    Assertions.assertEquals("kill", clientKillUnusedSegmentsQuery.getType());
   }
 
   @Test
   public void testGetDataSource()
   {
-    Assert.assertEquals(DATA_SOURCE, clientKillUnusedSegmentsQuery.getDataSource());
+    Assertions.assertEquals(DATA_SOURCE, clientKillUnusedSegmentsQuery.getDataSource());
   }
 
   @Test
   public void testGetInterval()
   {
-    Assert.assertEquals(INTERVAL, clientKillUnusedSegmentsQuery.getInterval());
+    Assertions.assertEquals(INTERVAL, clientKillUnusedSegmentsQuery.getInterval());
   }
 
   @Test
   public void testGetBatchSize()
   {
-    Assert.assertEquals(BATCH_SIZE, clientKillUnusedSegmentsQuery.getBatchSize());
+    Assertions.assertEquals(BATCH_SIZE, clientKillUnusedSegmentsQuery.getBatchSize());
   }
 
   @Test
   public void testGetLimit()
   {
-    Assert.assertEquals(LIMIT, clientKillUnusedSegmentsQuery.getLimit());
+    Assertions.assertEquals(LIMIT, clientKillUnusedSegmentsQuery.getLimit());
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/client/indexing/SamplerSpecTest.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/SamplerSpecTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.client.indexing;
 
 import org.apache.druid.java.util.common.UOE;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SamplerSpecTest
 {
@@ -37,12 +37,12 @@ public class SamplerSpecTest
   @Test
   public void testGetType()
   {
-    Assert.assertNull(SAMPLER_SPEC.getType());
+    Assertions.assertNull(SAMPLER_SPEC.getType());
   }
 
   @Test
   public void testGetInputSourceResources()
   {
-    Assert.assertThrows(UOE.class, SAMPLER_SPEC::getInputSourceResources);
+    Assertions.assertThrows(UOE.class, SAMPLER_SPEC::getInputSourceResources);
   }
 }

--- a/server/src/test/java/org/apache/druid/client/selector/ConnectionCountServerSelectorStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/client/selector/ConnectionCountServerSelectorStrategyTest.java
@@ -29,8 +29,8 @@ import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,7 +51,7 @@ public class ConnectionCountServerSelectorStrategyTest
     ServerSelector serverSelector = initSelector(s1, s2, s3);
 
     for (int i = 0; i < 100; ++i) {
-      Assert.assertEquals(s2, serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES));
+      Assertions.assertEquals(s2, serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES));
     }
   }
 
@@ -66,9 +66,9 @@ public class ConnectionCountServerSelectorStrategyTest
     for (int i = 0; i < 100; ++i) {
       pickedServers.add(serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES).getServer().getName());
     }
-    Assert.assertTrue(
-        "Multiple servers should be selected when the number of connections is equal.",
-        pickedServers.size() > 1
+    Assertions.assertTrue(
+        pickedServers.size() > 1,
+        "Multiple servers should be selected when the number of connections is equal."
     );
   }
 

--- a/server/src/test/java/org/apache/druid/client/selector/ServerSelectorTest.java
+++ b/server/src/test/java/org/apache/druid/client/selector/ServerSelectorTest.java
@@ -30,13 +30,14 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 
 public class ServerSelectorTest
 {
-  @Before
+  @BeforeEach
   public void setUp()
   {
     TierSelectorStrategy tierSelectorStrategy = EasyMock.createMock(TierSelectorStrategy.class);
@@ -101,17 +102,19 @@ public class ServerSelectorTest
                    .build()
     );
 
-    Assert.assertEquals(ImmutableList.of("a", "b", "c"), selector.getSegment().getDimensions());
+    Assertions.assertEquals(ImmutableList.of("a", "b", "c"), selector.getSegment().getDimensions());
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testSegmentCannotBeNull()
   {
-    final ServerSelector selector = new ServerSelector(
-        null,
-        new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy()),
-        HistoricalFilter.IDENTITY_FILTER
-    );
+    org.junit.jupiter.api.Assertions.assertThrows(NullPointerException.class, () -> {
+      final ServerSelector selector = new ServerSelector(
+          null,
+          new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy()),
+          HistoricalFilter.IDENTITY_FILTER
+      );
+    });
   }
 
   @Test
@@ -137,7 +140,7 @@ public class ServerSelectorTest
         new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy()),
         HistoricalFilter.IDENTITY_FILTER
     );
-    Assert.assertFalse(selector.hasData());
+    Assertions.assertFalse(selector.hasData());
   }
 
   @Test
@@ -165,7 +168,7 @@ public class ServerSelectorTest
         new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy()),
         HistoricalFilter.IDENTITY_FILTER
     );
-    Assert.assertTrue(selector.hasData());
+    Assertions.assertTrue(selector.hasData());
   }
 
 }

--- a/server/src/test/java/org/apache/druid/client/selector/ServerSelectorTest.java
+++ b/server/src/test/java/org/apache/druid/client/selector/ServerSelectorTest.java
@@ -108,7 +108,7 @@ public class ServerSelectorTest
   @Test
   public void testSegmentCannotBeNull()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(NullPointerException.class, () -> {
+    Assertions.assertThrows(NullPointerException.class, () -> {
       final ServerSelector selector = new ServerSelector(
           null,
           new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy()),

--- a/server/src/test/java/org/apache/druid/client/selector/TierSelectorStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/client/selector/TierSelectorStrategyTest.java
@@ -40,11 +40,12 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -67,7 +68,7 @@ public class TierSelectorStrategyTest
                                                                 .setDimensions(new DefaultDimensionSpec("dim2", "d0"))
                                                                 .build();
 
-  @Before
+  @BeforeEach
   public void testSetup()
   {
     serviceEmitter = StubServiceEmitter.createStarted();
@@ -270,10 +271,10 @@ public class TierSelectorStrategyTest
       serverSelector.addServerAndUpdateSegment(server, serverSelector.getSegment());
     }
 
-    Assert.assertEquals(expectedSelection[0], serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES));
-    Assert.assertEquals(expectedSelection[0], serverSelector.pick(EasyMock.createMock(Query.class), CloneQueryMode.EXCLUDECLONES));
-    Assert.assertEquals(expectedCandidates, serverSelector.getCandidates(-1, CloneQueryMode.EXCLUDECLONES));
-    Assert.assertEquals(expectedCandidates.subList(0, 2), serverSelector.getCandidates(2, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(expectedSelection[0], serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(expectedSelection[0], serverSelector.pick(EasyMock.createMock(Query.class), CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(expectedCandidates, serverSelector.getCandidates(-1, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(expectedCandidates.subList(0, 2), serverSelector.getCandidates(2, CloneQueryMode.EXCLUDECLONES));
   }
 
   @Test
@@ -287,8 +288,8 @@ public class TierSelectorStrategyTest
     Set<QueryableDruidServer> servers = new HashSet<>();
     servers.add(p0);
     RandomServerSelectorStrategy strategy = new RandomServerSelectorStrategy();
-    Assert.assertEquals(strategy.pick(servers, EasyMock.createMock(DataSegment.class)), p0);
-    Assert.assertEquals(
+    Assertions.assertEquals(strategy.pick(servers, EasyMock.createMock(DataSegment.class)), p0);
+    Assertions.assertEquals(
         strategy.pick(
             EasyMock.createMock(Query.class),
             servers,
@@ -306,11 +307,11 @@ public class TierSelectorStrategyTest
         return strategy.pick(servers, segment, numServersToPick);
       }
     };
-    Assert.assertEquals(
+    Assertions.assertEquals(
         defaultDeprecatedServerSelectorStrategy.pick(servers, EasyMock.createMock(DataSegment.class)),
         p0
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         defaultDeprecatedServerSelectorStrategy.pick(servers, EasyMock.createMock(DataSegment.class), 1)
                                                .get(0), p0
     );
@@ -355,20 +356,20 @@ public class TierSelectorStrategyTest
     }
 
     // Verify that the preferred tier is respected when picking a server
-    Assert.assertEquals(expectedSelection[0], serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES));
-    Assert.assertEquals(expectedSelection[0], serverSelector.pick(EasyMock.createMock(Query.class), CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(expectedSelection[0], serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(expectedSelection[0], serverSelector.pick(EasyMock.createMock(Query.class), CloneQueryMode.EXCLUDECLONES));
 
     // Verify that when getting all severs, the preferred tier is ignored, the returned list is sorted by priority
     List<DruidServerMetadata> allServers = new ArrayList<>(expectedCandidates);
     allServers.sort((o1, o2) -> tierSelectorStrategy.getComparator().compare(o1.getPriority(), o2.getPriority()));
     // verify the priority only because values with same priority may return in different order
-    Assert.assertEquals(
+    Assertions.assertEquals(
         allServers.stream().map(DruidServerMetadata::getPriority).collect(Collectors.toList()),
         serverSelector.getCandidates(-1, CloneQueryMode.EXCLUDECLONES).stream().map(DruidServerMetadata::getPriority).collect(Collectors.toList())
     );
 
     // Verify that when getting a limited number of candidates, returns the top N servers with preferred tier first
-    Assert.assertEquals(expectedCandidates.subList(0, 2), serverSelector.getCandidates(2, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(expectedCandidates.subList(0, 2), serverSelector.getCandidates(2, CloneQueryMode.EXCLUDECLONES));
   }
 
   @Test
@@ -454,20 +455,20 @@ public class TierSelectorStrategyTest
     }
 
     // Verify that the 2nd server is selected
-    Assert.assertEquals(preferredTierHighPriority2, serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES));
-    Assert.assertEquals(preferredTierHighPriority2, serverSelector.pick(EasyMock.createMock(Query.class), CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(preferredTierHighPriority2, serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(preferredTierHighPriority2, serverSelector.pick(EasyMock.createMock(Query.class), CloneQueryMode.EXCLUDECLONES));
 
     // Verify that when getting all severs, the preferred tier is ignored, the returned list is sorted by priority
     List<DruidServerMetadata> allServers = new ArrayList<>(expectedCandidates);
     allServers.sort((o1, o2) -> tierSelectorStrategy.getComparator().compare(o1.getPriority(), o2.getPriority()));
     // verify the priority only because values with same priority may return in different order
-    Assert.assertEquals(
+    Assertions.assertEquals(
         allServers.stream().map(DruidServerMetadata::getPriority).collect(Collectors.toList()),
         serverSelector.getCandidates(-1, CloneQueryMode.EXCLUDECLONES).stream().map(DruidServerMetadata::getPriority).collect(Collectors.toList())
     );
 
     // Verify that when getting 2 candidates, returns the top N servers with preferred tier first
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(
             preferredTierHighPriority.getServer().getMetadata(),
             preferredTierHighPriority2.getServer().getMetadata()
@@ -658,21 +659,21 @@ public class TierSelectorStrategyTest
 
     // Verify all 3 servers are registered
     List<DruidServerMetadata> allServers = serverSelector.getAllServers(CloneQueryMode.EXCLUDECLONES);
-    Assert.assertEquals(3, allServers.size());
+    Assertions.assertEquals(3, allServers.size());
 
-    Assert.assertEquals(p0, serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES));
-    Assert.assertEquals(p0, serverSelector.pick(SAMPLE_GROUPBY_QUERY, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(p0, serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(p0, serverSelector.pick(SAMPLE_GROUPBY_QUERY, CloneQueryMode.EXCLUDECLONES));
 
-    Assert.assertEquals(
-        "Only p0 should be returned when 1 candidate is requested",
+    Assertions.assertEquals(
         List.of(p0.getServer().getMetadata()),
-        serverSelector.getCandidates(1, CloneQueryMode.EXCLUDECLONES)
+        serverSelector.getCandidates(1, CloneQueryMode.EXCLUDECLONES),
+        "Only p0 should be returned when 1 candidate is requested"
     );
 
-    Assert.assertEquals(
-        "Only p0 and p2 should be returned, pNeg1 shouldn't be a candidate",
+    Assertions.assertEquals(
         List.of(p0.getServer().getMetadata(), p2.getServer().getMetadata()),
-        serverSelector.getCandidates(3, CloneQueryMode.EXCLUDECLONES)
+        serverSelector.getCandidates(3, CloneQueryMode.EXCLUDECLONES),
+        "Only p0 and p2 should be returned, pNeg1 shouldn't be a candidate"
     );
   }
 
@@ -708,19 +709,19 @@ public class TierSelectorStrategyTest
     }
 
     // Should return null when no matching priorities
-    Assert.assertNull(serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES));
-    Assert.assertNull(serverSelector.pick(SAMPLE_GROUPBY_QUERY, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertNull(serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertNull(serverSelector.pick(SAMPLE_GROUPBY_QUERY, CloneQueryMode.EXCLUDECLONES));
 
     serviceEmitter.verifyEmitted("tierSelector/noServer", 1);
 
     // Should return empty list for getCandidates
-    Assert.assertEquals(Collections.emptyList(), serverSelector.getCandidates(2, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(Collections.emptyList(), serverSelector.getCandidates(2, CloneQueryMode.EXCLUDECLONES));
   }
 
   @Test
   public void testEmptyStrictTierPrioritiesThrowsException()
   {
-    DruidException ex = Assert.assertThrows(
+    DruidException ex = Assertions.assertThrows(
         DruidException.class,
         () -> new StrictTierSelectorStrategy(
             new ConnectionCountServerSelectorStrategy(),
@@ -728,7 +729,7 @@ public class TierSelectorStrategyTest
             serviceEmitter
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "priorities must be non-empty when using strict tier selector on the Broker. Found priorities[[]].",
         ex.getMessage()
     );
@@ -770,48 +771,48 @@ public class TierSelectorStrategyTest
 
     // All 3 servers should be configured
     List<DruidServerMetadata> allServers = serverSelector.getAllServers(CloneQueryMode.EXCLUDECLONES);
-    Assert.assertEquals(3, allServers.size());
+    Assertions.assertEquals(3, allServers.size());
     Set<Integer> priorities = allServers.stream()
                                         .map(DruidServerMetadata::getPriority)
                                         .collect(Collectors.toSet());
-    Assert.assertEquals(Set.of(-1, 0, 2), priorities);
+    Assertions.assertEquals(Set.of(-1, 0, 2), priorities);
 
     // Test getCandidates with different sizes - verify correct count
     List<DruidServerMetadata> candidates1 = serverSelector.getCandidates(1, CloneQueryMode.EXCLUDECLONES);
-    Assert.assertEquals(1, candidates1.size());
-    Assert.assertTrue(Set.of(-1, 0, 2).contains(candidates1.get(0).getPriority()));
+    Assertions.assertEquals(1, candidates1.size());
+    Assertions.assertTrue(Set.of(-1, 0, 2).contains(candidates1.get(0).getPriority()));
 
     List<DruidServerMetadata> candidates2 = serverSelector.getCandidates(2, CloneQueryMode.EXCLUDECLONES);
-    Assert.assertEquals(2, candidates2.size());
+    Assertions.assertEquals(2, candidates2.size());
 
     List<DruidServerMetadata> candidates3 = serverSelector.getCandidates(3, CloneQueryMode.EXCLUDECLONES);
-    Assert.assertEquals(3, candidates3.size());
+    Assertions.assertEquals(3, candidates3.size());
     Set<Integer> candidates3Priorities = candidates3.stream()
                                                      .map(DruidServerMetadata::getPriority)
                                                      .collect(Collectors.toSet());
-    Assert.assertEquals(Set.of(-1, 0, 2), candidates3Priorities);
+    Assertions.assertEquals(Set.of(-1, 0, 2), candidates3Priorities);
 
     // Pick should return one of the three servers (any priority - demonstrates flattening)
     QueryableDruidServer picked = serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES);
-    Assert.assertNotNull(picked);
-    Assert.assertTrue(
-        "Picked server should have one of the configured priorities",
+    Assertions.assertNotNull(picked);
+    Assertions.assertTrue(
         picked.getServer().getPriority() == -1 ||
         picked.getServer().getPriority() == 0 ||
-        picked.getServer().getPriority() == 2
+        picked.getServer().getPriority() == 2,
+        "Picked server should have one of the configured priorities"
     );
 
     // Pick multiple times to verify servers from flattened pool are accessible
     Set<Integer> pickedPriorities = new HashSet<>();
     for (int i = 0; i < 20; i++) {
       QueryableDruidServer server = serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES);
-      Assert.assertNotNull(server);
+      Assertions.assertNotNull(server);
       pickedPriorities.add(server.getServer().getPriority());
     }
     // With RandomServerSelectorStrategy and 20 picks from 3 servers, we should see multiple priorities
-    Assert.assertTrue(
-        "Expected to see servers from multiple priorities, but only saw: " + pickedPriorities,
-        pickedPriorities.size() >= 2
+    Assertions.assertTrue(
+        pickedPriorities.size() >= 2,
+        "Expected to see servers from multiple priorities, but only saw: " + pickedPriorities
     );
   }
 
@@ -872,17 +873,17 @@ public class TierSelectorStrategyTest
 
     for (int i = 0; i < 20; i++) {
       QueryableDruidServer picked = selector.pick(null, CloneQueryMode.EXCLUDECLONES);
-      Assert.assertNotNull(picked);
+      Assertions.assertNotNull(picked);
 
       // Should always be one of the priority-2 replicas
-      Assert.assertEquals(2, picked.getServer().getPriority());
+      Assertions.assertEquals(2, picked.getServer().getPriority());
 
       if (picked.getServer().equals(p2a.getServer())) {
         c2a.incrementAndGet();
       } else if (picked.getServer().equals(p2b.getServer())) {
         c2b.incrementAndGet();
       } else {
-        Assert.fail("Expected pick to be either p2a or p2b but got: " + picked);
+        Assertions.fail("Expected pick to be either p2a or p2b but got: " + picked);
       }
     }
 
@@ -890,7 +891,7 @@ public class TierSelectorStrategyTest
     final Set<DruidServer> pickedServers = new HashSet<>();
     for (int i = 0; i < 50; i++) {
       QueryableDruidServer picked = selector.pick(null, CloneQueryMode.EXCLUDECLONES);
-      Assert.assertNotNull(picked);
+      Assertions.assertNotNull(picked);
 
       DruidServer pickedServer = picked.getServer();
       pickedServers.add(pickedServer);
@@ -906,7 +907,7 @@ public class TierSelectorStrategyTest
       }
     }
 
-    Assert.assertEquals(4, pickedServers.size());
+    Assertions.assertEquals(4, pickedServers.size());
 
     EasyMock.verify(client0, client1, client2a, client2b);
   }
@@ -946,17 +947,17 @@ public class TierSelectorStrategyTest
     }
 
     // Should return null since there are no matching priorities
-    Assert.assertNull(serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES));
-    Assert.assertNull(serverSelector.pick(SAMPLE_GROUPBY_QUERY, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertNull(serverSelector.pick(null, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertNull(serverSelector.pick(SAMPLE_GROUPBY_QUERY, CloneQueryMode.EXCLUDECLONES));
 
-    Assert.assertEquals(List.of(), serverSelector.getCandidates(1, CloneQueryMode.EXCLUDECLONES));
-    Assert.assertEquals(List.of(), serverSelector.getCandidates(2, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(List.of(), serverSelector.getCandidates(1, CloneQueryMode.EXCLUDECLONES));
+    Assertions.assertEquals(List.of(), serverSelector.getCandidates(2, CloneQueryMode.EXCLUDECLONES));
   }
 
   @Test
   public void testEmptyPooledTierPrioritiesThrowsException()
   {
-    DruidException ex = Assert.assertThrows(
+    DruidException ex = Assertions.assertThrows(
         DruidException.class,
         () -> new PooledTierSelectorStrategy(
             new ConnectionCountServerSelectorStrategy(),
@@ -964,7 +965,7 @@ public class TierSelectorStrategyTest
             serviceEmitter
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "priorities must be non-empty when using pooled tier selector on the Broker. Found priorities[[]].",
         ex.getMessage()
     );

--- a/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpecTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpecTest.java
@@ -21,7 +21,6 @@ package org.apache.druid.indexing.overlord.supervisor;
 
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.DruidExceptionMatcher;
-import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -65,7 +64,7 @@ public class SupervisorSpecTest
   @Test
   public void test()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assert.assertThrows(DruidException.class, SUPERVISOR_SPEC::getInputSourceResources),
         DruidExceptionMatcher.unsupported().expectMessageIs(
             "Supervisor type[abc] does not support input source based security"

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorMarkUsedTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorMarkUsedTest.java
@@ -37,7 +37,6 @@ import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.LinearShardSpec;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -405,7 +404,7 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assert.assertThrows(
             DruidException.class,
             () -> storageCoordinator.markNonOvershadowedSegmentsAsUsed("wrongDataSource", segmentIds)
@@ -431,7 +430,7 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assert.assertThrows(
             DruidException.class,
             () -> storageCoordinator.markNonOvershadowedSegmentsAsUsed(TestDataSource.KOALA, segmentIds)

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorReadOnlyTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorReadOnlyTest.java
@@ -43,7 +43,6 @@ import org.apache.druid.server.coordinator.simulate.BlockingExecutorService;
 import org.apache.druid.server.coordinator.simulate.TestDruidLeaderSelector;
 import org.apache.druid.server.coordinator.simulate.WrappingScheduledExecutorService;
 import org.apache.druid.timeline.partition.NumberedPartialShardSpec;
-import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -329,7 +328,7 @@ public class IndexerSQLMetadataStorageCoordinatorReadOnlyTest extends IndexerSql
 
   private static void verifyThrowsDefensiveException(ThrowingRunnable runnable)
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assert.assertThrows(DruidException.class, runnable),
         DruidExceptionMatcher.defensive().expectMessageIs(
             "Only Overlord can perform write transactions on segment metadata."

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -3596,7 +3596,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     }
 
     // Verify that the next attempt fails
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assert.assertThrows(
             DruidException.class,
             () -> allocatePendingSegmentForAppendTask(wiki, firstOfJan23, IdUtils.getRandomId())

--- a/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataQueryTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataQueryTest.java
@@ -40,7 +40,6 @@ import org.apache.druid.server.coordinator.CreateDataSegments;
 import org.apache.druid.timeline.CompactionState;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
@@ -923,7 +922,7 @@ public class SqlSegmentsMetadataQueryTest
     update(sql -> sql.markSegmentsAsUnused(Set.of(segment.getId()), markedAsUnusedAtTime));
 
     // Verify that the mark as used operation fails with a CONFLICT DruidException
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assert.assertThrows(
             DruidException.class,
             () -> updateWithConfig(sql -> markAsUsedFunction.apply(sql, segment), managerConfig)

--- a/server/src/test/java/org/apache/druid/query/LocatedSegmentDescriptorSerdeTest.java
+++ b/server/src/test/java/org/apache/druid/query/LocatedSegmentDescriptorSerdeTest.java
@@ -24,8 +24,8 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.ServerType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -53,6 +53,6 @@ public class LocatedSegmentDescriptorSerdeTest
         LocatedSegmentDescriptor.class
     );
 
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 }

--- a/server/src/test/java/org/apache/druid/query/QueryRunnerBasedOnClusteredClientTestBase.java
+++ b/server/src/test/java/org/apache/druid/query/QueryRunnerBasedOnClusteredClientTestBase.java
@@ -53,9 +53,9 @@ import org.apache.druid.server.QueryStackTests;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -109,13 +109,13 @@ public abstract class QueryRunnerBasedOnClusteredClientTestBase
     );
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAbstractClass() throws IOException
   {
     CLOSER.close();
   }
 
-  @Before
+  @BeforeEach
   public void setupTestBase()
   {
     segmentGenerator = new SegmentGenerator();
@@ -138,7 +138,7 @@ public abstract class QueryRunnerBasedOnClusteredClientTestBase
     servers = new ArrayList<>();
   }
 
-  @After
+  @AfterEach
   public void tearDownTestBase() throws IOException
   {
     segmentGenerator.close();

--- a/server/src/test/java/org/apache/druid/query/ResultLevelCachingQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/query/ResultLevelCachingQueryRunnerTest.java
@@ -33,10 +33,10 @@ import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
@@ -45,20 +45,20 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnClusteredClientTestBase
 {
   private Cache cache;
   private static final int DEFAULT_CACHE_ENTRY_MAX_SIZE = Integer.MAX_VALUE;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     cache = MapCache.create(1024);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException
   {
     cache.close();
@@ -79,9 +79,9 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
         responseContext()
     );
     final List<Result<TimeseriesResultValue>> results1 = sequence1.toList();
-    Assert.assertEquals(0, cache.getStats().getNumHits());
-    Assert.assertEquals(0, cache.getStats().getNumEntries());
-    Assert.assertEquals(0, cache.getStats().getNumMisses());
+    Assertions.assertEquals(0, cache.getStats().getNumHits());
+    Assertions.assertEquals(0, cache.getStats().getNumEntries());
+    Assertions.assertEquals(0, cache.getStats().getNumMisses());
 
     final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner2 = createQueryRunner(
         newCacheConfig(false, false, DEFAULT_CACHE_ENTRY_MAX_SIZE),
@@ -93,10 +93,10 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
         responseContext()
     );
     final List<Result<TimeseriesResultValue>> results2 = sequence2.toList();
-    Assert.assertEquals(results1, results2);
-    Assert.assertEquals(0, cache.getStats().getNumHits());
-    Assert.assertEquals(0, cache.getStats().getNumEntries());
-    Assert.assertEquals(0, cache.getStats().getNumMisses());
+    Assertions.assertEquals(results1, results2);
+    Assertions.assertEquals(0, cache.getStats().getNumHits());
+    Assertions.assertEquals(0, cache.getStats().getNumEntries());
+    Assertions.assertEquals(0, cache.getStats().getNumMisses());
 
     emitter.verifyNotEmitted(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT);
   }
@@ -116,9 +116,9 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
         responseContext()
     );
     final List<Result<TimeseriesResultValue>> results1 = sequence1.toList();
-    Assert.assertEquals(0, cache.getStats().getNumHits());
-    Assert.assertEquals(1, cache.getStats().getNumEntries());
-    Assert.assertEquals(0, cache.getStats().getNumMisses());
+    Assertions.assertEquals(0, cache.getStats().getNumHits());
+    Assertions.assertEquals(1, cache.getStats().getNumEntries());
+    Assertions.assertEquals(0, cache.getStats().getNumMisses());
 
     emitter.verifyNotEmitted(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT);
     emitter.flush();
@@ -133,10 +133,10 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
         responseContext()
     );
     final List<Result<TimeseriesResultValue>> results2 = sequence2.toList();
-    Assert.assertEquals(results1, results2);
-    Assert.assertEquals(0, cache.getStats().getNumHits());
-    Assert.assertEquals(1, cache.getStats().getNumEntries());
-    Assert.assertEquals(0, cache.getStats().getNumMisses());
+    Assertions.assertEquals(results1, results2);
+    Assertions.assertEquals(0, cache.getStats().getNumHits());
+    Assertions.assertEquals(1, cache.getStats().getNumEntries());
+    Assertions.assertEquals(0, cache.getStats().getNumMisses());
 
     emitter.verifyNotEmitted(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT);
   }
@@ -156,9 +156,9 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
         responseContext()
     );
     final List<Result<TimeseriesResultValue>> results1 = sequence1.toList();
-    Assert.assertEquals(0, cache.getStats().getNumHits());
-    Assert.assertEquals(0, cache.getStats().getNumEntries());
-    Assert.assertEquals(0, cache.getStats().getNumMisses());
+    Assertions.assertEquals(0, cache.getStats().getNumHits());
+    Assertions.assertEquals(0, cache.getStats().getNumEntries());
+    Assertions.assertEquals(0, cache.getStats().getNumMisses());
 
     emitter.verifyNotEmitted(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT);
     emitter.flush();
@@ -173,10 +173,10 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
         responseContext()
     );
     final List<Result<TimeseriesResultValue>> results2 = sequence2.toList();
-    Assert.assertEquals(results1, results2);
-    Assert.assertEquals(0, cache.getStats().getNumHits());
-    Assert.assertEquals(0, cache.getStats().getNumEntries());
-    Assert.assertEquals(1, cache.getStats().getNumMisses());
+    Assertions.assertEquals(results1, results2);
+    Assertions.assertEquals(0, cache.getStats().getNumHits());
+    Assertions.assertEquals(0, cache.getStats().getNumEntries());
+    Assertions.assertEquals(1, cache.getStats().getNumMisses());
 
     emitter.verifyEmitted(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 1);
     emitter.verifyValue(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 0);
@@ -197,9 +197,9 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
         responseContext()
     );
     final List<Result<TimeseriesResultValue>> results1 = sequence1.toList();
-    Assert.assertEquals(0, cache.getStats().getNumHits());
-    Assert.assertEquals(1, cache.getStats().getNumEntries());
-    Assert.assertEquals(1, cache.getStats().getNumMisses());
+    Assertions.assertEquals(0, cache.getStats().getNumHits());
+    Assertions.assertEquals(1, cache.getStats().getNumEntries());
+    Assertions.assertEquals(1, cache.getStats().getNumMisses());
 
     emitter.verifyEmitted(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 1);
     emitter.verifyValue(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 0);
@@ -215,10 +215,10 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
         responseContext()
     );
     final List<Result<TimeseriesResultValue>> results2 = sequence2.toList();
-    Assert.assertEquals(results1, results2);
-    Assert.assertEquals(1, cache.getStats().getNumHits());
-    Assert.assertEquals(1, cache.getStats().getNumEntries());
-    Assert.assertEquals(1, cache.getStats().getNumMisses());
+    Assertions.assertEquals(results1, results2);
+    Assertions.assertEquals(1, cache.getStats().getNumHits());
+    Assertions.assertEquals(1, cache.getStats().getNumEntries());
+    Assertions.assertEquals(1, cache.getStats().getNumMisses());
 
     emitter.verifyEmitted(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 1);
     emitter.verifyValue(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 1);
@@ -239,9 +239,9 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
         responseContext()
     );
     final List<Result<TimeseriesResultValue>> results1 = sequence1.toList();
-    Assert.assertEquals(0, cache.getStats().getNumHits());
-    Assert.assertEquals(0, cache.getStats().getNumEntries());
-    Assert.assertEquals(1, cache.getStats().getNumMisses());
+    Assertions.assertEquals(0, cache.getStats().getNumHits());
+    Assertions.assertEquals(0, cache.getStats().getNumEntries());
+    Assertions.assertEquals(1, cache.getStats().getNumMisses());
 
     emitter.verifyEmitted(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 1);
     emitter.verifyValue(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 0);
@@ -257,10 +257,10 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
         responseContext()
     );
     final List<Result<TimeseriesResultValue>> results2 = sequence2.toList();
-    Assert.assertEquals(results1, results2);
-    Assert.assertEquals(0, cache.getStats().getNumHits());
-    Assert.assertEquals(1, cache.getStats().getNumEntries());
-    Assert.assertEquals(2, cache.getStats().getNumMisses());
+    Assertions.assertEquals(results1, results2);
+    Assertions.assertEquals(0, cache.getStats().getNumHits());
+    Assertions.assertEquals(1, cache.getStats().getNumEntries());
+    Assertions.assertEquals(2, cache.getStats().getNumMisses());
 
     emitter.verifyEmitted(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 1);
     emitter.verifyValue(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 0);
@@ -293,12 +293,12 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
       fail("Expected to throw an exception");
     }
     catch (RuntimeException e) {
-      Assert.assertEquals("Exception for testing", e.getMessage());
+      Assertions.assertEquals("Exception for testing", e.getMessage());
     }
     finally {
-      Assert.assertEquals(0, cache.getStats().getNumHits());
-      Assert.assertEquals(0, cache.getStats().getNumEntries());
-      Assert.assertEquals(0, cache.getStats().getNumMisses());
+      Assertions.assertEquals(0, cache.getStats().getNumHits());
+      Assertions.assertEquals(0, cache.getStats().getNumEntries());
+      Assertions.assertEquals(0, cache.getStats().getNumMisses());
 
       emitter.verifyNotEmitted(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT);
     }
@@ -344,9 +344,9 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
         responseContext()
     );
     final List<Result<TimeseriesResultValue>> results1 = sequence1.toList();
-    Assert.assertEquals(0, cache.getStats().getNumHits());
-    Assert.assertEquals(1, cache.getStats().getNumEntries());
-    Assert.assertEquals(1, cache.getStats().getNumMisses());
+    Assertions.assertEquals(0, cache.getStats().getNumHits());
+    Assertions.assertEquals(1, cache.getStats().getNumEntries());
+    Assertions.assertEquals(1, cache.getStats().getNumMisses());
 
     emitter.verifyEmitted(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 1);
     emitter.verifyValue(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 0);
@@ -358,10 +358,10 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
         responseContext()
     );
     final List<Result<TimeseriesResultValue>> results2 = sequence2.toList();
-    Assert.assertEquals(results1, results2);
-    Assert.assertEquals(1, cache.getStats().getNumHits());
-    Assert.assertEquals(1, cache.getStats().getNumEntries());
-    Assert.assertEquals(1, cache.getStats().getNumMisses());
+    Assertions.assertEquals(results1, results2);
+    Assertions.assertEquals(1, cache.getStats().getNumHits());
+    Assertions.assertEquals(1, cache.getStats().getNumEntries());
+    Assertions.assertEquals(1, cache.getStats().getNumMisses());
 
     emitter.verifyEmitted(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 1);
     emitter.verifyValue(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 1);
@@ -372,10 +372,10 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
         responseContext()
     );
     final List<Result<TimeseriesResultValue>> results3 = sequence3.toList();
-    Assert.assertEquals(results1, results3);
-    Assert.assertEquals(2, cache.getStats().getNumHits());
-    Assert.assertEquals(1, cache.getStats().getNumEntries());
-    Assert.assertEquals(1, cache.getStats().getNumMisses());
+    Assertions.assertEquals(results1, results3);
+    Assertions.assertEquals(2, cache.getStats().getNumHits());
+    Assertions.assertEquals(1, cache.getStats().getNumEntries());
+    Assertions.assertEquals(1, cache.getStats().getNumMisses());
 
     emitter.verifyEmitted(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 1);
     emitter.verifyValue(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 1);
@@ -398,9 +398,9 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
         QueryPlus.wrap(query),
         responseContext()
     ).toList();
-    Assert.assertEquals(0, cache.getStats().getNumHits());
-    Assert.assertEquals(0, cache.getStats().getNumEntries());
-    Assert.assertEquals(1, cache.getStats().getNumMisses());
+    Assertions.assertEquals(0, cache.getStats().getNumHits());
+    Assertions.assertEquals(0, cache.getStats().getNumEntries());
+    Assertions.assertEquals(1, cache.getStats().getNumMisses());
 
     emitter.verifyEmitted(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 1);
     emitter.verifyValue(DefaultQueryMetrics.QUERY_RESULT_CACHE_HIT, 0);

--- a/server/src/test/java/org/apache/druid/query/ResultLevelCachingQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/query/ResultLevelCachingQueryRunnerTest.java
@@ -45,8 +45,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
 public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnClusteredClientTestBase
 {
   private Cache cache;
@@ -290,7 +288,7 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
     );
     try {
       sequence.toList();
-      fail("Expected to throw an exception");
+      Assertions.fail("Expected to throw an exception");
     }
     catch (RuntimeException e) {
       Assertions.assertEquals("Exception for testing", e.getMessage());
@@ -321,7 +319,7 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
     Mockito.doAnswer((Answer<Object>) invocation -> {
       List<ReferenceCountingResourceHolder<ByteBuffer>> resource = mergePool.takeBatch(1, 1);
       if (resource.isEmpty()) {
-        fail("Resource should not be empty");
+        Assertions.fail("Resource should not be empty");
       }
       Sequence<Result<TimeseriesResultValue>> realSequence = (Sequence<Result<TimeseriesResultValue>>) invocation.callRealMethod();
       Closer closer = Closer.create();

--- a/server/src/test/java/org/apache/druid/query/RetryQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/query/RetryQueryRunnerTest.java
@@ -28,17 +28,15 @@ import org.apache.druid.query.timeseries.TimeseriesResultValue;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.SegmentMissingException;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class RetryQueryRunnerTest extends QueryRunnerBasedOnClusteredClientTestBase
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testNoRetry()
@@ -52,9 +50,9 @@ public class RetryQueryRunnerTest extends QueryRunnerBasedOnClusteredClientTestB
     );
     final Sequence<Result<TimeseriesResultValue>> sequence = queryRunner.run(QueryPlus.wrap(query), responseContext());
     final List<Result<TimeseriesResultValue>> queryResult = sequence.toList();
-    Assert.assertEquals(0, queryRunner.getTotalNumRetries());
-    Assert.assertFalse(queryResult.isEmpty());
-    Assert.assertEquals(expectedTimeseriesResult(10), queryResult);
+    Assertions.assertEquals(0, queryRunner.getTotalNumRetries());
+    Assertions.assertFalse(queryResult.isEmpty());
+    Assertions.assertEquals(expectedTimeseriesResult(10), queryResult);
   }
 
   @Test
@@ -65,20 +63,19 @@ public class RetryQueryRunnerTest extends QueryRunnerBasedOnClusteredClientTestB
     final RetryQueryRunner<Result<TimeseriesResultValue>> queryRunner = createQueryRunner(
         newRetryQueryRunnerConfig(1, true),
         query,
-        () -> {
+        () ->
           // Let's move a segment
-          dropSegmentFromServerAndAddNewServerForSegment(servers.get(0));
-        }
+          dropSegmentFromServerAndAddNewServerForSegment(servers.get(0))
     );
     final Sequence<Result<TimeseriesResultValue>> sequence = queryRunner.run(QueryPlus.wrap(query), responseContext());
 
     final List<Result<TimeseriesResultValue>> queryResult = sequence.toList();
-    Assert.assertEquals(1, queryRunner.getTotalNumRetries());
+    Assertions.assertEquals(1, queryRunner.getTotalNumRetries());
     // Note that we dropped a segment from a server, but it's still announced in the server view.
     // As a result, we may get the full result or not depending on what server will get the retry query.
     // If we hit the same server, the query will return incomplete result.
-    Assert.assertTrue(queryResult.size() == 9 || queryResult.size() == 10);
-    Assert.assertEquals(expectedTimeseriesResult(queryResult.size()), queryResult);
+    Assertions.assertTrue(queryResult.size() == 9 || queryResult.size() == 10);
+    Assertions.assertEquals(expectedTimeseriesResult(queryResult.size()), queryResult);
   }
 
   @Test
@@ -89,38 +86,37 @@ public class RetryQueryRunnerTest extends QueryRunnerBasedOnClusteredClientTestB
     final RetryQueryRunner<Result<TimeseriesResultValue>> queryRunner = createQueryRunner(
         newRetryQueryRunnerConfig(100, false), // retry up to 100
         query,
-        () -> {
+        () ->
           // Let's move a segment
-          dropSegmentFromServerAndAddNewServerForSegment(servers.get(0));
-        }
+          dropSegmentFromServerAndAddNewServerForSegment(servers.get(0))
     );
     final Sequence<Result<TimeseriesResultValue>> sequence = queryRunner.run(QueryPlus.wrap(query), responseContext());
 
     final List<Result<TimeseriesResultValue>> queryResult = sequence.toList();
-    Assert.assertTrue(0 < queryRunner.getTotalNumRetries());
-    Assert.assertEquals(expectedTimeseriesResult(10), queryResult);
+    Assertions.assertTrue(0 < queryRunner.getTotalNumRetries());
+    Assertions.assertEquals(expectedTimeseriesResult(10), queryResult);
   }
 
   @Test
   public void testFailWithPartialResultsAfterRetry()
   {
-    prepareCluster(10);
-    final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
-    final RetryQueryRunner<Result<TimeseriesResultValue>> queryRunner = createQueryRunner(
-        newRetryQueryRunnerConfig(1, false),
-        query,
-        () -> dropSegmentFromServer(servers.get(0))
-    );
-    final Sequence<Result<TimeseriesResultValue>> sequence = queryRunner.run(QueryPlus.wrap(query), responseContext());
-
-    expectedException.expect(SegmentMissingException.class);
-    expectedException.expectMessage("No results found for segments");
-    try {
-      sequence.toList();
-    }
-    finally {
-      Assert.assertEquals(1, queryRunner.getTotalNumRetries());
-    }
+    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(SegmentMissingException.class, () -> {
+      prepareCluster(10);
+      final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
+      final RetryQueryRunner<Result<TimeseriesResultValue>> queryRunner = createQueryRunner(
+          newRetryQueryRunnerConfig(1, false),
+          query,
+          () -> dropSegmentFromServer(servers.get(0))
+      );
+      final Sequence<Result<TimeseriesResultValue>> sequence = queryRunner.run(QueryPlus.wrap(query), responseContext());
+      try {
+        sequence.toList();
+      }
+      finally {
+        Assertions.assertEquals(1, queryRunner.getTotalNumRetries());
+      }
+    });
+    assertTrue(exception.getMessage().contains("No results found for segments"));
   }
 
   /**
@@ -130,7 +126,7 @@ public class RetryQueryRunnerTest extends QueryRunnerBasedOnClusteredClientTestB
   private NonnullPair<DataSegment, QueryableIndex> dropSegmentFromServer(DruidServer fromServer)
   {
     final SimpleServerManager serverManager = httpClient.getServerManager(fromServer);
-    Assert.assertNotNull(serverManager);
+    Assertions.assertNotNull(serverManager);
     return serverManager.dropSegment();
   }
 

--- a/server/src/test/java/org/apache/druid/query/RetryQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/query/RetryQueryRunnerTest.java
@@ -98,7 +98,7 @@ public class RetryQueryRunnerTest extends QueryRunnerBasedOnClusteredClientTestB
   @Test
   public void testFailWithPartialResultsAfterRetry()
   {
-    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(SegmentMissingException.class, () -> {
+    Throwable exception = Assertions.assertThrows(SegmentMissingException.class, () -> {
       prepareCluster(10);
       final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
       final RetryQueryRunner<Result<TimeseriesResultValue>> queryRunner = createQueryRunner(

--- a/server/src/test/java/org/apache/druid/query/RetryQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/query/RetryQueryRunnerTest.java
@@ -33,8 +33,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 public class RetryQueryRunnerTest extends QueryRunnerBasedOnClusteredClientTestBase
 {
 
@@ -116,7 +114,7 @@ public class RetryQueryRunnerTest extends QueryRunnerBasedOnClusteredClientTestB
         Assertions.assertEquals(1, queryRunner.getTotalNumRetries());
       }
     });
-    assertTrue(exception.getMessage().contains("No results found for segments"));
+    Assertions.assertTrue(exception.getMessage().contains("No results found for segments"));
   }
 
   /**

--- a/server/src/test/java/org/apache/druid/query/dimension/LookupDimensionSpecTest.java
+++ b/server/src/test/java/org/apache/druid/query/dimension/LookupDimensionSpecTest.java
@@ -23,8 +23,6 @@ import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.google.common.collect.ImmutableMap;
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.extraction.ExtractionFn;
 import org.apache.druid.query.extraction.MapLookupExtractor;
@@ -35,16 +33,17 @@ import org.apache.druid.query.lookup.MapLookupExtractorFactory;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
-@RunWith(JUnitParamsRunner.class)
+
 public class LookupDimensionSpecTest extends InitializedNullHandlingTest
 {
   private static final Map<String, String> STRING_MAP = ImmutableMap.of("key", "value", "key2", "value2");
@@ -67,8 +66,8 @@ public class LookupDimensionSpecTest extends InitializedNullHandlingTest
       new LookupDimensionSpec("dimName", "outputName", MAP_LOOKUP_EXTRACTOR, false, null, null, true, null);
 
 
-  @Parameters
-  @Test
+  @MethodSource("parametersForTestSerDesr")
+  @ParameterizedTest
   public void testSerDesr(DimensionSpec lookupDimSpec) throws IOException
   {
     ObjectMapper mapper = new DefaultObjectMapper();
@@ -78,13 +77,13 @@ public class LookupDimensionSpecTest extends InitializedNullHandlingTest
         LOOKUP_REF_MANAGER
     );
     String serLookup = mapper.writeValueAsString(lookupDimSpec);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         lookupDimSpec,
         mapper.readerFor(DimensionSpec.class).with(injectableValues).readValue(serLookup)
     );
   }
 
-  private Object[] parametersForTestSerDesr()
+  private static Object[] parametersForTestSerDesr()
   {
     return new Object[]{
         new LookupDimensionSpec("dimName", "outputName", MAP_LOOKUP_EXTRACTOR, true, null, null, true, null),
@@ -103,31 +102,35 @@ public class LookupDimensionSpecTest extends InitializedNullHandlingTest
     };
   }
 
-  @Test(expected = Exception.class)
+  @Test
   public void testExceptionWhenNameAndLookupNotNull()
   {
-    new LookupDimensionSpec("dimName", "outputName", MAP_LOOKUP_EXTRACTOR, false, "replace", "name", true, null);
+    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> {
+      new LookupDimensionSpec("dimName", "outputName", MAP_LOOKUP_EXTRACTOR, false, "replace", "name", true, null);
+    });
   }
 
-  @Test(expected = Exception.class)
+  @Test
   public void testExceptionWhenNameAndLookupNull()
   {
-    new LookupDimensionSpec("dimName", "outputName", null, false, "replace", "", true, null);
+    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> {
+      new LookupDimensionSpec("dimName", "outputName", null, false, "replace", "", true, null);
+    });
   }
 
   @Test
   public void testGetDimension()
   {
-    Assert.assertEquals("dimName", lookupDimSpec.getDimension());
+    Assertions.assertEquals("dimName", lookupDimSpec.getDimension());
   }
 
   @Test
   public void testGetOutputName()
   {
-    Assert.assertEquals("outputName", lookupDimSpec.getOutputName());
+    Assertions.assertEquals("outputName", lookupDimSpec.getOutputName());
   }
 
-  public Object[] parametersForTestApply()
+  public static Object[] parametersForTestApply()
   {
     return new Object[]{
         new Object[]{
@@ -148,15 +151,15 @@ public class LookupDimensionSpecTest extends InitializedNullHandlingTest
         },
         new Object[]{
             new LookupDimensionSpec("dimName", "outputName", MAP_LOOKUP_EXTRACTOR, false, "Missing_value", null,
-                                    true,
-                                    null
+                true,
+                null
             ),
             ImmutableMap.of("not there", "Missing_value")
         },
         new Object[]{
             new LookupDimensionSpec("dimName", "outputName", null, false, "Missing_value", "lookupName",
-                                    true,
-                                    LOOKUP_REF_MANAGER
+                true,
+                LOOKUP_REF_MANAGER
             ),
             ImmutableMap.of("not there", "Missing_value")
         },
@@ -172,19 +175,19 @@ public class LookupDimensionSpecTest extends InitializedNullHandlingTest
     };
   }
 
-  @Test
-  @Parameters
+  @ParameterizedTest
+  @MethodSource("parametersForTestApply")
   public void testApply(DimensionSpec dimensionSpec, Map<String, String> map)
   {
     for (Map.Entry<String, String> entry : map.entrySet()) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           entry.getValue(),
           dimensionSpec.getExtractionFn().apply(entry.getKey())
       );
     }
   }
 
-  public Object[] parametersForTestGetCacheKey()
+  public static Object[] parametersForTestGetCacheKey()
   {
     return new Object[]{
         new Object[]{
@@ -193,8 +196,8 @@ public class LookupDimensionSpecTest extends InitializedNullHandlingTest
         },
         new Object[]{
             new LookupDimensionSpec("dimName", "outputName", MAP_LOOKUP_EXTRACTOR, false, "Missing_value", null,
-                                    true,
-                                    null
+                true,
+                null
             ),
             false
         },
@@ -217,22 +220,22 @@ public class LookupDimensionSpecTest extends InitializedNullHandlingTest
     };
   }
 
-  @Test
-  @Parameters
+  @ParameterizedTest
+  @MethodSource("parametersForTestGetCacheKey")
   public void testGetCacheKey(DimensionSpec dimensionSpec, boolean expectedResult)
   {
-    Assert.assertEquals(expectedResult, Arrays.equals(lookupDimSpec.getCacheKey(), dimensionSpec.getCacheKey()));
+    Assertions.assertEquals(expectedResult, Arrays.equals(lookupDimSpec.getCacheKey(), dimensionSpec.getCacheKey()));
   }
 
   @Test
   public void testPreservesOrdering()
   {
-    Assert.assertFalse(lookupDimSpec.preservesOrdering());
+    Assertions.assertFalse(lookupDimSpec.preservesOrdering());
   }
 
   @Test
   public void testIsOneToOne()
   {
-    Assert.assertEquals(lookupDimSpec.getExtractionFn().getExtractionType(), ExtractionFn.ExtractionType.ONE_TO_ONE);
+    Assertions.assertEquals(lookupDimSpec.getExtractionFn().getExtractionType(), ExtractionFn.ExtractionType.ONE_TO_ONE);
   }
 }

--- a/server/src/test/java/org/apache/druid/query/dimension/LookupDimensionSpecTest.java
+++ b/server/src/test/java/org/apache/druid/query/dimension/LookupDimensionSpecTest.java
@@ -105,7 +105,7 @@ public class LookupDimensionSpecTest extends InitializedNullHandlingTest
   @Test
   public void testExceptionWhenNameAndLookupNotNull()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> {
+    Assertions.assertThrows(Exception.class, () -> {
       new LookupDimensionSpec("dimName", "outputName", MAP_LOOKUP_EXTRACTOR, false, "replace", "name", true, null);
     });
   }
@@ -113,7 +113,7 @@ public class LookupDimensionSpecTest extends InitializedNullHandlingTest
   @Test
   public void testExceptionWhenNameAndLookupNull()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> {
+    Assertions.assertThrows(Exception.class, () -> {
       new LookupDimensionSpec("dimName", "outputName", null, false, "replace", "", true, null);
     });
   }

--- a/server/src/test/java/org/apache/druid/query/expression/LookupEnabledTestExprMacroTable.java
+++ b/server/src/test/java/org/apache/druid/query/expression/LookupEnabledTestExprMacroTable.java
@@ -32,6 +32,7 @@ import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.lookup.LookupIntrospectHandler;
 
 import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/server/src/test/java/org/apache/druid/query/expression/LookupExprMacroTest.java
+++ b/server/src/test/java/org/apache/druid/query/expression/LookupExprMacroTest.java
@@ -27,10 +27,10 @@ import org.apache.druid.math.expr.FunctionTest;
 import org.apache.druid.math.expr.InputBindings;
 import org.apache.druid.math.expr.Parser;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LookupExprMacroTest extends InitializedNullHandlingTest
 {
@@ -39,9 +39,6 @@ public class LookupExprMacroTest extends InitializedNullHandlingTest
           .put("x", InputBindings.inputSupplier(ExpressionType.STRING, () -> "foo"))
           .build()
   );
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testLookup()
@@ -57,9 +54,9 @@ public class LookupExprMacroTest extends InitializedNullHandlingTest
   @Test
   public void testLookupNotFound()
   {
-    expectedException.expect(IllegalStateException.class);
-    expectedException.expectMessage("Lookup [lookylook] not found");
-    assertExpr("lookup(x, 'lookylook')", null);
+    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () ->
+      assertExpr("lookup(x, 'lookylook')", null));
+    assertTrue(exception.getMessage().contains("Lookup [lookylook] not found"));
   }
 
   @Test
@@ -73,7 +70,7 @@ public class LookupExprMacroTest extends InitializedNullHandlingTest
         new ExprMacroTable(LookupEnabledTestExprMacroTable.makeTestMacros(ImmutableMap.of("x", "y", "a", "b")))
     );
     // same should have same cache key
-    Assert.assertArrayEquals(expr.getCacheKey(), exprSameLookup.getCacheKey());
+    Assertions.assertArrayEquals(expr.getCacheKey(), exprSameLookup.getCacheKey());
     // different should not have same key
     final byte[] exprBytes = expr.getCacheKey();
     final byte[] expr2Bytes = exprChangedLookup.getCacheKey();
@@ -83,7 +80,7 @@ public class LookupExprMacroTest extends InitializedNullHandlingTest
       for (int i = 0; i < exprBytes.length; i++) {
         allEqual = allEqual && (exprBytes[i] == expr2Bytes[i]);
       }
-      Assert.assertFalse(allEqual);
+      Assertions.assertFalse(allEqual);
     }
   }
 
@@ -98,7 +95,7 @@ public class LookupExprMacroTest extends InitializedNullHandlingTest
         new ExprMacroTable(LookupEnabledTestExprMacroTable.makeTestMacros(ImmutableMap.of("x", "y", "a", "b")))
     );
     // same should have same cache key
-    Assert.assertArrayEquals(expr.getCacheKey(), exprSameLookup.getCacheKey());
+    Assertions.assertArrayEquals(expr.getCacheKey(), exprSameLookup.getCacheKey());
     // different should not have same key
     final byte[] exprBytes = expr.getCacheKey();
     final byte[] expr2Bytes = exprChangedLookup.getCacheKey();
@@ -108,7 +105,7 @@ public class LookupExprMacroTest extends InitializedNullHandlingTest
       for (int i = 0; i < exprBytes.length; i++) {
         allEqual = allEqual && (exprBytes[i] == expr2Bytes[i]);
       }
-      Assert.assertFalse(allEqual);
+      Assertions.assertFalse(allEqual);
     }
   }
 

--- a/server/src/test/java/org/apache/druid/query/expression/LookupExprMacroTest.java
+++ b/server/src/test/java/org/apache/druid/query/expression/LookupExprMacroTest.java
@@ -30,8 +30,6 @@ import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 public class LookupExprMacroTest extends InitializedNullHandlingTest
 {
   private static final Expr.ObjectBinding BINDINGS = InputBindings.forInputSuppliers(
@@ -56,7 +54,7 @@ public class LookupExprMacroTest extends InitializedNullHandlingTest
   {
     Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () ->
       assertExpr("lookup(x, 'lookylook')", null));
-    assertTrue(exception.getMessage().contains("Lookup [lookylook] not found"));
+    Assertions.assertTrue(exception.getMessage().contains("Lookup [lookylook] not found"));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/query/expression/LookupExprMacroTest.java
+++ b/server/src/test/java/org/apache/druid/query/expression/LookupExprMacroTest.java
@@ -52,7 +52,7 @@ public class LookupExprMacroTest extends InitializedNullHandlingTest
   @Test
   public void testLookupNotFound()
   {
-    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () ->
+    Throwable exception = Assertions.assertThrows(IllegalStateException.class, () ->
       assertExpr("lookup(x, 'lookylook')", null));
     Assertions.assertTrue(exception.getMessage().contains("Lookup [lookylook] not found"));
   }

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupIntrospectionResourceTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupIntrospectionResourceTest.java
@@ -28,13 +28,14 @@ import org.apache.druid.query.extraction.MapLookupExtractor;
 import org.apache.druid.server.WebserverTestUtils;
 import org.easymock.EasyMock;
 import org.glassfish.grizzly.http.server.HttpServer;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
 import java.net.URI;
 import java.util.Optional;
 
@@ -54,7 +55,7 @@ public class LookupIntrospectionResourceTest
   private URI baseUri;
   private HttpServer server;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception
   {
     LookupExtractorFactory actualLookupExtractorFactory = new MapLookupExtractorFactory(
@@ -92,15 +93,14 @@ public class LookupIntrospectionResourceTest
         "lookup-test",
         baseUri,
         LookupIntrospectionResource.class.getName(),
-        binder -> {
+        binder ->
           binder.bind(LookupExtractorFactoryContainerProvider.class)
-                .toInstance(mockLookupExtractorFactoryContainerProvider);
-        }
+                .toInstance(mockLookupExtractorFactoryContainerProvider)
     );
     server.start();
   }
 
-  @After
+  @AfterEach
   public void teardown()
   {
     if (server != null) {
@@ -116,7 +116,7 @@ public class LookupIntrospectionResourceTest
             .andReturn(new MapLookupExtractor(ImmutableMap.of(), false))
             .anyTimes();
     EasyMock.replay(mockLookupExtractorFactory);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.status(Response.Status.NOT_FOUND).build().getStatus(),
         ((Response) lookupIntrospectionResource.introspectLookup("lookupId")).getStatus()
     );
@@ -125,7 +125,7 @@ public class LookupIntrospectionResourceTest
   @Test
   public void testNotExistingLookup()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.status(Response.Status.NOT_FOUND).build().getStatus(),
         ((Response) lookupIntrospectionResource.introspectLookup("not there")).getStatus()
     );
@@ -139,7 +139,7 @@ public class LookupIntrospectionResourceTest
             .andReturn(new MapLookupExtractor(ImmutableMap.of(), false))
             .anyTimes();
     EasyMock.replay(mockLookupExtractorFactory);
-    Assert.assertEquals(mockLookupIntrospectHandler, lookupIntrospectionResource.introspectLookup("lookupId"));
+    Assertions.assertEquals(mockLookupIntrospectHandler, lookupIntrospectionResource.introspectLookup("lookupId"));
   }
 
   @Test
@@ -152,8 +152,8 @@ public class LookupIntrospectionResourceTest
                                  .accept(MediaType.APPLICATION_JSON)
                                  .get(ClientResponse.class);
     String s = resp.getEntity(String.class);
-    Assert.assertEquals("[\"key\",\"key2\"]", s);
-    Assert.assertEquals(200, resp.getStatus());
+    Assertions.assertEquals("[\"key\",\"key2\"]", s);
+    Assertions.assertEquals(200, resp.getStatus());
   }
 
   @Test
@@ -166,8 +166,8 @@ public class LookupIntrospectionResourceTest
                                  .accept(MediaType.APPLICATION_JSON)
                                  .get(ClientResponse.class);
     String s = resp.getEntity(String.class);
-    Assert.assertEquals("[\"value\",\"value2\"]", s);
-    Assert.assertEquals(200, resp.getStatus());
+    Assertions.assertEquals("[\"value\",\"value2\"]", s);
+    Assertions.assertEquals(200, resp.getStatus());
   }
 
   @Test
@@ -180,7 +180,7 @@ public class LookupIntrospectionResourceTest
                                  .accept(MediaType.APPLICATION_JSON)
                                  .get(ClientResponse.class);
     String s = resp.getEntity(String.class);
-    Assert.assertEquals("{\"key\":\"value\",\"key2\":\"value2\"}", s);
-    Assert.assertEquals(200, resp.getStatus());
+    Assertions.assertEquals("{\"key\":\"value\",\"key2\":\"value2\"}", s);
+    Assertions.assertEquals(200, resp.getStatus());
   }
 }

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupListeningAnnouncerConfigTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupListeningAnnouncerConfigTest.java
@@ -37,12 +37,13 @@ import org.apache.druid.server.metrics.DefaultLoadSpecHolder;
 import org.apache.druid.server.metrics.LoadSpecHolder;
 import org.apache.druid.server.metrics.TestLoadSpecHolder;
 import org.apache.druid.server.metrics.TestTaskHolder;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 import java.util.Set;
+
 
 public class LookupListeningAnnouncerConfigTest
 {
@@ -72,7 +73,7 @@ public class LookupListeningAnnouncerConfigTest
 
   private final Properties properties = injector.getInstance(Properties.class);
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     properties.clear();
@@ -88,7 +89,7 @@ public class LookupListeningAnnouncerConfigTest
     );
     configProvider.inject(properties, configurator);
     final LookupListeningAnnouncerConfig config = configProvider.get();
-    Assert.assertEquals(LookupListeningAnnouncerConfig.DEFAULT_TIER, config.getLookupTier());
+    Assertions.assertEquals(LookupListeningAnnouncerConfig.DEFAULT_TIER, config.getLookupTier());
   }
 
   @Test
@@ -103,21 +104,23 @@ public class LookupListeningAnnouncerConfigTest
     );
     configProvider.inject(properties, configurator);
     final LookupListeningAnnouncerConfig config = configProvider.get();
-    Assert.assertEquals(lookupTier, config.getLookupTier());
+    Assertions.assertEquals(lookupTier, config.getLookupTier());
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testFailsOnEmptyTier()
   {
-    final JsonConfigurator configurator = injector.getBinding(JsonConfigurator.class).getProvider().get();
-    properties.put(PROPERTY_BASE + ".lookupTier", "");
-    final JsonConfigProvider<LookupListeningAnnouncerConfig> configProvider = JsonConfigProvider.of(
-        PROPERTY_BASE,
-        LookupListeningAnnouncerConfig.class
-    );
-    configProvider.inject(properties, configurator);
-    final LookupListeningAnnouncerConfig config = configProvider.get();
-    config.getLookupTier();
+    org.junit.jupiter.api.Assertions.assertThrows(NullPointerException.class, () -> {
+      final JsonConfigurator configurator = injector.getBinding(JsonConfigurator.class).getProvider().get();
+      properties.put(PROPERTY_BASE + ".lookupTier", "");
+      final JsonConfigProvider<LookupListeningAnnouncerConfig> configProvider = JsonConfigProvider.of(
+          PROPERTY_BASE,
+          LookupListeningAnnouncerConfig.class
+      );
+      configProvider.inject(properties, configurator);
+      final LookupListeningAnnouncerConfig config = configProvider.get();
+      config.getLookupTier();
+    });
   }
 
   @Test
@@ -131,7 +134,7 @@ public class LookupListeningAnnouncerConfigTest
     );
     configProvider.inject(properties, configurator);
     final LookupListeningAnnouncerConfig config = configProvider.get();
-    Assert.assertEquals("some_datasource", config.getLookupTier());
+    Assertions.assertEquals("some_datasource", config.getLookupTier());
   }
 
   @Test
@@ -139,23 +142,25 @@ public class LookupListeningAnnouncerConfigTest
   {
     final LoadSpecHolder taskHolder = new DefaultLoadSpecHolder();
     injector.injectMembers(taskHolder);
-    Assert.assertEquals(LookupLoadingSpec.Mode.ALL, taskHolder.getLookupLoadingSpec().getMode());
+    Assertions.assertEquals(LookupLoadingSpec.Mode.ALL, taskHolder.getLookupLoadingSpec().getMode());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFailsInjection()
   {
-    final String lookupTier = "some_tier";
-    final JsonConfigurator configurator = injector.getBinding(JsonConfigurator.class).getProvider().get();
-    properties.put(PROPERTY_BASE + ".lookupTier", lookupTier);
-    properties.put(PROPERTY_BASE + ".lookupTierIsDatasource", "true");
-    final JsonConfigProvider<LookupListeningAnnouncerConfig> configProvider = JsonConfigProvider.of(
-        PROPERTY_BASE,
-        LookupListeningAnnouncerConfig.class
-    );
-    configProvider.inject(properties, configurator);
-    final LookupListeningAnnouncerConfig config = configProvider.get();
-    Assert.assertEquals(lookupTier, config.getLookupTier());
+    org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      final String lookupTier = "some_tier";
+      final JsonConfigurator configurator = injector.getBinding(JsonConfigurator.class).getProvider().get();
+      properties.put(PROPERTY_BASE + ".lookupTier", lookupTier);
+      properties.put(PROPERTY_BASE + ".lookupTierIsDatasource", "true");
+      final JsonConfigProvider<LookupListeningAnnouncerConfig> configProvider = JsonConfigProvider.of(
+          PROPERTY_BASE,
+          LookupListeningAnnouncerConfig.class
+      );
+      configProvider.inject(properties, configurator);
+      final LookupListeningAnnouncerConfig config = configProvider.get();
+      Assertions.assertEquals(lookupTier, config.getLookupTier());
+    });
   }
 
   @Test
@@ -179,7 +184,7 @@ public class LookupListeningAnnouncerConfigTest
     );
     configProvider.inject(properties, configurator);
     final LookupListeningAnnouncerConfig config = configProvider.get();
-    Assert.assertEquals("__default", config.getLookupTier());
-    Assert.assertEquals(LookupLoadingSpec.ALL, config.getLookupLoadingSpec());
+    Assertions.assertEquals("__default", config.getLookupTier());
+    Assertions.assertEquals(LookupLoadingSpec.ALL, config.getLookupLoadingSpec());
   }
 }

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupListeningAnnouncerConfigTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupListeningAnnouncerConfigTest.java
@@ -110,7 +110,7 @@ public class LookupListeningAnnouncerConfigTest
   @Test
   public void testFailsOnEmptyTier()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(NullPointerException.class, () -> {
+    Assertions.assertThrows(NullPointerException.class, () -> {
       final JsonConfigurator configurator = injector.getBinding(JsonConfigurator.class).getProvider().get();
       properties.put(PROPERTY_BASE + ".lookupTier", "");
       final JsonConfigProvider<LookupListeningAnnouncerConfig> configProvider = JsonConfigProvider.of(
@@ -148,7 +148,7 @@ public class LookupListeningAnnouncerConfigTest
   @Test
   public void testFailsInjection()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
       final String lookupTier = "some_tier";
       final JsonConfigurator configurator = injector.getBinding(JsonConfigurator.class).getProvider().get();
       properties.put(PROPERTY_BASE + ".lookupTier", lookupTier);

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
@@ -29,15 +29,16 @@ import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
 import org.apache.druid.rpc.HttpResponseException;
 import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.easymock.EasyMock;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -52,8 +53,8 @@ public class LookupReferencesManagerTest
 {
   private static final String LOOKUP_TIER = "lookupTier";
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
   LookupReferencesManager lookupReferencesManager;
   LookupExtractorFactory lookupExtractorFactory;
   LookupExtractorFactoryContainer container;
@@ -61,7 +62,7 @@ public class LookupReferencesManagerTest
   private CoordinatorClientImpl coordinatorClient;
   private LookupListeningAnnouncerConfig config;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
     EmittingLogger.registerEmitter(new NoopServiceEmitter());
@@ -102,42 +103,46 @@ public class LookupReferencesManagerTest
     EasyMock.replay(config);
     EasyMock.expect(coordinatorClient.fetchLookupsForTierSync(LOOKUP_TIER)).andReturn(lookupMap);
     EasyMock.replay(coordinatorClient);
-    Assert.assertFalse(lookupReferencesManager.lifecycleLock.awaitStarted(1, TimeUnit.MICROSECONDS));
-    Assert.assertNull(lookupReferencesManager.mainThread);
-    Assert.assertNull(lookupReferencesManager.stateRef.get());
+    Assertions.assertFalse(lookupReferencesManager.lifecycleLock.awaitStarted(1, TimeUnit.MICROSECONDS));
+    Assertions.assertNull(lookupReferencesManager.mainThread);
+    Assertions.assertNull(lookupReferencesManager.stateRef.get());
 
     lookupReferencesManager.start();
-    Assert.assertTrue(lookupReferencesManager.lifecycleLock.awaitStarted(1, TimeUnit.MICROSECONDS));
-    Assert.assertTrue(lookupReferencesManager.mainThread.isAlive());
-    Assert.assertNotNull(lookupReferencesManager.stateRef.get());
+    Assertions.assertTrue(lookupReferencesManager.lifecycleLock.awaitStarted(1, TimeUnit.MICROSECONDS));
+    Assertions.assertTrue(lookupReferencesManager.mainThread.isAlive());
+    Assertions.assertNotNull(lookupReferencesManager.stateRef.get());
 
     lookupReferencesManager.stop();
-    Assert.assertFalse(lookupReferencesManager.lifecycleLock.awaitStarted(1, TimeUnit.MICROSECONDS));
-    Assert.assertFalse(lookupReferencesManager.mainThread.isAlive());
+    Assertions.assertFalse(lookupReferencesManager.lifecycleLock.awaitStarted(1, TimeUnit.MICROSECONDS));
+    Assertions.assertFalse(lookupReferencesManager.mainThread.isAlive());
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testGetExceptionWhenClosed()
   {
-    lookupReferencesManager.get("test");
+    org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () ->
+      lookupReferencesManager.get("test"));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testAddExceptionWhenClosed()
   {
-    lookupReferencesManager.add("test", EasyMock.createMock(LookupExtractorFactoryContainer.class));
+    org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () ->
+      lookupReferencesManager.add("test", EasyMock.createMock(LookupExtractorFactoryContainer.class)));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testRemoveExceptionWhenClosed()
   {
-    lookupReferencesManager.remove("test", null);
+    org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () ->
+      lookupReferencesManager.remove("test", null));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testGetAllLookupsStateExceptionWhenClosed()
   {
-    lookupReferencesManager.getAllLookupsState();
+    org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () ->
+      lookupReferencesManager.getAllLookupsState());
   }
 
   @Test
@@ -156,19 +161,19 @@ public class LookupReferencesManagerTest
     EasyMock.expect(coordinatorClient.fetchLookupsForTierSync(LOOKUP_TIER)).andReturn(lookupMap);
     EasyMock.replay(coordinatorClient);
     lookupReferencesManager.start();
-    Assert.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
+    Assertions.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
 
     LookupExtractorFactoryContainer testContainer = new LookupExtractorFactoryContainer("0", lookupExtractorFactory);
 
     lookupReferencesManager.add("test", testContainer);
     lookupReferencesManager.handlePendingNotices();
 
-    Assert.assertEquals(Optional.of(testContainer), lookupReferencesManager.get("test"));
+    Assertions.assertEquals(Optional.of(testContainer), lookupReferencesManager.get("test"));
 
     lookupReferencesManager.remove("test", testContainer);
     lookupReferencesManager.handlePendingNotices();
 
-    Assert.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
+    Assertions.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
   }
 
   @Test
@@ -188,14 +193,14 @@ public class LookupReferencesManagerTest
     EasyMock.expect(coordinatorClient.fetchLookupsForTierSync(LOOKUP_TIER)).andReturn(lookupMap);
     EasyMock.replay(coordinatorClient);
     lookupReferencesManager.start();
-    Assert.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
+    Assertions.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
 
     LookupExtractorFactoryContainer testContainer = new LookupExtractorFactoryContainer("0", lookupExtractorFactory);
 
     lookupReferencesManager.add("test", testContainer);
     lookupReferencesManager.handlePendingNotices();
 
-    Assert.assertEquals(Optional.of(testContainer), lookupReferencesManager.get("test"));
+    Assertions.assertEquals(Optional.of(testContainer), lookupReferencesManager.get("test"));
 
     LookupExtractorFactory badLookupExtractorFactory = EasyMock.createMock(LookupExtractorFactory.class);
     EasyMock.expect(badLookupExtractorFactory.start()).andReturn(false).anyTimes();
@@ -209,12 +214,12 @@ public class LookupReferencesManagerTest
 
     lookupReferencesManager.handlePendingNotices();
 
-    Assert.assertEquals(Optional.of(testContainer), lookupReferencesManager.get("test"));
+    Assertions.assertEquals(Optional.of(testContainer), lookupReferencesManager.get("test"));
 
     lookupReferencesManager.remove("test", testContainer);
     lookupReferencesManager.handlePendingNotices();
 
-    Assert.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
+    Assertions.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
   }
 
   @Test
@@ -234,14 +239,14 @@ public class LookupReferencesManagerTest
     EasyMock.expect(coordinatorClient.fetchLookupsForTierSync(LOOKUP_TIER)).andReturn(lookupMap);
     EasyMock.replay(coordinatorClient);
     lookupReferencesManager.start();
-    Assert.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
+    Assertions.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
 
     LookupExtractorFactoryContainer testContainer = new LookupExtractorFactoryContainer("0", lookupExtractorFactory);
 
     lookupReferencesManager.add("test", testContainer);
     lookupReferencesManager.handlePendingNotices();
 
-    Assert.assertEquals(Optional.of(testContainer), lookupReferencesManager.get("test"));
+    Assertions.assertEquals(Optional.of(testContainer), lookupReferencesManager.get("test"));
 
     LookupExtractorFactory badLookupExtractorFactory = EasyMock.createMock(LookupExtractorFactory.class);
     EasyMock.expect(badLookupExtractorFactory.start()).andReturn(false).anyTimes();
@@ -255,12 +260,12 @@ public class LookupReferencesManagerTest
 
     lookupReferencesManager.handlePendingNotices();
 
-    Assert.assertEquals(Optional.of(testContainer), lookupReferencesManager.get("test"));
+    Assertions.assertEquals(Optional.of(testContainer), lookupReferencesManager.get("test"));
 
     lookupReferencesManager.remove("test", testContainer);
     lookupReferencesManager.handlePendingNotices();
 
-    Assert.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
+    Assertions.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
   }
 
   @Test
@@ -321,7 +326,7 @@ public class LookupReferencesManagerTest
     EasyMock.expect(coordinatorClient.fetchLookupsForTierSync(LOOKUP_TIER)).andReturn(lookupMap);
     EasyMock.replay(coordinatorClient);
     lookupReferencesManager.start();
-    Assert.assertEquals(Optional.empty(), lookupReferencesManager.get("notThere"));
+    Assertions.assertEquals(Optional.empty(), lookupReferencesManager.get("notThere"));
   }
 
   @Test
@@ -392,7 +397,7 @@ public class LookupReferencesManagerTest
     lookupReferencesManager.start();
     lookupReferencesManager.add("testName", new LookupExtractorFactoryContainer("1", lookupExtractorFactory1));
     lookupReferencesManager.handlePendingNotices();
-    Assert.assertTrue(lookupReferencesManager.get("testName").isPresent());
+    Assertions.assertTrue(lookupReferencesManager.get("testName").isPresent());
     EasyMock.verify(lookupExtractorFactory1);
   }
 
@@ -432,9 +437,9 @@ public class LookupReferencesManagerTest
     lookupReferencesManager.add("two", container2);
     lookupReferencesManager.handlePendingNotices();
 
-    Assert.assertEquals(ImmutableSet.of("one", "two"), lookupReferencesManager.getAllLookupNames());
+    Assertions.assertEquals(ImmutableSet.of("one", "two"), lookupReferencesManager.getAllLookupNames());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of("one", "two"),
         (lookupReferencesManager).getAllLookupNames()
     );
@@ -444,7 +449,7 @@ public class LookupReferencesManagerTest
   public void testGetCanonicalLookupName()
   {
     String lookupName = "lookupName1";
-    Assert.assertEquals(lookupName, lookupReferencesManager.getCanonicalLookupName(lookupName));
+    Assertions.assertEquals(lookupName, lookupReferencesManager.getCanonicalLookupName(lookupName));
   }
 
   @Test
@@ -493,18 +498,19 @@ public class LookupReferencesManagerTest
 
     LookupsState state = lookupReferencesManager.getAllLookupsState();
 
-    Assert.assertEquals(2, state.getCurrent().size());
-    Assert.assertEquals(container1, state.getCurrent().get("one"));
-    Assert.assertEquals(container2, state.getCurrent().get("two"));
+    Assertions.assertEquals(2, state.getCurrent().size());
+    Assertions.assertEquals(container1, state.getCurrent().get("one"));
+    Assertions.assertEquals(container2, state.getCurrent().get("two"));
 
-    Assert.assertEquals(1, state.getToLoad().size());
-    Assert.assertEquals(container3, state.getToLoad().get("three"));
+    Assertions.assertEquals(1, state.getToLoad().size());
+    Assertions.assertEquals(container3, state.getToLoad().get("three"));
 
-    Assert.assertEquals(1, state.getToDrop().size());
-    Assert.assertTrue(state.getToDrop().contains("one"));
+    Assertions.assertEquals(1, state.getToDrop().size());
+    Assertions.assertTrue(state.getToDrop().contains("one"));
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRealModeWithMainThread() throws Exception
   {
     LookupReferencesManager lookupReferencesManager = new LookupReferencesManager(
@@ -518,14 +524,14 @@ public class LookupReferencesManagerTest
     EasyMock.expect(coordinatorClient.fetchLookupsForTierSync(LOOKUP_TIER)).andReturn(lookupMap);
     EasyMock.replay(coordinatorClient);
     lookupReferencesManager.start();
-    Assert.assertTrue(lookupReferencesManager.mainThread.isAlive());
+    Assertions.assertTrue(lookupReferencesManager.mainThread.isAlive());
 
     LookupExtractorFactory lookupExtractorFactory = EasyMock.createMock(LookupExtractorFactory.class);
     EasyMock.expect(lookupExtractorFactory.start()).andReturn(true).once();
     EasyMock.expect(lookupExtractorFactory.destroy()).andReturn(true).once();
     EasyMock.expect(lookupExtractorFactory.isInitialized()).andReturn(true).anyTimes();
     EasyMock.replay(lookupExtractorFactory);
-    Assert.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
+    Assertions.assertEquals(Optional.empty(), lookupReferencesManager.get("test"));
 
     LookupExtractorFactoryContainer testContainer = new LookupExtractorFactoryContainer("0", lookupExtractorFactory);
     lookupReferencesManager.add("test", testContainer);
@@ -534,7 +540,7 @@ public class LookupReferencesManagerTest
       Thread.sleep(100);
     }
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of("test", "testMockForRealModeWithMainThread"),
         lookupReferencesManager.getAllLookupNames()
     );
@@ -545,14 +551,14 @@ public class LookupReferencesManagerTest
       Thread.sleep(100);
     }
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of("testMockForRealModeWithMainThread"),
         lookupReferencesManager.getAllLookupNames()
     );
 
     lookupReferencesManager.stop();
 
-    Assert.assertFalse(lookupReferencesManager.mainThread.isAlive());
+    Assertions.assertFalse(lookupReferencesManager.mainThread.isAlive());
   }
 
   @Test
@@ -597,9 +603,9 @@ public class LookupReferencesManagerTest
     EasyMock.replay(coordinatorClient);
 
     lookupReferencesManager.start();
-    Assert.assertEquals(Optional.of(container1), lookupReferencesManager.get("testLookup1"));
-    Assert.assertEquals(Optional.of(container2), lookupReferencesManager.get("testLookup2"));
-    Assert.assertEquals(Optional.of(container3), lookupReferencesManager.get("testLookup3"));
+    Assertions.assertEquals(Optional.of(container1), lookupReferencesManager.get("testLookup1"));
+    Assertions.assertEquals(Optional.of(container2), lookupReferencesManager.get("testLookup2"));
+    Assertions.assertEquals(Optional.of(container3), lookupReferencesManager.get("testLookup3"));
 
   }
 
@@ -643,7 +649,7 @@ public class LookupReferencesManagerTest
   {
     Map<String, LookupExtractorFactoryContainer> lookupMap = getLookupMapForSelectiveLoadingOfLookups(LookupLoadingSpec.ALL);
     for (String lookupName : lookupMap.keySet()) {
-      Assert.assertEquals(Optional.of(lookupMap.get(lookupName)), lookupReferencesManager.get(lookupName));
+      Assertions.assertEquals(Optional.of(lookupMap.get(lookupName)), lookupReferencesManager.get(lookupName));
     }
   }
 
@@ -652,7 +658,7 @@ public class LookupReferencesManagerTest
   {
     Map<String, LookupExtractorFactoryContainer> lookupMap = getLookupMapForSelectiveLoadingOfLookups(LookupLoadingSpec.NONE);
     for (String lookupName : lookupMap.keySet()) {
-      Assert.assertFalse(lookupReferencesManager.get(lookupName).isPresent());
+      Assertions.assertFalse(lookupReferencesManager.get(lookupName).isPresent());
     }
   }
 
@@ -663,9 +669,9 @@ public class LookupReferencesManagerTest
         getLookupMapForSelectiveLoadingOfLookups(
             LookupLoadingSpec.loadOnly(ImmutableSet.of("testLookup1", "testLookup2"))
         );
-    Assert.assertEquals(Optional.of(lookupMap.get("testLookup1")), lookupReferencesManager.get("testLookup1"));
-    Assert.assertEquals(Optional.of(lookupMap.get("testLookup2")), lookupReferencesManager.get("testLookup2"));
-    Assert.assertFalse(lookupReferencesManager.get("testLookup3").isPresent());
+    Assertions.assertEquals(Optional.of(lookupMap.get("testLookup1")), lookupReferencesManager.get("testLookup1"));
+    Assertions.assertEquals(Optional.of(lookupMap.get("testLookup2")), lookupReferencesManager.get("testLookup2"));
+    Assertions.assertFalse(lookupReferencesManager.get("testLookup3").isPresent());
   }
 
   @Test
@@ -685,7 +691,7 @@ public class LookupReferencesManagerTest
     lookupReferencesManager.add("testLookup2", container2);
     lookupReferencesManager.handlePendingNotices();
 
-    Assert.assertEquals(Set.of("testLookup1"), lookupReferencesManager.getAllLookupNames());
+    Assertions.assertEquals(Set.of("testLookup1"), lookupReferencesManager.getAllLookupNames());
   }
 
   @Test
@@ -704,7 +710,7 @@ public class LookupReferencesManagerTest
     lookupReferencesManager.add("testLookup", container);
     lookupReferencesManager.handlePendingNotices();
 
-    Assert.assertTrue(lookupReferencesManager.getAllLookupNames().isEmpty());
+    Assertions.assertTrue(lookupReferencesManager.getAllLookupNames().isEmpty());
   }
 
   @Test
@@ -768,7 +774,7 @@ public class LookupReferencesManagerTest
     ).anyTimes();
     EasyMock.replay(coordinatorClient);
     lookupReferencesManager.start();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Optional.of(container),
         lookupReferencesManager.get("testMockForLoadLookupOnCoordinatorFailure")
     );
@@ -798,6 +804,6 @@ public class LookupReferencesManagerTest
 
     EasyMock.expect(coordinatorClient.fetchLookupsForTierSync(LOOKUP_TIER)).andReturn(lookupMap);
     lookupReferencesManager.start();
-    Assert.assertEquals(Optional.empty(), lookupReferencesManager.get("testMockForDisableLookupSync"));
+    Assertions.assertEquals(Optional.empty(), lookupReferencesManager.get("testMockForDisableLookupSync"));
   }
 }

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
@@ -120,28 +120,28 @@ public class LookupReferencesManagerTest
   @Test
   public void testGetExceptionWhenClosed()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () ->
+    Assertions.assertThrows(IllegalStateException.class, () ->
       lookupReferencesManager.get("test"));
   }
 
   @Test
   public void testAddExceptionWhenClosed()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () ->
+    Assertions.assertThrows(IllegalStateException.class, () ->
       lookupReferencesManager.add("test", EasyMock.createMock(LookupExtractorFactoryContainer.class)));
   }
 
   @Test
   public void testRemoveExceptionWhenClosed()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () ->
+    Assertions.assertThrows(IllegalStateException.class, () ->
       lookupReferencesManager.remove("test", null));
   }
 
   @Test
   public void testGetAllLookupsStateExceptionWhenClosed()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () ->
+    Assertions.assertThrows(IllegalStateException.class, () ->
       lookupReferencesManager.getAllLookupsState());
   }
 

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupSerdeModuleTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupSerdeModuleTest.java
@@ -35,16 +35,16 @@ import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.transform.ExpressionTransform;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LookupSerdeModuleTest
 {
   private Injector injector;
   private ObjectMapper objectMapper;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     injector = new CoreInjectorBuilder(new StartupInjectorBuilder().build())
@@ -67,7 +67,7 @@ public class LookupSerdeModuleTest
         injector.getInstance(ExprMacroTable.class)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         virtualColumn,
         objectMapper.readValue(objectMapper.writeValueAsBytes(virtualColumn), VirtualColumn.class)
     );
@@ -82,7 +82,7 @@ public class LookupSerdeModuleTest
         new RegisteredLookupExtractionFn(null, "beep", false, null, null, null)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         dimensionSpec,
         objectMapper.readValue(objectMapper.writeValueAsBytes(dimensionSpec), DimensionSpec.class)
     );
@@ -97,7 +97,7 @@ public class LookupSerdeModuleTest
         new RegisteredLookupExtractionFn(null, "beep", false, null, null, null)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         filter,
         objectMapper.readValue(objectMapper.writeValueAsBytes(filter), DimFilter.class)
     );
@@ -112,7 +112,7 @@ public class LookupSerdeModuleTest
         injector.getInstance(ExprMacroTable.class)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         transform,
         objectMapper.readValue(objectMapper.writeValueAsBytes(transform), ExpressionTransform.class)
     );
@@ -123,6 +123,6 @@ public class LookupSerdeModuleTest
   {
     LookupExtractorFactoryContainerProvider instance = injector.getInstance(LookupExtractorFactoryContainerProvider.class);
     String lookupName = "lookupName1";
-    Assert.assertEquals(lookupName, instance.getCanonicalLookupName(lookupName));
+    Assertions.assertEquals(lookupName, instance.getCanonicalLookupName(lookupName));
   }
 }

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupSnapshotTakerTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupSnapshotTakerTest.java
@@ -86,17 +86,24 @@ public class LookupSnapshotTakerTest
   }
 
   @Test
-  public void testIOExceptionDuringLookupPersist()
+  public void testIOExceptionDuringLookupPersist() throws IOException
   {
-    Throwable exception = Assertions.assertThrows(ISE.class, () -> {
-      File directory = temporaryFolder.newFolder();
-      LookupSnapshotTaker lookupSnapshotTaker = new LookupSnapshotTaker(mapper, directory.getAbsolutePath());
-      File snapshotFile = lookupSnapshotTaker.getPersistFile(TIER1);
-      Assertions.assertFalse(snapshotFile.exists());
-      Assertions.assertTrue(snapshotFile.createNewFile());
-      Assertions.assertTrue(snapshotFile.setReadOnly());
-      Assertions.assertTrue(snapshotFile.getParentFile().setReadOnly());
-      LookupBean lookupBean = new LookupBean(
+    final File directory = temporaryFolder.newFolder();
+    final LookupSnapshotTaker lookupSnapshotTaker = new LookupSnapshotTaker(mapper, directory.getAbsolutePath());
+    final File snapshotFile = lookupSnapshotTaker.getPersistFile(TIER1);
+    Assertions.assertFalse(snapshotFile.exists());
+    Assertions.assertTrue(snapshotFile.createNewFile());
+    try {
+      Assertions.assertTrue(
+          snapshotFile.setReadOnly(),
+          "test setup must be able to make the snapshot file read-only"
+      );
+      final File snapshotDirectory = snapshotFile.getParentFile();
+      Assertions.assertTrue(
+          snapshotDirectory.setReadOnly(),
+          "test setup must be able to make the snapshot directory read-only"
+      );
+      final LookupBean lookupBean = new LookupBean(
           "name",
           null,
           new LookupExtractorFactoryContainer(
@@ -109,10 +116,20 @@ public class LookupSnapshotTakerTest
               )
           )
       );
-      List<LookupBean> lookupBeanList = Collections.singletonList(lookupBean);
-      lookupSnapshotTaker.takeSnapshot(TIER1, lookupBeanList);
-    });
-    Assertions.assertTrue(exception.getMessage().contains("Exception during serialization of lookups"));
+      final List<LookupBean> lookupBeanList = Collections.singletonList(lookupBean);
+      final Throwable exception = Assertions.assertThrows(
+          ISE.class,
+          () -> lookupSnapshotTaker.takeSnapshot(TIER1, lookupBeanList)
+      );
+      Assertions.assertTrue(exception.getMessage().contains("Exception during serialization of lookups"));
+    }
+    finally {
+      Assertions.assertTrue(snapshotFile.setWritable(true), "test teardown must restore file write permission");
+      Assertions.assertTrue(
+          snapshotFile.getParentFile().setWritable(true),
+          "test teardown must restore directory write permission"
+      );
+    }
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupSnapshotTakerTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupSnapshotTakerTest.java
@@ -25,17 +25,18 @@ import com.google.common.io.Files;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.apache.druid.testing.TemporaryFolderExtension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class LookupSnapshotTakerTest
@@ -43,11 +44,8 @@ public class LookupSnapshotTakerTest
   private static final String TIER1 = "tier1";
   private static final String TIER2 = "tier2";
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   private final ObjectMapper mapper = TestHelper.makeJsonMapper();
 
@@ -55,7 +53,7 @@ public class LookupSnapshotTakerTest
   private LookupSnapshotTaker lookupSnapshotTaker;
   private String basePersistDirectory;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
     mapper.registerSubtypes(MapLookupExtractorFactory.class);
@@ -86,56 +84,58 @@ public class LookupSnapshotTakerTest
     lookupSnapshotTaker.takeSnapshot(TIER1, lookupBeanList1);
     List<LookupBean> lookupBeanList2 = Collections.singletonList(lookupBean2);
     lookupSnapshotTaker.takeSnapshot(TIER2, lookupBeanList2);
-    Assert.assertEquals(lookupBeanList1, lookupSnapshotTaker.pullExistingSnapshot(TIER1));
-    Assert.assertEquals(lookupBeanList2, lookupSnapshotTaker.pullExistingSnapshot(TIER2));
+    Assertions.assertEquals(lookupBeanList1, lookupSnapshotTaker.pullExistingSnapshot(TIER1));
+    Assertions.assertEquals(lookupBeanList2, lookupSnapshotTaker.pullExistingSnapshot(TIER2));
   }
 
   @Test
-  public void testIOExceptionDuringLookupPersist() throws IOException
+  public void testIOExceptionDuringLookupPersist()
   {
-    File directory = temporaryFolder.newFolder();
-    LookupSnapshotTaker lookupSnapshotTaker = new LookupSnapshotTaker(mapper, directory.getAbsolutePath());
-    File snapshotFile = lookupSnapshotTaker.getPersistFile(TIER1);
-    Assert.assertFalse(snapshotFile.exists());
-    Assert.assertTrue(snapshotFile.createNewFile());
-    Assert.assertTrue(snapshotFile.setReadOnly());
-    Assert.assertTrue(snapshotFile.getParentFile().setReadOnly());
-    LookupBean lookupBean = new LookupBean(
-        "name",
-        null,
-        new LookupExtractorFactoryContainer(
-            "v1",
-            new MapLookupExtractorFactory(
-                ImmutableMap.of(
-                    "key",
-                    "value"
-                ), true
-            )
-        )
-    );
-    List<LookupBean> lookupBeanList = Collections.singletonList(lookupBean);
-
-    expectedException.expect(ISE.class);
-    expectedException.expectMessage("Exception during serialization of lookups");
-    lookupSnapshotTaker.takeSnapshot(TIER1, lookupBeanList);
+    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(ISE.class, () -> {
+      File directory = temporaryFolder.newFolder();
+      LookupSnapshotTaker lookupSnapshotTaker = new LookupSnapshotTaker(mapper, directory.getAbsolutePath());
+      File snapshotFile = lookupSnapshotTaker.getPersistFile(TIER1);
+      Assertions.assertFalse(snapshotFile.exists());
+      Assertions.assertTrue(snapshotFile.createNewFile());
+      Assertions.assertTrue(snapshotFile.setReadOnly());
+      Assertions.assertTrue(snapshotFile.getParentFile().setReadOnly());
+      LookupBean lookupBean = new LookupBean(
+          "name",
+          null,
+          new LookupExtractorFactoryContainer(
+              "v1",
+              new MapLookupExtractorFactory(
+                  ImmutableMap.of(
+                      "key",
+                      "value"
+                  ), true
+              )
+          )
+      );
+      List<LookupBean> lookupBeanList = Collections.singletonList(lookupBean);
+      lookupSnapshotTaker.takeSnapshot(TIER1, lookupBeanList);
+    });
+    assertTrue(exception.getMessage().contains("Exception during serialization of lookups"));
   }
 
   @Test
   public void tesLookupPullingFromEmptyFile() throws IOException
   {
     File snapshotFile = lookupSnapshotTaker.getPersistFile(TIER1);
-    Assert.assertTrue(snapshotFile.createNewFile());
-    Assert.assertEquals(Collections.emptyList(), lookupSnapshotTaker.pullExistingSnapshot(TIER1));
+    Assertions.assertTrue(snapshotFile.createNewFile());
+    Assertions.assertEquals(Collections.emptyList(), lookupSnapshotTaker.pullExistingSnapshot(TIER1));
   }
 
-  @Test(expected = ISE.class)
-  public void tesLookupPullingFromCorruptFile() throws IOException
+  @Test
+  public void tesLookupPullingFromCorruptFile()
   {
-    File snapshotFile = lookupSnapshotTaker.getPersistFile(TIER1);
-    Assert.assertTrue(snapshotFile.createNewFile());
-    byte[] bytes = StringUtils.toUtf8("test corrupt file");
-    Files.write(bytes, snapshotFile);
-    lookupSnapshotTaker.pullExistingSnapshot(TIER1);
+    org.junit.jupiter.api.Assertions.assertThrows(ISE.class, () -> {
+      File snapshotFile = lookupSnapshotTaker.getPersistFile(TIER1);
+      Assertions.assertTrue(snapshotFile.createNewFile());
+      byte[] bytes = StringUtils.toUtf8("test corrupt file");
+      Files.write(bytes, snapshotFile);
+      lookupSnapshotTaker.pullExistingSnapshot(TIER1);
+    });
   }
 
   @Test
@@ -144,6 +144,7 @@ public class LookupSnapshotTakerTest
     File directory = temporaryFolder.newFolder();
     LookupSnapshotTaker lookupSnapshotTaker = new LookupSnapshotTaker(mapper, directory.getAbsolutePath());
     List<LookupBean> actualList = lookupSnapshotTaker.pullExistingSnapshot(TIER1);
-    Assert.assertEquals(Collections.emptyList(), actualList);
+    Assertions.assertEquals(Collections.emptyList(), actualList);
   }
+
 }

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupSnapshotTakerTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupSnapshotTakerTest.java
@@ -36,9 +36,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-
 public class LookupSnapshotTakerTest
 {
   private static final String TIER1 = "tier1";
@@ -115,7 +112,7 @@ public class LookupSnapshotTakerTest
       List<LookupBean> lookupBeanList = Collections.singletonList(lookupBean);
       lookupSnapshotTaker.takeSnapshot(TIER1, lookupBeanList);
     });
-    assertTrue(exception.getMessage().contains("Exception during serialization of lookups"));
+    Assertions.assertTrue(exception.getMessage().contains("Exception during serialization of lookups"));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupSnapshotTakerTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupSnapshotTakerTest.java
@@ -88,7 +88,7 @@ public class LookupSnapshotTakerTest
   @Test
   public void testIOExceptionDuringLookupPersist()
   {
-    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(ISE.class, () -> {
+    Throwable exception = Assertions.assertThrows(ISE.class, () -> {
       File directory = temporaryFolder.newFolder();
       LookupSnapshotTaker lookupSnapshotTaker = new LookupSnapshotTaker(mapper, directory.getAbsolutePath());
       File snapshotFile = lookupSnapshotTaker.getPersistFile(TIER1);
@@ -126,7 +126,7 @@ public class LookupSnapshotTakerTest
   @Test
   public void tesLookupPullingFromCorruptFile()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(ISE.class, () -> {
+    Assertions.assertThrows(ISE.class, () -> {
       File snapshotFile = lookupSnapshotTaker.getPersistFile(TIER1);
       Assertions.assertTrue(snapshotFile.createNewFile());
       byte[] bytes = StringUtils.toUtf8("test corrupt file");

--- a/server/src/test/java/org/apache/druid/query/lookup/MapLookupExtractorFactoryTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/MapLookupExtractorFactoryTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.query.lookup;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -36,19 +36,19 @@ public class MapLookupExtractorFactoryTest
   @Test
   public void testSimpleExtraction()
   {
-    Assert.assertEquals(FACTORY.get().apply(KEY), VALUE);
-    Assert.assertTrue(FACTORY.get().isOneToOne());
+    Assertions.assertEquals(FACTORY.get().apply(KEY), VALUE);
+    Assertions.assertTrue(FACTORY.get().isOneToOne());
   }
 
   @Test
   public void testReplaces()
   {
-    Assert.assertFalse(FACTORY.replaces(FACTORY));
-    Assert.assertFalse(FACTORY.replaces(new MapLookupExtractorFactory(ImmutableMap.of(KEY, VALUE), true)));
-    Assert.assertTrue(FACTORY.replaces(new MapLookupExtractorFactory(ImmutableMap.of(KEY, VALUE), false)));
-    Assert.assertTrue(FACTORY.replaces(new MapLookupExtractorFactory(ImmutableMap.of(KEY + "1", VALUE), true)));
-    Assert.assertTrue(FACTORY.replaces(new MapLookupExtractorFactory(ImmutableMap.of(KEY, VALUE + "1"), true)));
-    Assert.assertTrue(FACTORY.replaces(null));
+    Assertions.assertFalse(FACTORY.replaces(FACTORY));
+    Assertions.assertFalse(FACTORY.replaces(new MapLookupExtractorFactory(ImmutableMap.of(KEY, VALUE), true)));
+    Assertions.assertTrue(FACTORY.replaces(new MapLookupExtractorFactory(ImmutableMap.of(KEY, VALUE), false)));
+    Assertions.assertTrue(FACTORY.replaces(new MapLookupExtractorFactory(ImmutableMap.of(KEY + "1", VALUE), true)));
+    Assertions.assertTrue(FACTORY.replaces(new MapLookupExtractorFactory(ImmutableMap.of(KEY, VALUE + "1"), true)));
+    Assertions.assertTrue(FACTORY.replaces(null));
   }
 
   @Test
@@ -57,6 +57,6 @@ public class MapLookupExtractorFactoryTest
     ObjectMapper mapper = new DefaultObjectMapper();
     mapper.registerSubtypes(MapLookupExtractorFactory.class);
     LookupExtractorFactory lookupExtractorFactory = new MapLookupExtractorFactory(ImmutableMap.of("key", "value"), true);
-    Assert.assertEquals(lookupExtractorFactory, mapper.readerFor(LookupExtractorFactory.class).readValue(mapper.writeValueAsString(lookupExtractorFactory)));
+    Assertions.assertEquals(lookupExtractorFactory, mapper.readerFor(LookupExtractorFactory.class).readValue(mapper.writeValueAsString(lookupExtractorFactory)));
   }
 }

--- a/server/src/test/java/org/apache/druid/query/lookup/RegisteredLookupExtractionFnTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/RegisteredLookupExtractionFnTest.java
@@ -27,15 +27,16 @@ import org.apache.druid.query.extraction.ExtractionFn;
 import org.apache.druid.query.extraction.MapLookupExtractor;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTest
 {
@@ -45,9 +46,6 @@ public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTes
   );
   private static final LookupExtractor LOOKUP_EXTRACTOR = new MapLookupExtractor(MAP, true);
   private static final String LOOKUP_NAME = "some lookup";
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSimpleDelegation()
@@ -65,18 +63,18 @@ public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTes
     );
     EasyMock.verify(manager);
 
-    Assert.assertSame(LOOKUP_EXTRACTOR, fn.getDelegate().getLookup());
+    Assertions.assertSame(LOOKUP_EXTRACTOR, fn.getDelegate().getLookup());
 
-    Assert.assertEquals(false, fn.isInjective());
-    Assert.assertFalse(fn.getDelegate().isInjective());
+    Assertions.assertEquals(false, fn.isInjective());
+    Assertions.assertFalse(fn.getDelegate().isInjective());
 
-    Assert.assertEquals(ExtractionFn.ExtractionType.MANY_TO_ONE, fn.getExtractionType());
-    Assert.assertEquals(ExtractionFn.ExtractionType.MANY_TO_ONE, fn.getDelegate().getExtractionType());
+    Assertions.assertEquals(ExtractionFn.ExtractionType.MANY_TO_ONE, fn.getExtractionType());
+    Assertions.assertEquals(ExtractionFn.ExtractionType.MANY_TO_ONE, fn.getDelegate().getExtractionType());
 
     for (String orig : Arrays.asList(null, "foo", "bat")) {
-      Assert.assertEquals(LOOKUP_EXTRACTOR.apply(orig), fn.apply(orig));
+      Assertions.assertEquals(LOOKUP_EXTRACTOR.apply(orig), fn.apply(orig));
     }
-    Assert.assertEquals("not in the map", fn.apply("not in the map"));
+    Assertions.assertEquals("not in the map", fn.apply("not in the map"));
   }
 
   @Test
@@ -95,45 +93,48 @@ public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTes
     );
     EasyMock.verify(manager);
 
-    Assert.assertNull(fn.isInjective());
-    Assert.assertEquals(ExtractionFn.ExtractionType.ONE_TO_ONE, fn.getExtractionType());
+    Assertions.assertNull(fn.isInjective());
+    Assertions.assertEquals(ExtractionFn.ExtractionType.ONE_TO_ONE, fn.getExtractionType());
   }
 
   @Test
   public void testMissingDelegation()
   {
-    final LookupExtractorFactoryContainerProvider manager = EasyMock.createStrictMock(LookupReferencesManager.class);
-    EasyMock.expect(manager.get(EasyMock.eq(LOOKUP_NAME))).andReturn(Optional.empty()).once();
-    EasyMock.replay(manager);
-
-    expectedException.expectMessage("Lookup [some lookup] not found");
-    try {
-      new RegisteredLookupExtractionFn(
-          manager,
-          LOOKUP_NAME,
-          true,
-          null,
-          true,
-          false
-      ).apply("foo");
-    }
-    finally {
-      EasyMock.verify(manager);
-    }
+    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> {
+      final LookupExtractorFactoryContainerProvider manager = EasyMock.createStrictMock(LookupReferencesManager.class);
+      EasyMock.expect(manager.get(EasyMock.eq(LOOKUP_NAME))).andReturn(Optional.empty()).once();
+      EasyMock.replay(manager);
+      try {
+        new RegisteredLookupExtractionFn(
+            manager,
+            LOOKUP_NAME,
+            true,
+            null,
+            true,
+            false
+        ).apply("foo");
+      }
+      finally {
+        EasyMock.verify(manager);
+      }
+    });
+    assertTrue(exception.getMessage().contains("Lookup [some lookup] not found"));
   }
 
   @Test
   public void testNullLookup()
   {
-    expectedException.expectMessage("`lookup` required");
-    new RegisteredLookupExtractionFn(
-        null,
-        null,
-        true,
-        null,
-        true,
-        false
-    );
+    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> {
+      new RegisteredLookupExtractionFn(
+          null,
+          null,
+          true,
+          null,
+          true,
+          false
+      );
+    });
+    assertTrue(exception.getMessage().contains("`lookup` required"));
   }
 
   @Test
@@ -158,12 +159,12 @@ public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTes
         mapper.writeValueAsString(fn),
         JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
     );
-    Assert.assertEquals(mapper.convertValue(fn, JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT), result);
-    Assert.assertEquals(LOOKUP_NAME, result.get("lookup"));
-    Assert.assertEquals(true, result.get("retainMissingValue"));
-    Assert.assertEquals(true, result.get("injective"));
-    Assert.assertNull(result.get("replaceMissingValueWith"));
-    Assert.assertEquals(false, result.get("optimize"));
+    Assertions.assertEquals(mapper.convertValue(fn, JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT), result);
+    Assertions.assertEquals(LOOKUP_NAME, result.get("lookup"));
+    Assertions.assertEquals(true, result.get("retainMissingValue"));
+    Assertions.assertEquals(true, result.get("injective"));
+    Assertions.assertNull(result.get("replaceMissingValueWith"));
+    Assertions.assertEquals(false, result.get("optimize"));
   }
 
   @Test
@@ -180,7 +181,7 @@ public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTes
         true,
         false
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         fn,
         new RegisteredLookupExtractionFn(
             manager,
@@ -191,7 +192,7 @@ public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTes
             false
         )
     );
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         fn,
         new RegisteredLookupExtractionFn(
             manager,
@@ -203,7 +204,7 @@ public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTes
         )
     );
 
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         fn,
         new RegisteredLookupExtractionFn(
             manager,
@@ -216,7 +217,7 @@ public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTes
     );
 
 
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         fn,
         new RegisteredLookupExtractionFn(
             manager,
@@ -228,7 +229,7 @@ public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTes
         )
     );
 
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         fn,
         new RegisteredLookupExtractionFn(
             manager,
@@ -241,7 +242,7 @@ public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTes
     );
 
 
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         fn,
         new RegisteredLookupExtractionFn(
             manager,

--- a/server/src/test/java/org/apache/druid/query/lookup/RegisteredLookupExtractionFnTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/RegisteredLookupExtractionFnTest.java
@@ -98,7 +98,7 @@ public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTes
   @Test
   public void testMissingDelegation()
   {
-    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> {
+    Throwable exception = Assertions.assertThrows(Exception.class, () -> {
       final LookupExtractorFactoryContainerProvider manager = EasyMock.createStrictMock(LookupReferencesManager.class);
       EasyMock.expect(manager.get(EasyMock.eq(LOOKUP_NAME))).andReturn(Optional.empty()).once();
       EasyMock.replay(manager);
@@ -122,7 +122,7 @@ public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTes
   @Test
   public void testNullLookup()
   {
-    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> {
+    Throwable exception = Assertions.assertThrows(Exception.class, () -> {
       new RegisteredLookupExtractionFn(
           null,
           null,

--- a/server/src/test/java/org/apache/druid/query/lookup/RegisteredLookupExtractionFnTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/RegisteredLookupExtractionFnTest.java
@@ -36,8 +36,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTest
 {
   private static Map<String, String> MAP = ImmutableMap.of(
@@ -118,7 +116,7 @@ public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTes
         EasyMock.verify(manager);
       }
     });
-    assertTrue(exception.getMessage().contains("Lookup [some lookup] not found"));
+    Assertions.assertTrue(exception.getMessage().contains("Lookup [some lookup] not found"));
   }
 
   @Test
@@ -134,7 +132,7 @@ public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTes
           false
       );
     });
-    assertTrue(exception.getMessage().contains("`lookup` required"));
+    Assertions.assertTrue(exception.getMessage().contains("`lookup` required"));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
@@ -518,7 +518,7 @@ class DataSchemaTest extends InitializedNullHandlingTest
         );
       }
       catch (ValueInstantiationException e) {
-        MatcherAssert.assertThat(
+        DruidExceptionMatcher.assertThat(
             entry.getKey(),
             e.getCause(),
             DruidExceptionMatcher.invalidInput().expectMessageIs(

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
@@ -50,7 +50,6 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
 import org.apache.druid.utils.CompressionUtils;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Before;
@@ -181,7 +180,7 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
         TestIndex.INDEX_IO,
         jsonMapper
     );
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assert.assertThrows(
             DruidException.class,
             () -> manager.getCachedSegments()
@@ -981,7 +980,7 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
                                                                 .virtualStorageLoadThreads(0)
                                                                 .build();
     final List<StorageLocation> storageLocations = loaderConfig.toStorageLocations();
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assert.assertThrows(
             DruidException.class,
             () -> new SegmentLocalCacheManager(

--- a/server/src/test/java/org/apache/druid/server/ClientQuerySegmentWalkerTest.java
+++ b/server/src/test/java/org/apache/druid/server/ClientQuerySegmentWalkerTest.java
@@ -97,12 +97,10 @@ import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -113,6 +111,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests ClientQuerySegmentWalker.
@@ -216,9 +216,6 @@ public class ClientQuerySegmentWalkerTest
 
   private static final String DUMMY_QUERY_ID = "dummyQueryId";
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   private Closer closer;
   private QueryRunnerFactoryConglomerate conglomerate;
   private final StubServiceEmitter emitter = StubServiceEmitter.createStarted();
@@ -232,7 +229,7 @@ public class ClientQuerySegmentWalkerTest
 
   private ObservableQueryScheduler scheduler;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     closer = Closer.create();
@@ -247,7 +244,7 @@ public class ClientQuerySegmentWalkerTest
     initWalker(ImmutableMap.of(), scheduler);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException
   {
     closer.close();
@@ -272,10 +269,10 @@ public class ClientQuerySegmentWalkerTest
         ImmutableList.of(new Object[]{INTERVAL.getStartMillis(), 10L})
     );
 
-    Assert.assertEquals(1, scheduler.getTotalRun().get());
-    Assert.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(1, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(1, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(1, scheduler.getTotalRun().get());
+    Assertions.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(1, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(1, scheduler.getTotalReleased().get());
   }
 
   @Test
@@ -308,10 +305,10 @@ public class ClientQuerySegmentWalkerTest
         ImmutableList.of(new Object[]{INTERVAL.getStartMillis(), 10L})
     );
 
-    Assert.assertEquals(1, scheduler.getTotalRun().get());
-    Assert.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(1, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(1, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(1, scheduler.getTotalRun().get());
+    Assertions.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(1, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(1, scheduler.getTotalReleased().get());
   }
 
   @Test
@@ -332,10 +329,10 @@ public class ClientQuerySegmentWalkerTest
         ImmutableList.of(new Object[]{INTERVAL.getStartMillis(), 10L})
     );
 
-    Assert.assertEquals(1, scheduler.getTotalRun().get());
-    Assert.assertEquals(0, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(1, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(1, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(1, scheduler.getTotalRun().get());
+    Assertions.assertEquals(0, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(1, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(1, scheduler.getTotalReleased().get());
   }
 
   @Test
@@ -376,10 +373,10 @@ public class ClientQuerySegmentWalkerTest
 
     // note: this should really be 1, but in the interim queries that are composed of multiple queries count each
     // invocation of either the cluster or local walker in ClientQuerySegmentWalker
-    Assert.assertEquals(2, scheduler.getTotalRun().get());
-    Assert.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(2, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(2, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(2, scheduler.getTotalRun().get());
+    Assertions.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(2, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(2, scheduler.getTotalReleased().get());
   }
 
   @Test
@@ -410,10 +407,10 @@ public class ClientQuerySegmentWalkerTest
         ImmutableList.of(new Object[]{3L})
     );
 
-    Assert.assertEquals(1, scheduler.getTotalRun().get());
-    Assert.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(1, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(1, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(1, scheduler.getTotalRun().get());
+    Assertions.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(1, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(1, scheduler.getTotalReleased().get());
   }
 
   @Test
@@ -444,10 +441,10 @@ public class ClientQuerySegmentWalkerTest
         ImmutableList.of(new Object[]{3L})
     );
 
-    Assert.assertEquals(1, scheduler.getTotalRun().get());
-    Assert.assertEquals(0, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(1, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(1, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(1, scheduler.getTotalRun().get());
+    Assertions.assertEquals(0, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(1, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(1, scheduler.getTotalReleased().get());
   }
 
   @Test
@@ -488,10 +485,10 @@ public class ClientQuerySegmentWalkerTest
 
     // note: this should really be 1, but in the interim queries that are composed of multiple queries count each
     // invocation of either the cluster or local walker in ClientQuerySegmentWalker
-    Assert.assertEquals(2, scheduler.getTotalRun().get());
-    Assert.assertEquals(2, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(2, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(2, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(2, scheduler.getTotalRun().get());
+    Assertions.assertEquals(2, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(2, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(2, scheduler.getTotalReleased().get());
   }
 
   @Test
@@ -521,10 +518,10 @@ public class ClientQuerySegmentWalkerTest
         )
     );
 
-    Assert.assertEquals(1, scheduler.getTotalRun().get());
-    Assert.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(1, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(1, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(1, scheduler.getTotalRun().get());
+    Assertions.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(1, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(1, scheduler.getTotalReleased().get());
   }
 
   @Test
@@ -587,10 +584,10 @@ public class ClientQuerySegmentWalkerTest
 
     // note: this should really be 1, but in the interim queries that are composed of multiple queries count each
     // invocation of either the cluster or local walker in ClientQuerySegmentWalker
-    Assert.assertEquals(2, scheduler.getTotalRun().get());
-    Assert.assertEquals(2, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(2, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(2, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(2, scheduler.getTotalRun().get());
+    Assertions.assertEquals(2, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(2, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(2, scheduler.getTotalReleased().get());
   }
 
   @Test
@@ -684,10 +681,10 @@ public class ClientQuerySegmentWalkerTest
 
     // note: this should really be 1, but in the interim queries that are composed of multiple queries count each
     // invocation of either the cluster or local walker in ClientQuerySegmentWalker
-    Assert.assertEquals(4, scheduler.getTotalRun().get());
-    Assert.assertEquals(4, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(4, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(4, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(4, scheduler.getTotalRun().get());
+    Assertions.assertEquals(4, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(4, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(4, scheduler.getTotalReleased().get());
   }
 
   @Test
@@ -734,10 +731,10 @@ public class ClientQuerySegmentWalkerTest
         )
     );
 
-    Assert.assertEquals(2, scheduler.getTotalRun().get());
-    Assert.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(2, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(2, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(2, scheduler.getTotalRun().get());
+    Assertions.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(2, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(2, scheduler.getTotalReleased().get());
   }
 
   @Test
@@ -784,75 +781,73 @@ public class ClientQuerySegmentWalkerTest
         )
     );
 
-    Assert.assertEquals(2, scheduler.getTotalRun().get());
-    Assert.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(2, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(2, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(2, scheduler.getTotalRun().get());
+    Assertions.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(2, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(2, scheduler.getTotalReleased().get());
   }
 
   @Test
   public void testJoinOnTableErrorCantInlineTable()
   {
-    final GroupByQuery query =
-        (GroupByQuery) GroupByQuery.builder()
-                                   .setDataSource(
-                                       JoinDataSource.create(
-                                           new TableDataSource(FOO),
-                                           new TableDataSource(BAR),
-                                           "j.",
-                                           "\"j.s\" == \"s\"",
-                                           JoinType.INNER,
-                                           null,
-                                           ExprMacroTable.nil(),
-                                           null,
-                                           JoinAlgorithm.BROADCAST
-                                       )
-                                   )
-                                   .setGranularity(Granularities.ALL)
-                                   .setInterval(Intervals.ONLY_ETERNITY)
-                                   .setDimensions(DefaultDimensionSpec.of("s"), DefaultDimensionSpec.of("j.s"))
-                                   .setAggregatorSpecs(new CountAggregatorFactory("cnt"))
-                                   .build()
-                                   .withId(DUMMY_QUERY_ID);
+    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () -> {
+      final GroupByQuery query =
+          (GroupByQuery) GroupByQuery.builder()
+              .setDataSource(
+                  JoinDataSource.create(
+                      new TableDataSource(FOO),
+                      new TableDataSource(BAR),
+                      "j.",
+                      "\"j.s\" == \"s\"",
+                      JoinType.INNER,
+                      null,
+                      ExprMacroTable.nil(),
+                      null,
+                      JoinAlgorithm.BROADCAST
+                  )
+              )
+              .setGranularity(Granularities.ALL)
+              .setInterval(Intervals.ONLY_ETERNITY)
+              .setDimensions(DefaultDimensionSpec.of("s"), DefaultDimensionSpec.of("j.s"))
+              .setAggregatorSpecs(new CountAggregatorFactory("cnt"))
+              .build()
+              .withId(DUMMY_QUERY_ID);
 
-    expectedException.expect(IllegalStateException.class);
-    expectedException.expectMessage("Cannot handle subquery structure for dataSource");
-
-    testQuery(query, ImmutableList.of(), ImmutableList.of());
+      testQuery(query, ImmutableList.of(), ImmutableList.of());
+    });
+    assertTrue(exception.getMessage().contains("Cannot handle subquery structure for dataSource"));
   }
 
   @Test
   public void testTimeseriesOnGroupByOnTableErrorTooManyRows()
   {
-    initWalker(ImmutableMap.of("maxSubqueryRows", "2"));
+    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(ResourceLimitExceededException.class, () -> {
+      initWalker(ImmutableMap.of("maxSubqueryRows", "2"));
 
-    final GroupByQuery subquery =
-        GroupByQuery.builder()
-                    .setDataSource(FOO)
-                    .setGranularity(Granularities.ALL)
-                    .setInterval(Collections.singletonList(INTERVAL))
-                    .setDimensions(DefaultDimensionSpec.of("s"))
-                    .build();
+      final GroupByQuery subquery =
+          GroupByQuery.builder()
+              .setDataSource(FOO)
+              .setGranularity(Granularities.ALL)
+              .setInterval(Collections.singletonList(INTERVAL))
+              .setDimensions(DefaultDimensionSpec.of("s"))
+              .build();
 
-    final TimeseriesQuery query =
-        (TimeseriesQuery) Druids.newTimeseriesQueryBuilder()
-                                .dataSource(new QueryDataSource(subquery))
-                                .granularity(Granularities.ALL)
-                                .intervals(Intervals.ONLY_ETERNITY)
-                                .aggregators(new CountAggregatorFactory("cnt"))
-                                .build()
-                                .withId(DUMMY_QUERY_ID);
+      final TimeseriesQuery query =
+          (TimeseriesQuery) Druids.newTimeseriesQueryBuilder()
+              .dataSource(new QueryDataSource(subquery))
+              .granularity(Granularities.ALL)
+              .intervals(Intervals.ONLY_ETERNITY)
+              .aggregators(new CountAggregatorFactory("cnt"))
+              .build()
+              .withId(DUMMY_QUERY_ID);
 
-    expectedException.expect(ResourceLimitExceededException.class);
-    expectedException.expectMessage(
-        "Cannot issue the query, subqueries generated results beyond maximum[2] rows. Try setting the "
+      testQuery(query, ImmutableList.of(), ImmutableList.of());
+    });
+    assertTrue(exception.getMessage().contains("Cannot issue the query, subqueries generated results beyond maximum[2] rows. Try setting the "
         + "'maxSubqueryBytes' in the query context to 'auto' for enabling byte based limit, which chooses an optimal "
         + "limit based on memory size and result's heap usage or manually configure the values of either 'maxSubqueryBytes' "
         + "or 'maxSubqueryRows' in the query context. Manually alter the value carefully as it can cause the broker to go out "
-        + "of memory."
-    );
-
-    testQuery(query, ImmutableList.of(), ImmutableList.of());
+        + "of memory."));
   }
 
   @Test // Regression test for bug fixed in https://github.com/apache/druid/pull/15300
@@ -915,42 +910,40 @@ public class ClientQuerySegmentWalkerTest
         )
     );
 
-    Assert.assertEquals(2, scheduler.getTotalRun().get());
-    Assert.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(2, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(2, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(2, scheduler.getTotalRun().get());
+    Assertions.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(2, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(2, scheduler.getTotalReleased().get());
   }
 
   @Test
   public void testTimeseriesOnGroupByOnTableErrorTooLarge()
   {
-    final GroupByQuery subquery =
-        GroupByQuery.builder()
-                    .setDataSource(FOO)
-                    .setGranularity(Granularities.ALL)
-                    .setInterval(Collections.singletonList(INTERVAL))
-                    .setDimensions(DefaultDimensionSpec.of("s"))
-                    .build();
+    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(ResourceLimitExceededException.class, () -> {
+      final GroupByQuery subquery =
+          GroupByQuery.builder()
+              .setDataSource(FOO)
+              .setGranularity(Granularities.ALL)
+              .setInterval(Collections.singletonList(INTERVAL))
+              .setDimensions(DefaultDimensionSpec.of("s"))
+              .build();
 
-    final TimeseriesQuery query =
-        (TimeseriesQuery) Druids.newTimeseriesQueryBuilder()
-                                .dataSource(new QueryDataSource(subquery))
-                                .granularity(Granularities.ALL)
-                                .intervals(Intervals.ONLY_ETERNITY)
-                                .aggregators(new CountAggregatorFactory("cnt"))
-                                .context(ImmutableMap.of(QueryContexts.MAX_SUBQUERY_BYTES_KEY, "1"))
-                                .build()
-                                .withId(DUMMY_QUERY_ID);
+      final TimeseriesQuery query =
+          (TimeseriesQuery) Druids.newTimeseriesQueryBuilder()
+              .dataSource(new QueryDataSource(subquery))
+              .granularity(Granularities.ALL)
+              .intervals(Intervals.ONLY_ETERNITY)
+              .aggregators(new CountAggregatorFactory("cnt"))
+              .context(ImmutableMap.of(QueryContexts.MAX_SUBQUERY_BYTES_KEY, "1"))
+              .build()
+              .withId(DUMMY_QUERY_ID);
 
-    expectedException.expect(ResourceLimitExceededException.class);
-    expectedException.expectMessage(
-        "Cannot issue the query, subqueries generated results beyond maximum[1] bytes. Increase the "
+      testQuery(query, ImmutableList.of(), ImmutableList.of());
+    });
+    assertTrue(exception.getMessage().contains("Cannot issue the query, subqueries generated results beyond maximum[1] bytes. Increase the "
         + "JVM's memory or set the 'maxSubqueryBytes' in the query context to increase the space "
         + "allocated for subqueries to materialize their results. Manually alter the value carefully as it can cause "
-        + "the broker to go out of memory."
-    );
-
-    testQuery(query, ImmutableList.of(), ImmutableList.of());
+        + "the broker to go out of memory."));
   }
 
   @Test
@@ -992,11 +985,11 @@ public class ClientQuerySegmentWalkerTest
     for (ServiceMetricEvent event : emitter.getMetricEvents(ClientQuerySegmentWalker.ROWS_COUNT_METRIC)) {
       EventMap map = event.toMap();
       if (ClientQuerySegmentWalker.ROWS_COUNT_METRIC.equals(map.get("metric"))) {
-        Assert.assertTrue(map.containsKey("host"));
-        Assert.assertTrue(map.containsKey("service"));
-        Assert.assertEquals(DUMMY_QUERY_ID, map.get(DruidMetrics.ID));
-        Assert.assertEquals("1.1", map.get(DruidMetrics.SUBQUERY_ID));
-        Assert.assertEquals(3, map.get("value"));
+        Assertions.assertTrue(map.containsKey("host"));
+        Assertions.assertTrue(map.containsKey("service"));
+        Assertions.assertEquals(DUMMY_QUERY_ID, map.get(DruidMetrics.ID));
+        Assertions.assertEquals("1.1", map.get(DruidMetrics.SUBQUERY_ID));
+        Assertions.assertEquals(3, map.get("value"));
       }
     }
   }
@@ -1040,20 +1033,20 @@ public class ClientQuerySegmentWalkerTest
 
     for (ServiceMetricEvent event : emitter.getMetricEvents(ClientQuerySegmentWalker.ROWS_COUNT_METRIC)) {
       EventMap map = event.toMap();
-      Assert.assertTrue(map.containsKey("host"));
-      Assert.assertTrue(map.containsKey("service"));
-      Assert.assertEquals(DUMMY_QUERY_ID, map.get(DruidMetrics.ID));
-      Assert.assertEquals("1.1", map.get(DruidMetrics.SUBQUERY_ID));
-      Assert.assertEquals(3, map.get("value"));
+      Assertions.assertTrue(map.containsKey("host"));
+      Assertions.assertTrue(map.containsKey("service"));
+      Assertions.assertEquals(DUMMY_QUERY_ID, map.get(DruidMetrics.ID));
+      Assertions.assertEquals("1.1", map.get(DruidMetrics.SUBQUERY_ID));
+      Assertions.assertEquals(3, map.get("value"));
     }
 
     for (ServiceMetricEvent event : emitter.getMetricEvents(ClientQuerySegmentWalker.BYTES_COUNT_METRIC)) {
       EventMap map = event.toMap();
-      Assert.assertTrue(map.containsKey("host"));
-      Assert.assertTrue(map.containsKey("service"));
-      Assert.assertEquals(DUMMY_QUERY_ID, map.get(DruidMetrics.ID));
-      Assert.assertEquals("1.1", map.get(DruidMetrics.SUBQUERY_ID));
-      Assert.assertEquals(43L, map.get("value"));
+      Assertions.assertTrue(map.containsKey("host"));
+      Assertions.assertTrue(map.containsKey("service"));
+      Assertions.assertEquals(DUMMY_QUERY_ID, map.get(DruidMetrics.ID));
+      Assertions.assertEquals("1.1", map.get(DruidMetrics.SUBQUERY_ID));
+      Assertions.assertEquals(43L, map.get("value"));
     }
   }
 
@@ -1138,10 +1131,10 @@ public class ClientQuerySegmentWalkerTest
           )
     );
 
-    Assert.assertEquals(1, scheduler.getTotalRun().get());
-    Assert.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(1, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(1, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(1, scheduler.getTotalRun().get());
+    Assertions.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(1, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(1, scheduler.getTotalReleased().get());
   }
 
   @Test
@@ -1226,10 +1219,10 @@ public class ClientQuerySegmentWalkerTest
         )
     );
 
-    Assert.assertEquals(1, scheduler.getTotalRun().get());
-    Assert.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(1, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(1, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(1, scheduler.getTotalRun().get());
+    Assertions.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(1, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(1, scheduler.getTotalReleased().get());
   }
 
   @Test
@@ -1308,37 +1301,35 @@ public class ClientQuerySegmentWalkerTest
         )
     );
 
-    Assert.assertEquals(1, scheduler.getTotalRun().get());
-    Assert.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(1, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(1, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(1, scheduler.getTotalRun().get());
+    Assertions.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(1, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(1, scheduler.getTotalReleased().get());
   }
 
 
   @Test
   public void testTopNArraysDoubles()
   {
-    final TopNQuery query =
-        (TopNQuery) new TopNQueryBuilder().dataSource(ARRAY)
-                                          .granularity(Granularities.ALL)
-                                          .intervals(Intervals.ONLY_ETERNITY)
-                                          .dimension(DefaultDimensionSpec.of("ad"))
-                                          .metric("sum_n")
-                                          .threshold(1000)
-                                          .aggregators(new LongSumAggregatorFactory("sum_n", "n"))
-                                          .build()
-                                          .withId(DUMMY_QUERY_ID);
+    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class, () -> {
+      final TopNQuery query =
+          (TopNQuery) new TopNQueryBuilder().dataSource(ARRAY)
+              .granularity(Granularities.ALL)
+              .intervals(Intervals.ONLY_ETERNITY)
+              .dimension(DefaultDimensionSpec.of("ad"))
+              .metric("sum_n")
+              .threshold(1000)
+              .aggregators(new LongSumAggregatorFactory("sum_n", "n"))
+              .build()
+              .withId(DUMMY_QUERY_ID);
 
-
-    // group by cannot handle true array types, expect this, RuntimeExeception with IAE in stack trace
-    expectedException.expect(RuntimeException.class);
-    expectedException.expectMessage("Cannot create query type helper from invalid type [ARRAY<DOUBLE>]");
-
-    testQuery(
-        query,
-        ImmutableList.of(ExpectedQuery.cluster(query)),
-        ImmutableList.of()
-    );
+      testQuery(
+          query,
+          ImmutableList.of(ExpectedQuery.cluster(query)),
+          ImmutableList.of()
+      );
+    });
+    assertTrue(exception.getMessage().contains("Cannot create query type helper from invalid type [ARRAY<DOUBLE>]"));
   }
 
   @Test
@@ -1371,35 +1362,34 @@ public class ClientQuerySegmentWalkerTest
         )
     );
 
-    Assert.assertEquals(1, scheduler.getTotalRun().get());
-    Assert.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(1, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(1, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(1, scheduler.getTotalRun().get());
+    Assertions.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(1, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(1, scheduler.getTotalReleased().get());
   }
 
   @Test
   public void testTopNOnArraysLongs()
   {
-    final TopNQuery query =
-        (TopNQuery) new TopNQueryBuilder().dataSource(ARRAY)
-                                          .granularity(Granularities.ALL)
-                                          .intervals(Intervals.ONLY_ETERNITY)
-                                          .dimension(DefaultDimensionSpec.of("al"))
-                                          .metric("sum_n")
-                                          .threshold(1000)
-                                          .aggregators(new LongSumAggregatorFactory("sum_n", "n"))
-                                          .build()
-                                          .withId(DUMMY_QUERY_ID);
+    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class, () -> {
+      final TopNQuery query =
+          (TopNQuery) new TopNQueryBuilder().dataSource(ARRAY)
+              .granularity(Granularities.ALL)
+              .intervals(Intervals.ONLY_ETERNITY)
+              .dimension(DefaultDimensionSpec.of("al"))
+              .metric("sum_n")
+              .threshold(1000)
+              .aggregators(new LongSumAggregatorFactory("sum_n", "n"))
+              .build()
+              .withId(DUMMY_QUERY_ID);
 
-    // group by cannot handle true array types, expect this, RuntimeExeception with IAE in stack trace
-    expectedException.expect(RuntimeException.class);
-    expectedException.expectMessage("Cannot create query type helper from invalid type [ARRAY<LONG>]");
-
-    testQuery(
-        query,
-        ImmutableList.of(ExpectedQuery.cluster(query)),
-        ImmutableList.of()
-    );
+      testQuery(
+          query,
+          ImmutableList.of(ExpectedQuery.cluster(query)),
+          ImmutableList.of()
+      );
+    });
+    assertTrue(exception.getMessage().contains("Cannot create query type helper from invalid type [ARRAY<LONG>]"));
   }
 
   @Test
@@ -1432,36 +1422,34 @@ public class ClientQuerySegmentWalkerTest
         )
     );
 
-    Assert.assertEquals(1, scheduler.getTotalRun().get());
-    Assert.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(1, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(1, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(1, scheduler.getTotalRun().get());
+    Assertions.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(1, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(1, scheduler.getTotalReleased().get());
   }
 
   @Test
   public void testTopNOnArraysStrings()
   {
-    final TopNQuery query =
-        (TopNQuery) new TopNQueryBuilder().dataSource(ARRAY)
-                                          .granularity(Granularities.ALL)
-                                          .intervals(Intervals.ONLY_ETERNITY)
-                                          .dimension(DefaultDimensionSpec.of("as"))
-                                          .metric("sum_n")
-                                          .threshold(1000)
-                                          .aggregators(new LongSumAggregatorFactory("sum_n", "n"))
-                                          .build()
-                                          .withId(DUMMY_QUERY_ID);
+    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class, () -> {
+      final TopNQuery query =
+          (TopNQuery) new TopNQueryBuilder().dataSource(ARRAY)
+              .granularity(Granularities.ALL)
+              .intervals(Intervals.ONLY_ETERNITY)
+              .dimension(DefaultDimensionSpec.of("as"))
+              .metric("sum_n")
+              .threshold(1000)
+              .aggregators(new LongSumAggregatorFactory("sum_n", "n"))
+              .build()
+              .withId(DUMMY_QUERY_ID);
 
-
-    // group by cannot handle true array types, expect this, RuntimeExeception with IAE in stack trace
-    expectedException.expect(RuntimeException.class);
-    expectedException.expectMessage("Cannot create query type helper from invalid type [ARRAY<STRING>]");
-
-    testQuery(
-        query,
-        ImmutableList.of(ExpectedQuery.cluster(query)),
-        ImmutableList.of()
-    );
+      testQuery(
+          query,
+          ImmutableList.of(ExpectedQuery.cluster(query)),
+          ImmutableList.of()
+      );
+    });
+    assertTrue(exception.getMessage().contains("Cannot create query type helper from invalid type [ARRAY<STRING>]"));
   }
 
   @Test
@@ -1494,10 +1482,10 @@ public class ClientQuerySegmentWalkerTest
         )
     );
 
-    Assert.assertEquals(1, scheduler.getTotalRun().get());
-    Assert.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(1, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(1, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(1, scheduler.getTotalRun().get());
+    Assertions.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(1, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(1, scheduler.getTotalReleased().get());
   }
 
   @Test
@@ -1520,10 +1508,10 @@ public class ClientQuerySegmentWalkerTest
         ImmutableList.of(new Object[]{INTERVAL.getStartMillis(), null})
     );
 
-    Assert.assertEquals(1, scheduler.getTotalRun().get());
-    Assert.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(1, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(1, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(1, scheduler.getTotalRun().get());
+    Assertions.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(1, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(1, scheduler.getTotalReleased().get());
   }
 
   @Test
@@ -1546,10 +1534,10 @@ public class ClientQuerySegmentWalkerTest
         ImmutableList.of(new Object[]{INTERVAL.getStartMillis(), null})
     );
 
-    Assert.assertEquals(1, scheduler.getTotalRun().get());
-    Assert.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(1, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(1, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(1, scheduler.getTotalRun().get());
+    Assertions.assertEquals(1, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(1, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(1, scheduler.getTotalReleased().get());
   }
 
   @Test
@@ -1598,10 +1586,10 @@ public class ClientQuerySegmentWalkerTest
         ImmutableList.of(new Object[] {10L}, new Object[] {10L})
     );
 
-    Assert.assertEquals(3, scheduler.getTotalRun().get());
-    Assert.assertEquals(2, scheduler.getTotalPrioritizedAndLaned().get());
-    Assert.assertEquals(3, scheduler.getTotalAcquired().get());
-    Assert.assertEquals(3, scheduler.getTotalReleased().get());
+    Assertions.assertEquals(3, scheduler.getTotalRun().get());
+    Assertions.assertEquals(2, scheduler.getTotalPrioritizedAndLaned().get());
+    Assertions.assertEquals(3, scheduler.getTotalAcquired().get());
+    Assertions.assertEquals(3, scheduler.getTotalReleased().get());
   }
 
   /**
@@ -1755,7 +1743,7 @@ public class ClientQuerySegmentWalkerTest
     }
 
     QueryToolChestTestHelper.assertArrayResultsEquals(expectedResults, Sequences.simple(arrays));
-    Assert.assertEquals(expectedQueries, issuedQueries);
+    Assertions.assertEquals(expectedQueries, issuedQueries);
   }
 
   private enum ClusterOrLocal

--- a/server/src/test/java/org/apache/druid/server/ClientQuerySegmentWalkerTest.java
+++ b/server/src/test/java/org/apache/druid/server/ClientQuerySegmentWalkerTest.java
@@ -112,8 +112,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 /**
  * Tests ClientQuerySegmentWalker.
  *
@@ -815,7 +813,7 @@ public class ClientQuerySegmentWalkerTest
 
       testQuery(query, ImmutableList.of(), ImmutableList.of());
     });
-    assertTrue(exception.getMessage().contains("Cannot handle subquery structure for dataSource"));
+    Assertions.assertTrue(exception.getMessage().contains("Cannot handle subquery structure for dataSource"));
   }
 
   @Test
@@ -843,7 +841,7 @@ public class ClientQuerySegmentWalkerTest
 
       testQuery(query, ImmutableList.of(), ImmutableList.of());
     });
-    assertTrue(exception.getMessage().contains("Cannot issue the query, subqueries generated results beyond maximum[2] rows. Try setting the "
+    Assertions.assertTrue(exception.getMessage().contains("Cannot issue the query, subqueries generated results beyond maximum[2] rows. Try setting the "
         + "'maxSubqueryBytes' in the query context to 'auto' for enabling byte based limit, which chooses an optimal "
         + "limit based on memory size and result's heap usage or manually configure the values of either 'maxSubqueryBytes' "
         + "or 'maxSubqueryRows' in the query context. Manually alter the value carefully as it can cause the broker to go out "
@@ -940,7 +938,7 @@ public class ClientQuerySegmentWalkerTest
 
       testQuery(query, ImmutableList.of(), ImmutableList.of());
     });
-    assertTrue(exception.getMessage().contains("Cannot issue the query, subqueries generated results beyond maximum[1] bytes. Increase the "
+    Assertions.assertTrue(exception.getMessage().contains("Cannot issue the query, subqueries generated results beyond maximum[1] bytes. Increase the "
         + "JVM's memory or set the 'maxSubqueryBytes' in the query context to increase the space "
         + "allocated for subqueries to materialize their results. Manually alter the value carefully as it can cause "
         + "the broker to go out of memory."));
@@ -1329,7 +1327,7 @@ public class ClientQuerySegmentWalkerTest
           ImmutableList.of()
       );
     });
-    assertTrue(exception.getMessage().contains("Cannot create query type helper from invalid type [ARRAY<DOUBLE>]"));
+    Assertions.assertTrue(exception.getMessage().contains("Cannot create query type helper from invalid type [ARRAY<DOUBLE>]"));
   }
 
   @Test
@@ -1389,7 +1387,7 @@ public class ClientQuerySegmentWalkerTest
           ImmutableList.of()
       );
     });
-    assertTrue(exception.getMessage().contains("Cannot create query type helper from invalid type [ARRAY<LONG>]"));
+    Assertions.assertTrue(exception.getMessage().contains("Cannot create query type helper from invalid type [ARRAY<LONG>]"));
   }
 
   @Test
@@ -1449,7 +1447,7 @@ public class ClientQuerySegmentWalkerTest
           ImmutableList.of()
       );
     });
-    assertTrue(exception.getMessage().contains("Cannot create query type helper from invalid type [ARRAY<STRING>]"));
+    Assertions.assertTrue(exception.getMessage().contains("Cannot create query type helper from invalid type [ARRAY<STRING>]"));
   }
 
   @Test
@@ -1871,4 +1869,3 @@ public class ClientQuerySegmentWalkerTest
     return timeline;
   }
 }
-

--- a/server/src/test/java/org/apache/druid/server/ClientQuerySegmentWalkerTest.java
+++ b/server/src/test/java/org/apache/druid/server/ClientQuerySegmentWalkerTest.java
@@ -788,7 +788,7 @@ public class ClientQuerySegmentWalkerTest
   @Test
   public void testJoinOnTableErrorCantInlineTable()
   {
-    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () -> {
+    Throwable exception = Assertions.assertThrows(IllegalStateException.class, () -> {
       final GroupByQuery query =
           (GroupByQuery) GroupByQuery.builder()
               .setDataSource(
@@ -819,7 +819,7 @@ public class ClientQuerySegmentWalkerTest
   @Test
   public void testTimeseriesOnGroupByOnTableErrorTooManyRows()
   {
-    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(ResourceLimitExceededException.class, () -> {
+    Throwable exception = Assertions.assertThrows(ResourceLimitExceededException.class, () -> {
       initWalker(ImmutableMap.of("maxSubqueryRows", "2"));
 
       final GroupByQuery subquery =
@@ -917,7 +917,7 @@ public class ClientQuerySegmentWalkerTest
   @Test
   public void testTimeseriesOnGroupByOnTableErrorTooLarge()
   {
-    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(ResourceLimitExceededException.class, () -> {
+    Throwable exception = Assertions.assertThrows(ResourceLimitExceededException.class, () -> {
       final GroupByQuery subquery =
           GroupByQuery.builder()
               .setDataSource(FOO)
@@ -1309,7 +1309,7 @@ public class ClientQuerySegmentWalkerTest
   @Test
   public void testTopNArraysDoubles()
   {
-    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class, () -> {
+    Throwable exception = Assertions.assertThrows(RuntimeException.class, () -> {
       final TopNQuery query =
           (TopNQuery) new TopNQueryBuilder().dataSource(ARRAY)
               .granularity(Granularities.ALL)
@@ -1369,7 +1369,7 @@ public class ClientQuerySegmentWalkerTest
   @Test
   public void testTopNOnArraysLongs()
   {
-    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class, () -> {
+    Throwable exception = Assertions.assertThrows(RuntimeException.class, () -> {
       final TopNQuery query =
           (TopNQuery) new TopNQueryBuilder().dataSource(ARRAY)
               .granularity(Granularities.ALL)
@@ -1429,7 +1429,7 @@ public class ClientQuerySegmentWalkerTest
   @Test
   public void testTopNOnArraysStrings()
   {
-    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class, () -> {
+    Throwable exception = Assertions.assertThrows(RuntimeException.class, () -> {
       final TopNQuery query =
           (TopNQuery) new TopNQueryBuilder().dataSource(ARRAY)
               .granularity(Granularities.ALL)

--- a/server/src/test/java/org/apache/druid/server/QueryBlocklistRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryBlocklistRuleTest.java
@@ -25,8 +25,9 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.util.Map;
 import java.util.Set;
 
@@ -36,7 +37,7 @@ public class QueryBlocklistRuleTest
   public void testMatchAllCriteria_rejectsNullCriteria()
   {
     // Rule with all null criteria would block ALL queries - this should be rejected
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new DefaultQueryBlocklistRule("match-all", null, null, null)
     );
@@ -46,7 +47,7 @@ public class QueryBlocklistRuleTest
   public void testMatchAllCriteria_rejectsEmptyCollections()
   {
     // Rule with all empty collections should also be rejected (same as null)
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new DefaultQueryBlocklistRule("match-all", ImmutableSet.of(), ImmutableSet.of(), ImmutableMap.of())
     );
@@ -63,14 +64,14 @@ public class QueryBlocklistRuleTest
                                    .dataSource("sensitive_data")
                                    .intervals("2020-01-01/2020-01-02")
                                    .build();
-    Assert.assertTrue(rule.matches(matchingQuery));
+    Assertions.assertTrue(rule.matches(matchingQuery));
 
     // Should not match when datasource is not in the list
     TimeseriesQuery nonMatchingQuery = Druids.newTimeseriesQueryBuilder()
                                       .dataSource("safe_data")
                                       .intervals("2020-01-01/2020-01-02")
                                       .build();
-    Assert.assertFalse(rule.matches(nonMatchingQuery));
+    Assertions.assertFalse(rule.matches(nonMatchingQuery));
   }
 
   @Test
@@ -85,7 +86,7 @@ public class QueryBlocklistRuleTest
                                    .intervals("2020-01-01/2020-01-02")
                                    .context(ImmutableMap.of("priority", "0", "application", "rogue-app"))
                                    .build();
-    Assert.assertTrue(rule.matches(matchingQuery));
+    Assertions.assertTrue(rule.matches(matchingQuery));
 
     // Should not match when context values don't match
     TimeseriesQuery nonMatchingQuery = Druids.newTimeseriesQueryBuilder()
@@ -93,14 +94,14 @@ public class QueryBlocklistRuleTest
                                       .intervals("2020-01-01/2020-01-02")
                                       .context(ImmutableMap.of("priority", "1", "application", "rogue-app"))
                                       .build();
-    Assert.assertFalse(rule.matches(nonMatchingQuery));
+    Assertions.assertFalse(rule.matches(nonMatchingQuery));
 
     // Should not match when context is missing
     TimeseriesQuery noContextQuery = Druids.newTimeseriesQueryBuilder()
                                     .dataSource("test")
                                     .intervals("2020-01-01/2020-01-02")
                                     .build();
-    Assert.assertFalse(rule.matches(noContextQuery));
+    Assertions.assertFalse(rule.matches(noContextQuery));
   }
 
   @Test
@@ -114,7 +115,7 @@ public class QueryBlocklistRuleTest
                                    .dataSource("test")
                                    .intervals("2020-01-01/2020-01-02")
                                    .build();
-    Assert.assertTrue(rule.matches(matchingQuery));
+    Assertions.assertTrue(rule.matches(matchingQuery));
   }
 
   @Test
@@ -136,7 +137,7 @@ public class QueryBlocklistRuleTest
                                    .intervals("2020-01-01/2020-01-02")
                                    .context(ImmutableMap.of("priority", "0"))
                                    .build();
-    Assert.assertTrue(rule.matches(matchingQuery));
+    Assertions.assertTrue(rule.matches(matchingQuery));
 
     // Should not match when only datasource matches
     TimeseriesQuery onlyDataSourceMatches = Druids.newTimeseriesQueryBuilder()
@@ -144,7 +145,7 @@ public class QueryBlocklistRuleTest
                                            .intervals("2020-01-01/2020-01-02")
                                            .context(ImmutableMap.of("priority", "1"))
                                            .build();
-    Assert.assertFalse(rule.matches(onlyDataSourceMatches));
+    Assertions.assertFalse(rule.matches(onlyDataSourceMatches));
 
     // Should not match when only context matches
     TimeseriesQuery onlyContextMatches = Druids.newTimeseriesQueryBuilder()
@@ -152,7 +153,7 @@ public class QueryBlocklistRuleTest
                                         .intervals("2020-01-01/2020-01-02")
                                         .context(ImmutableMap.of("priority", "0"))
                                         .build();
-    Assert.assertFalse(rule.matches(onlyContextMatches));
+    Assertions.assertFalse(rule.matches(onlyContextMatches));
   }
 
   @Test
@@ -170,14 +171,14 @@ public class QueryBlocklistRuleTest
                            .intervals("2020-01-01/2020-01-02")
                            .build();
 
-    Assert.assertTrue(rule.matches(query));
+    Assertions.assertTrue(rule.matches(query));
   }
 
   @Test
   public void testRuleNameValidation_null()
   {
     // Rule name cannot be null
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new DefaultQueryBlocklistRule(null, ImmutableSet.of("ds"), null, null)
     );
@@ -187,7 +188,7 @@ public class QueryBlocklistRuleTest
   public void testRuleNameValidation_empty()
   {
     // Rule name cannot be empty
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new DefaultQueryBlocklistRule("", ImmutableSet.of("ds"), null, null)
     );
@@ -199,8 +200,8 @@ public class QueryBlocklistRuleTest
     ObjectMapper mapper = TestHelper.makeJsonMapper();
     String json = "{\"ruleName\":\"block-ds\",\"dataSources\":[\"foo\"]}";
     QueryBlocklistRule rule = mapper.readValue(json, QueryBlocklistRule.class);
-    Assert.assertTrue(rule instanceof DefaultQueryBlocklistRule);
-    Assert.assertEquals("block-ds", rule.getRuleName());
+    Assertions.assertTrue(rule instanceof DefaultQueryBlocklistRule);
+    Assertions.assertEquals("block-ds", rule.getRuleName());
   }
 
   @Test
@@ -209,8 +210,8 @@ public class QueryBlocklistRuleTest
     ObjectMapper mapper = TestHelper.makeJsonMapper();
     String json = "{\"type\":\"default\",\"ruleName\":\"block-ds\",\"dataSources\":[\"foo\"]}";
     QueryBlocklistRule rule = mapper.readValue(json, QueryBlocklistRule.class);
-    Assert.assertTrue(rule instanceof DefaultQueryBlocklistRule);
-    Assert.assertEquals("block-ds", rule.getRuleName());
+    Assertions.assertTrue(rule instanceof DefaultQueryBlocklistRule);
+    Assertions.assertEquals("block-ds", rule.getRuleName());
   }
 
   @Test
@@ -218,10 +219,10 @@ public class QueryBlocklistRuleTest
   {
     ObjectMapper mapper = TestHelper.makeJsonMapper();
     String json = "{\"type\":\"customExtension\",\"ruleName\":\"block-ds\",\"dataSources\":[\"foo\"]}";
-    Exception e = Assert.assertThrows(
+    Exception e = Assertions.assertThrows(
         Exception.class,
         () -> mapper.readValue(json, QueryBlocklistRule.class)
     );
-    Assert.assertTrue(e.getMessage().contains("Could not resolve type id 'customExtension'"));
+    Assertions.assertTrue(e.getMessage().contains("Could not resolve type id 'customExtension'"));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/QueryDetailsTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryDetailsTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.server;
 
 import org.apache.druid.query.context.ResponseContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -41,7 +41,7 @@ public class QueryDetailsTest
       QueryResource.transferEntityTag(responseContext, responseBuilder);
       Response response = responseBuilder.build();
       MultivaluedMap<String, Object> metadata = response.getMetadata();
-      Assert.assertNull(metadata.get(QueryResource.HEADER_ETAG));
+      Assertions.assertNull(metadata.get(QueryResource.HEADER_ETAG));
     }
 
     // Provided ETAG is passed along.
@@ -53,7 +53,7 @@ public class QueryDetailsTest
       QueryResource.transferEntityTag(responseContext, responseBuilder);
       Response response = responseBuilder.build();
       MultivaluedMap<String, Object> metadata = response.getMetadata();
-      Assert.assertEquals(etagValue, metadata.getFirst(QueryResource.HEADER_ETAG));
+      Assertions.assertEquals(etagValue, metadata.getFirst(QueryResource.HEADER_ETAG));
     }
   }
 }

--- a/server/src/test/java/org/apache/druid/server/QueryLifecycleTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryLifecycleTest.java
@@ -73,18 +73,19 @@ import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceType;
 import org.easymock.EasyMock;
 import org.easymock.IArgumentMatcher;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @LazySingleton
 public class QueryLifecycleTest
@@ -138,10 +139,7 @@ public class QueryLifecycleTest
 
   Injector injector;
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
-  @Before
+  @BeforeEach
   public void setup()
   {
     conglomerate = EasyMock.createMock(QueryRunnerFactoryConglomerate.class);
@@ -173,7 +171,7 @@ public class QueryLifecycleTest
     return queryLifecycleFactory.factorize();
   }
 
-  @After
+  @AfterEach
   public void teardown()
   {
     EasyMock.verify(
@@ -213,19 +211,20 @@ public class QueryLifecycleTest
   @Test
   public void testRunSimpleUnauthorized()
   {
-    expectedException.expect(DruidException.class);
-    expectedException.expectMessage("Unexpected state [UNAUTHORIZED], expecting [AUTHORIZED]");
+    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, () -> {
 
-    EasyMock.expect(queryConfig.getContext()).andReturn(ImmutableMap.of()).anyTimes();
-    EasyMock.expect(authenticationResult.getIdentity()).andReturn(IDENTITY).anyTimes();
-    EasyMock.expect(conglomerate.getToolChest(EasyMock.anyObject()))
-            .andReturn(toolChest)
-            .once();
-    EasyMock.expect(toolChest.makeMetrics(EasyMock.anyObject())).andReturn(metrics).anyTimes();
-    replayAll();
+      EasyMock.expect(queryConfig.getContext()).andReturn(ImmutableMap.of()).anyTimes();
+      EasyMock.expect(authenticationResult.getIdentity()).andReturn(IDENTITY).anyTimes();
+      EasyMock.expect(conglomerate.getToolChest(EasyMock.anyObject()))
+          .andReturn(toolChest)
+          .once();
+      EasyMock.expect(toolChest.makeMetrics(EasyMock.anyObject())).andReturn(metrics).anyTimes();
+      replayAll();
 
-    QueryLifecycle lifecycle = createLifecycle();
-    lifecycle.runSimple(query, authenticationResult, AuthorizationResult.DENY);
+      QueryLifecycle lifecycle = createLifecycle();
+      lifecycle.runSimple(query, authenticationResult, AuthorizationResult.DENY);
+    });
+    assertTrue(exception.getMessage().contains("Unexpected state [UNAUTHORIZED], expecting [AUTHORIZED]"));
   }
 
   @Test
@@ -315,13 +314,13 @@ public class QueryLifecycleTest
     replayAll();
 
     QueryLifecycle lifecycle = createLifecycle();
-    DruidException e = Assert.assertThrows(
+    DruidException e = Assertions.assertThrows(
         DruidException.class,
         () -> lifecycle.runSimple(query, authenticationResult, authorizationResult)
     );
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
-    Assert.assertEquals(DruidException.Category.FORBIDDEN, e.getCategory());
-    Assert.assertEquals(
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals(DruidException.Category.FORBIDDEN, e.getCategory());
+    Assertions.assertEquals(
         "You do not have permission to run a segmentMetadata query on table[some_datasource].",
         e.getMessage()
     );
@@ -350,41 +349,39 @@ public class QueryLifecycleTest
   @Test
   public void testRunSimple_foundDifferentPolicyRestrictions()
   {
-    // Multiple policy restrictions indicates most likely the system is trying to double-authorizing the request
-    // This is not allowed in any case.
-    expectedException.expect(ISE.class);
-    expectedException.expectMessage(
-        "Different restrictions on table [some_datasource]: previous policy [RowFilterPolicy{rowFilter=some-column IS NULL}] and new policy [RowFilterPolicy{rowFilter=some-column2 IS NULL}]");
+    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(ISE.class, () -> {
 
-    DimFilter originalFilterOnRDS = new NullFilter("some-column", null);
-    Policy originalFilterPolicy = RowFilterPolicy.from(originalFilterOnRDS);
+      DimFilter originalFilterOnRDS = new NullFilter("some-column", null);
+      Policy originalFilterPolicy = RowFilterPolicy.from(originalFilterOnRDS);
 
-    Policy newFilterPolicy = RowFilterPolicy.from(new NullFilter("some-column2", null));
-    AuthorizationResult authorizationResult = AuthorizationResult.allowWithRestriction(ImmutableMap.of(
-        DATASOURCE,
-        Optional.of(newFilterPolicy)
-    ));
+      Policy newFilterPolicy = RowFilterPolicy.from(new NullFilter("some-column2", null));
+      AuthorizationResult authorizationResult = AuthorizationResult.allowWithRestriction(ImmutableMap.of(
+          DATASOURCE,
+          Optional.of(newFilterPolicy)
+      ));
 
-    final TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
-                                        .dataSource(RestrictedDataSource.create(
-                                            TableDataSource.create(DATASOURCE),
-                                            originalFilterPolicy
-                                        ))
-                                        .intervals(ImmutableList.of(Intervals.ETERNITY))
-                                        .aggregators(new CountAggregatorFactory("chocula"))
-                                        .build();
-    EasyMock.expect(queryConfig.getContext()).andReturn(ImmutableMap.of()).anyTimes();
-    EasyMock.expect(authenticationResult.getIdentity()).andReturn(IDENTITY).anyTimes();
-    EasyMock.expect(authenticationResult.getAuthorizerName()).andReturn(AUTHORIZER).anyTimes();
-    EasyMock.expect(conglomerate.getToolChest(EasyMock.anyObject())).andReturn(toolChest).anyTimes();
-    EasyMock.expect(toolChest.makeMetrics(EasyMock.anyObject())).andReturn(metrics).anyTimes();
-    EasyMock.expect(texasRanger.getQueryRunnerForIntervals(EasyMock.anyObject(), EasyMock.anyObject()))
-            .andReturn(runner).anyTimes();
-    EasyMock.expect(runner.run(EasyMock.anyObject(), EasyMock.anyObject())).andReturn(Sequences.empty()).anyTimes();
-    replayAll();
+      final TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
+          .dataSource(RestrictedDataSource.create(
+              TableDataSource.create(DATASOURCE),
+              originalFilterPolicy
+          ))
+          .intervals(ImmutableList.of(Intervals.ETERNITY))
+          .aggregators(new CountAggregatorFactory("chocula"))
+          .build();
+      EasyMock.expect(queryConfig.getContext()).andReturn(ImmutableMap.of()).anyTimes();
+      EasyMock.expect(authenticationResult.getIdentity()).andReturn(IDENTITY).anyTimes();
+      EasyMock.expect(authenticationResult.getAuthorizerName()).andReturn(AUTHORIZER).anyTimes();
+      EasyMock.expect(conglomerate.getToolChest(EasyMock.anyObject())).andReturn(toolChest).anyTimes();
+      EasyMock.expect(toolChest.makeMetrics(EasyMock.anyObject())).andReturn(metrics).anyTimes();
+      EasyMock.expect(texasRanger.getQueryRunnerForIntervals(EasyMock.anyObject(), EasyMock.anyObject()))
+          .andReturn(runner).anyTimes();
+      EasyMock.expect(runner.run(EasyMock.anyObject(), EasyMock.anyObject())).andReturn(Sequences.empty()).anyTimes();
+      replayAll();
 
-    QueryLifecycle lifecycle = createLifecycle();
-    lifecycle.runSimple(query, authenticationResult, authorizationResult);
+      QueryLifecycle lifecycle = createLifecycle();
+      lifecycle.runSimple(query, authenticationResult, authorizationResult);
+    });
+    assertTrue(exception.getMessage().contains("Different restrictions on table [some_datasource]: previous policy [RowFilterPolicy{rowFilter=some-column IS NULL}] and new policy [RowFilterPolicy{rowFilter=some-column2 IS NULL}]"));
   }
 
   @Test
@@ -424,7 +421,7 @@ public class QueryLifecycleTest
     ));
     QueryLifecycle lifecycle = createLifecycle();
     lifecycle.initialize(query);
-    Assert.assertTrue(lifecycle.authorize(authenticationResult).allowBasicAccess());
+    Assertions.assertTrue(lifecycle.authorize(authenticationResult).allowBasicAccess());
     // Success, query has a RowFilterPolicy, and is allowed by PolicyEnforcer.
     lifecycle.execute();
   }
@@ -454,10 +451,10 @@ public class QueryLifecycleTest
     QueryLifecycle lifecycle = createLifecycle();
     lifecycle.initialize(query);
     // Fail, only NoRestrictionPolicy is allowed.
-    DruidException e = Assert.assertThrows(DruidException.class, () -> lifecycle.authorize(authenticationResult));
-    Assert.assertEquals(DruidException.Category.FORBIDDEN, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
-    Assert.assertEquals("Failed security validation with dataSource [some_datasource]", e.getMessage());
+    DruidException e = Assertions.assertThrows(DruidException.class, () -> lifecycle.authorize(authenticationResult));
+    Assertions.assertEquals(DruidException.Category.FORBIDDEN, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
+    Assertions.assertEquals("Failed security validation with dataSource [some_datasource]", e.getMessage());
   }
 
   @Test
@@ -494,7 +491,7 @@ public class QueryLifecycleTest
     authConfig = AuthConfig.newBuilder().setAuthorizeQueryContextParams(true).build();
     QueryLifecycle lifecycle = createLifecycle();
     lifecycle.initialize(query);
-    Assert.assertTrue(lifecycle.authorize(authenticationResult).allowBasicAccess());
+    Assertions.assertTrue(lifecycle.authorize(authenticationResult).allowBasicAccess());
     lifecycle.execute();
   }
 
@@ -542,18 +539,18 @@ public class QueryLifecycleTest
     lifecycle.initialize(query);
 
     final Map<String, Object> revisedContext = new HashMap<>(lifecycle.getQuery().getContext());
-    Assert.assertTrue(lifecycle.getQuery().getContext().containsKey("queryId"));
+    Assertions.assertTrue(lifecycle.getQuery().getContext().containsKey("queryId"));
     revisedContext.remove("queryId");
-    Assert.assertEquals(
+    Assertions.assertEquals(
         userContext,
         revisedContext
     );
 
-    Assert.assertTrue(lifecycle.authorize(mockRequest()).allowAccessWithNoRestriction());
+    Assertions.assertTrue(lifecycle.authorize(mockRequest()).allowAccessWithNoRestriction());
 
     lifecycle = createLifecycle();
     lifecycle.initialize(query);
-    Assert.assertTrue(lifecycle.authorize(authenticationResult).allowAccessWithNoRestriction());
+    Assertions.assertTrue(lifecycle.authorize(authenticationResult).allowAccessWithNoRestriction());
   }
 
   @Test
@@ -593,11 +590,11 @@ public class QueryLifecycleTest
     authConfig = AuthConfig.newBuilder().setAuthorizeQueryContextParams(true).build();
     QueryLifecycle lifecycle = createLifecycle();
     lifecycle.initialize(query);
-    Assert.assertFalse(lifecycle.authorize(mockRequest()).allowBasicAccess());
+    Assertions.assertFalse(lifecycle.authorize(mockRequest()).allowBasicAccess());
 
     lifecycle = createLifecycle();
     lifecycle.initialize(query);
-    Assert.assertFalse(lifecycle.authorize(authenticationResult).allowBasicAccess());
+    Assertions.assertFalse(lifecycle.authorize(authenticationResult).allowBasicAccess());
   }
 
   @Test
@@ -632,18 +629,18 @@ public class QueryLifecycleTest
     lifecycle.initialize(query);
 
     final Map<String, Object> revisedContext = new HashMap<>(lifecycle.getQuery().getContext());
-    Assert.assertTrue(lifecycle.getQuery().getContext().containsKey("queryId"));
+    Assertions.assertTrue(lifecycle.getQuery().getContext().containsKey("queryId"));
     revisedContext.remove("queryId");
-    Assert.assertEquals(
+    Assertions.assertEquals(
         userContext,
         revisedContext
     );
 
-    Assert.assertTrue(lifecycle.authorize(mockRequest()).allowAccessWithNoRestriction());
+    Assertions.assertTrue(lifecycle.authorize(mockRequest()).allowAccessWithNoRestriction());
 
     lifecycle = createLifecycle();
     lifecycle.initialize(query);
-    Assert.assertTrue(lifecycle.authorize(authenticationResult).allowAccessWithNoRestriction());
+    Assertions.assertTrue(lifecycle.authorize(authenticationResult).allowAccessWithNoRestriction());
   }
 
   @Test
@@ -683,18 +680,18 @@ public class QueryLifecycleTest
     lifecycle.initialize(query);
 
     final Map<String, Object> revisedContext = new HashMap<>(lifecycle.getQuery().getContext());
-    Assert.assertTrue(lifecycle.getQuery().getContext().containsKey("queryId"));
+    Assertions.assertTrue(lifecycle.getQuery().getContext().containsKey("queryId"));
     revisedContext.remove("queryId");
-    Assert.assertEquals(
+    Assertions.assertEquals(
         userContext,
         revisedContext
     );
 
-    Assert.assertTrue(lifecycle.authorize(mockRequest()).allowBasicAccess());
+    Assertions.assertTrue(lifecycle.authorize(mockRequest()).allowBasicAccess());
 
     lifecycle = createLifecycle();
     lifecycle.initialize(query);
-    Assert.assertTrue(lifecycle.authorize(authenticationResult).allowBasicAccess());
+    Assertions.assertTrue(lifecycle.authorize(authenticationResult).allowBasicAccess());
   }
 
   @Test
@@ -739,11 +736,11 @@ public class QueryLifecycleTest
                            .build();
     QueryLifecycle lifecycle = createLifecycle();
     lifecycle.initialize(query);
-    Assert.assertFalse(lifecycle.authorize(mockRequest()).allowBasicAccess());
+    Assertions.assertFalse(lifecycle.authorize(mockRequest()).allowBasicAccess());
 
     lifecycle = createLifecycle();
     lifecycle.initialize(query);
-    Assert.assertFalse(lifecycle.authorize(authenticationResult).allowBasicAccess());
+    Assertions.assertFalse(lifecycle.authorize(authenticationResult).allowBasicAccess());
   }
 
   @Test
@@ -794,16 +791,16 @@ public class QueryLifecycleTest
     lifecycle.initialize(query);
 
     final Map<String, Object> revisedContext = lifecycle.getQuery().getContext();
-    Assert.assertNotNull(revisedContext);
-    Assert.assertTrue(revisedContext.containsKey("foo"));
-    Assert.assertTrue(revisedContext.containsKey("baz"));
-    Assert.assertTrue(revisedContext.containsKey("queryId"));
+    Assertions.assertNotNull(revisedContext);
+    Assertions.assertTrue(revisedContext.containsKey("foo"));
+    Assertions.assertTrue(revisedContext.containsKey("baz"));
+    Assertions.assertTrue(revisedContext.containsKey("queryId"));
 
-    Assert.assertTrue(lifecycle.authorize(mockRequest()).allowBasicAccess());
+    Assertions.assertTrue(lifecycle.authorize(mockRequest()).allowBasicAccess());
 
     lifecycle = createLifecycle();
     lifecycle.initialize(query);
-    Assert.assertTrue(lifecycle.authorize(mockRequest()).allowBasicAccess());
+    Assertions.assertTrue(lifecycle.authorize(mockRequest()).allowBasicAccess());
   }
 
   public static Query<?> queryMatchDataSource(DataSource dataSource)
@@ -866,14 +863,14 @@ public class QueryLifecycleTest
     );
 
     // This should throw because query matches blocklist rule
-    DruidException e = Assert.assertThrows(
+    DruidException e = Assertions.assertThrows(
         DruidException.class,
         () -> lifecycle.runSimple(query, authenticationResult, AuthorizationResult.ALLOW_NO_RESTRICTION)
     );
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
-    Assert.assertEquals(DruidException.Category.FORBIDDEN, e.getCategory());
-    Assert.assertTrue(e.getMessage().contains("blocked by rule"));
-    Assert.assertTrue(e.getMessage().contains("test-rule"));
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals(DruidException.Category.FORBIDDEN, e.getCategory());
+    Assertions.assertTrue(e.getMessage().contains("blocked by rule"));
+    Assertions.assertTrue(e.getMessage().contains("test-rule"));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/QueryLifecycleTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryLifecycleTest.java
@@ -209,7 +209,7 @@ public class QueryLifecycleTest
   @Test
   public void testRunSimpleUnauthorized()
   {
-    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, () -> {
+    Throwable exception = Assertions.assertThrows(DruidException.class, () -> {
 
       EasyMock.expect(queryConfig.getContext()).andReturn(ImmutableMap.of()).anyTimes();
       EasyMock.expect(authenticationResult.getIdentity()).andReturn(IDENTITY).anyTimes();
@@ -347,7 +347,7 @@ public class QueryLifecycleTest
   @Test
   public void testRunSimple_foundDifferentPolicyRestrictions()
   {
-    Throwable exception = org.junit.jupiter.api.Assertions.assertThrows(ISE.class, () -> {
+    Throwable exception = Assertions.assertThrows(ISE.class, () -> {
 
       DimFilter originalFilterOnRDS = new NullFilter("some-column", null);
       Policy originalFilterPolicy = RowFilterPolicy.from(originalFilterOnRDS);

--- a/server/src/test/java/org/apache/druid/server/QueryLifecycleTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryLifecycleTest.java
@@ -85,8 +85,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 @LazySingleton
 public class QueryLifecycleTest
 {
@@ -224,7 +222,7 @@ public class QueryLifecycleTest
       QueryLifecycle lifecycle = createLifecycle();
       lifecycle.runSimple(query, authenticationResult, AuthorizationResult.DENY);
     });
-    assertTrue(exception.getMessage().contains("Unexpected state [UNAUTHORIZED], expecting [AUTHORIZED]"));
+    Assertions.assertTrue(exception.getMessage().contains("Unexpected state [UNAUTHORIZED], expecting [AUTHORIZED]"));
   }
 
   @Test
@@ -381,7 +379,7 @@ public class QueryLifecycleTest
       QueryLifecycle lifecycle = createLifecycle();
       lifecycle.runSimple(query, authenticationResult, authorizationResult);
     });
-    assertTrue(exception.getMessage().contains("Different restrictions on table [some_datasource]: previous policy [RowFilterPolicy{rowFilter=some-column IS NULL}] and new policy [RowFilterPolicy{rowFilter=some-column2 IS NULL}]"));
+    Assertions.assertTrue(exception.getMessage().contains("Different restrictions on table [some_datasource]: previous policy [RowFilterPolicy{rowFilter=some-column IS NULL}] and new policy [RowFilterPolicy{rowFilter=some-column2 IS NULL}]"));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -100,6 +100,7 @@ import org.apache.druid.server.security.AuthorizerMapper;
 import org.apache.druid.server.security.ForbiddenException;
 import org.apache.druid.server.security.Resource;
 import org.apache.http.HttpStatus;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.eclipse.jetty.http.HttpHeader;
 import org.joda.time.Interval;
 import org.junit.jupiter.api.Assertions;
@@ -1726,7 +1727,7 @@ public class QueryResourceTest
         () -> jsonMapper.readValue(baos.toByteArray(), Object.class)
     );
 
-    org.assertj.core.api.Assertions.assertThat(e).hasMessageContaining("expected close marker for Array");
+    AssertionsForClassTypes.assertThat(e).hasMessageContaining("expected close marker for Array");
   }
 
   private void createScheduledQueryResource(
@@ -1959,7 +1960,7 @@ public class QueryResourceTest
     // A QueryException keeps its own status and its legacy response body.
     Assertions.assertNotNull(response);
     Assertions.assertEquals(429, response.getStatus());
-    org.assertj.core.api.Assertions.assertThat(StringUtils.fromUtf8((byte[]) response.getEntity())).contains("too busy");
+    AssertionsForClassTypes.assertThat(StringUtils.fromUtf8((byte[]) response.getEntity())).contains("too busy");
 
     // It now shares the DruidException path, so the failure is recorded server-side and not just returned.
     Assertions.assertEquals(1, failingQueryResource.getFailedQueryCount());

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -35,6 +35,7 @@ import com.google.inject.Key;
 import org.apache.druid.client.BrokerViewOfBrokerConfig;
 import org.apache.druid.common.exception.ErrorResponseTransformStrategy;
 import org.apache.druid.error.DruidException;
+import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.error.ErrorResponse;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.guice.GuiceInjectors;
@@ -1812,12 +1813,9 @@ public class QueryResourceTest
     Assertions.assertEquals(Status.FORBIDDEN.getStatusCode(), response.getStatus());
     Assertions.assertNotNull(response.getMetadata().getFirst(QueryResource.QUERY_ID_RESPONSE_HEADER));
 
-    assertDruidExceptionMessageContains(
+    DruidExceptionMatcher.assertThat(
         ((ErrorResponse) response.getEntity()).getUnderlyingException(),
-        DruidException.Persona.USER,
-        DruidException.Category.FORBIDDEN,
-        "general",
-        "blocked by rule[block-mmx]"
+        DruidExceptionMatcher.forbidden().expectMessageContains("blocked by rule[block-mmx]")
     );
 
     // Blocked queries are still recorded in metrics and the request log. FORBIDDEN maps to no query counter, the
@@ -2098,19 +2096,6 @@ public class QueryResourceTest
     Assertions.assertEquals(
         message,
         assertDruidException(exception, persona, category, errorCode).getMessage()
-    );
-  }
-
-  private static void assertDruidExceptionMessageContains(
-      Throwable exception,
-      DruidException.Persona persona,
-      DruidException.Category category,
-      String errorCode,
-      String message
-  )
-  {
-    Assertions.assertTrue(
-        assertDruidException(exception, persona, category, errorCode).getMessage().contains(message)
     );
   }
 

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -460,12 +460,13 @@ public class QueryResourceTest
     Assertions.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
 
     final ErrorResponse entity = (ErrorResponse) response.getEntity();
-    assertDruidExceptionMessageIs(
+    DruidExceptionMatcher.assertThat(
         entity.getUnderlyingException(),
-        DruidException.Persona.OPERATOR,
-        DruidException.Category.RUNTIME_FAILURE,
-        "general",
-        "failing for coverage!"
+        new DruidExceptionMatcher(
+            DruidException.Persona.OPERATOR,
+            DruidException.Category.RUNTIME_FAILURE,
+            "general"
+        ).expectMessageIs("failing for coverage!")
     );
 
     Assertions.assertEquals(1, testRequestLogger.getNativeQuerylogs().size());
@@ -799,12 +800,13 @@ public class QueryResourceTest
     Assertions.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
 
     final ErrorResponse entity = (ErrorResponse) response.getEntity();
-    assertDruidExceptionMessageIs(
+    DruidExceptionMatcher.assertThat(
         entity.getUnderlyingException(),
-        DruidException.Persona.OPERATOR,
-        DruidException.Category.RUNTIME_FAILURE,
-        "legacyQueryException",
-        "something"
+        new DruidExceptionMatcher(
+            DruidException.Persona.OPERATOR,
+            DruidException.Category.RUNTIME_FAILURE,
+            "legacyQueryException"
+        ).expectMessageIs("something")
     );
     emitter.verifyEmitted("query/time", 1);
     Assertions.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
@@ -1207,12 +1209,15 @@ public class QueryResourceTest
     Assertions.assertEquals(QueryTimeoutException.STATUS_CODE, response.getStatus());
 
     ErrorResponse entity = (ErrorResponse) response.getEntity();
-    assertDruidExceptionMessageIs(
+    DruidExceptionMatcher.assertThat(
         entity.getUnderlyingException(),
-        DruidException.Persona.OPERATOR,
-        DruidException.Category.TIMEOUT,
-        "legacyQueryException",
-        "Query did not complete within configured timeout period. You can increase query timeout or tune the performance of query."
+        new DruidExceptionMatcher(
+            DruidException.Persona.OPERATOR,
+            DruidException.Category.TIMEOUT,
+            "legacyQueryException"
+        ).expectMessageIs(
+            "Query did not complete within configured timeout period. You can increase query timeout or tune the performance of query."
+        )
     );
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -1484,12 +1489,15 @@ public class QueryResourceTest
           QueryCapacityExceededException ex;
 
           final ErrorResponse entity = (ErrorResponse) response.getEntity();
-          assertDruidExceptionMessageIs(
+          DruidExceptionMatcher.assertThat(
               entity.getUnderlyingException(),
-              DruidException.Persona.OPERATOR,
-              DruidException.Category.CAPACITY_EXCEEDED,
-              "legacyQueryException",
-              "Too many concurrent queries, total query capacity of 2 exceeded. Please try your query again later."
+              new DruidExceptionMatcher(
+                  DruidException.Persona.OPERATOR,
+                  DruidException.Category.CAPACITY_EXCEEDED,
+                  "legacyQueryException"
+              ).expectMessageIs(
+                  "Too many concurrent queries, total query capacity of 2 exceeded. Please try your query again later."
+              )
           );
 
           try {
@@ -1555,12 +1563,15 @@ public class QueryResourceTest
           QueryCapacityExceededException ex;
 
           final ErrorResponse entity = (ErrorResponse) response.getEntity();
-          assertDruidExceptionMessageIs(
+          DruidExceptionMatcher.assertThat(
               entity.getUnderlyingException(),
-              DruidException.Persona.OPERATOR,
-              DruidException.Category.CAPACITY_EXCEEDED,
-              "legacyQueryException",
-              "Too many concurrent queries for lane 'low', query capacity of 1 exceeded. Please try your query again later."
+              new DruidExceptionMatcher(
+                  DruidException.Persona.OPERATOR,
+                  DruidException.Category.CAPACITY_EXCEEDED,
+                  "legacyQueryException"
+              ).expectMessageIs(
+                  "Too many concurrent queries for lane 'low', query capacity of 1 exceeded. Please try your query again later."
+              )
           );
 
           try {
@@ -1632,12 +1643,15 @@ public class QueryResourceTest
           QueryCapacityExceededException ex;
 
           final ErrorResponse entity = (ErrorResponse) response.getEntity();
-          assertDruidExceptionMessageIs(
+          DruidExceptionMatcher.assertThat(
               entity.getUnderlyingException(),
-              DruidException.Persona.OPERATOR,
-              DruidException.Category.CAPACITY_EXCEEDED,
-              "legacyQueryException",
-              "Too many concurrent queries for lane 'low', query capacity of 1 exceeded. Please try your query again later."
+              new DruidExceptionMatcher(
+                  DruidException.Persona.OPERATOR,
+                  DruidException.Category.CAPACITY_EXCEEDED,
+                  "legacyQueryException"
+              ).expectMessageIs(
+                  "Too many concurrent queries for lane 'low', query capacity of 1 exceeded. Please try your query again later."
+              )
           );
 
           try {
@@ -1872,12 +1886,13 @@ public class QueryResourceTest
 
     final Object queryId = response.getMetadata().getFirst(QueryResource.QUERY_ID_RESPONSE_HEADER);
     Assertions.assertNotNull(queryId);
-    assertDruidExceptionMessageIs(
+    DruidExceptionMatcher.assertThat(
         ((ErrorResponse) response.getEntity()).getUnderlyingException(),
-        DruidException.Persona.USER,
-        DruidException.Category.RUNTIME_FAILURE,
-        "general",
-        StringUtils.format("sanitized[%s]", queryId)
+        new DruidExceptionMatcher(
+            DruidException.Persona.USER,
+            DruidException.Category.RUNTIME_FAILURE,
+            "general"
+        ).expectMessageIs(StringUtils.format("sanitized[%s]", queryId))
     );
 
     // Sanitization applies to the client response only; the request log keeps the original 403.
@@ -2069,34 +2084,6 @@ public class QueryResourceTest
       }
       return true;
     });
-  }
-
-  private static DruidException assertDruidException(
-      Throwable exception,
-      DruidException.Persona persona,
-      DruidException.Category category,
-      String errorCode
-  )
-  {
-    final DruidException druidException = Assertions.assertInstanceOf(DruidException.class, exception);
-    Assertions.assertEquals(persona, druidException.getTargetPersona());
-    Assertions.assertEquals(category, druidException.getCategory());
-    Assertions.assertEquals(errorCode, druidException.getErrorCode());
-    return druidException;
-  }
-
-  private static void assertDruidExceptionMessageIs(
-      Throwable exception,
-      DruidException.Persona persona,
-      DruidException.Category category,
-      String errorCode,
-      String message
-  )
-  {
-    Assertions.assertEquals(
-        message,
-        assertDruidException(exception, persona, category, errorCode).getMessage()
-    );
   }
 
   private Response expectSynchronousRequestFlow(String simpleTimeseriesQuery) throws IOException

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -140,8 +140,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class QueryResourceTest
 {
   private static final DefaultQueryRunnerFactoryConglomerate CONGLOMERATE = DefaultQueryRunnerFactoryConglomerate.buildFromQueryRunnerFactories(
@@ -1713,7 +1711,7 @@ public class QueryResourceTest
         () -> jsonMapper.readValue(baos.toByteArray(), Object.class)
     );
 
-    assertThat(e).hasMessageContaining("expected close marker for Array");
+    org.assertj.core.api.Assertions.assertThat(e).hasMessageContaining("expected close marker for Array");
   }
 
   private void createScheduledQueryResource(
@@ -1948,7 +1946,7 @@ public class QueryResourceTest
     // A QueryException keeps its own status and its legacy response body.
     Assertions.assertNotNull(response);
     Assertions.assertEquals(429, response.getStatus());
-    assertThat(StringUtils.fromUtf8((byte[]) response.getEntity())).contains("too busy");
+    org.assertj.core.api.Assertions.assertThat(StringUtils.fromUtf8((byte[]) response.getEntity())).contains("too busy");
 
     // It now shares the DruidException path, so the failure is recorded server-side and not just returned.
     Assertions.assertEquals(1, failingQueryResource.getFailedQueryCount());

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -35,7 +35,6 @@ import com.google.inject.Key;
 import org.apache.druid.client.BrokerViewOfBrokerConfig;
 import org.apache.druid.common.exception.ErrorResponseTransformStrategy;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.error.ErrorResponse;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.guice.GuiceInjectors;
@@ -101,14 +100,12 @@ import org.apache.druid.server.security.ForbiddenException;
 import org.apache.druid.server.security.Resource;
 import org.apache.http.HttpStatus;
 import org.eclipse.jetty.http.HttpHeader;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -119,6 +116,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -136,10 +134,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class QueryResourceTest
 {
@@ -249,13 +250,13 @@ public class QueryResourceTest
   private TestRequestLogger testRequestLogger;
   private StubServiceEmitter emitter;
 
-  @BeforeClass
+  @BeforeAll
   public static void staticSetup()
   {
     EmittingLogger.registerEmitter(NOOP_SERVICE_EMITTER);
   }
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     Injector injector = GuiceInjectors.makeStartupInjector();
@@ -343,14 +344,14 @@ public class QueryResourceTest
     expectPermissiveHappyPathAuth();
 
     HttpServletResponse servletResponse = expectAsyncRequestFlow(SIMPLE_TIMESERIES_QUERY);
-    Assert.assertEquals(200, servletResponse.getStatus());
-    Assert.assertTrue(servletResponse.containsHeader(HttpHeader.TRAILER.toString()));
+    Assertions.assertEquals(200, servletResponse.getStatus());
+    Assertions.assertTrue(servletResponse.containsHeader(HttpHeader.TRAILER.toString()));
 
     final Map<String, String> fields = servletResponse.getTrailerFields().get();
-    Assert.assertFalse(fields.containsKey(QueryResource.ERROR_MESSAGE_TRAILER_HEADER));
+    Assertions.assertFalse(fields.containsKey(QueryResource.ERROR_MESSAGE_TRAILER_HEADER));
 
-    Assert.assertTrue(fields.containsKey(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER));
-    Assert.assertEquals(fields.get(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER), "true");
+    Assertions.assertTrue(fields.containsKey(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER));
+    Assertions.assertEquals(fields.get(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER), "true");
   }
 
   @Test
@@ -377,7 +378,7 @@ public class QueryResourceTest
     expectPermissiveHappyPathAuth();
 
     final MockHttpServletResponse response = expectAsyncRequestFlow(SIMPLE_TIMESERIES_QUERY);
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
     final List<Result<TimeBoundaryResultValue>> responses = jsonMapper.readValue(
         response.baos.toByteArray(),
@@ -386,16 +387,16 @@ public class QueryResourceTest
         }
     );
 
-    Assert.assertEquals(0, responses.size());
-    Assert.assertEquals(1, testRequestLogger.getNativeQuerylogs().size());
-    Assert.assertNotNull(testRequestLogger.getNativeQuerylogs().get(0).getQuery());
-    Assert.assertNotNull(testRequestLogger.getNativeQuerylogs().get(0).getQuery().getContext());
-    Assert.assertTrue(testRequestLogger.getNativeQuerylogs()
+    Assertions.assertEquals(0, responses.size());
+    Assertions.assertEquals(1, testRequestLogger.getNativeQuerylogs().size());
+    Assertions.assertNotNull(testRequestLogger.getNativeQuerylogs().get(0).getQuery());
+    Assertions.assertNotNull(testRequestLogger.getNativeQuerylogs().get(0).getQuery().getContext());
+    Assertions.assertTrue(testRequestLogger.getNativeQuerylogs()
                                        .get(0)
                                        .getQuery()
                                        .getContext()
                                        .containsKey(overrideConfigKey));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         overrideConfigValue,
         testRequestLogger.getNativeQuerylogs().get(0).getQuery().getContext().get(overrideConfigKey)
     );
@@ -455,26 +456,28 @@ public class QueryResourceTest
     expectPermissiveHappyPathAuth();
 
     final Response response = expectSynchronousRequestFlow(SIMPLE_TIMESERIES_QUERY);
-    Assert.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assertions.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
 
     final ErrorResponse entity = (ErrorResponse) response.getEntity();
-    MatcherAssert.assertThat(
+    assertDruidExceptionMessageIs(
         entity.getUnderlyingException(),
-        new DruidExceptionMatcher(DruidException.Persona.OPERATOR, DruidException.Category.RUNTIME_FAILURE, "general")
-            .expectMessageIs("failing for coverage!")
+        DruidException.Persona.OPERATOR,
+        DruidException.Category.RUNTIME_FAILURE,
+        "general",
+        "failing for coverage!"
     );
 
-    Assert.assertEquals(1, testRequestLogger.getNativeQuerylogs().size());
-    Assert.assertNotNull(testRequestLogger.getNativeQuerylogs().get(0).getQuery());
-    Assert.assertNotNull(testRequestLogger.getNativeQuerylogs().get(0).getQuery().getContext());
-    Assert.assertTrue(testRequestLogger.getNativeQuerylogs()
+    Assertions.assertEquals(1, testRequestLogger.getNativeQuerylogs().size());
+    Assertions.assertNotNull(testRequestLogger.getNativeQuerylogs().get(0).getQuery());
+    Assertions.assertNotNull(testRequestLogger.getNativeQuerylogs().get(0).getQuery().getContext());
+    Assertions.assertTrue(testRequestLogger.getNativeQuerylogs()
                                        .get(0)
                                        .getQuery()
                                        .getContext()
                                        .containsKey(overrideConfigKey));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         overrideConfigValue,
         testRequestLogger.getNativeQuerylogs().get(0).getQuery().getContext().get(overrideConfigKey)
     );
@@ -545,21 +548,21 @@ public class QueryResourceTest
 
     HttpServletResponse response = expectAsyncRequestFlow(testServletRequest, SIMPLE_TIMESERIES_QUERY.getBytes(StandardCharsets.UTF_8), queryResource);
 
-    Assert.assertTrue(response.containsHeader(HttpHeader.TRAILER.toString()));
-    Assert.assertEquals(response.getHeader(HttpHeader.TRAILER.toString()), QueryResultPusher.RESULT_TRAILER_HEADERS);
+    Assertions.assertTrue(response.containsHeader(HttpHeader.TRAILER.toString()));
+    Assertions.assertEquals(response.getHeader(HttpHeader.TRAILER.toString()), QueryResultPusher.RESULT_TRAILER_HEADERS);
 
     final Map<String, String> fields = response.getTrailerFields().get();
-    Assert.assertTrue(fields.containsKey(QueryResource.ERROR_MESSAGE_TRAILER_HEADER));
-    Assert.assertEquals(
+    Assertions.assertTrue(fields.containsKey(QueryResource.ERROR_MESSAGE_TRAILER_HEADER));
+    Assertions.assertEquals(
         fields.get(QueryResource.ERROR_MESSAGE_TRAILER_HEADER),
         "Query did not complete within configured timeout period. You can increase query timeout or tune the performance of query."
     );
 
-    Assert.assertTrue(fields.containsKey(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER));
-    Assert.assertEquals(fields.get(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER), "false");
+    Assertions.assertTrue(fields.containsKey(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER));
+    Assertions.assertEquals(fields.get(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER), "false");
 
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(504, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assertions.assertEquals(504, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -626,14 +629,14 @@ public class QueryResourceTest
                                                               queryResource
     );
     String actualOutput = response.baos.toString(Charset.defaultCharset());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "[{\"maxTime\":\"2014-08-02T00:00:00.000Z\"},{\"error\":\"druidException\","
         + "\"errorCode\":\"invalidInput\",\"persona\":\"USER\",\"category\":\"INVALID_INPUT\","
         + "\"errorMessage\":\"mid-flight exception\",\"context\":{}}]",
         actualOutput
     );
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(400, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assertions.assertEquals(400, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -712,21 +715,21 @@ public class QueryResourceTest
 
     HttpServletResponse response = expectAsyncRequestFlow(testServletRequest, SIMPLE_TIMESERIES_QUERY.getBytes(StandardCharsets.UTF_8), queryResource);
 
-    Assert.assertTrue(response.containsHeader(HttpHeader.TRAILER.toString()));
-    Assert.assertEquals(QueryResultPusher.RESULT_TRAILER_HEADERS, response.getHeader(HttpHeader.TRAILER.toString()));
+    Assertions.assertTrue(response.containsHeader(HttpHeader.TRAILER.toString()));
+    Assertions.assertEquals(QueryResultPusher.RESULT_TRAILER_HEADERS, response.getHeader(HttpHeader.TRAILER.toString()));
 
     final Map<String, String> fields = response.getTrailerFields().get();
-    Assert.assertTrue(response.containsHeader(QueryResource.HEADER_RESPONSE_CONTEXT));
-    Assert.assertEquals(
+    Assertions.assertTrue(response.containsHeader(QueryResource.HEADER_RESPONSE_CONTEXT));
+    Assertions.assertEquals(
         jsonMapper.writeValueAsString(ImmutableMap.of("missingSegments", ImmutableList.of(missingSegDesc))),
         response.getHeader(QueryResource.HEADER_RESPONSE_CONTEXT)
     );
 
-    Assert.assertTrue(fields.containsKey(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER));
-    Assert.assertEquals("true", fields.get(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER));
+    Assertions.assertTrue(fields.containsKey(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER));
+    Assertions.assertEquals("true", fields.get(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER));
 
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assertions.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
 
@@ -784,7 +787,7 @@ public class QueryResourceTest
               public void emitLogsAndMetrics(@Nullable Throwable e, @Nullable String remoteAddress, long bytesWritten)
               {
                 super.emitLogsAndMetrics(e, remoteAddress, bytesWritten);
-                Assert.assertTrue(Throwables.getStackTraceAsString(e).contains(embeddedExceptionMessage));
+                Assertions.assertTrue(Throwables.getStackTraceAsString(e).contains(embeddedExceptionMessage));
               }
             };
           }
@@ -794,19 +797,18 @@ public class QueryResourceTest
     expectPermissiveHappyPathAuth();
 
     final Response response = expectSynchronousRequestFlow(SIMPLE_TIMESERIES_QUERY);
-    Assert.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
 
     final ErrorResponse entity = (ErrorResponse) response.getEntity();
-    MatcherAssert.assertThat(
+    assertDruidExceptionMessageIs(
         entity.getUnderlyingException(),
-        new DruidExceptionMatcher(
-            DruidException.Persona.OPERATOR,
-            DruidException.Category.RUNTIME_FAILURE, "legacyQueryException"
-        )
-            .expectMessageIs("something")
+        DruidException.Persona.OPERATOR,
+        DruidException.Category.RUNTIME_FAILURE,
+        "legacyQueryException",
+        "something"
     );
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assertions.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -841,23 +843,23 @@ public class QueryResourceTest
         }
     );
 
-    Assert.assertNotNull(response);
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    Assert.assertEquals(0, responses.size());
-    Assert.assertEquals(1, testRequestLogger.getNativeQuerylogs().size());
-    Assert.assertNotNull(testRequestLogger.getNativeQuerylogs().get(0).getQuery());
-    Assert.assertNotNull(testRequestLogger.getNativeQuerylogs().get(0).getQuery().getContext());
-    Assert.assertTrue(testRequestLogger.getNativeQuerylogs()
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(0, responses.size());
+    Assertions.assertEquals(1, testRequestLogger.getNativeQuerylogs().size());
+    Assertions.assertNotNull(testRequestLogger.getNativeQuerylogs().get(0).getQuery());
+    Assertions.assertNotNull(testRequestLogger.getNativeQuerylogs().get(0).getQuery().getContext());
+    Assertions.assertTrue(testRequestLogger.getNativeQuerylogs()
                                        .get(0)
                                        .getQuery()
                                        .getContext()
                                        .containsKey(overrideConfigKey));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         -1,
         testRequestLogger.getNativeQuerylogs().get(0).getQuery().getContext().get(overrideConfigKey)
     );
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assertions.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -872,18 +874,18 @@ public class QueryResourceTest
         SIMPLE_TIMESERIES_QUERY.getBytes(StandardCharsets.UTF_8),
         queryResource
     );
-    Assert.assertEquals(1, queryResource.getInterruptedQueryCount());
-    Assert.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatus());
+    Assertions.assertEquals(1, queryResource.getInterruptedQueryCount());
+    Assertions.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatus());
     final String expectedException = new QueryInterruptedException(
         new TruncatedResponseContextException("Serialized response context exceeds the max size[0]"),
         DRUID_NODE.getHostAndPortToUse()
     ).toString();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedException,
         jsonMapper.readValue(response.baos.toByteArray(), QueryInterruptedException.class).toString()
     );
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assertions.assertEquals(500, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -897,11 +899,11 @@ public class QueryResourceTest
         SIMPLE_TIMESERIES_QUERY.getBytes(StandardCharsets.UTF_8),
         queryResource
     );
-    Assert.assertEquals(HttpStatus.SC_OK, response.getStatus());
+    Assertions.assertEquals(HttpStatus.SC_OK, response.getStatus());
 
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
-    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assertions.assertEquals(1, queryResource.getSuccessfulQueryCount());
+    Assertions.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -911,13 +913,13 @@ public class QueryResourceTest
     expectPermissiveHappyPathAuth();
 
     final MockHttpServletResponse response = expectAsyncRequestFlow(SIMPLE_TIMESERIES_QUERY);
-    Assert.assertEquals(HttpStatus.SC_OK, response.getStatus());
+    Assertions.assertEquals(HttpStatus.SC_OK, response.getStatus());
     //since accept header is null, the response content type should be same as the value of 'Content-Type' header
-    Assert.assertEquals(MediaType.APPLICATION_JSON, response.getContentType());
+    Assertions.assertEquals(MediaType.APPLICATION_JSON, response.getContentType());
 
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
-    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assertions.assertEquals(1, queryResource.getSuccessfulQueryCount());
+    Assertions.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -928,13 +930,13 @@ public class QueryResourceTest
 
     final MockHttpServletResponse response = expectAsyncRequestFlow(SIMPLE_TIMESERIES_QUERY);
 
-    Assert.assertEquals(HttpStatus.SC_OK, response.getStatus());
+    Assertions.assertEquals(HttpStatus.SC_OK, response.getStatus());
     //since accept header is empty, the response content type should be same as the value of 'Content-Type' header
-    Assert.assertEquals(MediaType.APPLICATION_JSON, response.getContentType());
+    Assertions.assertEquals(MediaType.APPLICATION_JSON, response.getContentType());
 
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
-    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assertions.assertEquals(1, queryResource.getSuccessfulQueryCount());
+    Assertions.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -946,14 +948,14 @@ public class QueryResourceTest
     testServletRequest.headers.put("Accept", SmileMediaTypes.APPLICATION_JACKSON_SMILE);
 
     final MockHttpServletResponse response = expectAsyncRequestFlow(SIMPLE_TIMESERIES_QUERY);
-    Assert.assertEquals(HttpStatus.SC_OK, response.getStatus());
+    Assertions.assertEquals(HttpStatus.SC_OK, response.getStatus());
 
     // Content-Type in response should be Smile
-    Assert.assertEquals(SmileMediaTypes.APPLICATION_JACKSON_SMILE, response.getContentType());
+    Assertions.assertEquals(SmileMediaTypes.APPLICATION_JACKSON_SMILE, response.getContentType());
 
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
-    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assertions.assertEquals(1, queryResource.getSuccessfulQueryCount());
+    Assertions.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -970,14 +972,14 @@ public class QueryResourceTest
         smileMapper.writeValueAsBytes(jsonMapper.readTree(
             SIMPLE_TIMESERIES_QUERY))
     );
-    Assert.assertEquals(HttpStatus.SC_OK, response.getStatus());
+    Assertions.assertEquals(HttpStatus.SC_OK, response.getStatus());
 
     // Content-Type in response should be Smile
-    Assert.assertEquals(SmileMediaTypes.APPLICATION_JACKSON_SMILE, response.getContentType());
+    Assertions.assertEquals(SmileMediaTypes.APPLICATION_JACKSON_SMILE, response.getContentType());
 
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
-    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assertions.assertEquals(1, queryResource.getSuccessfulQueryCount());
+    Assertions.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -993,14 +995,14 @@ public class QueryResourceTest
         testServletRequest,
         smileMapper.writeValueAsBytes(jsonMapper.readTree(SIMPLE_TIMESERIES_QUERY))
     );
-    Assert.assertEquals(HttpStatus.SC_OK, response.getStatus());
+    Assertions.assertEquals(HttpStatus.SC_OK, response.getStatus());
 
     // Content-Type in response should default to Content-Type from request
-    Assert.assertEquals(SmileMediaTypes.APPLICATION_JACKSON_SMILE, response.getContentType());
+    Assertions.assertEquals(SmileMediaTypes.APPLICATION_JACKSON_SMILE, response.getContentType());
 
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(1, queryResource.getSuccessfulQueryCount());
-    Assert.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assertions.assertEquals(1, queryResource.getSuccessfulQueryCount());
+    Assertions.assertEquals(200, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -1011,11 +1013,11 @@ public class QueryResourceTest
         null /*pretty*/,
         testServletRequest
     );
-    Assert.assertNotNull(response);
-    Assert.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     QueryException e = jsonMapper.readValue((byte[]) response.getEntity(), QueryException.class);
-    Assert.assertEquals(QueryException.JSON_PARSE_ERROR_CODE, e.getErrorCode());
-    Assert.assertEquals(BadJsonQueryException.ERROR_CLASS, e.getErrorClass());
+    Assertions.assertEquals(QueryException.JSON_PARSE_ERROR_CODE, e.getErrorCode());
+    Assertions.assertEquals(BadJsonQueryException.ERROR_CLASS, e.getErrorClass());
   }
 
   @Test
@@ -1027,12 +1029,12 @@ public class QueryResourceTest
         testServletRequest
     );
 
-    Assert.assertNotNull(response);
-    Assert.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     final QueryException e = jsonMapper.readValue((byte[]) response.getEntity(), QueryException.class);
-    Assert.assertEquals(QueryException.JSON_PARSE_ERROR_CODE, e.getErrorCode());
-    Assert.assertEquals(ValueInstantiationException.class.getName(), e.getErrorClass());
-    Assert.assertEquals("Invalid native query: dataSource can't be null", e.getMessage());
+    Assertions.assertEquals(QueryException.JSON_PARSE_ERROR_CODE, e.getErrorCode());
+    Assertions.assertEquals(ValueInstantiationException.class.getName(), e.getErrorClass());
+    Assertions.assertEquals("Invalid native query: dataSource can't be null", e.getMessage());
   }
 
   @Test
@@ -1048,11 +1050,11 @@ public class QueryResourceTest
           testServletRequest
       );
     }
-    Assert.assertNotNull(response);
-    Assert.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     QueryException e = jsonMapper.readValue((byte[]) response.getEntity(), QueryException.class);
-    Assert.assertEquals(QueryException.RESOURCE_LIMIT_EXCEEDED_ERROR_CODE, e.getErrorCode());
-    Assert.assertEquals(ResourceLimitExceededException.class.getName(), e.getErrorClass());
+    Assertions.assertEquals(QueryException.RESOURCE_LIMIT_EXCEEDED_ERROR_CODE, e.getErrorCode());
+    Assertions.assertEquals(ResourceLimitExceededException.class.getName(), e.getErrorClass());
   }
 
   @Test
@@ -1069,11 +1071,11 @@ public class QueryResourceTest
           testServletRequest
       );
     }
-    Assert.assertNotNull(response);
-    Assert.assertEquals(QueryUnsupportedException.STATUS_CODE, response.getStatus());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(QueryUnsupportedException.STATUS_CODE, response.getStatus());
     QueryException ex = jsonMapper.readValue((byte[]) response.getEntity(), QueryException.class);
-    Assert.assertEquals(errorMessage, ex.getMessage());
-    Assert.assertEquals(QueryException.QUERY_UNSUPPORTED_ERROR_CODE, ex.getErrorCode());
+    Assertions.assertEquals(errorMessage, ex.getMessage());
+    Assertions.assertEquals(QueryException.QUERY_UNSUPPORTED_ERROR_CODE, ex.getErrorCode());
   }
 
   @Test
@@ -1129,7 +1131,7 @@ public class QueryResourceTest
           null /*pretty*/,
           testServletRequest.mimic()
       );
-      Assert.fail("doPost did not throw ForbiddenException for an unauthorized query");
+      Assertions.fail("doPost did not throw ForbiddenException for an unauthorized query");
     }
     catch (ForbiddenException e) {
     }
@@ -1138,7 +1140,7 @@ public class QueryResourceTest
         "{\"queryType\":\"timeBoundary\", \"dataSource\":\"allow\"}",
         testServletRequest.mimic()
     );
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
     final List<Result<TimeBoundaryResultValue>> responses = jsonMapper.readValue(
         response.baos.toByteArray(),
@@ -1147,13 +1149,13 @@ public class QueryResourceTest
         }
     );
 
-    Assert.assertEquals(0, responses.size());
-    Assert.assertEquals(1, testRequestLogger.getNativeQuerylogs().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(0, responses.size());
+    Assertions.assertEquals(1, testRequestLogger.getNativeQuerylogs().size());
+    Assertions.assertEquals(
         true,
         testRequestLogger.getNativeQuerylogs().get(0).getQueryStats().getStats().get("success")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "druid",
         testRequestLogger.getNativeQuerylogs().get(0).getQueryStats().getStats().get("identity")
     );
@@ -1203,33 +1205,31 @@ public class QueryResourceTest
         SIMPLE_TIMESERIES_QUERY.getBytes(StandardCharsets.UTF_8),
         timeoutQueryResource
     );
-    Assert.assertEquals(QueryTimeoutException.STATUS_CODE, response.getStatus());
+    Assertions.assertEquals(QueryTimeoutException.STATUS_CODE, response.getStatus());
 
     ErrorResponse entity = (ErrorResponse) response.getEntity();
-    MatcherAssert.assertThat(
+    assertDruidExceptionMessageIs(
         entity.getUnderlyingException(),
-        new DruidExceptionMatcher(
-            DruidException.Persona.OPERATOR,
-            DruidException.Category.TIMEOUT,
-            "legacyQueryException"
-        )
-            .expectMessageIs(
-                "Query did not complete within configured timeout period. You can increase query timeout or tune the performance of query.")
+        DruidException.Persona.OPERATOR,
+        DruidException.Category.TIMEOUT,
+        "legacyQueryException",
+        "Query did not complete within configured timeout period. You can increase query timeout or tune the performance of query."
     );
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     jsonMapper.writeValue(baos, entity);
     QueryTimeoutException ex = jsonMapper.readValue(baos.toByteArray(), QueryTimeoutException.class);
-    Assert.assertEquals("Query did not complete within configured timeout period. You can " +
+    Assertions.assertEquals("Query did not complete within configured timeout period. You can " +
                         "increase query timeout or tune the performance of query.", ex.getMessage());
-    Assert.assertEquals(QueryException.QUERY_TIMEOUT_ERROR_CODE, ex.getErrorCode());
-    Assert.assertEquals(1, timeoutQueryResource.getTimedOutQueryCount());
+    Assertions.assertEquals(QueryException.QUERY_TIMEOUT_ERROR_CODE, ex.getErrorCode());
+    Assertions.assertEquals(1, timeoutQueryResource.getTimedOutQueryCount());
 
     emitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals(504, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
+    Assertions.assertEquals(504, emitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE));
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testSecuredCancelQuery() throws Exception
   {
     final CountDownLatch waitForCancellationLatch = new CountDownLatch(1);
@@ -1330,7 +1330,7 @@ public class QueryResourceTest
     Executors.newSingleThreadExecutor().submit(
         () -> {
           Response response = queryResource.cancelQuery("id_1", testServletRequest);
-          Assert.assertEquals(Status.ACCEPTED.getStatusCode(), response.getStatus());
+          Assertions.assertEquals(Status.ACCEPTED.getStatusCode(), response.getStatus());
           waitForCancellationLatch.countDown();
           waitFinishLatch.countDown();
         }
@@ -1338,12 +1338,13 @@ public class QueryResourceTest
     waitFinishLatch.await();
     cancelledCountDownLatch.await();
 
-    Assert.assertTrue(future.isCancelled());
+    Assertions.assertTrue(future.isCancelled());
     final Response response = responseFromEndpoint.get();
-    Assert.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testDenySecuredCancelQuery() throws Exception
   {
     final CountDownLatch waitForCancellationLatch = new CountDownLatch(1);
@@ -1447,10 +1448,11 @@ public class QueryResourceTest
     );
     waitFinishLatch.await();
 
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), future.get().getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), future.get().getStatus());
   }
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
   public void testTooManyQuery() throws InterruptedException, ExecutionException
   {
     expectPermissiveHappyPathAuth();
@@ -1469,29 +1471,26 @@ public class QueryResourceTest
     createScheduledQueryResource(laningScheduler, Collections.emptyList(), ImmutableList.of(waitTwoScheduled));
     back2.add(eventuallyAssertAsyncResponse(
         SIMPLE_TIMESERIES_QUERY,
-        response -> Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus())
+        response -> Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus())
     ));
     back2.add(eventuallyAssertAsyncResponse(
         SIMPLE_TIMESERIES_QUERY,
-        response -> Assert.assertEquals(Status.OK.getStatusCode(), response.getStatus())
+        response -> Assertions.assertEquals(Status.OK.getStatusCode(), response.getStatus())
     ));
     waitTwoScheduled.await();
     back2.add(eventuallyaAssertSynchronousResponse(
         SIMPLE_TIMESERIES_QUERY,
         response -> {
-          Assert.assertEquals(QueryCapacityExceededException.STATUS_CODE, response.getStatus());
+          Assertions.assertEquals(QueryCapacityExceededException.STATUS_CODE, response.getStatus());
           QueryCapacityExceededException ex;
 
           final ErrorResponse entity = (ErrorResponse) response.getEntity();
-          MatcherAssert.assertThat(
+          assertDruidExceptionMessageIs(
               entity.getUnderlyingException(),
-              new DruidExceptionMatcher(
-                  DruidException.Persona.OPERATOR,
-                  DruidException.Category.CAPACITY_EXCEEDED,
-                  "legacyQueryException"
-              )
-                  .expectMessageIs(
-                      "Too many concurrent queries, total query capacity of 2 exceeded. Please try your query again later.")
+              DruidException.Persona.OPERATOR,
+              DruidException.Category.CAPACITY_EXCEEDED,
+              "legacyQueryException",
+              "Too many concurrent queries, total query capacity of 2 exceeded. Please try your query again later."
           );
 
           try {
@@ -1505,16 +1504,16 @@ public class QueryResourceTest
           catch (IOException e) {
             throw new RuntimeException(e);
           }
-          Assert.assertEquals(QueryCapacityExceededException.makeTotalErrorMessage(2), ex.getMessage());
-          Assert.assertEquals(QueryException.QUERY_CAPACITY_EXCEEDED_ERROR_CODE, ex.getErrorCode());
+          Assertions.assertEquals(QueryCapacityExceededException.makeTotalErrorMessage(2), ex.getMessage());
+          Assertions.assertEquals(QueryException.QUERY_CAPACITY_EXCEEDED_ERROR_CODE, ex.getErrorCode());
         }
     ));
 
     for (Future<Boolean> theFuture : back2) {
-      Assert.assertTrue(theFuture.get());
+      Assertions.assertTrue(theFuture.get());
     }
-    Assert.assertEquals(2, queryResource.getSuccessfulQueryCount());
-    Assert.assertEquals(1, queryResource.getFailedQueryCount());
+    Assertions.assertEquals(2, queryResource.getSuccessfulQueryCount());
+    Assertions.assertEquals(1, queryResource.getFailedQueryCount());
 
     emitter.verifyEmitted("query/time", 3);
     Map<Integer, Long> codeFrequencies = emitter.getMetricEvents("query/time").stream()
@@ -1524,10 +1523,11 @@ public class QueryResourceTest
                                                     code -> code,
                                                     Collectors.counting()
                                                 ));
-    Assert.assertEquals(Map.of(200, 2L, 429, 1L), codeFrequencies);
+    Assertions.assertEquals(Map.of(200, 2L, 429, 1L), codeFrequencies);
   }
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
   public void testTooManyQueryInLane() throws InterruptedException, ExecutionException
   {
     expectPermissiveHappyPathAuth();
@@ -1546,25 +1546,22 @@ public class QueryResourceTest
 
     back2.add(eventuallyAssertAsyncResponse(
         SIMPLE_TIMESERIES_QUERY_LOW_PRIORITY,
-        response -> Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus())
+        response -> Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus())
     ));
     waitOneScheduled.await();
     back2.add(eventuallyaAssertSynchronousResponse(
         SIMPLE_TIMESERIES_QUERY_LOW_PRIORITY,
         response -> {
-          Assert.assertEquals(QueryCapacityExceededException.STATUS_CODE, response.getStatus());
+          Assertions.assertEquals(QueryCapacityExceededException.STATUS_CODE, response.getStatus());
           QueryCapacityExceededException ex;
 
           final ErrorResponse entity = (ErrorResponse) response.getEntity();
-          MatcherAssert.assertThat(
+          assertDruidExceptionMessageIs(
               entity.getUnderlyingException(),
-              new DruidExceptionMatcher(
-                  DruidException.Persona.OPERATOR,
-                  DruidException.Category.CAPACITY_EXCEEDED,
-                  "legacyQueryException"
-              )
-                  .expectMessageIs(
-                      "Too many concurrent queries for lane 'low', query capacity of 1 exceeded. Please try your query again later.")
+              DruidException.Persona.OPERATOR,
+              DruidException.Category.CAPACITY_EXCEEDED,
+              "legacyQueryException",
+              "Too many concurrent queries for lane 'low', query capacity of 1 exceeded. Please try your query again later."
           );
 
           try {
@@ -1578,22 +1575,22 @@ public class QueryResourceTest
           catch (IOException e) {
             throw new RuntimeException(e);
           }
-          Assert.assertEquals(
+          Assertions.assertEquals(
               QueryCapacityExceededException.makeLaneErrorMessage(HiLoQueryLaningStrategy.LOW, 1),
               ex.getMessage()
           );
-          Assert.assertEquals(QueryException.QUERY_CAPACITY_EXCEEDED_ERROR_CODE, ex.getErrorCode());
+          Assertions.assertEquals(QueryException.QUERY_CAPACITY_EXCEEDED_ERROR_CODE, ex.getErrorCode());
 
         }
     ));
     waitTwoStarted.await();
     back2.add(eventuallyAssertAsyncResponse(
         SIMPLE_TIMESERIES_QUERY,
-        response -> Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus())
+        response -> Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus())
     ));
 
     for (Future<Boolean> theFuture : back2) {
-      Assert.assertTrue(theFuture.get());
+      Assertions.assertTrue(theFuture.get());
     }
 
     emitter.verifyEmitted("query/time", 3);
@@ -1604,10 +1601,11 @@ public class QueryResourceTest
                                                     code -> code,
                                                     Collectors.counting()
                                                 ));
-    Assert.assertEquals(Map.of(200, 2L, 429, 1L), codeFrequencies);
+    Assertions.assertEquals(Map.of(200, 2L, 429, 1L), codeFrequencies);
   }
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
   public void testTooManyQueryInLaneImplicitFromDurationThreshold() throws InterruptedException, ExecutionException
   {
     expectPermissiveHappyPathAuth();
@@ -1625,25 +1623,22 @@ public class QueryResourceTest
 
     back2.add(eventuallyAssertAsyncResponse(
         SIMPLE_TIMESERIES_QUERY,
-        response -> Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus())
+        response -> Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus())
     ));
     waitOneScheduled.await();
     back2.add(eventuallyaAssertSynchronousResponse(
         SIMPLE_TIMESERIES_QUERY,
         response -> {
-          Assert.assertEquals(QueryCapacityExceededException.STATUS_CODE, response.getStatus());
+          Assertions.assertEquals(QueryCapacityExceededException.STATUS_CODE, response.getStatus());
           QueryCapacityExceededException ex;
 
           final ErrorResponse entity = (ErrorResponse) response.getEntity();
-          MatcherAssert.assertThat(
+          assertDruidExceptionMessageIs(
               entity.getUnderlyingException(),
-              new DruidExceptionMatcher(
-                  DruidException.Persona.OPERATOR,
-                  DruidException.Category.CAPACITY_EXCEEDED,
-                  "legacyQueryException"
-              )
-                  .expectMessageIs(
-                      "Too many concurrent queries for lane 'low', query capacity of 1 exceeded. Please try your query again later.")
+              DruidException.Persona.OPERATOR,
+              DruidException.Category.CAPACITY_EXCEEDED,
+              "legacyQueryException",
+              "Too many concurrent queries for lane 'low', query capacity of 1 exceeded. Please try your query again later."
           );
 
           try {
@@ -1657,21 +1652,21 @@ public class QueryResourceTest
           catch (IOException e) {
             throw new RuntimeException(e);
           }
-          Assert.assertEquals(
+          Assertions.assertEquals(
               QueryCapacityExceededException.makeLaneErrorMessage(HiLoQueryLaningStrategy.LOW, 1),
               ex.getMessage()
           );
-          Assert.assertEquals(QueryException.QUERY_CAPACITY_EXCEEDED_ERROR_CODE, ex.getErrorCode());
+          Assertions.assertEquals(QueryException.QUERY_CAPACITY_EXCEEDED_ERROR_CODE, ex.getErrorCode());
         }
     ));
     waitTwoStarted.await();
     back2.add(eventuallyAssertAsyncResponse(
         SIMPLE_TIMESERIES_QUERY_SMALLISH_INTERVAL,
-        response -> Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus())
+        response -> Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus())
     ));
 
     for (Future<Boolean> theFuture : back2) {
-      Assert.assertTrue(theFuture.get());
+      Assertions.assertTrue(theFuture.get());
     }
     emitter.verifyEmitted("query/time", 3);
     Map<Integer, Long> codeFrequencies = emitter.getMetricEvents("query/time").stream()
@@ -1681,7 +1676,7 @@ public class QueryResourceTest
                                                     code -> code,
                                                     Collectors.counting()
                                                 ));
-    Assert.assertEquals(Map.of(200, 2L, 429, 1L), codeFrequencies);
+    Assertions.assertEquals(Map.of(200, 2L, 429, 1L), codeFrequencies);
   }
 
   @Test
@@ -1695,7 +1690,7 @@ public class QueryResourceTest
     writer.writeResponseEnd();
     writer.close();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             ImmutableList.of("foo", "bar"),
             ImmutableList.of("baz")
@@ -1713,15 +1708,12 @@ public class QueryResourceTest
     writer.writeRow(Arrays.asList("foo", "bar"));
     writer.close(); // Simulate an error that occurs midstream; close writer without calling writeResponseEnd.
 
-    final JsonProcessingException e = Assert.assertThrows(
+    final JsonProcessingException e = Assertions.assertThrows(
         JsonProcessingException.class,
         () -> jsonMapper.readValue(baos.toByteArray(), Object.class)
     );
 
-    MatcherAssert.assertThat(
-        e,
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("expected close marker for Array"))
-    );
+    assertThat(e).hasMessageContaining("expected close marker for Array");
   }
 
   private void createScheduledQueryResource(
@@ -1818,25 +1810,28 @@ public class QueryResourceTest
         testServletRequest
     );
 
-    Assert.assertNotNull(response);
-    Assert.assertEquals(Status.FORBIDDEN.getStatusCode(), response.getStatus());
-    Assert.assertNotNull(response.getMetadata().getFirst(QueryResource.QUERY_ID_RESPONSE_HEADER));
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    Assertions.assertNotNull(response.getMetadata().getFirst(QueryResource.QUERY_ID_RESPONSE_HEADER));
 
-    MatcherAssert.assertThat(
+    assertDruidExceptionMessageContains(
         ((ErrorResponse) response.getEntity()).getUnderlyingException(),
-        DruidExceptionMatcher.forbidden().expectMessageContains("blocked by rule[block-mmx]")
+        DruidException.Persona.USER,
+        DruidException.Category.FORBIDDEN,
+        "general",
+        "blocked by rule[block-mmx]"
     );
 
     // Blocked queries are still recorded in metrics and the request log. FORBIDDEN maps to no query counter, the
     // same as when the exception surfaces through QueryResultPusher.
-    Assert.assertEquals(0, blockingQueryResource.getFailedQueryCount());
-    Assert.assertEquals(0, blockingQueryResource.getInterruptedQueryCount());
-    Assert.assertEquals(1, testRequestLogger.getNativeQuerylogs().size());
+    Assertions.assertEquals(0, blockingQueryResource.getFailedQueryCount());
+    Assertions.assertEquals(0, blockingQueryResource.getInterruptedQueryCount());
+    Assertions.assertEquals(1, testRequestLogger.getNativeQuerylogs().size());
     final Map<String, Object> stats = testRequestLogger.getNativeQuerylogs().get(0).getQueryStats().getStats();
-    Assert.assertEquals(false, stats.get("success"));
+    Assertions.assertEquals(false, stats.get("success"));
     // The blocklist throws mid-authorization, so the identity is only present if it was recorded before that point.
-    Assert.assertEquals(AUTHENTICATION_RESULT.getIdentity(), stats.get("identity"));
-    Assert.assertEquals(Status.FORBIDDEN.getStatusCode(), stats.get(DruidMetrics.STATUS_CODE));
+    Assertions.assertEquals(AUTHENTICATION_RESULT.getIdentity(), stats.get("identity"));
+    Assertions.assertEquals(Status.FORBIDDEN.getStatusCode(), stats.get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -1875,24 +1870,23 @@ public class QueryResourceTest
         testServletRequest
     );
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     // The transformed exception's own category now drives the status code, not the original FORBIDDEN.
-    Assert.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
 
     final Object queryId = response.getMetadata().getFirst(QueryResource.QUERY_ID_RESPONSE_HEADER);
-    Assert.assertNotNull(queryId);
-    MatcherAssert.assertThat(
+    Assertions.assertNotNull(queryId);
+    assertDruidExceptionMessageIs(
         ((ErrorResponse) response.getEntity()).getUnderlyingException(),
-        new DruidExceptionMatcher(
-            DruidException.Persona.USER,
-            DruidException.Category.RUNTIME_FAILURE,
-            "general"
-        ).expectMessageIs(StringUtils.format("sanitized[%s]", queryId))
+        DruidException.Persona.USER,
+        DruidException.Category.RUNTIME_FAILURE,
+        "general",
+        StringUtils.format("sanitized[%s]", queryId)
     );
 
     // Sanitization applies to the client response only; the request log keeps the original 403.
-    Assert.assertEquals(1, testRequestLogger.getNativeQuerylogs().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, testRequestLogger.getNativeQuerylogs().size());
+    Assertions.assertEquals(
         Status.FORBIDDEN.getStatusCode(),
         testRequestLogger.getNativeQuerylogs().get(0).getQueryStats().getStats().get(DruidMetrics.STATUS_CODE)
     );
@@ -1922,10 +1916,10 @@ public class QueryResourceTest
         testServletRequest
     );
 
-    Assert.assertNotNull(response);
-    Assert.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
-    Assert.assertEquals(1, failingQueryResource.getFailedQueryCount());
-    Assert.assertEquals(0, failingQueryResource.getInterruptedQueryCount());
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(1, failingQueryResource.getFailedQueryCount());
+    Assertions.assertEquals(0, failingQueryResource.getInterruptedQueryCount());
   }
 
   @Test
@@ -1952,19 +1946,16 @@ public class QueryResourceTest
     );
 
     // A QueryException keeps its own status and its legacy response body.
-    Assert.assertNotNull(response);
-    Assert.assertEquals(429, response.getStatus());
-    MatcherAssert.assertThat(
-        StringUtils.fromUtf8((byte[]) response.getEntity()),
-        CoreMatchers.containsString("too busy")
-    );
+    Assertions.assertNotNull(response);
+    Assertions.assertEquals(429, response.getStatus());
+    assertThat(StringUtils.fromUtf8((byte[]) response.getEntity())).contains("too busy");
 
     // It now shares the DruidException path, so the failure is recorded server-side and not just returned.
-    Assert.assertEquals(1, failingQueryResource.getFailedQueryCount());
-    Assert.assertEquals(1, testRequestLogger.getNativeQuerylogs().size());
+    Assertions.assertEquals(1, failingQueryResource.getFailedQueryCount());
+    Assertions.assertEquals(1, testRequestLogger.getNativeQuerylogs().size());
     final Map<String, Object> stats = testRequestLogger.getNativeQuerylogs().get(0).getQueryStats().getStats();
-    Assert.assertEquals(false, stats.get("success"));
-    Assert.assertEquals(429, stats.get(DruidMetrics.STATUS_CODE));
+    Assertions.assertEquals(false, stats.get("success"));
+    Assertions.assertEquals(429, stats.get(DruidMetrics.STATUS_CODE));
   }
 
   @Test
@@ -1983,7 +1974,7 @@ public class QueryResourceTest
         blockingQueryResource
     );
 
-    Assert.assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Status.OK.getStatusCode(), response.getStatus());
   }
 
   private QueryResource createQueryResourceWithBlocklist(ServerConfig serverConfig, QueryBlocklistRule... rules)
@@ -2054,7 +2045,7 @@ public class QueryResourceTest
   {
     final MockHttpServletResponse response = MockHttpServletResponse.forRequest(req);
 
-    Assert.assertNull(queryResource.doPost(
+    Assertions.assertNull(queryResource.doPost(
         new ByteArrayInputStream(queryBytes),
         null /*pretty*/,
         req
@@ -2082,6 +2073,47 @@ public class QueryResourceTest
       }
       return true;
     });
+  }
+
+  private static DruidException assertDruidException(
+      Throwable exception,
+      DruidException.Persona persona,
+      DruidException.Category category,
+      String errorCode
+  )
+  {
+    final DruidException druidException = Assertions.assertInstanceOf(DruidException.class, exception);
+    Assertions.assertEquals(persona, druidException.getTargetPersona());
+    Assertions.assertEquals(category, druidException.getCategory());
+    Assertions.assertEquals(errorCode, druidException.getErrorCode());
+    return druidException;
+  }
+
+  private static void assertDruidExceptionMessageIs(
+      Throwable exception,
+      DruidException.Persona persona,
+      DruidException.Category category,
+      String errorCode,
+      String message
+  )
+  {
+    Assertions.assertEquals(
+        message,
+        assertDruidException(exception, persona, category, errorCode).getMessage()
+    );
+  }
+
+  private static void assertDruidExceptionMessageContains(
+      Throwable exception,
+      DruidException.Persona persona,
+      DruidException.Category category,
+      String errorCode,
+      String message
+  )
+  {
+    Assertions.assertTrue(
+        assertDruidException(exception, persona, category, errorCode).getMessage().contains(message)
+    );
   }
 
   private Response expectSynchronousRequestFlow(String simpleTimeseriesQuery) throws IOException

--- a/server/src/test/java/org/apache/druid/server/QueryResultPusherTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResultPusherTest.java
@@ -26,7 +26,7 @@ import org.apache.druid.server.QueryResource.QueryMetricCounter;
 import org.apache.druid.server.QueryResultPusher.ResultsWriter;
 import org.apache.druid.server.QueryResultPusher.Writer;
 import org.apache.druid.server.mocks.MockHttpServletRequest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.MediaType;
@@ -38,7 +38,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QueryResultPusherTest
 {
@@ -133,7 +133,7 @@ public class QueryResultPusherTest
 
     pusher.push();
 
-    assertTrue("recordFailure(e) should have been invoked!", recordFailureInvoked.get());
+    assertTrue(recordFailureInvoked.get(), "recordFailure(e) should have been invoked!");
   }
 
   static class NoopQueryMetricCounter implements QueryMetricCounter

--- a/server/src/test/java/org/apache/druid/server/QueryResultPusherTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResultPusherTest.java
@@ -26,6 +26,7 @@ import org.apache.druid.server.QueryResource.QueryMetricCounter;
 import org.apache.druid.server.QueryResultPusher.ResultsWriter;
 import org.apache.druid.server.QueryResultPusher.Writer;
 import org.apache.druid.server.mocks.MockHttpServletRequest;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
@@ -37,8 +38,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QueryResultPusherTest
 {
@@ -91,7 +90,7 @@ public class QueryResultPusherTest
       @Override
       public void recordFailure(Exception e, long bytesWritten)
       {
-        assertTrue(Throwables.getStackTraceAsString(e).contains(embeddedExceptionMessage));
+        Assertions.assertTrue(Throwables.getStackTraceAsString(e).contains(embeddedExceptionMessage));
         recordFailureInvoked.set(true);
       }
 
@@ -133,7 +132,7 @@ public class QueryResultPusherTest
 
     pusher.push();
 
-    assertTrue(recordFailureInvoked.get(), "recordFailure(e) should have been invoked!");
+    Assertions.assertTrue(recordFailureInvoked.get(), "recordFailure(e) should have been invoked!");
   }
 
   static class NoopQueryMetricCounter implements QueryMetricCounter

--- a/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
+++ b/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
@@ -67,6 +67,7 @@ import org.apache.druid.server.scheduling.HiLoQueryLaningStrategy;
 import org.apache.druid.server.scheduling.ManualQueryPrioritizationStrategy;
 import org.apache.druid.server.scheduling.NoQueryLaningStrategy;
 import org.apache.druid.server.scheduling.WeightedQueryLaningStrategy;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -542,7 +543,7 @@ public class QuerySchedulerTest
     properties.setProperty(propertyPrefix + ".prioritization.strategy", "threshold");
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
     Throwable t = Assertions.assertThrows(ProvisionException.class, () -> provider.get().get());
-    org.assertj.core.api.Assertions.assertThat(t.getMessage()).containsSubsequence(
+    AssertionsForClassTypes.assertThat(t.getMessage()).containsSubsequence(
         "Problem parsing object at prefix[druid.query.scheduler]:",
         "problem: periodThreshold, durationThreshold, segmentCountThreshold or segmentRangeThreshold must be set"
     );

--- a/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
+++ b/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
@@ -31,7 +31,6 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.ProvisionException;
 import org.apache.druid.client.SegmentServerSelector;
-import org.apache.druid.error.ExceptionMatcher;
 import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.JsonConfigurator;
@@ -58,7 +57,6 @@ import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.groupby.GroupByQuery;
 import org.apache.druid.query.groupby.GroupByQueryConfig;
-import org.apache.druid.query.groupby.GroupByQueryRunnerTest;
 import org.apache.druid.query.groupby.GroupByQueryRunnerTestHelper;
 import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.query.groupby.having.HavingSpec;
@@ -70,11 +68,10 @@ import org.apache.druid.server.scheduling.ManualQueryPrioritizationStrategy;
 import org.apache.druid.server.scheduling.NoQueryLaningStrategy;
 import org.apache.druid.server.scheduling.WeightedQueryLaningStrategy;
 import org.easymock.EasyMock;
-import org.hamcrest.text.StringContainsInOrder;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -100,7 +97,7 @@ public class QuerySchedulerTest
   private ListeningExecutorService executorService;
   private ObservableQueryScheduler scheduler;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     executorService = MoreExecutors.listeningDecorator(
@@ -115,7 +112,7 @@ public class QuerySchedulerTest
     );
   }
 
-  @After
+  @AfterEach
   public void teardown()
   {
     executorService.shutdownNow();
@@ -129,7 +126,7 @@ public class QuerySchedulerTest
       try {
         Query<?> scheduled = scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(interactive), ImmutableSet.of());
 
-        Assert.assertNotNull(scheduled);
+        Assertions.assertNotNull(scheduled);
 
         Sequence<Integer> underlyingSequence = makeSequence(10);
         underlyingSequence = Sequences.wrap(underlyingSequence, new SequenceWrapper()
@@ -137,22 +134,22 @@ public class QuerySchedulerTest
           @Override
           public void before()
           {
-            Assert.assertEquals(4, scheduler.getTotalAvailableCapacity());
-            Assert.assertEquals(2, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
+            Assertions.assertEquals(4, scheduler.getTotalAvailableCapacity());
+            Assertions.assertEquals(2, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
           }
         });
         Sequence<Integer> results = scheduler.run(scheduled, underlyingSequence);
         int rowCount = consumeAndCloseSequence(results);
 
-        Assert.assertEquals(10, rowCount);
+        Assertions.assertEquals(10, rowCount);
       }
       catch (IOException ex) {
         throw new RuntimeException(ex);
       }
     });
     future.get();
-    Assert.assertEquals(TEST_HI_CAPACITY, scheduler.getTotalAvailableCapacity());
-    Assert.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
+    Assertions.assertEquals(TEST_HI_CAPACITY, scheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
   }
 
   @Test
@@ -162,8 +159,8 @@ public class QuerySchedulerTest
     ListenableFuture<?> future = executorService.submit(() -> {
       try {
         Query<?> scheduledReport = scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(report), ImmutableSet.of());
-        Assert.assertNotNull(scheduledReport);
-        Assert.assertEquals(HiLoQueryLaningStrategy.LOW, scheduledReport.context().getLane());
+        Assertions.assertNotNull(scheduledReport);
+        Assertions.assertEquals(HiLoQueryLaningStrategy.LOW, scheduledReport.context().getLane());
 
         Sequence<Integer> underlyingSequence = makeSequence(10);
         underlyingSequence = Sequences.wrap(underlyingSequence, new SequenceWrapper()
@@ -171,14 +168,14 @@ public class QuerySchedulerTest
           @Override
           public void before()
           {
-            Assert.assertEquals(4, scheduler.getTotalAvailableCapacity());
-            Assert.assertEquals(1, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
+            Assertions.assertEquals(4, scheduler.getTotalAvailableCapacity());
+            Assertions.assertEquals(1, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
           }
         });
         Sequence<Integer> results = scheduler.run(scheduledReport, underlyingSequence);
 
         int rowCount = consumeAndCloseSequence(results);
-        Assert.assertEquals(10, rowCount);
+        Assertions.assertEquals(10, rowCount);
       }
       catch (IOException ex) {
         throw new RuntimeException(ex);
@@ -186,7 +183,7 @@ public class QuerySchedulerTest
     });
     future.get();
     assertHiLoHasAllCapacity(TEST_HI_CAPACITY, TEST_LO_CAPACITY);
-    Assert.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
+    Assertions.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
   }
 
   @Test
@@ -197,7 +194,7 @@ public class QuerySchedulerTest
       try {
         Query<?> scheduled = scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(interactive), ImmutableSet.of());
 
-        Assert.assertNotNull(scheduled);
+        Assertions.assertNotNull(scheduled);
 
         Sequence<Integer> underlyingSequence = makeExplodingSequence(10);
         underlyingSequence = Sequences.wrap(underlyingSequence, new SequenceWrapper()
@@ -205,7 +202,7 @@ public class QuerySchedulerTest
           @Override
           public void before()
           {
-            Assert.assertEquals(4, scheduler.getTotalAvailableCapacity());
+            Assertions.assertEquals(4, scheduler.getTotalAvailableCapacity());
           }
         });
         Sequence<Integer> results = scheduler.run(scheduled, underlyingSequence);
@@ -216,9 +213,9 @@ public class QuerySchedulerTest
         throw new RuntimeException(ex);
       }
     });
-    Throwable t = Assert.assertThrows(ExecutionException.class, future::get);
-    Assert.assertEquals("java.lang.RuntimeException: exploded", t.getMessage());
-    Assert.assertEquals(5, scheduler.getTotalAvailableCapacity());
+    Throwable t = Assertions.assertThrows(ExecutionException.class, future::get);
+    Assertions.assertEquals("java.lang.RuntimeException: exploded", t.getMessage());
+    Assertions.assertEquals(5, scheduler.getTotalAvailableCapacity());
   }
 
   @Test
@@ -227,21 +224,21 @@ public class QuerySchedulerTest
     Query<?> report1 = scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(makeReportQuery()), ImmutableSet.of());
     Sequence<?> sequence = scheduler.run(report1, Sequences.empty());
     // making the sequence doesn't count, only running it does
-    Assert.assertEquals(5, scheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(5, scheduler.getTotalAvailableCapacity());
     // this counts though since we are doing stuff
     Yielders.each(sequence);
-    Assert.assertNotNull(report1);
-    Assert.assertEquals(4, scheduler.getTotalAvailableCapacity());
-    Assert.assertEquals(1, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertNotNull(report1);
+    Assertions.assertEquals(4, scheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(1, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
 
     Query<?> report2 = scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(makeReportQuery()), ImmutableSet.of());
     Yielders.each(scheduler.run(report2, Sequences.empty()));
-    Assert.assertNotNull(report2);
-    Assert.assertEquals(3, scheduler.getTotalAvailableCapacity());
-    Assert.assertEquals(0, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertNotNull(report2);
+    Assertions.assertEquals(3, scheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(0, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
 
     // too many reports
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         QueryCapacityExceededException.class,
         () -> Yielders.each(
             scheduler.run(
@@ -250,7 +247,7 @@ public class QuerySchedulerTest
             )
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Too many concurrent queries for lane 'low', query capacity of 2 exceeded. Please try your query again later.",
         t.getMessage()
     );
@@ -262,43 +259,43 @@ public class QuerySchedulerTest
     Query<?> interactive1 = scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(makeInteractiveQuery()), ImmutableSet.of());
     Sequence<?> sequence = scheduler.run(interactive1, Sequences.empty());
     // making the sequence doesn't count, only running it does
-    Assert.assertEquals(5, scheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(5, scheduler.getTotalAvailableCapacity());
     // this counts tho
     Yielders.each(sequence);
-    Assert.assertNotNull(interactive1);
-    Assert.assertEquals(4, scheduler.getTotalAvailableCapacity());
+    Assertions.assertNotNull(interactive1);
+    Assertions.assertEquals(4, scheduler.getTotalAvailableCapacity());
 
     Query<?> report1 = scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(makeReportQuery()), ImmutableSet.of());
     Yielders.each(scheduler.run(report1, Sequences.empty()));
-    Assert.assertNotNull(report1);
-    Assert.assertEquals(3, scheduler.getTotalAvailableCapacity());
-    Assert.assertEquals(1, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertNotNull(report1);
+    Assertions.assertEquals(3, scheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(1, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
 
     Query<?> interactive2 = scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(makeInteractiveQuery()), ImmutableSet.of());
     Yielders.each(scheduler.run(interactive2, Sequences.empty()));
-    Assert.assertNotNull(interactive2);
-    Assert.assertEquals(2, scheduler.getTotalAvailableCapacity());
+    Assertions.assertNotNull(interactive2);
+    Assertions.assertEquals(2, scheduler.getTotalAvailableCapacity());
 
     Query<?> report2 = scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(makeReportQuery()), ImmutableSet.of());
     Yielders.each(scheduler.run(report2, Sequences.empty()));
-    Assert.assertNotNull(report2);
-    Assert.assertEquals(1, scheduler.getTotalAvailableCapacity());
-    Assert.assertEquals(0, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertNotNull(report2);
+    Assertions.assertEquals(1, scheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(0, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
 
     Query<?> interactive3 = scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(makeInteractiveQuery()), ImmutableSet.of());
     Yielders.each(scheduler.run(interactive3, Sequences.empty()));
-    Assert.assertNotNull(interactive3);
-    Assert.assertEquals(0, scheduler.getTotalAvailableCapacity());
+    Assertions.assertNotNull(interactive3);
+    Assertions.assertEquals(0, scheduler.getTotalAvailableCapacity());
 
     // one too many
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         QueryCapacityExceededException.class,
         () -> Yielders.each(scheduler.run(
             scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(makeInteractiveQuery()), ImmutableSet.of()),
             Sequences.empty()
         ))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Too many concurrent queries, total query capacity of 5 exceeded. Please try your query again later.",
         t.getMessage()
     );
@@ -366,7 +363,7 @@ public class QuerySchedulerTest
         new NoQueryLaningStrategy(),
         serverConfig
     );
-    Assert.assertEquals(serverConfig.getNumThreads() - 1, queryScheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(serverConfig.getNumThreads() - 1, queryScheduler.getTotalAvailableCapacity());
   }
 
   @Test
@@ -379,7 +376,7 @@ public class QuerySchedulerTest
         new NoQueryLaningStrategy(),
         serverConfig
     );
-    Assert.assertEquals(-1, queryScheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(-1, queryScheduler.getTotalAvailableCapacity());
   }
 
   @Test
@@ -392,7 +389,7 @@ public class QuerySchedulerTest
         SERVER_CONFIG_WITH_TOTAL
     );
 
-    QueryRunnerFactory factory = GroupByQueryRunnerTest.makeQueryRunnerFactory(
+    QueryRunnerFactory factory = QueryStackTests.makeGroupByQueryRunnerFactory(
         new GroupByQueryConfig()
         {
 
@@ -439,10 +436,10 @@ public class QuerySchedulerTest
         NUM_ROWS
     );
 
-    Assert.assertEquals(5, scheduler.getTotalAvailableCapacity());
-    Throwable t = Assert.assertThrows(Throwable.class, f::get);
-    Assert.assertEquals("java.lang.RuntimeException: exploded", t.getMessage());
-    Assert.assertEquals(5, scheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(5, scheduler.getTotalAvailableCapacity());
+    Throwable t = Assertions.assertThrows(Throwable.class, f::get);
+    Assertions.assertEquals("java.lang.RuntimeException: exploded", t.getMessage());
+    Assertions.assertEquals(5, scheduler.getTotalAvailableCapacity());
   }
 
   @Test
@@ -458,9 +455,9 @@ public class QuerySchedulerTest
     properties.setProperty(propertyPrefix + ".numThreads", "10");
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
     final QueryScheduler scheduler = provider.get().get();
-    Assert.assertEquals(10, scheduler.getTotalAvailableCapacity());
-    Assert.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
-    Assert.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
+    Assertions.assertEquals(10, scheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
   }
 
   @Test
@@ -479,9 +476,9 @@ public class QuerySchedulerTest
 
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
     final QueryScheduler scheduler = provider.get().get();
-    Assert.assertEquals(10, scheduler.getTotalAvailableCapacity());
-    Assert.assertEquals(2, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
-    Assert.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
+    Assertions.assertEquals(10, scheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(2, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
   }
 
 
@@ -497,14 +494,6 @@ public class QuerySchedulerTest
     final Properties properties = new Properties();
     properties.setProperty(propertyPrefix + ".laning.strategy", "hilo");
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
-    ExceptionMatcher
-        .of(ProvisionException.class)
-        .expectMessage(
-            new StringContainsInOrder(List.of(
-                "Problem parsing object at prefix[druid.query.scheduler]:",
-                "problem: maxLowPercent must be set"
-            ))
-      );
   }
 
   @Test
@@ -525,9 +514,9 @@ public class QuerySchedulerTest
     properties.setProperty(propertyPrefix + ".prioritization.segmentCountThreshold", "1");
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
     final QueryScheduler scheduler = provider.get().get();
-    Assert.assertEquals(10, scheduler.getTotalAvailableCapacity());
-    Assert.assertEquals(2, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
-    Assert.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
+    Assertions.assertEquals(10, scheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(2, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
 
     Query<?> query = scheduler.prioritizeAndLaneQuery(
         QueryPlus.wrap(makeDefaultQuery()),
@@ -536,8 +525,8 @@ public class QuerySchedulerTest
             EasyMock.createMock(SegmentServerSelector.class)
         )
     );
-    Assert.assertEquals(-5, query.context().getPriority());
-    Assert.assertEquals(HiLoQueryLaningStrategy.LOW, query.context().getLane());
+    Assertions.assertEquals(-5, query.context().getPriority());
+    Assertions.assertEquals(HiLoQueryLaningStrategy.LOW, query.context().getLane());
   }
 
   @Test
@@ -552,15 +541,11 @@ public class QuerySchedulerTest
     final Properties properties = new Properties();
     properties.setProperty(propertyPrefix + ".prioritization.strategy", "threshold");
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
-    Throwable t = Assert.assertThrows(ProvisionException.class, () -> provider.get().get());
-    ExceptionMatcher
-        .of(ProvisionException.class)
-        .expectMessage(
-            new StringContainsInOrder(List.of(
-                "Problem parsing object at prefix[druid.query.scheduler]:",
-                "problem: periodThreshold, durationThreshold, segmentCountThreshold or segmentRangeThreshold must be set"
-            ))
-      );
+    Throwable t = Assertions.assertThrows(ProvisionException.class, () -> provider.get().get());
+    org.assertj.core.api.Assertions.assertThat(t.getMessage()).containsSubsequence(
+        "Problem parsing object at prefix[druid.query.scheduler]:",
+        "problem: periodThreshold, durationThreshold, segmentCountThreshold or segmentRangeThreshold must be set"
+    );
   }
 
 
@@ -580,10 +565,10 @@ public class QuerySchedulerTest
     properties.put(propertyPrefix + ".laning.lanes.two", "2");
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
     final QueryScheduler scheduler = provider.get().get();
-    Assert.assertEquals(10, scheduler.getTotalAvailableCapacity());
-    Assert.assertEquals(1, scheduler.getLaneAvailableCapacity("one"));
-    Assert.assertEquals(2, scheduler.getLaneAvailableCapacity("two"));
-    Assert.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
+    Assertions.assertEquals(10, scheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(1, scheduler.getLaneAvailableCapacity("one"));
+    Assertions.assertEquals(2, scheduler.getLaneAvailableCapacity("two"));
+    Assertions.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
   }
 
   @Test
@@ -603,10 +588,10 @@ public class QuerySchedulerTest
     properties.put(propertyPrefix + ".laning.lanes.twenty", "20");
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
     final QueryScheduler scheduler = provider.get().get();
-    Assert.assertEquals(10, scheduler.getTotalAvailableCapacity());
-    Assert.assertEquals(1, scheduler.getLaneAvailableCapacity("one"));
-    Assert.assertEquals(2, scheduler.getLaneAvailableCapacity("twenty"));
-    Assert.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
+    Assertions.assertEquals(10, scheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(1, scheduler.getLaneAvailableCapacity("one"));
+    Assertions.assertEquals(2, scheduler.getLaneAvailableCapacity("twenty"));
+    Assertions.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
   }
 
   @Test
@@ -625,9 +610,9 @@ public class QuerySchedulerTest
     properties.setProperty(propertyPrefix + ".laning.lanes", "{\"low\": {\"minCost\": 1, \"maxPercent\": 30}}");
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
     final QueryScheduler scheduler = provider.get().get();
-    Assert.assertEquals(10, scheduler.getTotalAvailableCapacity());
-    Assert.assertEquals(3, scheduler.getLaneAvailableCapacity("low"));
-    Assert.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
+    Assertions.assertEquals(10, scheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(3, scheduler.getLaneAvailableCapacity("low"));
+    Assertions.assertEquals(QueryScheduler.UNAVAILABLE, scheduler.getLaneAvailableCapacity("non-existent"));
   }
 
   @Test
@@ -654,14 +639,14 @@ public class QuerySchedulerTest
             EasyMock.createMock(SegmentServerSelector.class)
         )
     );
-    Assert.assertEquals("low", query.context().getLane());
+    Assertions.assertEquals("low", query.context().getLane());
 
     // Query with 0 segments → no lane
     Query<?> noLaneQuery = weightedScheduler.prioritizeAndLaneQuery(
         QueryPlus.wrap(makeDefaultQuery()),
         Set.of()
     );
-    Assert.assertNull(noLaneQuery.context().getLane());
+    Assertions.assertNull(noLaneQuery.context().getLane());
   }
 
   @Test
@@ -688,14 +673,14 @@ public class QuerySchedulerTest
     // Fill the low lane (capacity = ceil(5 * 40/100) = 2)
     Query<?> q1 = weightedScheduler.prioritizeAndLaneQuery(QueryPlus.wrap(makeDefaultQuery()), manySegments);
     Yielders.each(weightedScheduler.run(q1, Sequences.empty()));
-    Assert.assertEquals(1, weightedScheduler.getLaneAvailableCapacity("low"));
+    Assertions.assertEquals(1, weightedScheduler.getLaneAvailableCapacity("low"));
 
     Query<?> q2 = weightedScheduler.prioritizeAndLaneQuery(QueryPlus.wrap(makeDefaultQuery()), manySegments);
     Yielders.each(weightedScheduler.run(q2, Sequences.empty()));
-    Assert.assertEquals(0, weightedScheduler.getLaneAvailableCapacity("low"));
+    Assertions.assertEquals(0, weightedScheduler.getLaneAvailableCapacity("low"));
 
     // Third should fail with 429
-    Assert.assertThrows(
+    Assertions.assertThrows(
         QueryCapacityExceededException.class,
         () -> Yielders.each(
             weightedScheduler.run(
@@ -764,8 +749,7 @@ public class QuerySchedulerTest
 
   private Sequence<Integer> makeSequence(int count)
   {
-    return new LazySequence<>(() -> {
-      return new BaseSequence<>(
+    return new LazySequence<>(() -> new BaseSequence<>(
           new BaseSequence.IteratorMaker<Integer, Iterator<Integer>>()
           {
             @Override
@@ -796,8 +780,7 @@ public class QuerySchedulerTest
               // nothing to cleanup
             }
           }
-      );
-    });
+      ));
   }
 
   private Sequence<Integer> makeExplodingSequence(int explodeAfter)
@@ -852,13 +835,13 @@ public class QuerySchedulerTest
       try {
         Query<?> scheduled = scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(query), ImmutableSet.of());
 
-        Assert.assertNotNull(scheduled);
+        Assertions.assertNotNull(scheduled);
 
         Sequence<Integer> underlyingSequence = makeSequence(numRows);
         Sequence<Integer> results = scheduler.run(scheduled, underlyingSequence);
 
         final int actualNumRows = consumeAndCloseSequence(results);
-        Assert.assertEquals(actualNumRows, numRows);
+        Assertions.assertEquals(actualNumRows, numRows);
       }
       catch (IOException ex) {
         throw new RuntimeException(ex);
@@ -879,7 +862,7 @@ public class QuerySchedulerTest
       try {
         Query<?> scheduled = scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(query), ImmutableSet.of());
 
-        Assert.assertNotNull(scheduled);
+        Assertions.assertNotNull(scheduled);
 
         FluentQueryRunner runner = FluentQueryRunner
             .create(
@@ -897,7 +880,7 @@ public class QuerySchedulerTest
         final int actualNumRows = consumeAndCloseSequence(
             runner.run(QueryPlus.wrap(GroupByQueryRunnerTestHelper.populateResourceId(query)))
         );
-        Assert.assertEquals(actualNumRows, numRows);
+        Assertions.assertEquals(actualNumRows, numRows);
       }
       catch (IOException ex) {
         throw new RuntimeException(ex);
@@ -932,21 +915,21 @@ public class QuerySchedulerTest
         other++;
       }
     }
-    Assert.assertEquals(0, other);
+    Assertions.assertEquals(0, other);
     if (expectNoneLimited) {
-      Assert.assertEquals(0, denied);
-      Assert.assertEquals(NUM_QUERIES, success);
-      Assert.assertEquals(0, scheduler.getTotalAcquired().get());
-      Assert.assertEquals(0, scheduler.getLaneAcquired().get());
+      Assertions.assertEquals(0, denied);
+      Assertions.assertEquals(NUM_QUERIES, success);
+      Assertions.assertEquals(0, scheduler.getTotalAcquired().get());
+      Assertions.assertEquals(0, scheduler.getLaneAcquired().get());
     } else {
-      Assert.assertTrue(denied > 0);
+      Assertions.assertTrue(denied > 0);
       if (successEqualsTotal) {
-        Assert.assertEquals(success, scheduler.getTotalAcquired().get());
+        Assertions.assertEquals(success, scheduler.getTotalAcquired().get());
       } else {
-        Assert.assertTrue(success > 0 && success <= scheduler.getTotalAcquired().get());
+        Assertions.assertTrue(success > 0 && success <= scheduler.getTotalAcquired().get());
       }
-      Assert.assertEquals(scheduler.getTotalReleased().get(), scheduler.getTotalAcquired().get());
-      Assert.assertEquals(
+      Assertions.assertEquals(scheduler.getTotalReleased().get(), scheduler.getTotalAcquired().get());
+      Assertions.assertEquals(
           scheduler.getLaneReleased().get(),
           scheduler.getLaneAcquired().get() + scheduler.getLaneNotAcquired().get()
       );
@@ -955,8 +938,8 @@ public class QuerySchedulerTest
 
   private void assertHiLoHasAllCapacity(int hi, int lo)
   {
-    Assert.assertEquals(lo, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
-    Assert.assertEquals(hi, scheduler.getTotalAvailableCapacity());
+    Assertions.assertEquals(lo, scheduler.getLaneAvailableCapacity(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertEquals(hi, scheduler.getTotalAvailableCapacity());
   }
 
   private Injector createInjector()

--- a/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
+++ b/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
@@ -389,7 +389,7 @@ public class QuerySchedulerTest
         SERVER_CONFIG_WITH_TOTAL
     );
 
-    QueryRunnerFactory factory = QueryStackTests.makeGroupByQueryRunnerFactory(
+    QueryRunnerFactory factory = GroupByQueryRunnerTestHelper.makeQueryRunnerFactory(
         new GroupByQueryConfig()
         {
 

--- a/server/src/test/java/org/apache/druid/server/QueryStackTests.java
+++ b/server/src/test/java/org/apache/druid/server/QueryStackTests.java
@@ -20,6 +20,7 @@
 package org.apache.druid.server;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -32,6 +33,7 @@ import org.apache.druid.guice.ExpressionModule;
 import org.apache.druid.guice.SegmentWranglerModule;
 import org.apache.druid.guice.StartupInjectorBuilder;
 import org.apache.druid.initialization.CoreInjectorBuilder;
+import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.query.BrokerParallelMergeConfig;
@@ -50,10 +52,14 @@ import org.apache.druid.query.QuerySegmentWalker;
 import org.apache.druid.query.RetryQueryRunnerConfig;
 import org.apache.druid.query.TestBufferPool;
 import org.apache.druid.query.expression.LookupEnabledTestExprMacroTable;
+import org.apache.druid.query.groupby.DefaultGroupByQueryMetricsFactory;
 import org.apache.druid.query.groupby.GroupByQuery;
 import org.apache.druid.query.groupby.GroupByQueryConfig;
+import org.apache.druid.query.groupby.GroupByQueryQueryToolChest;
 import org.apache.druid.query.groupby.GroupByQueryRunnerFactory;
-import org.apache.druid.query.groupby.GroupByQueryRunnerTest;
+import org.apache.druid.query.groupby.GroupByResourcesReservationPool;
+import org.apache.druid.query.groupby.GroupByStatsProvider;
+import org.apache.druid.query.groupby.GroupingEngine;
 import org.apache.druid.query.groupby.TestGroupByBuffers;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.metadata.SegmentMetadataQueryConfig;
@@ -163,6 +169,33 @@ public class QueryStackTests
   public static final int DEFAULT_NUM_MERGE_BUFFERS = -1;
 
   private static final int COMPUTE_BUFFER_SIZE = 10 * 1024 * 1024;
+
+  private static final DruidProcessingConfig DEFAULT_GROUP_BY_PROCESSING_CONFIG = new DruidProcessingConfig()
+  {
+    @Override
+    public String getFormatString()
+    {
+      return null;
+    }
+
+    @Override
+    public int intermediateComputeSizeBytes()
+    {
+      return COMPUTE_BUFFER_SIZE;
+    }
+
+    @Override
+    public int getNumMergeBuffers()
+    {
+      return 4;
+    }
+
+    @Override
+    public int getNumThreads()
+    {
+      return 2;
+    }
+  };
 
   private QueryStackTests()
   {
@@ -403,7 +436,7 @@ public class QueryStackTests
       final TestBufferPool testBufferPool,
       final TestGroupByBuffers groupByBuffers)
   {
-    final GroupByQueryRunnerFactory groupByQueryRunnerFactory = GroupByQueryRunnerTest.makeQueryRunnerFactory(
+    final GroupByQueryRunnerFactory groupByQueryRunnerFactory = makeGroupByQueryRunnerFactory(
         jsonMapper,
         new GroupByQueryConfig()
         {
@@ -463,6 +496,64 @@ public class QueryStackTests
             )
         )
         .build();
+  }
+
+  public static GroupByQueryRunnerFactory makeGroupByQueryRunnerFactory(final GroupByQueryConfig config)
+  {
+    return makeGroupByQueryRunnerFactory(
+        TestHelper.makeSmileMapper(),
+        config,
+        new TestGroupByBuffers(
+            DEFAULT_GROUP_BY_PROCESSING_CONFIG.intermediateComputeSizeBytes(),
+            DEFAULT_GROUP_BY_PROCESSING_CONFIG.getNumMergeBuffers()
+        ),
+        DEFAULT_GROUP_BY_PROCESSING_CONFIG
+    );
+  }
+
+  private static GroupByQueryRunnerFactory makeGroupByQueryRunnerFactory(
+      final ObjectMapper mapper,
+      final GroupByQueryConfig config,
+      final TestGroupByBuffers bufferPools,
+      final DruidProcessingConfig processingConfig
+  )
+  {
+    if (bufferPools.getBufferSize() != processingConfig.intermediateComputeSizeBytes()) {
+      throw new ISE(
+          "Provided buffer size [%,d] does not match configured size [%,d]",
+          bufferPools.getBufferSize(),
+          processingConfig.intermediateComputeSizeBytes()
+      );
+    }
+    if (bufferPools.getNumMergeBuffers() != processingConfig.getNumMergeBuffers()) {
+      throw new ISE(
+          "Provided merge buffer count [%,d] does not match configured count [%,d]",
+          bufferPools.getNumMergeBuffers(),
+          processingConfig.getNumMergeBuffers()
+      );
+    }
+
+    final GroupByStatsProvider statsProvider = new GroupByStatsProvider();
+    final Supplier<GroupByQueryConfig> configSupplier = Suppliers.ofInstance(config);
+    final GroupByResourcesReservationPool groupByResourcesReservationPool =
+        new GroupByResourcesReservationPool(bufferPools.getMergePool(), config);
+    final GroupingEngine groupingEngine = new GroupingEngine(
+        processingConfig,
+        configSupplier,
+        groupByResourcesReservationPool,
+        mapper,
+        mapper,
+        QueryRunnerTestHelper.NOOP_QUERYWATCHER,
+        statsProvider
+    );
+    final GroupByQueryQueryToolChest toolChest = new GroupByQueryQueryToolChest(
+        groupingEngine,
+        configSupplier,
+        DefaultGroupByQueryMetricsFactory.instance(),
+        groupByResourcesReservationPool,
+        statsProvider
+    );
+    return new GroupByQueryRunnerFactory(groupingEngine, toolChest, bufferPools.getProcessingPool());
   }
 
   public static JoinableFactory makeJoinableFactoryForLookup(

--- a/server/src/test/java/org/apache/druid/server/QueryStackTests.java
+++ b/server/src/test/java/org/apache/druid/server/QueryStackTests.java
@@ -465,18 +465,6 @@ public class QueryStackTests
         .build();
   }
 
-  public static GroupByQueryRunnerFactory makeGroupByQueryRunnerFactory(final GroupByQueryConfig config)
-  {
-    return GroupByQueryRunnerTestHelper.makeQueryRunnerFactory(
-        TestHelper.makeSmileMapper(),
-        config,
-        new TestGroupByBuffers(
-            COMPUTE_BUFFER_SIZE,
-            4
-        )
-    );
-  }
-
   public static JoinableFactory makeJoinableFactoryForLookup(
       LookupExtractorFactoryContainerProvider lookupProvider
   )

--- a/server/src/test/java/org/apache/druid/server/QueryStackTests.java
+++ b/server/src/test/java/org/apache/druid/server/QueryStackTests.java
@@ -20,7 +20,6 @@
 package org.apache.druid.server;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -33,7 +32,6 @@ import org.apache.druid.guice.ExpressionModule;
 import org.apache.druid.guice.SegmentWranglerModule;
 import org.apache.druid.guice.StartupInjectorBuilder;
 import org.apache.druid.initialization.CoreInjectorBuilder;
-import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.query.BrokerParallelMergeConfig;
@@ -52,14 +50,10 @@ import org.apache.druid.query.QuerySegmentWalker;
 import org.apache.druid.query.RetryQueryRunnerConfig;
 import org.apache.druid.query.TestBufferPool;
 import org.apache.druid.query.expression.LookupEnabledTestExprMacroTable;
-import org.apache.druid.query.groupby.DefaultGroupByQueryMetricsFactory;
 import org.apache.druid.query.groupby.GroupByQuery;
 import org.apache.druid.query.groupby.GroupByQueryConfig;
-import org.apache.druid.query.groupby.GroupByQueryQueryToolChest;
 import org.apache.druid.query.groupby.GroupByQueryRunnerFactory;
-import org.apache.druid.query.groupby.GroupByResourcesReservationPool;
-import org.apache.druid.query.groupby.GroupByStatsProvider;
-import org.apache.druid.query.groupby.GroupingEngine;
+import org.apache.druid.query.groupby.GroupByQueryRunnerTestHelper;
 import org.apache.druid.query.groupby.TestGroupByBuffers;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.metadata.SegmentMetadataQueryConfig;
@@ -169,33 +163,6 @@ public class QueryStackTests
   public static final int DEFAULT_NUM_MERGE_BUFFERS = -1;
 
   private static final int COMPUTE_BUFFER_SIZE = 10 * 1024 * 1024;
-
-  private static final DruidProcessingConfig DEFAULT_GROUP_BY_PROCESSING_CONFIG = new DruidProcessingConfig()
-  {
-    @Override
-    public String getFormatString()
-    {
-      return null;
-    }
-
-    @Override
-    public int intermediateComputeSizeBytes()
-    {
-      return COMPUTE_BUFFER_SIZE;
-    }
-
-    @Override
-    public int getNumMergeBuffers()
-    {
-      return 4;
-    }
-
-    @Override
-    public int getNumThreads()
-    {
-      return 2;
-    }
-  };
 
   private QueryStackTests()
   {
@@ -436,7 +403,7 @@ public class QueryStackTests
       final TestBufferPool testBufferPool,
       final TestGroupByBuffers groupByBuffers)
   {
-    final GroupByQueryRunnerFactory groupByQueryRunnerFactory = makeGroupByQueryRunnerFactory(
+    final GroupByQueryRunnerFactory groupByQueryRunnerFactory = GroupByQueryRunnerTestHelper.makeQueryRunnerFactory(
         jsonMapper,
         new GroupByQueryConfig()
         {
@@ -500,60 +467,14 @@ public class QueryStackTests
 
   public static GroupByQueryRunnerFactory makeGroupByQueryRunnerFactory(final GroupByQueryConfig config)
   {
-    return makeGroupByQueryRunnerFactory(
+    return GroupByQueryRunnerTestHelper.makeQueryRunnerFactory(
         TestHelper.makeSmileMapper(),
         config,
         new TestGroupByBuffers(
-            DEFAULT_GROUP_BY_PROCESSING_CONFIG.intermediateComputeSizeBytes(),
-            DEFAULT_GROUP_BY_PROCESSING_CONFIG.getNumMergeBuffers()
-        ),
-        DEFAULT_GROUP_BY_PROCESSING_CONFIG
+            COMPUTE_BUFFER_SIZE,
+            4
+        )
     );
-  }
-
-  private static GroupByQueryRunnerFactory makeGroupByQueryRunnerFactory(
-      final ObjectMapper mapper,
-      final GroupByQueryConfig config,
-      final TestGroupByBuffers bufferPools,
-      final DruidProcessingConfig processingConfig
-  )
-  {
-    if (bufferPools.getBufferSize() != processingConfig.intermediateComputeSizeBytes()) {
-      throw new ISE(
-          "Provided buffer size [%,d] does not match configured size [%,d]",
-          bufferPools.getBufferSize(),
-          processingConfig.intermediateComputeSizeBytes()
-      );
-    }
-    if (bufferPools.getNumMergeBuffers() != processingConfig.getNumMergeBuffers()) {
-      throw new ISE(
-          "Provided merge buffer count [%,d] does not match configured count [%,d]",
-          bufferPools.getNumMergeBuffers(),
-          processingConfig.getNumMergeBuffers()
-      );
-    }
-
-    final GroupByStatsProvider statsProvider = new GroupByStatsProvider();
-    final Supplier<GroupByQueryConfig> configSupplier = Suppliers.ofInstance(config);
-    final GroupByResourcesReservationPool groupByResourcesReservationPool =
-        new GroupByResourcesReservationPool(bufferPools.getMergePool(), config);
-    final GroupingEngine groupingEngine = new GroupingEngine(
-        processingConfig,
-        configSupplier,
-        groupByResourcesReservationPool,
-        mapper,
-        mapper,
-        QueryRunnerTestHelper.NOOP_QUERYWATCHER,
-        statsProvider
-    );
-    final GroupByQueryQueryToolChest toolChest = new GroupByQueryQueryToolChest(
-        groupingEngine,
-        configSupplier,
-        DefaultGroupByQueryMetricsFactory.instance(),
-        groupByResourcesReservationPool,
-        statsProvider
-    );
-    return new GroupByQueryRunnerFactory(groupingEngine, toolChest, bufferPools.getProcessingPool());
   }
 
   public static JoinableFactory makeJoinableFactoryForLookup(

--- a/server/src/test/java/org/apache/druid/server/SetAndVerifyContextQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/server/SetAndVerifyContextQueryRunnerTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.query.scan.ScanResultValue;
 import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
 import org.apache.druid.server.initialization.ServerConfig;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SetAndVerifyContextQueryRunnerTest
 {
@@ -56,7 +56,7 @@ public class SetAndVerifyContextQueryRunnerTest
     // timeout is set to 1, so withTimeoutAndMaxScatterGatherBytes should set QUERY_FAIL_TIME to be the current
     // time + 1 at the time the method was called
     // this means that after sleeping for 1 millis, the fail time should be less than the current time when checking
-    Assert.assertTrue(
+    Assertions.assertTrue(
         System.currentTimeMillis() > transformed.context().getLong(DirectDruidClient.QUERY_FAIL_TIME)
     );
   }
@@ -84,7 +84,7 @@ public class SetAndVerifyContextQueryRunnerTest
     Query<ScanResultValue> transformed = queryRunner.withTimeoutAndMaxScatterGatherBytes(query, defaultConfig);
 
     // timeout is not set, default timeout has been set to long.max, make sure timeout is still in the future
-    Assert.assertEquals(Long.MAX_VALUE, (long) transformed.context().getLong(DirectDruidClient.QUERY_FAIL_TIME));
+    Assertions.assertEquals(Long.MAX_VALUE, (long) transformed.context().getLong(DirectDruidClient.QUERY_FAIL_TIME));
   }
 
   @Test
@@ -106,7 +106,7 @@ public class SetAndVerifyContextQueryRunnerTest
     // timeout is set to 0, so withTimeoutAndMaxScatterGatherBytes should set QUERY_FAIL_TIME to be the current
     // time + max query timeout at the time the method was called
     // since default is long max, expect long max since current time would overflow
-    Assert.assertEquals(Long.MAX_VALUE, (long) transformed.context().getLong(DirectDruidClient.QUERY_FAIL_TIME));
+    Assertions.assertEquals(Long.MAX_VALUE, (long) transformed.context().getLong(DirectDruidClient.QUERY_FAIL_TIME));
   }
 
   @Test
@@ -135,7 +135,7 @@ public class SetAndVerifyContextQueryRunnerTest
     // timeout is set to 0, so withTimeoutAndMaxScatterGatherBytes should set QUERY_FAIL_TIME to be the current
     // time + max query timeout at the time the method was called
     // this means that the fail time should be greater than the current time when checking
-    Assert.assertTrue(
+    Assertions.assertTrue(
         System.currentTimeMillis() < transformed.context().getLong(DirectDruidClient.QUERY_FAIL_TIME)
     );
   }
@@ -165,7 +165,7 @@ public class SetAndVerifyContextQueryRunnerTest
 
     // The existing fail time (1s from now) is earlier than computed (startTime + 300s),
     // so it must be preserved — not extended to startTime + 300s.
-    Assert.assertEquals(existingFailTime, (long) transformed.context().getLong(DirectDruidClient.QUERY_FAIL_TIME));
+    Assertions.assertEquals(existingFailTime, (long) transformed.context().getLong(DirectDruidClient.QUERY_FAIL_TIME));
   }
 
   @Test
@@ -192,7 +192,7 @@ public class SetAndVerifyContextQueryRunnerTest
 
     // Computed fail time is startTime + 1ms, which is earlier than the existing 10-min deadline.
     // The computed (stricter) value must win.
-    Assert.assertTrue(
+    Assertions.assertTrue(
         transformed.context().getLong(DirectDruidClient.QUERY_FAIL_TIME) < existingFailTime
     );
   }
@@ -227,6 +227,6 @@ public class SetAndVerifyContextQueryRunnerTest
 
     Query<ScanResultValue> transformed = queryRunner.withTimeoutAndMaxScatterGatherBytes(query, defaultConfig);
 
-    Assert.assertEquals(existingFailTime, (long) transformed.context().getLong(DirectDruidClient.QUERY_FAIL_TIME));
+    Assertions.assertEquals(existingFailTime, (long) transformed.context().getLong(DirectDruidClient.QUERY_FAIL_TIME));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/TestClusterQuerySegmentWalker.java
+++ b/server/src/test/java/org/apache/druid/server/TestClusterQuerySegmentWalker.java
@@ -60,6 +60,7 @@ import org.apache.druid.utils.CloseableUtils;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorConfigTest.java
@@ -34,7 +34,6 @@ import org.apache.druid.server.coordinator.config.DruidCoordinatorConfig;
 import org.apache.druid.server.coordinator.config.HttpLoadQueuePeonConfig;
 import org.apache.druid.server.coordinator.config.KillUnusedSegmentsConfig;
 import org.apache.druid.server.coordinator.config.MetadataCleanupConfig;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.Duration;
 import org.joda.time.Period;
 import org.junit.Assert;
@@ -448,7 +447,7 @@ public class DruidCoordinatorConfigTest
     );
 
     final String expectedMessage = StringUtils.format(expectedMessageFormat, args);
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         exception,
         new DruidExceptionMatcher(
             DruidException.Persona.OPERATOR,

--- a/server/src/test/java/org/apache/druid/server/coordinator/config/HttpLoadQueuePeonConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/config/HttpLoadQueuePeonConfigTest.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.google.common.base.Throwables;
 import org.apache.druid.error.DruidExceptionMatcher;
-import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -35,7 +34,7 @@ public class HttpLoadQueuePeonConfigTest
   {
     final ObjectMapper jsonMapper = new ObjectMapper();
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Throwables.getRootCause(
             Assert.assertThrows(ValueInstantiationException.class, () ->
                 jsonMapper.readValue("{\"batchSize\":0}", HttpLoadQueuePeonConfig.class)

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/PartialLoadProfileTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/PartialLoadProfileTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableMap;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.DruidExceptionMatcher;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -54,7 +53,7 @@ public class PartialLoadProfileTest
   @Test
   public void testForRequestRejectsNullWrappedLoadSpec()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> PartialLoadProfile.forRequest(null, FINGERPRINT)
@@ -66,7 +65,7 @@ public class PartialLoadProfileTest
   @Test
   public void testForRequestRejectsEmptyWrappedLoadSpec()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> PartialLoadProfile.forRequest(Map.of(), FINGERPRINT)
@@ -87,7 +86,7 @@ public class PartialLoadProfileTest
   @Test
   public void testForLoadedRejectsEmptyWrappedLoadSpec()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> PartialLoadProfile.forLoaded(Map.of(), FINGERPRINT, 100L)

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/CompositePartialLoadMatcherTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/CompositePartialLoadMatcherTest.java
@@ -36,7 +36,6 @@ import org.apache.druid.timeline.ClusterGroupTuples;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,7 +66,7 @@ class CompositePartialLoadMatcherTest
   @Test
   void testConstructorRejectsNullMatchers()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(DruidException.class, () -> new CompositePartialLoadMatcher(null)),
         DruidExceptionMatcher.invalidInput().expectMessageContains("matchers must not be null or empty")
     );
@@ -76,7 +75,7 @@ class CompositePartialLoadMatcherTest
   @Test
   void testConstructorRejectsEmptyMatchers()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(DruidException.class, () -> new CompositePartialLoadMatcher(List.of())),
         DruidExceptionMatcher.invalidInput().expectMessageContains("matchers must not be null or empty")
     );
@@ -85,7 +84,7 @@ class CompositePartialLoadMatcherTest
   @Test
   void testConstructorRejectsNullMember()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new CompositePartialLoadMatcher(Arrays.asList(exactProjection("p"), null))

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/ExactProjectionPartialLoadMatcherTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/ExactProjectionPartialLoadMatcherTest.java
@@ -30,7 +30,6 @@ import org.apache.druid.segment.loading.PartialBaseTableLoadSpec;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -126,7 +125,7 @@ public class ExactProjectionPartialLoadMatcherTest
   @Test
   void testConstructorRejectsNullNames()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new ExactProjectionPartialLoadMatcher(null)
@@ -138,7 +137,7 @@ public class ExactProjectionPartialLoadMatcherTest
   @Test
   void testConstructorRejectsEmptyNames()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new ExactProjectionPartialLoadMatcher(Collections.emptyList())

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/ForeverLoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/ForeverLoadRuleTest.java
@@ -25,7 +25,6 @@ import org.apache.druid.client.DruidServer;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -51,7 +50,7 @@ public class ForeverLoadRuleTest
   @Test
   public void testCreatingNegativeTieredReplicants()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assert.assertThrows(DruidException.class, () ->
             new ForeverLoadRule(
                 ImmutableMap.of(DruidServer.DEFAULT_TIER, -1),
@@ -80,7 +79,7 @@ public class ForeverLoadRuleTest
     Map<String, Integer> tieredReplicants = new HashMap<>();
     tieredReplicants.put("tier", null);
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assert.assertThrows(DruidException.class, () ->
             new ForeverLoadRule(
                 tieredReplicants,

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/IntervalLoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/IntervalLoadRuleTest.java
@@ -26,7 +26,6 @@ import org.apache.druid.error.DruidException;
 import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
-import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -70,7 +69,7 @@ public class IntervalLoadRuleTest
   @Test
   public void testCreatingNegativeTieredReplicants()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assert.assertThrows(DruidException.class, () ->
             new IntervalLoadRule(
                 Intervals.of("0/3000"),
@@ -91,7 +90,7 @@ public class IntervalLoadRuleTest
     Map<String, Integer> tieredReplicants = new HashMap<>();
     tieredReplicants.put("tier", null);
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assert.assertThrows(DruidException.class, () ->
             new IntervalLoadRule(
                 Intervals.of("0/3000"),

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/PartialLoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/PartialLoadRuleTest.java
@@ -33,7 +33,6 @@ import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
@@ -227,7 +226,7 @@ public class PartialLoadRuleTest
   @Test
   void testConstructorRejectsNullMatcher()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new PeriodPartialLoadRule(new Period("P1D"), false, tier(1), null, null, null)

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodLoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodLoadRuleTest.java
@@ -30,7 +30,6 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
@@ -199,7 +198,7 @@ public class PeriodLoadRuleTest
   @Test
   public void testCreatingNegativeTieredReplicants()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assert.assertThrows(DruidException.class, () ->
             new PeriodLoadRule(
                 Period.days(1),
@@ -221,7 +220,7 @@ public class PeriodLoadRuleTest
     Map<String, Integer> tieredReplicants = new HashMap<>();
     tieredReplicants.put("tier", null);
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assert.assertThrows(DruidException.class, () ->
             new PeriodLoadRule(
                 Period.days(1),

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/WildcardProjectionPartialLoadMatcherTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/WildcardProjectionPartialLoadMatcherTest.java
@@ -30,7 +30,6 @@ import org.apache.druid.segment.loading.PartialBaseTableLoadSpec;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -62,7 +61,7 @@ public class WildcardProjectionPartialLoadMatcherTest
   @Test
   void testConstructorRejectsNullPatterns()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new WildcardProjectionPartialLoadMatcher(null, null)
@@ -74,7 +73,7 @@ public class WildcardProjectionPartialLoadMatcherTest
   @Test
   void testConstructorRejectsEmptyPatterns()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new WildcardProjectionPartialLoadMatcher(Collections.emptyList(), null)
@@ -287,7 +286,7 @@ public class WildcardProjectionPartialLoadMatcherTest
   @Test
   void testRejectsTrailingBackslash()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new WildcardProjectionPartialLoadMatcher(List.of("foo\\"), null)
@@ -299,7 +298,7 @@ public class WildcardProjectionPartialLoadMatcherTest
   @Test
   void testRejectsTrailingBackslashInExcludePatterns()
   {
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         Assertions.assertThrows(
             DruidException.class,
             () -> new WildcardProjectionPartialLoadMatcher(List.of("*"), List.of("foo\\"))

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionResourceTest.java
@@ -26,7 +26,6 @@ import org.apache.druid.server.compaction.CompactionStatusResponse;
 import org.apache.druid.server.coordinator.AutoCompactionSnapshot;
 import org.apache.druid.server.coordinator.DruidCoordinator;
 import org.easymock.EasyMock;
-import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -147,7 +146,7 @@ public class CoordinatorCompactionResourceTest
     final Object responseEntity = response.getEntity();
     Assert.assertTrue(responseEntity instanceof ErrorResponse);
 
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         ((ErrorResponse) responseEntity).getUnderlyingException(),
         DruidExceptionMatcher.invalidInput().expectMessageIs("No DataSource specified")
     );

--- a/server/src/test/java/org/apache/druid/server/http/ServletResourceUtilsTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/ServletResourceUtilsTest.java
@@ -26,7 +26,6 @@ import org.apache.druid.error.InvalidInput;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
 import org.apache.druid.rpc.HttpResponseException;
-import org.hamcrest.MatcherAssert;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
@@ -68,7 +67,7 @@ public class ServletResourceUtilsTest
 
     Object entity = response.getEntity();
     Assert.assertTrue(entity instanceof ErrorResponse);
-    MatcherAssert.assertThat(
+    DruidExceptionMatcher.assertThat(
         ((ErrorResponse) entity).getUnderlyingException(),
         DruidExceptionMatcher.invalidInput().expectMessageIs("Invalid value of [inputKey]")
     );

--- a/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
@@ -121,7 +121,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -1142,9 +1141,7 @@ public class BaseCalciteQueryTest extends CalciteTestBase
       final DruidExceptionMatcher exceptionMatcher
   )
   {
-    // DruidExceptionMatcher is a Hamcrest matcher, so this delegates to Hamcrest's MatcherAssert.assertThat.
-    // Remove this bridge in the final cleanup after all DruidExceptionMatcher callers are migrated.
-    assertThat(exception, exceptionMatcher);
+    DruidExceptionMatcher.assertThat(exception, exceptionMatcher);
   }
 
   public void analyzeResources(


### PR DESCRIPTION
## Summary

- Migrate the first server JUnit 5 test batch, including client, query-serving, and shared test-fixture consumers.
- Preserve class-level parameterization and use the Jupiter-compatible shared test APIs.
- Replace the Druid exception Hamcrest matcher implementation with JUnit 5 assertions while retaining the fluent `DruidExceptionMatcher` API.
- Remove Hamcrest matcher usage from the shared MSQ expected-error assertion path.

## Validation

- `mvn -ntp -pl multi-stage-query -am -DskipTests -Dweb.console.skip=true -T1C test-compile`
- 130 affected MSQ tests passed with zero failures or errors.
- `mvn -ntp -pl multi-stage-query -am -DskipTests -Dweb.console.skip=true -T1C spotbugs:check`
- Checkstyle, PMD, forbidden APIs, and SpotBugs passed.

## Tracking

Part of [#13948](https://github.com/apache/druid/issues/13948).
