### PR TITLE
fix(processing): finalize SuperSorter progress before completion

### DIFF
--- a/processing/src/main/java/org/apache/druid/frame/processor/SuperSorter.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/SuperSorter.java
@@ -184,6 +184,9 @@ public class SuperSorter
   private SettableFuture<OutputChannels> allDone = null;
 
   @GuardedBy("runWorkersLock")
+  private boolean totalMergersForUltimateLevelSet = false;
+
+  @GuardedBy("runWorkersLock")
   SuperSorterProgressTracker superSorterProgressTracker;
 
   @GuardedBy("runWorkersLock")
@@ -299,7 +302,7 @@ public class SuperSorter
           () -> {
             synchronized (runWorkersLock) {
               if (outputPartitionsFuture.isDone()) { // Update the progress tracker
-                superSorterProgressTracker.setTotalMergersForUltimateLevel(getOutputPartitions().size());
+                setTotalMergersForUltimateLevel();
               }
               runWorkersIfPossible();
               setAllDoneIfPossible();
@@ -415,7 +418,7 @@ public class SuperSorter
         }
 
         // OK to use wrap, not wrapReadOnly, because nil channels are already read-only.
-        allDone.set(OutputChannels.wrap(channels));
+        setAllDone(OutputChannels.wrap(channels));
       } else if (rowLimit == 0 && activeProcessors == 0) {
         // We had a row limit, and got it all the way down to zero.
         // Generate empty output channels for any partitions that we haven't written yet.
@@ -427,18 +430,34 @@ public class SuperSorter
         }
 
         // OK to use wrap, not wrapReadOnly, because all channels in this list are already read-only.
-        allDone.set(OutputChannels.wrap(outputChannels));
+        setAllDone(OutputChannels.wrap(outputChannels));
       } else if (totalMergingLevels != UNKNOWN_LEVEL
                  && outputsReadyByLevel.containsKey(totalMergingLevels - 1)
                  && (outputsReadyByLevel.get(totalMergingLevels - 1).size() ==
                      getTotalMergersInLevel(totalMergingLevels - 1))) {
         // We're done!!
         // OK to use wrap, not wrapReadOnly, because all channels in this list are already read-only.
-        allDone.set(OutputChannels.wrap(outputChannels));
+        setAllDone(OutputChannels.wrap(outputChannels));
       }
     }
     catch (Throwable e) {
       allDone.setException(e);
+    }
+  }
+
+  @GuardedBy("runWorkersLock")
+  private void setAllDone(final OutputChannels channels)
+  {
+    setTotalMergersForUltimateLevel();
+    allDone.set(channels);
+  }
+
+  @GuardedBy("runWorkersLock")
+  private void setTotalMergersForUltimateLevel()
+  {
+    if (!totalMergersForUltimateLevelSet) {
+      superSorterProgressTracker.setTotalMergersForUltimateLevel(getOutputPartitions().size());
+      totalMergersForUltimateLevelSet = true;
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterTest.java
@@ -74,6 +74,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -85,6 +86,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -117,6 +119,32 @@ public class SuperSorterTest
     public void tearDown()
     {
       exec.getExecutorService().shutdownNow();
+    }
+
+    private static class ListenerDelayingFrameProcessorExecutor extends FrameProcessorExecutor
+    {
+      private int asExecutorCalls;
+      private Runnable pendingListener;
+
+      private ListenerDelayingFrameProcessorExecutor()
+      {
+        super(MoreExecutors.listeningDecorator(Execs.multiThreaded(NUM_THREADS, "super-sorter-test-%d")));
+      }
+
+      @Override
+      public Executor asExecutor(final String cancellationId)
+      {
+        // The worker callback is registered first; delay the output-partitions listener registered by run().
+        if (++asExecutorCalls == 2) {
+          return command -> pendingListener = command;
+        }
+        return super.asExecutor(cancellationId);
+      }
+
+      private void runListener()
+      {
+        pendingListener.run();
+      }
     }
 
     @Test
@@ -161,10 +189,16 @@ public class SuperSorterTest
     @Test
     public void testSingleEmptyInputChannel_immediately_fileStorage() throws Exception
     {
+      exec.getExecutorService().shutdownNow();
+      final ListenerDelayingFrameProcessorExecutor listenerDelayingExec =
+          new ListenerDelayingFrameProcessorExecutor();
+      exec = listenerDelayingExec;
+
       final BlockingQueueFrameChannel inputChannel = BlockingQueueFrameChannel.minimal();
       inputChannel.writable().close();
 
-      final SuperSorterProgressTracker superSorterProgressTracker = new SuperSorterProgressTracker();
+      final SuperSorterProgressTracker superSorterProgressTracker =
+          Mockito.spy(new SuperSorterProgressTracker());
 
       final File tempFolder = temporaryFolder.newFolder();
       final SuperSorter superSorter = new SuperSorter(
@@ -188,10 +222,13 @@ public class SuperSorterTest
 
       final OutputChannels channels = superSorter.run().get();
       Assertions.assertEquals(1, channels.getAllChannels().size());
+      Mockito.verify(superSorterProgressTracker).setTotalMergersForUltimateLevel(1L);
+      Assertions.assertEquals(1.0, superSorterProgressTracker.snapshot().getProgressDigest(), 0.0f);
+
+      listenerDelayingExec.runListener();
 
       final ReadableFrameChannel channel = Iterables.getOnlyElement(channels.getAllChannels()).getReadableChannel();
       Assertions.assertTrue(channel.isFinished());
-      Assertions.assertEquals(1.0, superSorterProgressTracker.snapshot().getProgressDigest(), 0.0f);
       channel.close();
     }
 


### PR DESCRIPTION
### Description

`SuperSorter` could complete its `allDone` future before the asynchronous output-partitions listener initialized the progress tracker's ultimate merger count. A caller returning from `run().get()` could therefore briefly observe a progress digest of `0.0` instead of `1.0`. This surfaced as repeated `SuperSorterTest` flakes in the JDK 25 `S*` CI shard.

This change routes every successful sorter completion through a helper that initializes the ultimate merger count before publishing `allDone`. Initialization is idempotent under the existing `runWorkersLock`, so the output-partitions listener can run either before or after worker completion without double-setting the tracker.

The regression test delays the output-partitions listener, waits for sorting to complete, and verifies that final progress was already initialized before releasing the listener.

#### CI evidence

The same `SuperSorterTest` progress assertion (`expected: <1.0> but was: <0.0>`) appeared independently in these JDK 25 `S*` jobs:

* [PR #20044 failing `S*` job](https://github.com/apache/druid/actions/runs/32082683887/job/95607248841)
* [PR #20045 failing `S*` job](https://github.com/apache/druid/actions/runs/32101462998/job/95602734401)

The unchanged #20045 head then passed on an [exact job rerun](https://github.com/apache/druid/actions/runs/32101462998/job/95612094751), confirming that the failure is timing-sensitive.

The same SuperSorterTest failure also reproduced on PR #20078's initial JDK 25 S* job (https://github.com/apache/druid/actions/runs/32325623822/job/96296160599); its single permitted rerun (https://github.com/apache/druid/actions/runs/32325623822/job/96324754231) reproduced the flake, further confirming the timing-sensitive failure.

The same `expected: <1.0> but was: <0.0>` assertion also reproduced on [PR #20085's failing JDK 25 `S*` job](https://github.com/apache/druid/actions/runs/32336673783/job/96336495851), specifically in `SuperSorterTest$ParameterizedCasesTest.test_clusterByPlacementishDescRowNumberAsc_fourPartitions`; the shard later timed out after 60 minutes.

#### Release note

None. This fixes internal progress-reporting ordering and test flakiness without changing configuration, APIs, persisted data, or query results.

<hr>

##### Key changed/added classes in this PR

* `SuperSorter`
* `SuperSorterTest`

<hr>

This PR has:

- [x] been self-reviewed.
  - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md).
- [x] added comments explaining the concurrency intent where it is not obvious.
- [x] added or updated unit tests to cover the affected ordering.

Validation:

```text
JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-25.jdk/Contents/Home \
mvn test -pl processing -am \
  -Dtest='org.apache.druid.frame.processor.SuperSorterTest*' \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Pskip-static-checks -Dweb.console.skip=true -T1C
```

Result: 10,905 tests run, 0 failures, 0 errors, 0 skipped.