### PR TITLE
fix: embedded-tests start metric event collector early so logs are less noisy

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/docker/IngestionBackwardCompatibilityDockerTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/docker/IngestionBackwardCompatibilityDockerTest.java
@@ -65,6 +65,7 @@ public class IngestionBackwardCompatibilityDockerTest extends IngestionSmokeTest
     return cluster
         .useContainerFriendlyHostname()
         .useDefaultTimeoutForLatchableEmitter(60)
+        .addServer(eventCollector)
         .addResource(containerOverlord)
         .addResource(containerCoordinator)
         .addServer(overlord)
@@ -72,7 +73,6 @@ public class IngestionBackwardCompatibilityDockerTest extends IngestionSmokeTest
         .addServer(broker)
         .addServer(new EmbeddedHistorical())
         .addServer(new EmbeddedRouter())
-        .addServer(eventCollector)
         .addCommonProperty(
             "druid.extensions.loadList",
             "[\"druid-s3-extensions\", \"druid-kafka-indexing-service\","

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/docker/IngestionDockerTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/docker/IngestionDockerTest.java
@@ -54,6 +54,7 @@ public class IngestionDockerTest extends IngestionSmokeTest implements LatestIma
     return cluster
         .useDefaultTimeoutForLatchableEmitter(240)
         .useContainerFriendlyHostname()
+        .addServer(eventCollector)
         .addResource(containerOverlord)
         .addResource(containerCoordinator)
         .addResource(middleManager)
@@ -61,7 +62,6 @@ public class IngestionDockerTest extends IngestionSmokeTest implements LatestIma
         .addResource(router)
         .addServer(overlord)
         .addServer(broker)
-        .addServer(eventCollector)
         .addCommonProperty(
             "druid.extensions.loadList",
             "[\"druid-s3-extensions\", \"druid-kafka-indexing-service\","

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/IngestionSmokeTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/IngestionSmokeTest.java
@@ -133,11 +133,11 @@ public class IngestionSmokeTest extends EmbeddedClusterTestBase
   protected EmbeddedDruidCluster addServers(EmbeddedDruidCluster cluster)
   {
     return cluster
+        .addServer(eventCollector)
         .addServer(new EmbeddedCoordinator())
         .addServer(overlord)
         .addServer(indexer)
         .addServer(broker)
-        .addServer(eventCollector)
         .addServer(new EmbeddedHistorical())
         .addServer(new EmbeddedRouter());
   }

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/k8s/KubernetesClusterDockerTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/k8s/KubernetesClusterDockerTest.java
@@ -56,10 +56,10 @@ public class KubernetesClusterDockerTest extends IngestionSmokeTest implements L
     return cluster
         .useContainerFriendlyHostname()
         .useDefaultTimeoutForLatchableEmitter(60)
+        .addServer(eventCollector)
         .addResource(k3sCluster)
         .addServer(overlord)
         .addServer(broker)
-        .addServer(eventCollector)
         .addCommonProperty(
             "druid.extensions.loadList",
             "[\"druid-s3-extensions\", \"druid-kafka-indexing-service\", \"postgresql-metadata-storage\"]"


### PR DESCRIPTION
### Description
Noticed while running a test that the logs complained a bunch during service startup because they wanted to emit metrics but the collector was not running yet, leaving a bunch of errors like:

```
2026-08-18T09:22:53,034 WARN [HttpPostEmitter-2] org.apache.druid.java.util.common.RetryUtils - Retrying (2 of 2) in 1,221ms.
java.util.concurrent.ExecutionException: java.net.ConnectException: Connection refused: /192.168.1.80:9301
	at java.base/java.util.concurrent.CompletableFuture.wrapInExecutionException(CompletableFuture.java:345)
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:440)
...
	at org.apache.druid.java.util.emitter.core.HttpPostEmitter$EmittingThread.sendWithRetries(HttpPostEmitter.java:661)
	at 
...
```