### PR TITLE
fix: segment ID mismatch in parallel indexing with non-UTC segmentGranularity

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexTaskRunner.java
@@ -32,6 +32,7 @@ import org.apache.druid.indexing.common.task.AbstractBatchIndexTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.batch.parallel.TaskMonitor.SubTaskCompleteEvent;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.NonnullPair;
 import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
 import org.apache.druid.timeline.SegmentId;
@@ -251,9 +252,17 @@ public class SinglePhaseParallelIndexTaskRunner extends ParallelIndexPhaseRunner
         );
       } else {
         final int partitionNum = Counters.getAndIncrementInt(partitionNumCountersPerInterval, intervalAndVersion.lhs);
+        // Normalize to UTC so that toString() is consistent with what Intervals.of() produces
+        // after JSON deserialization. Without this, a non-UTC segmentGranularity (e.g. timeZone: Europe/Warsaw)
+        // causes the parent to store "..._2026-04-08T00:00:00.000+02:00_..." while the subtask sends back
+        // "..._2026-04-07T22:00:00.000Z_..." as prevSegmentId, making indexOf() return -1.
+        final Interval utcInterval = Intervals.utc(
+            intervalAndVersion.lhs.getStartMillis(),
+            intervalAndVersion.lhs.getEndMillis()
+        );
         newSegmentId = new SegmentIdWithShardSpec(
             dataSource,
-            intervalAndVersion.lhs,
+            utcInterval,
             intervalAndVersion.rhs,
             new BuildingNumberedShardSpec(partitionNum)
         );


### PR DESCRIPTION
### Description

SinglePhaseParallelIndexTaskRunner built the parent's SegmentIdWithShardSpec using the interval as returned from the sub-task, which retains its original time zone. When segmentGranularity specifies a non-UTC time zone (e.g. Europe/Warsaw), Interval#toString() renders with the zone offset (e.g. "2026-04-08T00:00:00.000+02:00"), while the sub-task's own segment ID for the same interval is built from a JSON-deserialized interval that normalizes to UTC ("2026-04-07T22:00:00.000Z"). The two string representations differ, so matching prevSegmentId via indexOf() fails and parallel indexing breaks for non-UTC segment granularities.

Normalize the interval to UTC before constructing the parent's segment ID so it matches what sub-tasks produce.


This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.