### PR TITLE
test(server): migrate scoped tests to JUnit 5

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -359,6 +359,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>

--- a/server/src/test/java/org/apache/druid/catalog/model/ClusteredValueGroupsBaseTableMetadataTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/ClusteredValueGroupsBaseTableMetadataTest.java
@@ -44,8 +44,8 @@ import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -84,7 +84,7 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
     );
     final String json = mapper.writeValueAsString(metadata);
     final DatasourceBaseTableMetadata fromJson = mapper.readValue(json, DatasourceBaseTableMetadata.class);
-    Assert.assertEquals(metadata, fromJson);
+    Assertions.assertEquals(metadata, fromJson);
   }
 
   @Test
@@ -96,10 +96,10 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         null
     );
     final String json = mapper.writeValueAsString(metadata);
-    Assert.assertFalse(json.contains("virtualColumns"));
-    Assert.assertFalse(json.contains("columnSchemas"));
+    Assertions.assertFalse(json.contains("virtualColumns"));
+    Assertions.assertFalse(json.contains("columnSchemas"));
     final DatasourceBaseTableMetadata fromJson = mapper.readValue(json, DatasourceBaseTableMetadata.class);
-    Assert.assertEquals(metadata, fromJson);
+    Assertions.assertEquals(metadata, fromJson);
   }
 
   @Test
@@ -116,7 +116,7 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
     );
     final String json = mapper.writeValueAsString(metadata);
     final DatasourceBaseTableMetadata fromJson = mapper.readValue(json, DatasourceBaseTableMetadata.class);
-    Assert.assertEquals(metadata, fromJson);
+    Assertions.assertEquals(metadata, fromJson);
   }
 
   @Test
@@ -130,9 +130,9 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         null
     );
     final String json = mapper.writeValueAsString(Collections.singletonMap("baseTable", metadata));
-    Assert.assertTrue(json.contains("\"type\":\"clusteredValueGroups\""));
+    Assertions.assertTrue(json.contains("\"type\":\"clusteredValueGroups\""));
     final Map<String, Object> untyped = mapper.readValue(json, new TypeReference<>() {});
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metadata,
         mapper.convertValue(untyped.get("baseTable"), DatasourceBaseTableMetadata.class)
     );
@@ -148,7 +148,7 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
     );
     // The declared column order is the physical segment order, used verbatim; types map through Columns.druidType
     // with untyped -> STRING.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ClusteredValueGroupsBaseTableProjectionSpec.builder()
                                                    .columns(
                                                        new StringDimensionSchema("tenant"),
@@ -183,7 +183,7 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         new ColumnSpec("tenant", Columns.SQL_VARCHAR, null),
         new ColumnSpec("region", Columns.SQL_VARCHAR, null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ClusteredValueGroupsBaseTableProjectionSpec.builder()
                                                    .virtualColumns(virtualColumns)
                                                    .columns(
@@ -213,7 +213,7 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
             new AutoTypeColumnSchema("value", ColumnType.DOUBLE, null)
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ClusteredValueGroupsBaseTableProjectionSpec.builder()
                                                    .columns(
                                                        new StringDimensionSchema("tenant"),
@@ -248,7 +248,7 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         new ColumnSpec("ratio", Columns.SQL_FLOAT, null),
         new ColumnSpec("attrs", ColumnType.NESTED_DATA.asTypeString(), null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ClusteredValueGroupsBaseTableProjectionSpec.builder()
                                                    .columns(
                                                        new StringDimensionSchema("tenant"),
@@ -272,8 +272,8 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         null,
         Collections.singletonList(AutoTypeColumnSchema.of("value"))
     );
-    final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
-    Assert.assertTrue(
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
+    Assertions.assertTrue(
         e.getMessage().contains("columnSchemas entry [value] is an auto column schema without a castToType")
     );
   }
@@ -286,8 +286,8 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         null,
         Collections.singletonList(new AutoTypeColumnSchema("region", ColumnType.LONG, null))
     );
-    final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
-    Assert.assertTrue(
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
+    Assertions.assertTrue(
         e.getMessage().contains("columnSchemas entry [region] of type [LONG] does not match the column's declared type [STRING]")
     );
   }
@@ -301,8 +301,8 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         null,
         Collections.singletonList(new NestedDataColumnSchema("region", NestedDataColumnSchema.DEFAULT_FORMAT_VERSION))
     );
-    final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
-    Assert.assertTrue(
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
+    Assertions.assertTrue(
         e.getMessage().contains(
             "columnSchemas entry [region] of type [COMPLEX<json>] does not match the column's declared type [STRING]"
         )
@@ -317,8 +317,8 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         null,
         Collections.singletonList(new StringDimensionSchema("no_such_column"))
     );
-    final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
-    Assert.assertTrue(
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
+    Assertions.assertTrue(
         e.getMessage().contains("columnSchemas entry [no_such_column] does not customize a declared column")
     );
   }
@@ -331,8 +331,8 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         null,
         Collections.singletonList(new StringDimensionSchema("tenant", DimensionSchema.MultiValueHandling.ARRAY, false))
     );
-    final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
-    Assert.assertTrue(e.getMessage().contains("columnSchemas cannot customize clustering column [tenant]"));
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
+    Assertions.assertTrue(e.getMessage().contains("columnSchemas cannot customize clustering column [tenant]"));
   }
 
   @Test
@@ -343,8 +343,8 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         null,
         Collections.singletonList(new LongDimensionSchema(Columns.TIME_COLUMN))
     );
-    final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
-    Assert.assertTrue(e.getMessage().contains("columnSchemas cannot customize [__time]"));
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
+    Assertions.assertTrue(e.getMessage().contains("columnSchemas cannot customize [__time]"));
   }
 
   @Test
@@ -357,8 +357,8 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         null,
         Collections.singletonList(new LongDimensionSchema("region"))
     );
-    final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
-    Assert.assertTrue(
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
+    Assertions.assertTrue(
         e.getMessage().contains("columnSchemas entry [region] of type [LONG] does not match the column's declared type [STRING]")
     );
   }
@@ -370,8 +370,8 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         "{\"type\":\"clusteredValueGroups\",\"clusteringColumns\":[\"tenant\"],\"columnSchemas\":[null]}",
         DatasourceBaseTableMetadata.class
     );
-    final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
-    Assert.assertTrue(e.getMessage().contains("columnSchemas must not contain null entries"));
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
+    Assertions.assertTrue(e.getMessage().contains("columnSchemas must not contain null entries"));
   }
 
   @Test
@@ -385,8 +385,8 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
             new StringDimensionSchema("region", DimensionSchema.MultiValueHandling.ARRAY, false)
         )
     );
-    final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
-    Assert.assertTrue(e.getMessage().contains("columnSchemas contains duplicate entries for column [region]"));
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
+    Assertions.assertTrue(e.getMessage().contains("columnSchemas contains duplicate entries for column [region]"));
   }
 
   @Test
@@ -403,7 +403,7 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         new ColumnSpec(Columns.TIME_COLUMN, null, null),
         new ColumnSpec("delta", Columns.SQL_BIGINT, null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ClusteredValueGroupsBaseTableProjectionSpec.builder()
                                                    .columns(
                                                        new StringDimensionSchema("region"),
@@ -440,7 +440,7 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
     // to the declared type (an all-null batch has no values to infer from; FLOAT ARRAY is stored as DOUBLE ARRAY by
     // the auto schema). COMPLEX<json> resolves through its dimension handler to an uncast auto column, which is how
     // json columns are stored everywhere else.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ClusteredValueGroupsBaseTableProjectionSpec.builder()
                                                    .columns(
                                                        new StringDimensionSchema("tenant"),
@@ -476,8 +476,8 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         new ColumnSpec(Columns.TIME_COLUMN, null, null),
         new ColumnSpec("unique_things", "COMPLEX<hyperUnique>", null)
     );
-    final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(columns));
-    Assert.assertEquals(
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(columns));
+    Assertions.assertEquals(
         "Complex type[hyperUnique] for dimension[unique_things] is not a valid type",
         e.getMessage()
     );
@@ -517,8 +517,8 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
 
     final List<DimensionSchema> specColumns = metadata.createSpec(columns).getDimensionsSpec().getDimensions();
     final DimensionSchema stored = specColumns.get(specColumns.size() - 1);
-    Assert.assertEquals("sketch", stored.getName());
-    Assert.assertEquals(ColumnType.ofComplex(typeName), stored.getColumnType());
+    Assertions.assertEquals("sketch", stored.getName());
+    Assertions.assertEquals(ColumnType.ofComplex(typeName), stored.getColumnType());
   }
 
   @Test
@@ -537,15 +537,15 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
 
     final List<DimensionSchema> specColumns = metadata.createSpec(columns).getDimensionsSpec().getDimensions();
     final DimensionSchema stored = specColumns.get(specColumns.size() - 1);
-    Assert.assertEquals(AutoTypeColumnSchema.of("payload"), stored);
-    Assert.assertEquals(ColumnType.NESTED_DATA, stored.getColumnType());
+    Assertions.assertEquals(AutoTypeColumnSchema.of("payload"), stored);
+    Assertions.assertEquals(ColumnType.NESTED_DATA, stored.getColumnType());
     // The schema a json column used to get here, retained for backwards compatibility, selects the same handler
     // (DimensionHandler has no equals, so compare the class and the dimension spec it hands out, which carries the
     // type the handler stores).
     final DimensionHandler<?, ?, ?> legacyHandler =
         new NestedDataColumnSchema("payload", NestedDataColumnSchema.DEFAULT_FORMAT_VERSION).getDimensionHandler();
-    Assert.assertEquals(legacyHandler.getClass(), stored.getDimensionHandler().getClass());
-    Assert.assertEquals(legacyHandler.getDimensionSpec(), stored.getDimensionHandler().getDimensionSpec());
+    Assertions.assertEquals(legacyHandler.getClass(), stored.getDimensionHandler().getClass());
+    Assertions.assertEquals(legacyHandler.getDimensionSpec(), stored.getDimensionHandler().getDimensionSpec());
   }
 
   @Test
@@ -565,10 +565,10 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
           new ColumnSpec(Columns.TIME_COLUMN, null, null),
           new ColumnSpec("busted", badType, null)
       );
-      final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(columns));
-      Assert.assertTrue(
-          "expected unrecognized-type error for [" + badType + "] but got: " + e.getMessage(),
-          e.getMessage().contains("column [busted] has an unrecognized type [" + badType + "]")
+      final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(columns));
+      Assertions.assertTrue(
+          e.getMessage().contains("column [busted] has an unrecognized type [" + badType + "]"),
+          "expected unrecognized-type error for [" + badType + "] but got: " + e.getMessage()
       );
     }
   }
@@ -583,8 +583,8 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         null,
         null
     );
-    final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
-    Assert.assertTrue(e.getMessage().contains("clusteringColumns must be the leading prefix of columns"));
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
+    Assertions.assertTrue(e.getMessage().contains("clusteringColumns must be the leading prefix of columns"));
   }
 
   @Test
@@ -600,8 +600,8 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         new ColumnSpec("tenant", Columns.SQL_VARCHAR, null),
         new ColumnSpec(Columns.TIME_COLUMN, null, null)
     );
-    final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(columns));
-    Assert.assertTrue(e.getMessage().contains("clusteringColumns must be the leading prefix of columns"));
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(columns));
+    Assertions.assertTrue(e.getMessage().contains("clusteringColumns must be the leading prefix of columns"));
   }
 
   @Test
@@ -612,8 +612,8 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         null,
         null
     );
-    final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
-    Assert.assertTrue(e.getMessage().contains("clustering column [no_such_column] is not a declared column"));
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
+    Assertions.assertTrue(e.getMessage().contains("clustering column [no_such_column] is not a declared column"));
   }
 
   @Test
@@ -628,8 +628,8 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         new ColumnSpec("tenant", Columns.SQL_VARCHAR, null),
         new ColumnSpec("region", Columns.SQL_VARCHAR, null)
     );
-    final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(columns));
-    Assert.assertTrue(e.getMessage().contains("must include [__time]"));
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(columns));
+    Assertions.assertTrue(e.getMessage().contains("must include [__time]"));
   }
 
   @Test
@@ -644,16 +644,16 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         new ColumnSpec("tags", Columns.SQL_VARCHAR_ARRAY, null),
         new ColumnSpec(Columns.TIME_COLUMN, Columns.SQL_TIMESTAMP, null)
     );
-    final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(columns));
-    Assert.assertTrue(e.getMessage().contains("unsupported type"));
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(columns));
+    Assertions.assertTrue(e.getMessage().contains("unsupported type"));
   }
 
   @Test
   public void testCreateSpecEmptyClusteringColumnsFails()
   {
     final DatasourceBaseTableMetadata metadata = new ClusteredValueGroupsBaseTableMetadata(null, null, null);
-    final DruidException e = Assert.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
-    Assert.assertTrue(e.getMessage().contains("clusteringColumns must be non-empty"));
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> metadata.createSpec(COLUMNS));
+    Assertions.assertTrue(e.getMessage().contains("clusteringColumns must be non-empty"));
   }
 
   @Test
@@ -664,11 +664,11 @@ public class ClusteredValueGroupsBaseTableMetadataTest extends InitializedNullHa
         null,
         null
     );
-    final DruidException e = Assert.assertThrows(
+    final DruidException e = Assertions.assertThrows(
         DruidException.class,
         () -> metadata.createSpec(Collections.emptyList())
     );
-    Assert.assertTrue(e.getMessage().contains("without declared columns"));
+    Assertions.assertTrue(e.getMessage().contains("without declared columns"));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/catalog/model/PropertyDefnTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/PropertyDefnTest.java
@@ -58,8 +58,8 @@ public class PropertyDefnTest
     prop.validate(10, mapper);
 
     // But, it does have its limits.
-    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> prop.decode(Arrays.asList("a", "b"), mapper));
-    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> prop.validate(Arrays.asList("a", "b"), mapper));
+    Assertions.assertThrows(Exception.class, () -> prop.decode(Arrays.asList("a", "b"), mapper));
+    Assertions.assertThrows(Exception.class, () -> prop.validate(Arrays.asList("a", "b"), mapper));
   }
 
   @Test
@@ -90,7 +90,7 @@ public class PropertyDefnTest
     Assertions.assertEquals((Integer) 0, prop.decode("0", mapper));
     Assertions.assertEquals((Integer) 10, prop.decode(10, mapper));
     Assertions.assertEquals((Integer) 10, prop.decode("10", mapper));
-    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> prop.decode("foo", mapper));
+    Assertions.assertThrows(Exception.class, () -> prop.decode("foo", mapper));
   }
 
   @Test
@@ -105,8 +105,8 @@ public class PropertyDefnTest
     List<String> value = Arrays.asList("a", "b");
     Assertions.assertEquals(value, prop.decode(value, mapper));
     prop.validate(value, mapper);
-    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> prop.decode("foo", mapper));
-    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> prop.validate("foo", mapper));
+    Assertions.assertThrows(Exception.class, () -> prop.decode("foo", mapper));
+    Assertions.assertThrows(Exception.class, () -> prop.validate("foo", mapper));
   }
 
   @Test
@@ -130,6 +130,6 @@ public class PropertyDefnTest
         new ClusterKeySpec("b", true)
     );
     Assertions.assertEquals(expected, prop.decode(value, mapper));
-    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> prop.decode("foo", mapper));
+    Assertions.assertThrows(Exception.class, () -> prop.decode("foo", mapper));
   }
 }

--- a/server/src/test/java/org/apache/druid/catalog/model/PropertyDefnTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/PropertyDefnTest.java
@@ -22,27 +22,22 @@ package org.apache.druid.catalog.model;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-import org.apache.druid.catalog.CatalogTest;
 import org.apache.druid.catalog.model.ModelProperties.BooleanPropertyDefn;
 import org.apache.druid.catalog.model.ModelProperties.IntPropertyDefn;
 import org.apache.druid.catalog.model.ModelProperties.ListPropertyDefn;
 import org.apache.druid.catalog.model.ModelProperties.StringListPropertyDefn;
 import org.apache.druid.catalog.model.ModelProperties.StringPropertyDefn;
 import org.apache.druid.catalog.model.table.ClusterKeySpec;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
-@Category(CatalogTest.class)
+@Tag("CatalogTest")
 public class PropertyDefnTest
 {
   private final ObjectMapper mapper = new ObjectMapper();
@@ -51,67 +46,67 @@ public class PropertyDefnTest
   public void testString()
   {
     StringPropertyDefn prop = new StringPropertyDefn("prop");
-    assertEquals("prop", prop.name());
-    assertEquals("String", prop.typeName());
+    Assertions.assertEquals("prop", prop.name());
+    Assertions.assertEquals("String", prop.typeName());
 
-    assertNull(prop.decode(null, mapper));
-    assertEquals("value", prop.decode("value", mapper));
+    Assertions.assertNull(prop.decode(null, mapper));
+    Assertions.assertEquals("value", prop.decode("value", mapper));
     prop.validate("value", mapper);
 
     // Jackson is permissive in its conversions
-    assertEquals("10", prop.decode(10, mapper));
+    Assertions.assertEquals("10", prop.decode(10, mapper));
     prop.validate(10, mapper);
 
     // But, it does have its limits.
-    assertThrows(Exception.class, () -> prop.decode(Arrays.asList("a", "b"), mapper));
-    assertThrows(Exception.class, () -> prop.validate(Arrays.asList("a", "b"), mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> prop.decode(Arrays.asList("a", "b"), mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> prop.validate(Arrays.asList("a", "b"), mapper));
   }
 
   @Test
   public void testBoolean()
   {
     BooleanPropertyDefn prop = new BooleanPropertyDefn("prop");
-    assertEquals("prop", prop.name());
-    assertEquals("Boolean", prop.typeName());
+    Assertions.assertEquals("prop", prop.name());
+    Assertions.assertEquals("Boolean", prop.typeName());
 
-    assertNull(prop.decode(null, mapper));
-    assertTrue(prop.decode("true", mapper));
-    assertTrue(prop.decode(true, mapper));
-    assertFalse(prop.decode("false", mapper));
-    assertFalse(prop.decode(false, mapper));
-    assertFalse(prop.decode(0, mapper));
-    assertTrue(prop.decode(10, mapper));
+    Assertions.assertNull(prop.decode(null, mapper));
+    Assertions.assertTrue(prop.decode("true", mapper));
+    Assertions.assertTrue(prop.decode(true, mapper));
+    Assertions.assertFalse(prop.decode("false", mapper));
+    Assertions.assertFalse(prop.decode(false, mapper));
+    Assertions.assertFalse(prop.decode(0, mapper));
+    Assertions.assertTrue(prop.decode(10, mapper));
   }
 
   @Test
   public void testInt()
   {
     IntPropertyDefn prop = new IntPropertyDefn("prop");
-    assertEquals("prop", prop.name());
-    assertEquals("Integer", prop.typeName());
+    Assertions.assertEquals("prop", prop.name());
+    Assertions.assertEquals("Integer", prop.typeName());
 
-    assertNull(prop.decode(null, mapper));
-    assertEquals((Integer) 0, prop.decode(0, mapper));
-    assertEquals((Integer) 0, prop.decode("0", mapper));
-    assertEquals((Integer) 10, prop.decode(10, mapper));
-    assertEquals((Integer) 10, prop.decode("10", mapper));
-    assertThrows(Exception.class, () -> prop.decode("foo", mapper));
+    Assertions.assertNull(prop.decode(null, mapper));
+    Assertions.assertEquals((Integer) 0, prop.decode(0, mapper));
+    Assertions.assertEquals((Integer) 0, prop.decode("0", mapper));
+    Assertions.assertEquals((Integer) 10, prop.decode(10, mapper));
+    Assertions.assertEquals((Integer) 10, prop.decode("10", mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> prop.decode("foo", mapper));
   }
 
   @Test
   public void testStringList()
   {
     StringListPropertyDefn prop = new StringListPropertyDefn("prop");
-    assertEquals("prop", prop.name());
-    assertEquals("string list", prop.typeName());
+    Assertions.assertEquals("prop", prop.name());
+    Assertions.assertEquals("string list", prop.typeName());
 
-    assertNull(prop.decode(null, mapper));
+    Assertions.assertNull(prop.decode(null, mapper));
     prop.validate(null, mapper);
     List<String> value = Arrays.asList("a", "b");
-    assertEquals(value, prop.decode(value, mapper));
+    Assertions.assertEquals(value, prop.decode(value, mapper));
     prop.validate(value, mapper);
-    assertThrows(Exception.class, () -> prop.decode("foo", mapper));
-    assertThrows(Exception.class, () -> prop.validate("foo", mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> prop.decode("foo", mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> prop.validate("foo", mapper));
   }
 
   @Test
@@ -122,10 +117,10 @@ public class PropertyDefnTest
         "cluster key list",
         new TypeReference<>() {}
     );
-    assertEquals("prop", prop.name());
-    assertEquals("cluster key list", prop.typeName());
+    Assertions.assertEquals("prop", prop.name());
+    Assertions.assertEquals("cluster key list", prop.typeName());
 
-    assertNull(prop.decode(null, mapper));
+    Assertions.assertNull(prop.decode(null, mapper));
     List<Map<String, Object>> value = Arrays.asList(
         ImmutableMap.of("column", "a"),
         ImmutableMap.of("column", "b", "desc", true)
@@ -134,7 +129,7 @@ public class PropertyDefnTest
         new ClusterKeySpec("a", false),
         new ClusterKeySpec("b", true)
     );
-    assertEquals(expected, prop.decode(value, mapper));
-    assertThrows(Exception.class, () -> prop.decode("foo", mapper));
+    Assertions.assertEquals(expected, prop.decode(value, mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> prop.decode("foo", mapper));
   }
 }

--- a/server/src/test/java/org/apache/druid/catalog/model/TableMetadataTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/TableMetadataTest.java
@@ -21,35 +21,31 @@ package org.apache.druid.catalog.model;
 
 import com.google.common.collect.ImmutableMap;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.apache.druid.catalog.CatalogTest;
 import org.apache.druid.catalog.model.TableMetadata.TableState;
 import org.apache.druid.catalog.model.table.DatasourceDefn;
 import org.apache.druid.java.util.common.IAE;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
 
-@Category(CatalogTest.class)
+@Tag("CatalogTest")
 public class TableMetadataTest
 {
   @Test
   public void testId()
   {
     TableId id1 = new TableId("schema", "table");
-    assertEquals("schema", id1.schema());
-    assertEquals("table", id1.name());
-    assertEquals("\"schema\".\"table\"", id1.sqlName());
-    assertEquals(id1.sqlName(), id1.toString());
+    Assertions.assertEquals("schema", id1.schema());
+    Assertions.assertEquals("table", id1.name());
+    Assertions.assertEquals("\"schema\".\"table\"", id1.sqlName());
+    Assertions.assertEquals(id1.sqlName(), id1.toString());
 
     TableId id2 = TableId.datasource("ds");
-    assertEquals(TableId.DRUID_SCHEMA, id2.schema());
-    assertEquals("ds", id2.name());
+    Assertions.assertEquals(TableId.DRUID_SCHEMA, id2.schema());
+    Assertions.assertEquals("ds", id2.name());
   }
 
   @Test
@@ -76,12 +72,12 @@ public class TableMetadataTest
           spec
       );
       table.validate();
-      assertEquals(TableId.DRUID_SCHEMA, table.id().schema());
-      assertEquals("foo", table.id().name());
-      assertEquals(10, table.creationTime());
-      assertEquals(20, table.updateTime());
-      assertEquals(TableState.ACTIVE, table.state());
-      assertNotNull(table.spec());
+      Assertions.assertEquals(TableId.DRUID_SCHEMA, table.id().schema());
+      Assertions.assertEquals("foo", table.id().name());
+      Assertions.assertEquals(10, table.creationTime());
+      Assertions.assertEquals(20, table.updateTime());
+      Assertions.assertEquals(TableState.ACTIVE, table.state());
+      Assertions.assertNotNull(table.spec());
     }
 
     {
@@ -90,7 +86,7 @@ public class TableMetadataTest
           TableId.of(null, "foo"),
           spec
       );
-      assertThrows(IAE.class, () -> table.validate());
+      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> table.validate());
     }
 
     {
@@ -99,7 +95,7 @@ public class TableMetadataTest
           TableId.of(TableId.DRUID_SCHEMA, null),
           spec
       );
-      assertThrows(IAE.class, () -> table.validate());
+      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> table.validate());
     }
   }
   @Test
@@ -113,24 +109,24 @@ public class TableMetadataTest
         TableId.datasource("ds"),
         spec
     );
-    assertEquals(TableId.datasource("ds"), table.id());
-    assertEquals(TableState.ACTIVE, table.state());
-    assertEquals(0, table.updateTime());
-    assertSame(spec, table.spec());
+    Assertions.assertEquals(TableId.datasource("ds"), table.id());
+    Assertions.assertEquals(TableState.ACTIVE, table.state());
+    Assertions.assertEquals(0, table.updateTime());
+    Assertions.assertSame(spec, table.spec());
 
     TableMetadata table2 = TableMetadata.newTable(
         TableId.datasource("ds"),
         spec
     );
-    assertEquals(table, table2);
+    Assertions.assertEquals(table, table2);
 
     TableMetadata table3 = table2.fromInsert(10);
-    assertEquals(10, table3.creationTime());
-    assertEquals(10, table3.updateTime());
+    Assertions.assertEquals(10, table3.creationTime());
+    Assertions.assertEquals(10, table3.updateTime());
 
     table3 = table3.asUpdate(20);
-    assertEquals(10, table3.creationTime());
-    assertEquals(20, table3.updateTime());
+    Assertions.assertEquals(10, table3.creationTime());
+    Assertions.assertEquals(20, table3.updateTime());
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/catalog/model/TableMetadataTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/TableMetadataTest.java
@@ -86,7 +86,7 @@ public class TableMetadataTest
           TableId.of(null, "foo"),
           spec
       );
-      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> table.validate());
+      Assertions.assertThrows(IAE.class, () -> table.validate());
     }
 
     {
@@ -95,7 +95,7 @@ public class TableMetadataTest
           TableId.of(TableId.DRUID_SCHEMA, null),
           spec
       );
-      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> table.validate());
+      Assertions.assertThrows(IAE.class, () -> table.validate());
     }
   }
   @Test

--- a/server/src/test/java/org/apache/druid/catalog/model/table/CsvInputFormatTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/CsvInputFormatTest.java
@@ -28,7 +28,8 @@ import org.apache.druid.catalog.model.table.TableFunction.ParameterDefn;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.impl.CsvInputFormat;
 import org.apache.druid.data.input.impl.InlineInputSource;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,9 +37,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 
 public class CsvInputFormatTest extends BaseExternTableTest
 {
@@ -56,10 +54,10 @@ public class CsvInputFormatTest extends BaseExternTableTest
     InputFormatDefn defn = registry.inputFormatDefnFor(CsvInputFormat.TYPE_KEY);
     InputFormat inputFormat = defn.convertFromTable(new ResolvedExternalTable(resolved));
     CsvInputFormat csvFormat = (CsvInputFormat) inputFormat;
-    assertEquals(0, csvFormat.getSkipHeaderRows());
-    assertFalse(csvFormat.isFindColumnsFromHeader());
-    assertNull(csvFormat.getListDelimiter());
-    assertEquals(Collections.singletonList("a"), csvFormat.getColumns());
+    Assertions.assertEquals(0, csvFormat.getSkipHeaderRows());
+    Assertions.assertFalse(csvFormat.isFindColumnsFromHeader());
+    Assertions.assertNull(csvFormat.getListDelimiter());
+    Assertions.assertEquals(Collections.singletonList("a"), csvFormat.getColumns());
   }
 
   @Test
@@ -79,10 +77,10 @@ public class CsvInputFormatTest extends BaseExternTableTest
     InputFormatDefn defn = registry.inputFormatDefnFor(CsvInputFormat.TYPE_KEY);
     InputFormat inputFormat = defn.convertFromTable(new ResolvedExternalTable(resolved));
     CsvInputFormat csvFormat = (CsvInputFormat) inputFormat;
-    assertEquals(1, csvFormat.getSkipHeaderRows());
-    assertFalse(csvFormat.isFindColumnsFromHeader());
-    assertEquals(";", csvFormat.getListDelimiter());
-    assertEquals(Arrays.asList("a", "b"), csvFormat.getColumns());
+    Assertions.assertEquals(1, csvFormat.getSkipHeaderRows());
+    Assertions.assertFalse(csvFormat.isFindColumnsFromHeader());
+    Assertions.assertEquals(";", csvFormat.getListDelimiter());
+    Assertions.assertEquals(Arrays.asList("a", "b"), csvFormat.getColumns());
   }
 
   @Test
@@ -90,7 +88,7 @@ public class CsvInputFormatTest extends BaseExternTableTest
   {
     InputFormatDefn defn = registry.inputFormatDefnFor(CsvInputFormat.TYPE_KEY);
     List<ParameterDefn> params = defn.parameters();
-    assertEquals(2, params.size());
+    Assertions.assertEquals(2, params.size());
   }
 
   @Test
@@ -103,9 +101,9 @@ public class CsvInputFormatTest extends BaseExternTableTest
     List<ColumnSpec> columns = Collections.singletonList(new ColumnSpec("a", null, null));
     InputFormat inputFormat = defn.convertFromArgs(args, columns, mapper);
     CsvInputFormat csvFormat = (CsvInputFormat) inputFormat;
-    assertEquals(1, csvFormat.getSkipHeaderRows());
-    assertFalse(csvFormat.isFindColumnsFromHeader());
-    assertEquals(";", csvFormat.getListDelimiter());
-    assertEquals(Collections.singletonList("a"), csvFormat.getColumns());
+    Assertions.assertEquals(1, csvFormat.getSkipHeaderRows());
+    Assertions.assertFalse(csvFormat.isFindColumnsFromHeader());
+    Assertions.assertEquals(";", csvFormat.getListDelimiter());
+    Assertions.assertEquals(Collections.singletonList("a"), csvFormat.getColumns());
   }
 }

--- a/server/src/test/java/org/apache/druid/catalog/model/table/DatasourceTableTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/DatasourceTableTest.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.apache.druid.catalog.CatalogTest;
 import org.apache.druid.catalog.model.ClusteredValueGroupsBaseTableMetadata;
 import org.apache.druid.catalog.model.ColumnSpec;
 import org.apache.druid.catalog.model.Columns;
@@ -44,9 +43,10 @@ import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,19 +54,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test of validation and serialization of the catalog table definitions.
  */
-@Category(CatalogTest.class)
+@Tag("CatalogTest")
 public class DatasourceTableTest extends InitializedNullHandlingTest
 {
   private static final Logger LOG = new Logger(DatasourceTableTest.class);
@@ -84,19 +76,19 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
 
     TableSpec spec = new TableSpec(DatasourceDefn.TABLE_TYPE, props, null);
     ResolvedTable table = registry.resolve(spec);
-    assertNotNull(table);
-    assertTrue(table.defn() instanceof DatasourceDefn);
+    Assertions.assertNotNull(table);
+    Assertions.assertTrue(table.defn() instanceof DatasourceDefn);
     table.validate();
     DatasourceFacade facade = new DatasourceFacade(registry.resolve(table.spec()));
-    assertEquals("P1D", facade.segmentGranularityString());
-    assertNull(facade.targetSegmentRows());
-    assertTrue(facade.hiddenColumns().isEmpty());
-    assertFalse(facade.isSealed());
+    Assertions.assertEquals("P1D", facade.segmentGranularityString());
+    Assertions.assertNull(facade.targetSegmentRows());
+    Assertions.assertTrue(facade.hiddenColumns().isEmpty());
+    Assertions.assertFalse(facade.isSealed());
   }
 
   private void expectValidationFails(final ResolvedTable table)
   {
-    assertThrows(IAE.class, () -> table.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> table.validate());
   }
 
   private void expectValidationFails(final TableSpec spec)
@@ -116,7 +108,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
   {
     {
       TableSpec spec = new TableSpec(null, ImmutableMap.of(), null);
-      assertThrows(IAE.class, () -> registry.resolve(spec));
+      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> registry.resolve(spec));
     }
 
     {
@@ -182,8 +174,8 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
           columns
       );
       ResolvedTable table = registry.resolve(spec);
-      DruidException e = assertThrows(DruidException.class, table::validate);
-      assertTrue(e.getMessage().contains("must also set [sealed] to true"));
+      DruidException e = org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, table::validate);
+      Assertions.assertTrue(e.getMessage().contains("must also set [sealed] to true"));
     }
 
     {
@@ -199,7 +191,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
           columns
       );
       ResolvedTable table = registry.resolve(spec);
-      assertThrows(DruidException.class, table::validate);
+      org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, table::validate);
     }
 
     {
@@ -215,7 +207,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
           columns
       );
       ResolvedTable table = registry.resolve(spec);
-      assertThrows(DruidException.class, table::validate);
+      org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, table::validate);
     }
 
     {
@@ -230,7 +222,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
           Collections.singletonList(new ColumnSpec("tenant", Columns.SQL_VARCHAR, null))
       );
       ResolvedTable table = registry.resolve(spec);
-      assertThrows(DruidException.class, table::validate);
+      org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, table::validate);
     }
   }
 
@@ -263,17 +255,17 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
     ResolvedTable table = registryWithInjectables.resolve(spec);
     table.validate();
     DatasourceFacade facade = new DatasourceFacade(table);
-    assertEquals(baseTable, facade.baseTableMetadata());
+    Assertions.assertEquals(baseTable, facade.baseTableMetadata());
 
     // insertColumn enforces the catalog write rules: declared columns resolve, undeclared columns are rejected by
     // the sealed schema, and columns computed by a virtual column at ingest time cannot be written directly.
-    assertSame(facade.column("tenant"), facade.insertColumn("tenant", "druid.tbl"));
+    Assertions.assertSame(facade.column("tenant"), facade.insertColumn("tenant", "druid.tbl"));
     DruidException sealedError =
-        assertThrows(DruidException.class, () -> facade.insertColumn("no_such_column", "druid.tbl"));
-    assertTrue(sealedError.getMessage().contains("not defined in the target table [druid.tbl] strict schema"));
+        org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, () -> facade.insertColumn("no_such_column", "druid.tbl"));
+    Assertions.assertTrue(sealedError.getMessage().contains("not defined in the target table [druid.tbl] strict schema"));
     DruidException computedError =
-        assertThrows(DruidException.class, () -> facade.insertColumn("tenant_lower", "druid.tbl"));
-    assertTrue(computedError.getMessage().contains("computed by a virtual column at ingest time"));
+        org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, () -> facade.insertColumn("tenant_lower", "druid.tbl"));
+    Assertions.assertTrue(computedError.getMessage().contains("computed by a virtual column at ingest time"));
 
     // An undeclared column of a non-sealed table resolves to null: the caller adds it from the query type.
     DatasourceFacade unsealed = new DatasourceFacade(registryWithInjectables.resolve(new TableSpec(
@@ -281,7 +273,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
         ImmutableMap.of(),
         Collections.singletonList(new ColumnSpec(Columns.TIME_COLUMN, null, null))
     )));
-    assertNull(unsealed.insertColumn("anything", "druid.tbl"));
+    Assertions.assertNull(unsealed.insertColumn("anything", "druid.tbl"));
   }
 
   @Test
@@ -298,11 +290,11 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
 
     TableSpec spec = new TableSpec(DatasourceDefn.TABLE_TYPE, props, null);
     DatasourceFacade facade = new DatasourceFacade(registry.resolve(spec));
-    assertEquals("P1D", facade.segmentGranularityString());
-    assertEquals(1_000_000, (int) facade.targetSegmentRows());
-    assertEquals(Arrays.asList("foo", "bar"), facade.hiddenColumns());
-    assertEquals(Collections.singletonList(new ClusterKeySpec("clusterKeyA", false)), facade.clusterKeys());
-    assertTrue(facade.isSealed());
+    Assertions.assertEquals("P1D", facade.segmentGranularityString());
+    Assertions.assertEquals(1_000_000, (int) facade.targetSegmentRows());
+    Assertions.assertEquals(Arrays.asList("foo", "bar"), facade.hiddenColumns());
+    Assertions.assertEquals(Collections.singletonList(new ClusterKeySpec("clusterKeyA", false)), facade.clusterKeys());
+    Assertions.assertTrue(facade.isSealed());
   }
 
   @Test
@@ -310,7 +302,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
   {
     {
       TableSpec spec = new TableSpec("bogus", ImmutableMap.of(), null);
-      assertThrows(IAE.class, () -> registry.resolve(spec));
+      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> registry.resolve(spec));
     }
 
     // Segment granularity
@@ -371,7 +363,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
     // Name is required
     {
       ColumnSpec spec = new ColumnSpec(null, null, null);
-      assertThrows(IAE.class, () -> spec.validate());
+      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> spec.validate());
     }
     {
       ColumnSpec spec = new ColumnSpec("foo", null, null);
@@ -397,7 +389,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
       ResolvedTable table = registry.resolve(spec);
       table.validate();
       DatasourceFacade facade = new DatasourceFacade(registry.resolve(table.spec()));
-      assertTrue(facade.columnFacades().isEmpty());
+      Assertions.assertTrue(facade.columnFacades().isEmpty());
     }
 
     // OK to have no column type
@@ -409,12 +401,12 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
       table.validate();
 
       DatasourceFacade facade = new DatasourceFacade(registry.resolve(table.spec()));
-      assertEquals(1, facade.columnFacades().size());
+      Assertions.assertEquals(1, facade.columnFacades().size());
       ColumnFacade col = facade.columnFacades().get(0);
-      assertSame(spec.columns().get(0), col.spec());
-      assertFalse(col.isTime());
-      assertFalse(col.hasType());
-      assertNull(col.druidType());
+      Assertions.assertSame(spec.columns().get(0), col.spec());
+      Assertions.assertFalse(col.isTime());
+      Assertions.assertFalse(col.hasType());
+      Assertions.assertNull(col.druidType());
     }
 
     // Can have a legal scalar type
@@ -425,12 +417,12 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
       ResolvedTable table = registry.resolve(spec);
       table.validate();
       DatasourceFacade facade = new DatasourceFacade(registry.resolve(table.spec()));
-      assertEquals(1, facade.columnFacades().size());
+      Assertions.assertEquals(1, facade.columnFacades().size());
       ColumnFacade col = facade.columnFacades().get(0);
-      assertSame(spec.columns().get(0), col.spec());
-      assertFalse(col.isTime());
-      assertTrue(col.hasType());
-      assertSame(ColumnType.STRING, col.druidType());
+      Assertions.assertSame(spec.columns().get(0), col.spec());
+      Assertions.assertFalse(col.isTime());
+      Assertions.assertTrue(col.hasType());
+      Assertions.assertSame(ColumnType.STRING, col.druidType());
     }
 
     // Reject duplicate columns
@@ -454,24 +446,24 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
       TableSpec spec = builder.copy()
           .column("foo", "FOO")
           .buildSpec();
-      DruidException e = assertThrows(DruidException.class, () -> registry.resolve(spec).validate());
-      assertTrue(e.getMessage().contains("Column [foo] has an unrecognized type [FOO]"));
+      DruidException e = org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, () -> registry.resolve(spec).validate());
+      Assertions.assertTrue(e.getMessage().contains("Column [foo] has an unrecognized type [FOO]"));
     }
     {
       // A parameterized type missing its closing bracket is malformed, and must not silently pass as undeclared.
       TableSpec spec = builder.copy()
           .column("foo", "COMPLEX<json")
           .buildSpec();
-      DruidException e = assertThrows(DruidException.class, () -> registry.resolve(spec).validate());
-      assertTrue(e.getMessage().contains("Column [foo] has an unrecognized type [COMPLEX<json]"));
+      DruidException e = org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, () -> registry.resolve(spec).validate());
+      Assertions.assertTrue(e.getMessage().contains("Column [foo] has an unrecognized type [COMPLEX<json]"));
     }
     {
       // An unrecognized array element type is an invalid input, not an internal error.
       TableSpec spec = builder.copy()
           .column("foo", "ARRAY<FOO>")
           .buildSpec();
-      DruidException e = assertThrows(DruidException.class, () -> registry.resolve(spec).validate());
-      assertTrue(e.getMessage().contains("Column [foo] has an unrecognized type [ARRAY<FOO>]"));
+      DruidException e = org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, () -> registry.resolve(spec).validate());
+      Assertions.assertTrue(e.getMessage().contains("Column [foo] has an unrecognized type [ARRAY<FOO>]"));
     }
     {
       // Parse-level validation only: any well-formed complex type is accepted at the logical layer, whether or not
@@ -497,12 +489,12 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
       table.validate();
 
       DatasourceFacade facade = new DatasourceFacade(registry.resolve(table.spec()));
-      assertEquals(1, facade.columnFacades().size());
+      Assertions.assertEquals(1, facade.columnFacades().size());
       ColumnFacade col = facade.columnFacades().get(0);
-      assertSame(spec.columns().get(0), col.spec());
-      assertTrue(col.isTime());
-      assertTrue(col.hasType());
-      assertSame(ColumnType.LONG, col.druidType());
+      Assertions.assertSame(spec.columns().get(0), col.spec());
+      Assertions.assertTrue(col.isTime());
+      Assertions.assertTrue(col.hasType());
+      Assertions.assertSame(ColumnType.LONG, col.druidType());
     }
 
     // Time column can only have TIMESTAMP type
@@ -513,12 +505,12 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
       ResolvedTable table = registry.resolve(spec);
       table.validate();
       DatasourceFacade facade = new DatasourceFacade(registry.resolve(table.spec()));
-      assertEquals(1, facade.columnFacades().size());
+      Assertions.assertEquals(1, facade.columnFacades().size());
       ColumnFacade col = facade.columnFacades().get(0);
-      assertSame(spec.columns().get(0), col.spec());
-      assertTrue(col.isTime());
-      assertTrue(col.hasType());
-      assertSame(ColumnType.LONG, col.druidType());
+      Assertions.assertSame(spec.columns().get(0), col.spec());
+      Assertions.assertTrue(col.isTime());
+      Assertions.assertTrue(col.hasType());
+      Assertions.assertSame(ColumnType.LONG, col.druidType());
     }
 
     {
@@ -564,7 +556,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
   private TableSpec mergeTables(TableSpec spec, TableSpec update)
   {
     ResolvedTable table = registry.resolve(spec);
-    assertNotNull(table);
+    Assertions.assertNotNull(table);
     return table.merge(update).spec();
   }
 
@@ -575,12 +567,12 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
     TableSpec update = new TableSpec(null, null, null);
 
     TableSpec merged = mergeTables(spec, update);
-    assertEquals(spec, merged);
+    Assertions.assertEquals(spec, merged);
   }
 
   private void assertMergeFails(TableSpec spec, TableSpec update)
   {
-    assertThrows(IAE.class, () -> mergeTables(spec, update));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> mergeTables(spec, update));
   }
 
   @Test
@@ -596,7 +588,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
     // Same type
     update = new TableSpec(spec.type(), null, null);
     TableSpec merged = mergeTables(spec, update);
-    assertEquals(spec, merged);
+    Assertions.assertEquals(spec, merged);
   }
 
   @Test
@@ -622,13 +614,13 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
     // We know that an empty map will leave the spec unchanged
     // due to testMergeEmpty. Here we verify those that we
     // changed.
-    assertNotEquals(spec, merged);
-    assertEquals(
+    Assertions.assertNotEquals(spec, merged);
+    Assertions.assertEquals(
         updatedProps.get(DatasourceDefn.SEGMENT_GRANULARITY_PROPERTY),
         merged.properties().get(DatasourceDefn.SEGMENT_GRANULARITY_PROPERTY)
     );
-    assertFalse(merged.properties().containsKey("tag1"));
-    assertEquals(
+    Assertions.assertFalse(merged.properties().containsKey("tag1"));
+    Assertions.assertEquals(
         updatedProps.get("tag3"),
         merged.properties().get("tag3")
     );
@@ -645,7 +637,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
     TableSpec update = new TableSpec(null, updatedProps, null);
     TableSpec merged = mergeTables(spec, update);
     expectValidationSucceeds(merged);
-    assertFalse(
+    Assertions.assertFalse(
         merged.properties().containsKey(DatasourceDefn.HIDDEN_COLUMNS_PROPERTY)
     );
 
@@ -664,7 +656,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
     merged = mergeTables(spec, update);
     expectValidationSucceeds(merged);
 
-    assertEquals(
+    Assertions.assertEquals(
         Arrays.asList("foo", "bar", "mumble"),
         merged.properties().get(DatasourceDefn.HIDDEN_COLUMNS_PROPERTY)
     );
@@ -688,9 +680,9 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
     TableSpec update = new TableSpec(null, null, colUpdates);
     TableSpec merged = mergeTables(spec, update);
     List<ColumnSpec> columns = merged.columns();
-    assertEquals(1, columns.size());
-    assertEquals("a", columns.get(0).name());
-    assertEquals(Columns.LONG, columns.get(0).dataType());
+    Assertions.assertEquals(1, columns.size());
+    Assertions.assertEquals("a", columns.get(0).name());
+    Assertions.assertEquals(Columns.LONG, columns.get(0).dataType());
   }
 
   @Test
@@ -721,18 +713,18 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
     TableSpec update = new TableSpec(null, null, colUpdates);
     TableSpec merged = mergeTables(spec, update);
 
-    assertNotEquals(spec, merged);
+    Assertions.assertNotEquals(spec, merged);
     List<ColumnSpec> columns = merged.columns();
-    assertEquals(3, columns.size());
-    assertEquals("a", columns.get(0).name());
-    assertEquals(Columns.LONG, columns.get(0).dataType());
+    Assertions.assertEquals(3, columns.size());
+    Assertions.assertEquals("a", columns.get(0).name());
+    Assertions.assertEquals(Columns.LONG, columns.get(0).dataType());
     Map<String, Object> colProps = columns.get(0).properties();
-    assertEquals(2, colProps.size());
-    assertEquals("new value", colProps.get("colProp1"));
-    assertEquals("third value", colProps.get("tag3"));
+    Assertions.assertEquals(2, colProps.size());
+    Assertions.assertEquals("new value", colProps.get("colProp1"));
+    Assertions.assertEquals("third value", colProps.get("tag3"));
 
-    assertEquals("c", columns.get(2).name());
-    assertEquals(Columns.STRING, columns.get(2).dataType());
+    Assertions.assertEquals("c", columns.get(2).name());
+    Assertions.assertEquals(Columns.STRING, columns.get(2).dataType());
   }
 
   /**
@@ -741,7 +733,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
    * and pieces in multiple places.
    */
   @Test
-  @Ignore
+  @Disabled
   public void docExample()
   {
     TableSpec spec = TableBuilder.datasource("foo", "PT1H")

--- a/server/src/test/java/org/apache/druid/catalog/model/table/DatasourceTableTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/DatasourceTableTest.java
@@ -88,7 +88,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
 
   private void expectValidationFails(final ResolvedTable table)
   {
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> table.validate());
+    Assertions.assertThrows(IAE.class, () -> table.validate());
   }
 
   private void expectValidationFails(final TableSpec spec)
@@ -108,7 +108,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
   {
     {
       TableSpec spec = new TableSpec(null, ImmutableMap.of(), null);
-      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> registry.resolve(spec));
+      Assertions.assertThrows(IAE.class, () -> registry.resolve(spec));
     }
 
     {
@@ -174,7 +174,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
           columns
       );
       ResolvedTable table = registry.resolve(spec);
-      DruidException e = org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, table::validate);
+      DruidException e = Assertions.assertThrows(DruidException.class, table::validate);
       Assertions.assertTrue(e.getMessage().contains("must also set [sealed] to true"));
     }
 
@@ -191,7 +191,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
           columns
       );
       ResolvedTable table = registry.resolve(spec);
-      org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, table::validate);
+      Assertions.assertThrows(DruidException.class, table::validate);
     }
 
     {
@@ -207,7 +207,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
           columns
       );
       ResolvedTable table = registry.resolve(spec);
-      org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, table::validate);
+      Assertions.assertThrows(DruidException.class, table::validate);
     }
 
     {
@@ -222,7 +222,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
           Collections.singletonList(new ColumnSpec("tenant", Columns.SQL_VARCHAR, null))
       );
       ResolvedTable table = registry.resolve(spec);
-      org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, table::validate);
+      Assertions.assertThrows(DruidException.class, table::validate);
     }
   }
 
@@ -261,10 +261,10 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
     // the sealed schema, and columns computed by a virtual column at ingest time cannot be written directly.
     Assertions.assertSame(facade.column("tenant"), facade.insertColumn("tenant", "druid.tbl"));
     DruidException sealedError =
-        org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, () -> facade.insertColumn("no_such_column", "druid.tbl"));
+        Assertions.assertThrows(DruidException.class, () -> facade.insertColumn("no_such_column", "druid.tbl"));
     Assertions.assertTrue(sealedError.getMessage().contains("not defined in the target table [druid.tbl] strict schema"));
     DruidException computedError =
-        org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, () -> facade.insertColumn("tenant_lower", "druid.tbl"));
+        Assertions.assertThrows(DruidException.class, () -> facade.insertColumn("tenant_lower", "druid.tbl"));
     Assertions.assertTrue(computedError.getMessage().contains("computed by a virtual column at ingest time"));
 
     // An undeclared column of a non-sealed table resolves to null: the caller adds it from the query type.
@@ -302,7 +302,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
   {
     {
       TableSpec spec = new TableSpec("bogus", ImmutableMap.of(), null);
-      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> registry.resolve(spec));
+      Assertions.assertThrows(IAE.class, () -> registry.resolve(spec));
     }
 
     // Segment granularity
@@ -363,7 +363,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
     // Name is required
     {
       ColumnSpec spec = new ColumnSpec(null, null, null);
-      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> spec.validate());
+      Assertions.assertThrows(IAE.class, () -> spec.validate());
     }
     {
       ColumnSpec spec = new ColumnSpec("foo", null, null);
@@ -446,7 +446,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
       TableSpec spec = builder.copy()
           .column("foo", "FOO")
           .buildSpec();
-      DruidException e = org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, () -> registry.resolve(spec).validate());
+      DruidException e = Assertions.assertThrows(DruidException.class, () -> registry.resolve(spec).validate());
       Assertions.assertTrue(e.getMessage().contains("Column [foo] has an unrecognized type [FOO]"));
     }
     {
@@ -454,7 +454,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
       TableSpec spec = builder.copy()
           .column("foo", "COMPLEX<json")
           .buildSpec();
-      DruidException e = org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, () -> registry.resolve(spec).validate());
+      DruidException e = Assertions.assertThrows(DruidException.class, () -> registry.resolve(spec).validate());
       Assertions.assertTrue(e.getMessage().contains("Column [foo] has an unrecognized type [COMPLEX<json]"));
     }
     {
@@ -462,7 +462,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
       TableSpec spec = builder.copy()
           .column("foo", "ARRAY<FOO>")
           .buildSpec();
-      DruidException e = org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, () -> registry.resolve(spec).validate());
+      DruidException e = Assertions.assertThrows(DruidException.class, () -> registry.resolve(spec).validate());
       Assertions.assertTrue(e.getMessage().contains("Column [foo] has an unrecognized type [ARRAY<FOO>]"));
     }
     {
@@ -572,7 +572,7 @@ public class DatasourceTableTest extends InitializedNullHandlingTest
 
   private void assertMergeFails(TableSpec spec, TableSpec update)
   {
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> mergeTables(spec, update));
+    Assertions.assertThrows(IAE.class, () -> mergeTables(spec, update));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/catalog/model/table/DelimitedInputFormatTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/DelimitedInputFormatTest.java
@@ -30,7 +30,8 @@ import org.apache.druid.catalog.model.table.TableFunction.ParameterDefn;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.impl.DelimitedInputFormat;
 import org.apache.druid.data.input.impl.InlineInputSource;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -38,10 +39,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 public class DelimitedInputFormatTest extends BaseExternTableTest
 {
@@ -63,11 +60,11 @@ public class DelimitedInputFormatTest extends BaseExternTableTest
     InputFormatDefn defn = registry.inputFormatDefnFor(DelimitedInputFormat.TYPE_KEY);
     InputFormat inputFormat = defn.convertFromTable(new ResolvedExternalTable(resolved));
     DelimitedInputFormat delmited = (DelimitedInputFormat) inputFormat;
-    assertEquals(0, delmited.getSkipHeaderRows());
-    assertFalse(delmited.isFindColumnsFromHeader());
-    assertNull(delmited.getListDelimiter());
-    assertEquals("|", delmited.getDelimiter());
-    assertEquals(Collections.singletonList("a"), delmited.getColumns());
+    Assertions.assertEquals(0, delmited.getSkipHeaderRows());
+    Assertions.assertFalse(delmited.isFindColumnsFromHeader());
+    Assertions.assertNull(delmited.getListDelimiter());
+    Assertions.assertEquals("|", delmited.getDelimiter());
+    Assertions.assertEquals(Collections.singletonList("a"), delmited.getColumns());
   }
 
   @Test
@@ -87,11 +84,11 @@ public class DelimitedInputFormatTest extends BaseExternTableTest
     InputFormatDefn defn = registry.inputFormatDefnFor(DelimitedInputFormat.TYPE_KEY);
     InputFormat inputFormat = defn.convertFromTable(new ResolvedExternalTable(resolved));
     DelimitedInputFormat delmited = (DelimitedInputFormat) inputFormat;
-    assertEquals(1, delmited.getSkipHeaderRows());
-    assertFalse(delmited.isFindColumnsFromHeader());
-    assertEquals(";", delmited.getListDelimiter());
-    assertEquals("|", delmited.getDelimiter());
-    assertEquals(Arrays.asList("a", "b"), delmited.getColumns());
+    Assertions.assertEquals(1, delmited.getSkipHeaderRows());
+    Assertions.assertFalse(delmited.isFindColumnsFromHeader());
+    Assertions.assertEquals(";", delmited.getListDelimiter());
+    Assertions.assertEquals("|", delmited.getDelimiter());
+    Assertions.assertEquals(Arrays.asList("a", "b"), delmited.getColumns());
   }
 
   @Test
@@ -99,8 +96,8 @@ public class DelimitedInputFormatTest extends BaseExternTableTest
   {
     InputFormatDefn defn = registry.inputFormatDefnFor(DelimitedInputFormat.TYPE_KEY);
     List<ParameterDefn> params = defn.parameters();
-    assertEquals(3, params.size());
-    assertTrue(hasParam(params, DelimitedFormatDefn.DELIMITER_PARAMETER));
+    Assertions.assertEquals(3, params.size());
+    Assertions.assertTrue(hasParam(params, DelimitedFormatDefn.DELIMITER_PARAMETER));
   }
 
   @Test
@@ -114,10 +111,10 @@ public class DelimitedInputFormatTest extends BaseExternTableTest
     List<ColumnSpec> columns = Collections.singletonList(new ColumnSpec("a", null, null));
     InputFormat inputFormat = defn.convertFromArgs(args, columns, mapper);
     DelimitedInputFormat delmited = (DelimitedInputFormat) inputFormat;
-    assertEquals(1, delmited.getSkipHeaderRows());
-    assertFalse(delmited.isFindColumnsFromHeader());
-    assertEquals(";", delmited.getListDelimiter());
-    assertEquals("|", delmited.getDelimiter());
-    assertEquals(Collections.singletonList("a"), delmited.getColumns());
+    Assertions.assertEquals(1, delmited.getSkipHeaderRows());
+    Assertions.assertFalse(delmited.isFindColumnsFromHeader());
+    Assertions.assertEquals(";", delmited.getListDelimiter());
+    Assertions.assertEquals("|", delmited.getDelimiter());
+    Assertions.assertEquals(Collections.singletonList("a"), delmited.getColumns());
   }
 }

--- a/server/src/test/java/org/apache/druid/catalog/model/table/ExternalTableTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/ExternalTableTest.java
@@ -34,8 +34,9 @@ import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.metadata.DefaultPasswordProvider;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.net.URI;
@@ -43,8 +44,6 @@ import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Map;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 public class ExternalTableTest extends BaseExternTableTest
 {
@@ -58,7 +57,7 @@ public class ExternalTableTest extends BaseExternTableTest
     // Empty table: not valid
     TableMetadata table = TableBuilder.external("foo").build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -69,7 +68,7 @@ public class ExternalTableTest extends BaseExternTableTest
         .inputSource(ImmutableMap.of())
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -80,7 +79,7 @@ public class ExternalTableTest extends BaseExternTableTest
         .inputSource(ImmutableMap.of("type", "unknown"))
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -104,7 +103,7 @@ public class ExternalTableTest extends BaseExternTableTest
         .inputFormat(ImmutableMap.of())
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -116,7 +115,7 @@ public class ExternalTableTest extends BaseExternTableTest
         .inputFormat(ImmutableMap.of("type", "unknown"))
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -148,10 +147,10 @@ public class ExternalTableTest extends BaseExternTableTest
           .column("a", badType)
           .build();
       ResolvedTable resolved = registry.resolve(table.spec());
-      DruidException e = assertThrows(DruidException.class, () -> resolved.validate());
-      assertTrue(
-          "expected unrecognized-type error for [" + badType + "] but got: " + e.getMessage(),
-          e.getMessage().contains("Column [a] has an unrecognized type [" + badType + "]")
+      DruidException e = org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, () -> resolved.validate());
+      Assertions.assertTrue(
+          e.getMessage().contains("Column [a] has an unrecognized type [" + badType + "]"),
+          "expected unrecognized-type error for [" + badType + "] but got: " + e.getMessage()
       );
     }
   }
@@ -162,7 +161,7 @@ public class ExternalTableTest extends BaseExternTableTest
    * and pieces in multiple places.
    */
   @Test
-  @Ignore
+  @Disabled
   public void wikipediaDocExample()
   {
     JsonInputFormat format = new JsonInputFormat(null, null, true, true, false);
@@ -186,7 +185,7 @@ public class ExternalTableTest extends BaseExternTableTest
   }
 
   @Test
-  @Ignore
+  @Disabled
   public void httpDocExample() throws URISyntaxException
   {
     HttpInputSource inputSource = new HttpInputSource(
@@ -212,7 +211,7 @@ public class ExternalTableTest extends BaseExternTableTest
   }
 
   @Test
-  @Ignore
+  @Disabled
   public void httpConnDocExample() throws URISyntaxException
   {
     HttpInputSource inputSource = new HttpInputSource(
@@ -231,7 +230,7 @@ public class ExternalTableTest extends BaseExternTableTest
   }
 
   @Test
-  @Ignore
+  @Disabled
   public void localDocExample()
   {
     Map<String, Object> sourceMap = ImmutableMap.of(

--- a/server/src/test/java/org/apache/druid/catalog/model/table/ExternalTableTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/ExternalTableTest.java
@@ -57,7 +57,7 @@ public class ExternalTableTest extends BaseExternTableTest
     // Empty table: not valid
     TableMetadata table = TableBuilder.external("foo").build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -68,7 +68,7 @@ public class ExternalTableTest extends BaseExternTableTest
         .inputSource(ImmutableMap.of())
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -79,7 +79,7 @@ public class ExternalTableTest extends BaseExternTableTest
         .inputSource(ImmutableMap.of("type", "unknown"))
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -103,7 +103,7 @@ public class ExternalTableTest extends BaseExternTableTest
         .inputFormat(ImmutableMap.of())
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -115,7 +115,7 @@ public class ExternalTableTest extends BaseExternTableTest
         .inputFormat(ImmutableMap.of("type", "unknown"))
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -147,7 +147,7 @@ public class ExternalTableTest extends BaseExternTableTest
           .column("a", badType)
           .build();
       ResolvedTable resolved = registry.resolve(table.spec());
-      DruidException e = org.junit.jupiter.api.Assertions.assertThrows(DruidException.class, () -> resolved.validate());
+      DruidException e = Assertions.assertThrows(DruidException.class, () -> resolved.validate());
       Assertions.assertTrue(
           e.getMessage().contains("Column [a] has an unrecognized type [" + badType + "]"),
           "expected unrecognized-type error for [" + badType + "] but got: " + e.getMessage()

--- a/server/src/test/java/org/apache/druid/catalog/model/table/HttpInputSourceDefnTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/HttpInputSourceDefnTest.java
@@ -68,7 +68,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -83,7 +83,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -104,7 +104,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -124,7 +124,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         .inputFormat(CSV_FORMAT)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -157,7 +157,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         .property(HttpInputSourceDefn.URI_TEMPLATE_PROPERTY, "http://example.com/{}")
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -169,7 +169,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     Map<String, Object> args = new HashMap<>();
     args.put(HttpInputSourceDefn.URIS_PARAMETER, new String[] {"http://foo.com/my.csv"});
     args.put(FormattedInputSourceDefn.FORMAT_PARAMETER, "bogus");
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
+    Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
   }
 
   @Test
@@ -181,7 +181,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     Map<String, Object> args = new HashMap<>();
     args.put(HttpInputSourceDefn.URIS_PARAMETER, new String[] {"bogus"});
     args.put(FormattedInputSourceDefn.FORMAT_PARAMETER, CsvFormatDefn.TYPE_KEY);
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
+    Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
   }
 
   @Test
@@ -204,7 +204,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     validateHappyPath(externSpec, true);
 
     // But, it fails if there are no columns.
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
+    Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
   }
 
   @Test
@@ -246,7 +246,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     validateHappyPath(externSpec, true);
 
     // But, it fails columns are provided since the table already has them.
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), COLUMNS, mapper));
+    Assertions.assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), COLUMNS, mapper));
   }
 
   @Test
@@ -268,7 +268,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     // Not a full table, can't directly convert
     // Convert to an external spec
     ExternalTableDefn externDefn = (ExternalTableDefn) resolved.defn();
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> externDefn.convert(resolved));
+    Assertions.assertThrows(IAE.class, () -> externDefn.convert(resolved));
 
     // Get the partial table function
     TableFunction fn = externDefn.tableFn(resolved);
@@ -317,7 +317,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     // Not a full table, can't directly convert
     // Convert to an external spec
     ExternalTableDefn externDefn = (ExternalTableDefn) resolved.defn();
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> externDefn.convert(resolved));
+    Assertions.assertThrows(IAE.class, () -> externDefn.convert(resolved));
 
     // Get the partial table function
     TableFunction fn = externDefn.tableFn(resolved);
@@ -361,7 +361,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     // Convert to an external spec
     ResolvedTable resolved = registry.resolve(table.spec());
     ExternalTableDefn externDefn = (ExternalTableDefn) resolved.defn();
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> externDefn.convert(resolved));
+    Assertions.assertThrows(IAE.class, () -> externDefn.convert(resolved));
 
     // Get the partial table function
     TableFunction fn = externDefn.tableFn(resolved);

--- a/server/src/test/java/org/apache/druid/catalog/model/table/HttpInputSourceDefnTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/HttpInputSourceDefnTest.java
@@ -34,8 +34,9 @@ import org.apache.druid.metadata.DefaultPasswordProvider;
 import org.apache.druid.metadata.EnvironmentVariablePasswordProvider;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -44,15 +45,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 public class HttpInputSourceDefnTest extends BaseExternTableTest
 {
-  @Before
+  @BeforeEach
   public void setup()
   {
     mapper.setInjectableValues(new InjectableValues.Std().addValue(
@@ -72,7 +68,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -87,7 +83,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -108,7 +104,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -128,7 +124,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         .inputFormat(CSV_FORMAT)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -161,7 +157,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         .property(HttpInputSourceDefn.URI_TEMPLATE_PROPERTY, "http://example.com/{}")
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -173,7 +169,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     Map<String, Object> args = new HashMap<>();
     args.put(HttpInputSourceDefn.URIS_PARAMETER, new String[] {"http://foo.com/my.csv"});
     args.put(FormattedInputSourceDefn.FORMAT_PARAMETER, "bogus");
-    assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
   }
 
   @Test
@@ -185,7 +181,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     Map<String, Object> args = new HashMap<>();
     args.put(HttpInputSourceDefn.URIS_PARAMETER, new String[] {"bogus"});
     args.put(FormattedInputSourceDefn.FORMAT_PARAMETER, CsvFormatDefn.TYPE_KEY);
-    assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
   }
 
   @Test
@@ -194,9 +190,9 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     InputSourceDefn httpDefn = registry.inputSourceDefnFor(HttpInputSourceDefn.TYPE_KEY);
 
     TableFunction fn = httpDefn.adHocTableFn();
-    assertTrue(hasParam(fn, HttpInputSourceDefn.URIS_PARAMETER));
-    assertTrue(hasParam(fn, FormattedInputSourceDefn.FORMAT_PARAMETER));
-    assertTrue(hasParam(fn, HttpInputSourceDefn.USER_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, HttpInputSourceDefn.URIS_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, FormattedInputSourceDefn.FORMAT_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, HttpInputSourceDefn.USER_PARAMETER));
 
     // Convert to an external table. Must provide the URIs plus format and columns.
     Map<String, Object> args = new HashMap<>();
@@ -208,7 +204,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     validateHappyPath(externSpec, true);
 
     // But, it fails if there are no columns.
-    assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
   }
 
   @Test
@@ -234,7 +230,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
 
     // Check registry
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertNotNull(resolved);
+    Assertions.assertNotNull(resolved);
 
     // Convert to an external spec
     ExternalTableDefn externDefn = (ExternalTableDefn) resolved.defn();
@@ -243,14 +239,14 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
 
     // Get the partial table function
     TableFunction fn = externDefn.tableFn(resolved);
-    assertTrue(fn.parameters().isEmpty());
+    Assertions.assertTrue(fn.parameters().isEmpty());
 
     // Convert to an external table.
     externSpec = fn.apply("x", Collections.emptyMap(), Collections.emptyList(), mapper);
     validateHappyPath(externSpec, true);
 
     // But, it fails columns are provided since the table already has them.
-    assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), COLUMNS, mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), COLUMNS, mapper));
   }
 
   @Test
@@ -267,21 +263,21 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     // Check validation
     table.validate();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertNotNull(resolved);
+    Assertions.assertNotNull(resolved);
 
     // Not a full table, can't directly convert
     // Convert to an external spec
     ExternalTableDefn externDefn = (ExternalTableDefn) resolved.defn();
-    assertThrows(IAE.class, () -> externDefn.convert(resolved));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> externDefn.convert(resolved));
 
     // Get the partial table function
     TableFunction fn = externDefn.tableFn(resolved);
-    assertEquals(5, fn.parameters().size());
-    assertTrue(hasParam(fn, HttpInputSourceDefn.URIS_PARAMETER));
-    assertTrue(hasParam(fn, HttpInputSourceDefn.USER_PARAMETER));
-    assertTrue(hasParam(fn, HttpInputSourceDefn.PASSWORD_PARAMETER));
-    assertTrue(hasParam(fn, HttpInputSourceDefn.PASSWORD_ENV_VAR_PARAMETER));
-    assertTrue(hasParam(fn, HttpInputSourceDefn.HEADERS));
+    Assertions.assertEquals(5, fn.parameters().size());
+    Assertions.assertTrue(hasParam(fn, HttpInputSourceDefn.URIS_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, HttpInputSourceDefn.USER_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, HttpInputSourceDefn.PASSWORD_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, HttpInputSourceDefn.PASSWORD_ENV_VAR_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, HttpInputSourceDefn.HEADERS));
 
     // Convert to an external table.
     ExternalTableSpec externSpec = fn.apply(
@@ -316,18 +312,18 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
 
     table.validate();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertNotNull(resolved);
+    Assertions.assertNotNull(resolved);
 
     // Not a full table, can't directly convert
     // Convert to an external spec
     ExternalTableDefn externDefn = (ExternalTableDefn) resolved.defn();
-    assertThrows(IAE.class, () -> externDefn.convert(resolved));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> externDefn.convert(resolved));
 
     // Get the partial table function
     TableFunction fn = externDefn.tableFn(resolved);
-    assertEquals(2, fn.parameters().size());
-    assertTrue(hasParam(fn, HttpInputSourceDefn.URIS_PARAMETER));
-    assertTrue(hasParam(fn, HttpInputSourceDefn.HEADERS));
+    Assertions.assertEquals(2, fn.parameters().size());
+    Assertions.assertTrue(hasParam(fn, HttpInputSourceDefn.URIS_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, HttpInputSourceDefn.HEADERS));
 
     // Convert to an external table.
     ExternalTableSpec externSpec = fn.apply(
@@ -365,13 +361,13 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     // Convert to an external spec
     ResolvedTable resolved = registry.resolve(table.spec());
     ExternalTableDefn externDefn = (ExternalTableDefn) resolved.defn();
-    assertThrows(IAE.class, () -> externDefn.convert(resolved));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> externDefn.convert(resolved));
 
     // Get the partial table function
     TableFunction fn = externDefn.tableFn(resolved);
-    assertTrue(hasParam(fn, HttpInputSourceDefn.URIS_PARAMETER));
-    assertTrue(hasParam(fn, FormattedInputSourceDefn.FORMAT_PARAMETER));
-    assertFalse(hasParam(fn, HttpInputSourceDefn.USER_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, HttpInputSourceDefn.URIS_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, FormattedInputSourceDefn.FORMAT_PARAMETER));
+    Assertions.assertFalse(hasParam(fn, HttpInputSourceDefn.USER_PARAMETER));
 
     // Convert to an external table. Must provide the URIs plus format and columns.
     Map<String, Object> args = new HashMap<>();
@@ -408,11 +404,11 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     ExternalTableSpec externSpec = externDefn.convert(resolved);
 
     HttpInputSource sourceSpec = (HttpInputSource) externSpec.inputSource;
-    assertEquals(
+    Assertions.assertEquals(
         CatalogUtils.stringListToUriList(Arrays.asList("http://foo.com/foo.csv", "http://foo.com/bar.csv")),
         sourceSpec.getUris()
     );
-    assertEquals(Collections.singleton(HttpInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
+    Assertions.assertEquals(Collections.singleton(HttpInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
   }
 
   @Test
@@ -441,8 +437,8 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     ResolvedTable resolved = registry.resolve(table.spec());
     ExternalTableDefn externDefn = (ExternalTableDefn) resolved.defn();
     TableFunction fn = externDefn.tableFn(resolved);
-    assertEquals(1, fn.parameters().size());
-    assertTrue(hasParam(fn, HttpInputSourceDefn.URIS_PARAMETER));
+    Assertions.assertEquals(1, fn.parameters().size());
+    Assertions.assertTrue(hasParam(fn, HttpInputSourceDefn.URIS_PARAMETER));
 
     // Convert to an external table.
     ExternalTableSpec externSpec = fn.apply(
@@ -454,11 +450,11 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     );
 
     HttpInputSource sourceSpec = (HttpInputSource) externSpec.inputSource;
-    assertEquals(
+    Assertions.assertEquals(
         CatalogUtils.stringListToUriList(Arrays.asList("http://foo.com/my.csv", "http://foo.com/bar.csv")),
         sourceSpec.getUris()
     );
-    assertEquals(Collections.singleton(HttpInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
+    Assertions.assertEquals(Collections.singleton(HttpInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
   }
 
   @Test
@@ -467,9 +463,9 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     InputSourceDefn httpDefn = registry.inputSourceDefnFor(HttpInputSourceDefn.TYPE_KEY);
 
     TableFunction fn = httpDefn.adHocTableFn();
-    assertTrue(hasParam(fn, HttpInputSourceDefn.URIS_PARAMETER));
-    assertTrue(hasParam(fn, FormattedInputSourceDefn.FORMAT_PARAMETER));
-    assertTrue(hasParam(fn, HttpInputSourceDefn.USER_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, HttpInputSourceDefn.URIS_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, FormattedInputSourceDefn.FORMAT_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, HttpInputSourceDefn.USER_PARAMETER));
 
     // Convert to an external table. Must provide the URIs plus format and columns.
     Map<String, Object> args = new HashMap<>();
@@ -478,11 +474,11 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     ExternalTableSpec externSpec = fn.apply("x", args, COLUMNS, mapper);
 
     HttpInputSource sourceSpec = (HttpInputSource) externSpec.inputSource;
-    assertEquals(
+    Assertions.assertEquals(
         CatalogUtils.stringListToUriList(Arrays.asList("http://foo.com/foo.csv", "http://foo.com/bar.csv")),
         sourceSpec.getUris()
     );
-    assertEquals(Collections.singleton(HttpInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
+    Assertions.assertEquals(Collections.singleton(HttpInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
   }
 
   @Test
@@ -512,31 +508,31 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     ExternalTableSpec externSpec = externDefn.convert(resolved);
 
     HttpInputSource sourceSpec = (HttpInputSource) externSpec.inputSource;
-    assertEquals("bob", sourceSpec.getHttpAuthenticationUsername());
-    assertEquals(
+    Assertions.assertEquals("bob", sourceSpec.getHttpAuthenticationUsername());
+    Assertions.assertEquals(
         "SECRET",
         ((EnvironmentVariablePasswordProvider) sourceSpec.getHttpAuthenticationPasswordProvider()).getVariable()
     );
-    assertEquals(Collections.singleton(HttpInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
+    Assertions.assertEquals(Collections.singleton(HttpInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
   }
 
   private void validateHappyPath(ExternalTableSpec externSpec, boolean withUser)
   {
     HttpInputSource sourceSpec = (HttpInputSource) externSpec.inputSource;
     if (withUser) {
-      assertEquals("bob", sourceSpec.getHttpAuthenticationUsername());
-      assertEquals("secret", ((DefaultPasswordProvider) sourceSpec.getHttpAuthenticationPasswordProvider()).getPassword());
+      Assertions.assertEquals("bob", sourceSpec.getHttpAuthenticationUsername());
+      Assertions.assertEquals("secret", ((DefaultPasswordProvider) sourceSpec.getHttpAuthenticationPasswordProvider()).getPassword());
     }
-    assertEquals("http://foo.com/my.csv", sourceSpec.getUris().get(0).toString());
+    Assertions.assertEquals("http://foo.com/my.csv", sourceSpec.getUris().get(0).toString());
     // Just a sanity check: details of CSV conversion are tested elsewhere.
     CsvInputFormat csvFormat = (CsvInputFormat) externSpec.inputFormat;
-    assertEquals(Arrays.asList("x", "y"), csvFormat.getColumns());
+    Assertions.assertEquals(Arrays.asList("x", "y"), csvFormat.getColumns());
 
     RowSignature sig = externSpec.signature;
-    assertEquals(Arrays.asList("x", "y"), sig.getColumnNames());
-    assertEquals(ColumnType.STRING, sig.getColumnType(0).get());
-    assertEquals(ColumnType.LONG, sig.getColumnType(1).get());
-    assertEquals(Collections.singleton(HttpInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
+    Assertions.assertEquals(Arrays.asList("x", "y"), sig.getColumnNames());
+    Assertions.assertEquals(ColumnType.STRING, sig.getColumnType(0).get());
+    Assertions.assertEquals(ColumnType.LONG, sig.getColumnType(1).get());
+    Assertions.assertEquals(Collections.singleton(HttpInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
   }
 
   private Map<String, Object> httpToMap(HttpInputSource source)

--- a/server/src/test/java/org/apache/druid/catalog/model/table/InlineInputSourceDefnTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/InlineInputSourceDefnTest.java
@@ -51,7 +51,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
         .column("x", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -63,7 +63,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
         .column("x", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -74,7 +74,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
         .inputFormat(CSV_FORMAT)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -105,7 +105,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
   {
     InputSourceDefn defn = registry.inputSourceDefnFor(InlineInputSourceDefn.TYPE_KEY);
     TableFunction fn = defn.adHocTableFn();
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", new HashMap<>(), Collections.emptyList(), mapper));
+    Assertions.assertThrows(IAE.class, () -> fn.apply("x", new HashMap<>(), Collections.emptyList(), mapper));
   }
 
   @Test
@@ -115,7 +115,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
     TableFunction fn = defn.adHocTableFn();
     Map<String, Object> args = new HashMap<>();
     args.put(InlineInputSourceDefn.DATA_PROPERTY, "a");
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
+    Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
   }
 
   @Test
@@ -144,7 +144,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
     Assertions.assertEquals(Collections.singleton(InlineInputSourceDefn.TYPE_KEY), extern.inputSourceTypesSupplier.get());
 
     // Fails if no columns are provided.
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", new HashMap<>(), Collections.emptyList(), mapper));
+    Assertions.assertThrows(IAE.class, () -> fn.apply("x", new HashMap<>(), Collections.emptyList(), mapper));
   }
 
   @Test
@@ -183,7 +183,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
         new ColumnSpec("a", Columns.STRING, null),
         new ColumnSpec("b", Columns.STRING, null)
     );
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", new HashMap<>(), columns, mapper));
+    Assertions.assertThrows(IAE.class, () -> fn.apply("x", new HashMap<>(), columns, mapper));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/catalog/model/table/InlineInputSourceDefnTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/InlineInputSourceDefnTest.java
@@ -29,7 +29,8 @@ import org.apache.druid.catalog.model.table.InputFormats.FlatTextFormatDefn;
 import org.apache.druid.data.input.impl.CsvInputFormat;
 import org.apache.druid.data.input.impl.InlineInputSource;
 import org.apache.druid.java.util.common.IAE;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -37,10 +38,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 public class InlineInputSourceDefnTest extends BaseExternTableTest
 {
@@ -54,7 +51,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
         .column("x", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -66,7 +63,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
         .column("x", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -77,7 +74,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
         .inputFormat(CSV_FORMAT)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -97,10 +94,10 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
   {
     InputSourceDefn defn = registry.inputSourceDefnFor(InlineInputSourceDefn.TYPE_KEY);
     TableFunction fn = defn.adHocTableFn();
-    assertNotNull(fn);
-    assertTrue(hasParam(fn, InlineInputSourceDefn.DATA_PROPERTY));
-    assertTrue(hasParam(fn, FormattedInputSourceDefn.FORMAT_PARAMETER));
-    assertTrue(hasParam(fn, FlatTextFormatDefn.LIST_DELIMITER_PARAMETER));
+    Assertions.assertNotNull(fn);
+    Assertions.assertTrue(hasParam(fn, InlineInputSourceDefn.DATA_PROPERTY));
+    Assertions.assertTrue(hasParam(fn, FormattedInputSourceDefn.FORMAT_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, FlatTextFormatDefn.LIST_DELIMITER_PARAMETER));
   }
 
   @Test
@@ -108,7 +105,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
   {
     InputSourceDefn defn = registry.inputSourceDefnFor(InlineInputSourceDefn.TYPE_KEY);
     TableFunction fn = defn.adHocTableFn();
-    assertThrows(IAE.class, () -> fn.apply("x", new HashMap<>(), Collections.emptyList(), mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", new HashMap<>(), Collections.emptyList(), mapper));
   }
 
   @Test
@@ -118,7 +115,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
     TableFunction fn = defn.adHocTableFn();
     Map<String, Object> args = new HashMap<>();
     args.put(InlineInputSourceDefn.DATA_PROPERTY, "a");
-    assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
   }
 
   @Test
@@ -137,17 +134,17 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
     final TableFunction fn = defn.adHocTableFn();
     ExternalTableSpec extern = fn.apply("x", args, columns, mapper);
 
-    assertTrue(extern.inputSource instanceof InlineInputSource);
+    Assertions.assertTrue(extern.inputSource instanceof InlineInputSource);
     InlineInputSource inputSource = (InlineInputSource) extern.inputSource;
-    assertEquals("a,b\nc,d\n", inputSource.getData());
-    assertTrue(extern.inputFormat instanceof CsvInputFormat);
+    Assertions.assertEquals("a,b\nc,d\n", inputSource.getData());
+    Assertions.assertTrue(extern.inputFormat instanceof CsvInputFormat);
     CsvInputFormat format = (CsvInputFormat) extern.inputFormat;
-    assertEquals(Arrays.asList("a", "b"), format.getColumns());
-    assertEquals(2, extern.signature.size());
-    assertEquals(Collections.singleton(InlineInputSourceDefn.TYPE_KEY), extern.inputSourceTypesSupplier.get());
+    Assertions.assertEquals(Arrays.asList("a", "b"), format.getColumns());
+    Assertions.assertEquals(2, extern.signature.size());
+    Assertions.assertEquals(Collections.singleton(InlineInputSourceDefn.TYPE_KEY), extern.inputSourceTypesSupplier.get());
 
     // Fails if no columns are provided.
-    assertThrows(IAE.class, () -> fn.apply("x", new HashMap<>(), Collections.emptyList(), mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", new HashMap<>(), Collections.emptyList(), mapper));
   }
 
   @Test
@@ -167,26 +164,26 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
     TableFunction fn = ((ExternalTableDefn) resolved.defn()).tableFn(resolved);
 
     // Inline is always fully defined: no arguments needed
-    assertTrue(fn.parameters().isEmpty());
+    Assertions.assertTrue(fn.parameters().isEmpty());
 
     // Verify the conversion
     ExternalTableSpec extern = fn.apply("x", new HashMap<>(), Collections.emptyList(), mapper);
 
-    assertTrue(extern.inputSource instanceof InlineInputSource);
+    Assertions.assertTrue(extern.inputSource instanceof InlineInputSource);
     InlineInputSource inputSource = (InlineInputSource) extern.inputSource;
-    assertEquals("a,b\nc,d\n", inputSource.getData());
-    assertTrue(extern.inputFormat instanceof CsvInputFormat);
+    Assertions.assertEquals("a,b\nc,d\n", inputSource.getData());
+    Assertions.assertTrue(extern.inputFormat instanceof CsvInputFormat);
     CsvInputFormat actualFormat = (CsvInputFormat) extern.inputFormat;
-    assertEquals(Arrays.asList("a", "b"), actualFormat.getColumns());
-    assertEquals(2, extern.signature.size());
-    assertEquals(Collections.singleton(InlineInputSourceDefn.TYPE_KEY), extern.inputSourceTypesSupplier.get());
+    Assertions.assertEquals(Arrays.asList("a", "b"), actualFormat.getColumns());
+    Assertions.assertEquals(2, extern.signature.size());
+    Assertions.assertEquals(Collections.singleton(InlineInputSourceDefn.TYPE_KEY), extern.inputSourceTypesSupplier.get());
 
     // Cannot supply columns with the function
     List<ColumnSpec> columns = Arrays.asList(
         new ColumnSpec("a", Columns.STRING, null),
         new ColumnSpec("b", Columns.STRING, null)
     );
-    assertThrows(IAE.class, () -> fn.apply("x", new HashMap<>(), columns, mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", new HashMap<>(), columns, mapper));
   }
 
   @Test
@@ -208,13 +205,13 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
     ExternalTableSpec extern = ((ExternalTableDefn) resolved.defn()).convert(resolved);
 
     // Verify the conversion
-    assertTrue(extern.inputSource instanceof InlineInputSource);
+    Assertions.assertTrue(extern.inputSource instanceof InlineInputSource);
     InlineInputSource inputSource = (InlineInputSource) extern.inputSource;
-    assertEquals("a,b\nc,d\n", inputSource.getData());
-    assertTrue(extern.inputFormat instanceof CsvInputFormat);
+    Assertions.assertEquals("a,b\nc,d\n", inputSource.getData());
+    Assertions.assertTrue(extern.inputFormat instanceof CsvInputFormat);
     CsvInputFormat actualFormat = (CsvInputFormat) extern.inputFormat;
-    assertEquals(Arrays.asList("a", "b"), actualFormat.getColumns());
-    assertEquals(2, extern.signature.size());
-    assertEquals(Collections.singleton(InlineInputSourceDefn.TYPE_KEY), extern.inputSourceTypesSupplier.get());
+    Assertions.assertEquals(Arrays.asList("a", "b"), actualFormat.getColumns());
+    Assertions.assertEquals(2, extern.signature.size());
+    Assertions.assertEquals(Collections.singleton(InlineInputSourceDefn.TYPE_KEY), extern.inputSourceTypesSupplier.get());
   }
 }

--- a/server/src/test/java/org/apache/druid/catalog/model/table/JsonInputFormatTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/JsonInputFormatTest.java
@@ -28,17 +28,14 @@ import org.apache.druid.catalog.model.table.TableFunction.ParameterDefn;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.impl.InlineInputSource;
 import org.apache.druid.data.input.impl.JsonInputFormat;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 public class JsonInputFormatTest extends BaseExternTableTest
 {
@@ -56,11 +53,11 @@ public class JsonInputFormatTest extends BaseExternTableTest
     InputFormatDefn defn = registry.inputFormatDefnFor(JsonInputFormat.TYPE_KEY);
     InputFormat inputFormat = defn.convertFromTable(new ResolvedExternalTable(resolved));
     JsonInputFormat jsonFormat = (JsonInputFormat) inputFormat;
-    assertNull(jsonFormat.getFlattenSpec());
-    assertTrue(jsonFormat.getFeatureSpec().isEmpty());
-    assertFalse(jsonFormat.isKeepNullColumns());
-    assertFalse(jsonFormat.isAssumeNewlineDelimited());
-    assertFalse(jsonFormat.isUseJsonNodeReader());
+    Assertions.assertNull(jsonFormat.getFlattenSpec());
+    Assertions.assertTrue(jsonFormat.getFeatureSpec().isEmpty());
+    Assertions.assertFalse(jsonFormat.isKeepNullColumns());
+    Assertions.assertFalse(jsonFormat.isAssumeNewlineDelimited());
+    Assertions.assertFalse(jsonFormat.isUseJsonNodeReader());
   }
 
   @Test
@@ -79,11 +76,11 @@ public class JsonInputFormatTest extends BaseExternTableTest
     InputFormatDefn defn = registry.inputFormatDefnFor(JsonInputFormat.TYPE_KEY);
     InputFormat inputFormat = defn.convertFromTable(new ResolvedExternalTable(resolved));
     JsonInputFormat jsonFormat = (JsonInputFormat) inputFormat;
-    assertNull(jsonFormat.getFlattenSpec());
-    assertTrue(jsonFormat.getFeatureSpec().isEmpty());
-    assertTrue(jsonFormat.isKeepNullColumns());
-    assertTrue(jsonFormat.isAssumeNewlineDelimited());
-    assertFalse(jsonFormat.isUseJsonNodeReader());
+    Assertions.assertNull(jsonFormat.getFlattenSpec());
+    Assertions.assertTrue(jsonFormat.getFeatureSpec().isEmpty());
+    Assertions.assertTrue(jsonFormat.isKeepNullColumns());
+    Assertions.assertTrue(jsonFormat.isAssumeNewlineDelimited());
+    Assertions.assertFalse(jsonFormat.isUseJsonNodeReader());
   }
 
   @Test
@@ -91,7 +88,7 @@ public class JsonInputFormatTest extends BaseExternTableTest
   {
     InputFormatDefn defn = registry.inputFormatDefnFor(JsonInputFormat.TYPE_KEY);
     List<ParameterDefn> params = defn.parameters();
-    assertEquals(0, params.size());
+    Assertions.assertEquals(0, params.size());
   }
 
   @Test
@@ -102,10 +99,10 @@ public class JsonInputFormatTest extends BaseExternTableTest
     List<ColumnSpec> columns = Collections.singletonList(new ColumnSpec("a", null, null));
     InputFormat inputFormat = defn.convertFromArgs(args, columns, mapper);
     JsonInputFormat jsonFormat = (JsonInputFormat) inputFormat;
-    assertNull(jsonFormat.getFlattenSpec());
-    assertTrue(jsonFormat.getFeatureSpec().isEmpty());
-    assertFalse(jsonFormat.isKeepNullColumns());
-    assertFalse(jsonFormat.isAssumeNewlineDelimited());
-    assertFalse(jsonFormat.isUseJsonNodeReader());
+    Assertions.assertNull(jsonFormat.getFlattenSpec());
+    Assertions.assertTrue(jsonFormat.getFeatureSpec().isEmpty());
+    Assertions.assertFalse(jsonFormat.isKeepNullColumns());
+    Assertions.assertFalse(jsonFormat.isAssumeNewlineDelimited());
+    Assertions.assertFalse(jsonFormat.isUseJsonNodeReader());
   }
 }

--- a/server/src/test/java/org/apache/druid/catalog/model/table/LocalInputSourceDefnTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/LocalInputSourceDefnTest.java
@@ -31,7 +31,8 @@ import org.apache.druid.data.input.impl.LocalInputSource;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Arrays;
@@ -40,12 +41,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 public class LocalInputSourceDefnTest extends BaseExternTableTest
 {
@@ -65,7 +60,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
         .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -79,7 +74,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
         .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -92,7 +87,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
         .inputFormat(CSV_FORMAT)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -173,17 +168,17 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
         .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    assertThrows(IAE.class, () -> resolved.validate());
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
   public void testAdHocParameters()
   {
     TableFunction fn = localDefn.adHocTableFn();
-    assertTrue(hasParam(fn, LocalInputSourceDefn.BASE_DIR_PARAMETER));
-    assertTrue(hasParam(fn, LocalInputSourceDefn.FILES_PARAMETER));
-    assertTrue(hasParam(fn, LocalInputSourceDefn.FILTER_PARAMETER));
-    assertTrue(hasParam(fn, FormattedInputSourceDefn.FORMAT_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, LocalInputSourceDefn.BASE_DIR_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, LocalInputSourceDefn.FILES_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, LocalInputSourceDefn.FILTER_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, FormattedInputSourceDefn.FORMAT_PARAMETER));
   }
 
   @Test
@@ -198,13 +193,13 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     ExternalTableSpec externSpec = fn.apply("x", args, COLUMNS, mapper);
 
     LocalInputSource sourceSpec = (LocalInputSource) externSpec.inputSource;
-    assertEquals(new File("/tmp"), sourceSpec.getBaseDir());
-    assertEquals("*.csv", sourceSpec.getFilter());
-    assertTrue(sourceSpec.getFiles().isEmpty());
+    Assertions.assertEquals(new File("/tmp"), sourceSpec.getBaseDir());
+    Assertions.assertEquals("*.csv", sourceSpec.getFilter());
+    Assertions.assertTrue(sourceSpec.getFiles().isEmpty());
     validateFormat(externSpec);
 
     // But, it fails if there are no columns.
-    assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
   }
 
   @Test
@@ -218,13 +213,13 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     ExternalTableSpec externSpec = fn.apply("x", args, COLUMNS, mapper);
 
     LocalInputSource sourceSpec = (LocalInputSource) externSpec.inputSource;
-    assertEquals(new File("/tmp"), sourceSpec.getBaseDir());
-    assertEquals("*", sourceSpec.getFilter());
-    assertTrue(sourceSpec.getFiles().isEmpty());
+    Assertions.assertEquals(new File("/tmp"), sourceSpec.getBaseDir());
+    Assertions.assertEquals("*", sourceSpec.getFilter());
+    Assertions.assertTrue(sourceSpec.getFiles().isEmpty());
     validateFormat(externSpec);
 
     // But, it fails if there are no columns.
-    assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
   }
 
   @Test
@@ -238,16 +233,16 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     ExternalTableSpec externSpec = fn.apply("x", args, COLUMNS, mapper);
 
     LocalInputSource sourceSpec = (LocalInputSource) externSpec.inputSource;
-    assertNull(sourceSpec.getBaseDir());
-    assertNull(sourceSpec.getFilter());
-    assertEquals(
+    Assertions.assertNull(sourceSpec.getBaseDir());
+    Assertions.assertNull(sourceSpec.getFilter());
+    Assertions.assertEquals(
         Arrays.asList(new File("/tmp/foo.csv"), new File("/tmp/bar.csv")),
         sourceSpec.getFiles()
     );
     validateFormat(externSpec);
 
     // But, it fails if there are no columns.
-    assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
   }
 
   @Test
@@ -262,16 +257,16 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     ExternalTableSpec externSpec = fn.apply("x", args, COLUMNS, mapper);
 
     LocalInputSource sourceSpec = (LocalInputSource) externSpec.inputSource;
-    assertNull(sourceSpec.getBaseDir());
-    assertNull(sourceSpec.getFilter());
-    assertEquals(
+    Assertions.assertNull(sourceSpec.getBaseDir());
+    Assertions.assertNull(sourceSpec.getFilter());
+    Assertions.assertEquals(
         Arrays.asList(new File("/tmp/foo.csv"), new File("/tmp/bar.csv")),
         sourceSpec.getFiles()
     );
     validateFormat(externSpec);
 
     // But, it fails if there are no columns.
-    assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
   }
 
   @Test
@@ -282,21 +277,21 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     {
       // Empty arguments: not valid
       Map<String, Object> args = new HashMap<>();
-      assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
+      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
     }
 
     {
       // Base dir without filter: not valid.
       Map<String, Object> args = new HashMap<>();
       args.put(LocalInputSourceDefn.BASE_DIR_PARAMETER, "/tmp");
-      assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
+      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
     }
 
     {
       // Filter without base dir: not valid
       Map<String, Object> args = new HashMap<>();
       args.put(LocalInputSourceDefn.FILTER_PARAMETER, "*.csv");
-      assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
+      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
     }
 
     {
@@ -305,7 +300,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
       args.put(LocalInputSourceDefn.BASE_DIR_PARAMETER, "/tmp");
       args.put(LocalInputSourceDefn.FILES_PARAMETER, "/tmp/foo.csv, /tmp/bar.csv");
       args.put(LocalInputSourceDefn.FILTER_PARAMETER, "*.csv");
-      assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
+      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
     }
   }
 
@@ -330,7 +325,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
 
     // Check registry
     TableDefnRegistry registry = new TableDefnRegistry(mapper);
-    assertNotNull(registry.resolve(table.spec()));
+    Assertions.assertNotNull(registry.resolve(table.spec()));
 
     // Convert to an external spec
     ResolvedTable resolved = registry.resolve(table.spec());
@@ -338,26 +333,26 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     ExternalTableSpec externSpec = externDefn.convert(resolved);
 
     LocalInputSource sourceSpec = (LocalInputSource) externSpec.inputSource;
-    assertEquals("/tmp", sourceSpec.getBaseDir().toString());
-    assertEquals("*.csv", sourceSpec.getFilter());
-    assertTrue(sourceSpec.getFiles().isEmpty());
+    Assertions.assertEquals("/tmp", sourceSpec.getBaseDir().toString());
+    Assertions.assertEquals("*.csv", sourceSpec.getFilter());
+    Assertions.assertTrue(sourceSpec.getFiles().isEmpty());
     validateFormat(externSpec);
 
     // Get the partial table function. Since table is fully defined,
     // no parameters available.
     TableFunction fn = externDefn.tableFn(resolved);
-    assertEquals(0, fn.parameters().size());
+    Assertions.assertEquals(0, fn.parameters().size());
 
     // Apply the function with no arguments and no columns (since columns are already defined.)
     externSpec = fn.apply("x", Collections.emptyMap(), Collections.emptyList(), mapper);
     sourceSpec = (LocalInputSource) externSpec.inputSource;
-    assertEquals("/tmp", sourceSpec.getBaseDir().toString());
-    assertEquals("*.csv", sourceSpec.getFilter());
-    assertTrue(sourceSpec.getFiles().isEmpty());
+    Assertions.assertEquals("/tmp", sourceSpec.getBaseDir().toString());
+    Assertions.assertEquals("*.csv", sourceSpec.getFilter());
+    Assertions.assertTrue(sourceSpec.getFiles().isEmpty());
     validateFormat(externSpec);
 
     // Fails if columns are provided.
-    assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), COLUMNS, mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), COLUMNS, mapper));
   }
 
   @Test
@@ -382,7 +377,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
 
     // Check registry
     TableDefnRegistry registry = new TableDefnRegistry(mapper);
-    assertNotNull(registry.resolve(table.spec()));
+    Assertions.assertNotNull(registry.resolve(table.spec()));
 
     // Convert to an external spec
     ResolvedTable resolved = registry.resolve(table.spec());
@@ -390,26 +385,26 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     ExternalTableSpec externSpec = externDefn.convert(resolved);
 
     LocalInputSource sourceSpec = (LocalInputSource) externSpec.inputSource;
-    assertNull(sourceSpec.getBaseDir());
-    assertNull(sourceSpec.getFilter());
-    assertEquals(files, sourceSpec.getFiles());
+    Assertions.assertNull(sourceSpec.getBaseDir());
+    Assertions.assertNull(sourceSpec.getFilter());
+    Assertions.assertEquals(files, sourceSpec.getFiles());
     validateFormat(externSpec);
 
     // Get the partial table function. Since table is fully defined,
     // no parameters available.
     TableFunction fn = externDefn.tableFn(resolved);
-    assertEquals(0, fn.parameters().size());
+    Assertions.assertEquals(0, fn.parameters().size());
 
     // Apply the function with no arguments and no columns (since columns are already defined.)
     externSpec = fn.apply("x", Collections.emptyMap(), Collections.emptyList(), mapper);
     sourceSpec = (LocalInputSource) externSpec.inputSource;
-    assertNull(sourceSpec.getBaseDir());
-    assertNull(sourceSpec.getFilter());
-    assertEquals(files, sourceSpec.getFiles());
+    Assertions.assertNull(sourceSpec.getBaseDir());
+    Assertions.assertNull(sourceSpec.getFilter());
+    Assertions.assertEquals(files, sourceSpec.getFiles());
     validateFormat(externSpec);
 
     // Fails if columns are provided.
-    assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), COLUMNS, mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), COLUMNS, mapper));
   }
 
   @Test
@@ -429,16 +424,16 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     TableDefnRegistry registry = new TableDefnRegistry(mapper);
     ResolvedTable resolved = registry.resolve(table.spec());
     ExternalTableDefn externDefn = (ExternalTableDefn) resolved.defn();
-    assertThrows(IAE.class, () -> externDefn.convert(resolved));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> externDefn.convert(resolved));
 
     // Get the partial table function.
     TableFunction fn = externDefn.tableFn(resolved);
-    assertTrue(hasParam(fn, LocalInputSourceDefn.FILES_PARAMETER));
-    assertTrue(hasParam(fn, LocalInputSourceDefn.FILTER_PARAMETER));
-    assertFalse(hasParam(fn, FormattedInputSourceDefn.FORMAT_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, LocalInputSourceDefn.FILES_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, LocalInputSourceDefn.FILTER_PARAMETER));
+    Assertions.assertFalse(hasParam(fn, FormattedInputSourceDefn.FORMAT_PARAMETER));
 
     // Must provide an additional parameter.
-    assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), Collections.emptyList(), mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), Collections.emptyList(), mapper));
 
     {
       // Create a table with a file pattern.
@@ -447,8 +442,8 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
       // Apply the function with no arguments and no columns (since columns are already defined.)
       ExternalTableSpec externSpec = fn.apply("x", args, Collections.emptyList(), mapper);
       LocalInputSource sourceSpec = (LocalInputSource) externSpec.inputSource;
-      assertEquals("/tmp", sourceSpec.getBaseDir().toString());
-      assertEquals("*.csv", sourceSpec.getFilter());
+      Assertions.assertEquals("/tmp", sourceSpec.getBaseDir().toString());
+      Assertions.assertEquals("*.csv", sourceSpec.getFilter());
       validateFormat(externSpec);
     }
 
@@ -458,13 +453,13 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
       args.put(LocalInputSourceDefn.FILES_PARAMETER, Arrays.asList("foo.csv", "bar.csv"));
       ExternalTableSpec externSpec = fn.apply("x", args, Collections.emptyList(), mapper);
       LocalInputSource sourceSpec = (LocalInputSource) externSpec.inputSource;
-      assertNull(sourceSpec.getBaseDir());
-      assertNull(sourceSpec.getFilter());
-      assertEquals(Arrays.asList(new File("/tmp/foo.csv"), new File("/tmp/bar.csv")), sourceSpec.getFiles());
+      Assertions.assertNull(sourceSpec.getBaseDir());
+      Assertions.assertNull(sourceSpec.getFilter());
+      Assertions.assertEquals(Arrays.asList(new File("/tmp/foo.csv"), new File("/tmp/bar.csv")), sourceSpec.getFiles());
       validateFormat(externSpec);
 
       // Fails if columns are provided.
-      assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
+      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
     }
   }
 
@@ -482,16 +477,16 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     TableDefnRegistry registry = new TableDefnRegistry(mapper);
     ResolvedTable resolved = registry.resolve(table.spec());
     ExternalTableDefn externDefn = (ExternalTableDefn) resolved.defn();
-    assertThrows(IAE.class, () -> externDefn.convert(resolved));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> externDefn.convert(resolved));
 
     // Get the partial table function.
     TableFunction fn = externDefn.tableFn(resolved);
-    assertTrue(hasParam(fn, LocalInputSourceDefn.FILES_PARAMETER));
-    assertTrue(hasParam(fn, LocalInputSourceDefn.FILTER_PARAMETER));
-    assertTrue(hasParam(fn, FormattedInputSourceDefn.FORMAT_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, LocalInputSourceDefn.FILES_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, LocalInputSourceDefn.FILTER_PARAMETER));
+    Assertions.assertTrue(hasParam(fn, FormattedInputSourceDefn.FORMAT_PARAMETER));
 
     // Must provide an additional parameter.
-    assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), Collections.emptyList(), mapper));
+    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), Collections.emptyList(), mapper));
 
     {
       // Create a table with a file pattern and format.
@@ -500,13 +495,13 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
       args.put(FormattedInputSourceDefn.FORMAT_PARAMETER, CsvFormatDefn.TYPE_KEY);
 
       // Function fails without columns, since the table has none.
-      assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
+      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
 
       // Apply the function with no arguments and columns
       ExternalTableSpec externSpec = fn.apply("x", args, COLUMNS, mapper);
       LocalInputSource sourceSpec = (LocalInputSource) externSpec.inputSource;
-      assertEquals("/tmp", sourceSpec.getBaseDir().toString());
-      assertEquals("*.csv", sourceSpec.getFilter());
+      Assertions.assertEquals("/tmp", sourceSpec.getBaseDir().toString());
+      Assertions.assertEquals("*.csv", sourceSpec.getFilter());
       validateFormat(externSpec);
     }
 
@@ -517,14 +512,14 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
       args.put(FormattedInputSourceDefn.FORMAT_PARAMETER, CsvFormatDefn.TYPE_KEY);
 
       // Function fails without columns, since the table has none.
-      assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
+      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
 
       // Provide format and columns.
       ExternalTableSpec externSpec = fn.apply("x", args, COLUMNS, mapper);
       LocalInputSource sourceSpec = (LocalInputSource) externSpec.inputSource;
-      assertNull(sourceSpec.getBaseDir());
-      assertNull(sourceSpec.getFilter());
-      assertEquals(Arrays.asList(new File("/tmp/foo.csv"), new File("/tmp/bar.csv")), sourceSpec.getFiles());
+      Assertions.assertNull(sourceSpec.getBaseDir());
+      Assertions.assertNull(sourceSpec.getFilter());
+      Assertions.assertEquals(Arrays.asList(new File("/tmp/foo.csv"), new File("/tmp/bar.csv")), sourceSpec.getFiles());
       validateFormat(externSpec);
     }
   }
@@ -533,12 +528,12 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
   {
     // Just a sanity check: details of CSV conversion are tested elsewhere.
     CsvInputFormat csvFormat = (CsvInputFormat) externSpec.inputFormat;
-    assertEquals(Arrays.asList("x", "y"), csvFormat.getColumns());
+    Assertions.assertEquals(Arrays.asList("x", "y"), csvFormat.getColumns());
 
     RowSignature sig = externSpec.signature;
-    assertEquals(Arrays.asList("x", "y"), sig.getColumnNames());
-    assertEquals(ColumnType.STRING, sig.getColumnType(0).get());
-    assertEquals(ColumnType.LONG, sig.getColumnType(1).get());
-    assertEquals(Collections.singleton(LocalInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
+    Assertions.assertEquals(Arrays.asList("x", "y"), sig.getColumnNames());
+    Assertions.assertEquals(ColumnType.STRING, sig.getColumnType(0).get());
+    Assertions.assertEquals(ColumnType.LONG, sig.getColumnType(1).get());
+    Assertions.assertEquals(Collections.singleton(LocalInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
   }
 }

--- a/server/src/test/java/org/apache/druid/catalog/model/table/LocalInputSourceDefnTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/LocalInputSourceDefnTest.java
@@ -60,7 +60,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
         .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -74,7 +74,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
         .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -87,7 +87,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
         .inputFormat(CSV_FORMAT)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -168,7 +168,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
         .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> resolved.validate());
+    Assertions.assertThrows(IAE.class, () -> resolved.validate());
   }
 
   @Test
@@ -199,7 +199,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     validateFormat(externSpec);
 
     // But, it fails if there are no columns.
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
+    Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
   }
 
   @Test
@@ -219,7 +219,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     validateFormat(externSpec);
 
     // But, it fails if there are no columns.
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
+    Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
   }
 
   @Test
@@ -242,7 +242,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     validateFormat(externSpec);
 
     // But, it fails if there are no columns.
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
+    Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
   }
 
   @Test
@@ -266,7 +266,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     validateFormat(externSpec);
 
     // But, it fails if there are no columns.
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
+    Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
   }
 
   @Test
@@ -277,21 +277,21 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     {
       // Empty arguments: not valid
       Map<String, Object> args = new HashMap<>();
-      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
+      Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
     }
 
     {
       // Base dir without filter: not valid.
       Map<String, Object> args = new HashMap<>();
       args.put(LocalInputSourceDefn.BASE_DIR_PARAMETER, "/tmp");
-      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
+      Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
     }
 
     {
       // Filter without base dir: not valid
       Map<String, Object> args = new HashMap<>();
       args.put(LocalInputSourceDefn.FILTER_PARAMETER, "*.csv");
-      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
+      Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
     }
 
     {
@@ -300,7 +300,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
       args.put(LocalInputSourceDefn.BASE_DIR_PARAMETER, "/tmp");
       args.put(LocalInputSourceDefn.FILES_PARAMETER, "/tmp/foo.csv, /tmp/bar.csv");
       args.put(LocalInputSourceDefn.FILTER_PARAMETER, "*.csv");
-      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
+      Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
     }
   }
 
@@ -352,7 +352,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     validateFormat(externSpec);
 
     // Fails if columns are provided.
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), COLUMNS, mapper));
+    Assertions.assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), COLUMNS, mapper));
   }
 
   @Test
@@ -404,7 +404,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     validateFormat(externSpec);
 
     // Fails if columns are provided.
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), COLUMNS, mapper));
+    Assertions.assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), COLUMNS, mapper));
   }
 
   @Test
@@ -424,7 +424,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     TableDefnRegistry registry = new TableDefnRegistry(mapper);
     ResolvedTable resolved = registry.resolve(table.spec());
     ExternalTableDefn externDefn = (ExternalTableDefn) resolved.defn();
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> externDefn.convert(resolved));
+    Assertions.assertThrows(IAE.class, () -> externDefn.convert(resolved));
 
     // Get the partial table function.
     TableFunction fn = externDefn.tableFn(resolved);
@@ -433,7 +433,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     Assertions.assertFalse(hasParam(fn, FormattedInputSourceDefn.FORMAT_PARAMETER));
 
     // Must provide an additional parameter.
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), Collections.emptyList(), mapper));
+    Assertions.assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), Collections.emptyList(), mapper));
 
     {
       // Create a table with a file pattern.
@@ -459,7 +459,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
       validateFormat(externSpec);
 
       // Fails if columns are provided.
-      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
+      Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
     }
   }
 
@@ -477,7 +477,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     TableDefnRegistry registry = new TableDefnRegistry(mapper);
     ResolvedTable resolved = registry.resolve(table.spec());
     ExternalTableDefn externDefn = (ExternalTableDefn) resolved.defn();
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> externDefn.convert(resolved));
+    Assertions.assertThrows(IAE.class, () -> externDefn.convert(resolved));
 
     // Get the partial table function.
     TableFunction fn = externDefn.tableFn(resolved);
@@ -486,7 +486,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     Assertions.assertTrue(hasParam(fn, FormattedInputSourceDefn.FORMAT_PARAMETER));
 
     // Must provide an additional parameter.
-    org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), Collections.emptyList(), mapper));
+    Assertions.assertThrows(IAE.class, () -> fn.apply("x", Collections.emptyMap(), Collections.emptyList(), mapper));
 
     {
       // Create a table with a file pattern and format.
@@ -495,7 +495,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
       args.put(FormattedInputSourceDefn.FORMAT_PARAMETER, CsvFormatDefn.TYPE_KEY);
 
       // Function fails without columns, since the table has none.
-      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
+      Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
 
       // Apply the function with no arguments and columns
       ExternalTableSpec externSpec = fn.apply("x", args, COLUMNS, mapper);
@@ -512,7 +512,7 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
       args.put(FormattedInputSourceDefn.FORMAT_PARAMETER, CsvFormatDefn.TYPE_KEY);
 
       // Function fails without columns, since the table has none.
-      org.junit.jupiter.api.Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
+      Assertions.assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
 
       // Provide format and columns.
       ExternalTableSpec externSpec = fn.apply("x", args, COLUMNS, mapper);

--- a/server/src/test/java/org/apache/druid/curator/CuratorConfigTest.java
+++ b/server/src/test/java/org/apache/druid/curator/CuratorConfigTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.curator;
 
 import org.apache.druid.guice.JsonConfigTesterBase;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CuratorConfigTest extends JsonConfigTesterBase<CuratorConfig>
 {
@@ -37,22 +37,22 @@ public class CuratorConfigTest extends JsonConfigTesterBase<CuratorConfig>
     testProperties.putAll(propertyValues);
     configProvider.inject(testProperties, configurator);
     CuratorConfig config = configProvider.get();
-    Assert.assertEquals("fooHost", config.getZkHosts());
-    Assert.assertEquals(true, config.getEnableAcl());
-    Assert.assertEquals("test-zk-user", config.getZkUser());
-    Assert.assertEquals("test-zk-pwd", config.getZkPwd());
-    Assert.assertEquals("auth", config.getAuthScheme());
-    Assert.assertEquals(20, config.getMaxZkRetries());
+    Assertions.assertEquals("fooHost", config.getZkHosts());
+    Assertions.assertEquals(true, config.getEnableAcl());
+    Assertions.assertEquals("test-zk-user", config.getZkUser());
+    Assertions.assertEquals("test-zk-pwd", config.getZkPwd());
+    Assertions.assertEquals("auth", config.getAuthScheme());
+    Assertions.assertEquals(20, config.getMaxZkRetries());
   }
 
   @Test
   public void testCreate()
   {
     CuratorConfig config = CuratorConfig.create("foo:2181,bar:2181");
-    Assert.assertEquals("foo:2181,bar:2181", config.getZkHosts());
-    Assert.assertEquals(false, config.getEnableAcl());
-    Assert.assertNull(config.getZkUser());
-    Assert.assertEquals("digest", config.getAuthScheme());
-    Assert.assertEquals(29, config.getMaxZkRetries());
+    Assertions.assertEquals("foo:2181,bar:2181", config.getZkHosts());
+    Assertions.assertEquals(false, config.getEnableAcl());
+    Assertions.assertNull(config.getZkUser());
+    Assertions.assertEquals("digest", config.getAuthScheme());
+    Assertions.assertEquals(29, config.getMaxZkRetries());
   }
 }

--- a/server/src/test/java/org/apache/druid/guice/BrokerProcessingModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/BrokerProcessingModuleTest.java
@@ -99,15 +99,16 @@ public class BrokerProcessingModuleTest
   @Test
   public void testMemoryCheckThrowsException()
   {
+    // JDK 9 and above do not support checking for direct memory size
+    // so this test only validates functionality for Java 8.
+    try {
+      JvmUtils.getRuntimeInfo().getDirectMemorySizeBytes();
+    }
+    catch (UnsupportedOperationException e) {
+      Assumptions.assumeTrue(false, e::getMessage);
+    }
+
     Assertions.assertThrows(ProvisionException.class, () -> {
-      // JDK 9 and above do not support checking for direct memory size
-      // so this test only validates functionality for Java 8.
-      try {
-        JvmUtils.getRuntimeInfo().getDirectMemorySizeBytes();
-      }
-      catch (UnsupportedOperationException e) {
-        Assumptions.assumeTrue(false, e::getMessage);
-      }
       Properties props = new Properties();
       props.setProperty("druid.processing.buffer.sizeBytes", "3GiB");
       Injector injector1 = makeInjector(props);

--- a/server/src/test/java/org/apache/druid/guice/BrokerProcessingModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/BrokerProcessingModuleTest.java
@@ -31,22 +31,25 @@ import org.apache.druid.initialization.Initialization;
 import org.apache.druid.query.BrokerParallelMergeConfig;
 import org.apache.druid.query.DruidProcessingConfig;
 import org.apache.druid.utils.JvmUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.util.Properties;
 
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class BrokerProcessingModuleTest
 {
   private Injector injector;
   private BrokerProcessingModule target;
-  private AutoCloseable mocks;
   @Mock
   private CacheConfig cacheConfig;
   @Mock
@@ -55,15 +58,8 @@ public class BrokerProcessingModuleTest
   @BeforeEach
   public void setUp()
   {
-    mocks = MockitoAnnotations.openMocks(this);
     target = new BrokerProcessingModule();
     injector = makeInjector(new Properties());
-  }
-
-  @AfterEach
-  public void tearDown() throws Exception
-  {
-    mocks.close();
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/guice/BrokerProcessingModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/BrokerProcessingModuleTest.java
@@ -31,32 +31,39 @@ import org.apache.druid.initialization.Initialization;
 import org.apache.druid.query.BrokerParallelMergeConfig;
 import org.apache.druid.query.DruidProcessingConfig;
 import org.apache.druid.utils.JvmUtils;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 
 import java.util.Properties;
 
 
-@RunWith(MockitoJUnitRunner.class)
 public class BrokerProcessingModuleTest
 {
   private Injector injector;
   private BrokerProcessingModule target;
+  private AutoCloseable mocks;
   @Mock
   private CacheConfig cacheConfig;
   @Mock
   private CachePopulatorStats cachePopulatorStats;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
+    mocks = MockitoAnnotations.openMocks(this);
     target = new BrokerProcessingModule();
     injector = makeInjector(new Properties());
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception
+  {
+    mocks.close();
   }
 
   @Test
@@ -86,27 +93,29 @@ public class BrokerProcessingModuleTest
   public void testCachePopulatorAsSingleton()
   {
     CachePopulator cachePopulator = injector.getInstance(CachePopulator.class);
-    Assert.assertNotNull(cachePopulator);
+    Assertions.assertNotNull(cachePopulator);
   }
 
-  @Test(expected = ProvisionException.class)
+  @Test
   public void testMemoryCheckThrowsException()
   {
-    // JDK 9 and above do not support checking for direct memory size
-    // so this test only validates functionality for Java 8.
-    try {
-      JvmUtils.getRuntimeInfo().getDirectMemorySizeBytes();
-    }
-    catch (UnsupportedOperationException e) {
-      Assume.assumeNoException(e);
-    }
-    Properties props = new Properties();
-    props.setProperty("druid.processing.buffer.sizeBytes", "3GiB");
-    Injector injector1 = makeInjector(props);
+    org.junit.jupiter.api.Assertions.assertThrows(ProvisionException.class, () -> {
+      // JDK 9 and above do not support checking for direct memory size
+      // so this test only validates functionality for Java 8.
+      try {
+        JvmUtils.getRuntimeInfo().getDirectMemorySizeBytes();
+      }
+      catch (UnsupportedOperationException e) {
+        Assumptions.assumeTrue(false, e::getMessage);
+      }
+      Properties props = new Properties();
+      props.setProperty("druid.processing.buffer.sizeBytes", "3GiB");
+      Injector injector1 = makeInjector(props);
 
-    DruidProcessingConfig processingBufferConfig = injector1.getInstance(DruidProcessingConfig.class);
-    BrokerProcessingModule module = new BrokerProcessingModule();
-    module.getMergeBufferPool(processingBufferConfig, JvmUtils.getRuntimeInfo());
+      DruidProcessingConfig processingBufferConfig = injector1.getInstance(DruidProcessingConfig.class);
+      BrokerProcessingModule module = new BrokerProcessingModule();
+      module.getMergeBufferPool(processingBufferConfig, JvmUtils.getRuntimeInfo());
+    });
   }
 
   private Injector makeInjector(Properties props)
@@ -132,4 +141,3 @@ public class BrokerProcessingModuleTest
     return injector;
   }
 }
-

--- a/server/src/test/java/org/apache/druid/guice/BrokerProcessingModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/BrokerProcessingModuleTest.java
@@ -99,7 +99,7 @@ public class BrokerProcessingModuleTest
   @Test
   public void testMemoryCheckThrowsException()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(ProvisionException.class, () -> {
+    Assertions.assertThrows(ProvisionException.class, () -> {
       // JDK 9 and above do not support checking for direct memory size
       // so this test only validates functionality for Java 8.
       try {

--- a/server/src/test/java/org/apache/druid/guice/DefaultServerHolderModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/DefaultServerHolderModuleTest.java
@@ -27,8 +27,8 @@ import org.apache.druid.java.util.metrics.NoopTaskHolder;
 import org.apache.druid.java.util.metrics.TaskHolder;
 import org.apache.druid.server.metrics.DefaultLoadSpecHolder;
 import org.apache.druid.server.metrics.LoadSpecHolder;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -39,24 +39,24 @@ public class DefaultServerHolderModuleTest
   public void testModuleLoadedForNonPeonRoles()
   {
     final Injector injector = makeInjector(Set.of());
-    Assert.assertTrue(injector.getInstance(TaskHolder.class) instanceof NoopTaskHolder);
-    Assert.assertTrue(injector.getInstance(LoadSpecHolder.class) instanceof DefaultLoadSpecHolder);
+    Assertions.assertTrue(injector.getInstance(TaskHolder.class) instanceof NoopTaskHolder);
+    Assertions.assertTrue(injector.getInstance(LoadSpecHolder.class) instanceof DefaultLoadSpecHolder);
   }
 
   @Test
   public void testModuleExcludedForPeonRole()
   {
     final Injector injector = makeInjector(Set.of(NodeRole.PEON));
-    Assert.assertThrows(
-        "TaskHolder should not be bound for Peon servers",
+    Assertions.assertThrows(
         ConfigurationException.class,
-        () -> injector.getInstance(TaskHolder.class)
+        () -> injector.getInstance(TaskHolder.class),
+        "TaskHolder should not be bound for Peon servers"
     );
 
-    Assert.assertThrows(
-        "LoadSpecHolder should not be bound for Peon servers",
+    Assertions.assertThrows(
         ConfigurationException.class,
-        () -> injector.getInstance(LoadSpecHolder.class)
+        () -> injector.getInstance(LoadSpecHolder.class),
+        "LoadSpecHolder should not be bound for Peon servers"
     );
   }
 

--- a/server/src/test/java/org/apache/druid/guice/DruidInjectorBuilderTest.java
+++ b/server/src/test/java/org/apache/druid/guice/DruidInjectorBuilderTest.java
@@ -35,17 +35,16 @@ import org.apache.druid.guice.annotations.LoadScope;
 import org.apache.druid.initialization.CoreInjectorBuilder;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.java.util.common.ISE;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 public class DruidInjectorBuilderTest
 {
@@ -117,7 +116,7 @@ public class DruidInjectorBuilderTest
 
     // Returns explicit properties
     Properties propsInstance = injector.getInstance(Properties.class);
-    assertSame(props, propsInstance);
+    Assertions.assertSame(props, propsInstance);
   }
 
   /**
@@ -141,21 +140,21 @@ public class DruidInjectorBuilderTest
         .build();
 
     // Verify injection occurred
-    assertSame(props, guiceModule.properties);
-    assertSame(props, druidModule.properties);
+    Assertions.assertSame(props, guiceModule.properties);
+    Assertions.assertSame(props, druidModule.properties);
     verifyInjector(injector);
   }
 
   private void verifyInjector(Injector injector) throws IOException
   {
     // Guice module did its thing
-    assertTrue(injector.getInstance(MockInterface.class) instanceof MockComponent);
+    Assertions.assertTrue(injector.getInstance(MockInterface.class) instanceof MockComponent);
 
     // And that the Druid module set up Jackson.
     String json = "{\"type\": \"extn\"}";
     ObjectMapper om = injector.getInstance(Key.get(ObjectMapper.class, Json.class));
     MockObject obj = om.readValue(json, MockObject.class);
-    assertTrue(obj instanceof MockObjectExtension);
+    Assertions.assertTrue(obj instanceof MockObjectExtension);
   }
 
   /**
@@ -190,7 +189,7 @@ public class DruidInjectorBuilderTest
           .withEmptyProperties()
           .build()
     );
-    assertThrows(ISE.class, () -> builder.addInput("I'm not a module"));
+    org.junit.jupiter.api.Assertions.assertThrows(ISE.class, () -> builder.addInput("I'm not a module"));
   }
 
   @Test
@@ -202,7 +201,7 @@ public class DruidInjectorBuilderTest
           .withEmptyProperties()
           .build()
     );
-    assertThrows(ISE.class, () -> builder.addInput(Object.class));
+    org.junit.jupiter.api.Assertions.assertThrows(ISE.class, () -> builder.addInput(Object.class));
   }
 
   @Test
@@ -254,7 +253,7 @@ public class DruidInjectorBuilderTest
         .addInput(MockDruidModule.class)
         .build();
 
-    assertThrows(IOException.class, () -> verifyInjector(injector));
+    org.junit.jupiter.api.Assertions.assertThrows(IOException.class, () -> verifyInjector(injector));
   }
 
   @Test
@@ -286,7 +285,7 @@ public class DruidInjectorBuilderTest
         .addModules(new MockGuiceModule(), new MockRoleModule())
         .build();
 
-    assertThrows(IOException.class, () -> verifyInjector(injector));
+    org.junit.jupiter.api.Assertions.assertThrows(IOException.class, () -> verifyInjector(injector));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/guice/DruidInjectorBuilderTest.java
+++ b/server/src/test/java/org/apache/druid/guice/DruidInjectorBuilderTest.java
@@ -189,7 +189,7 @@ public class DruidInjectorBuilderTest
           .withEmptyProperties()
           .build()
     );
-    org.junit.jupiter.api.Assertions.assertThrows(ISE.class, () -> builder.addInput("I'm not a module"));
+    Assertions.assertThrows(ISE.class, () -> builder.addInput("I'm not a module"));
   }
 
   @Test
@@ -201,7 +201,7 @@ public class DruidInjectorBuilderTest
           .withEmptyProperties()
           .build()
     );
-    org.junit.jupiter.api.Assertions.assertThrows(ISE.class, () -> builder.addInput(Object.class));
+    Assertions.assertThrows(ISE.class, () -> builder.addInput(Object.class));
   }
 
   @Test
@@ -253,7 +253,7 @@ public class DruidInjectorBuilderTest
         .addInput(MockDruidModule.class)
         .build();
 
-    org.junit.jupiter.api.Assertions.assertThrows(IOException.class, () -> verifyInjector(injector));
+    Assertions.assertThrows(IOException.class, () -> verifyInjector(injector));
   }
 
   @Test
@@ -285,7 +285,7 @@ public class DruidInjectorBuilderTest
         .addModules(new MockGuiceModule(), new MockRoleModule())
         .build();
 
-    org.junit.jupiter.api.Assertions.assertThrows(IOException.class, () -> verifyInjector(injector));
+    Assertions.assertThrows(IOException.class, () -> verifyInjector(injector));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/guice/DruidProcessingModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/DruidProcessingModuleTest.java
@@ -22,42 +22,45 @@ package org.apache.druid.guice;
 import com.google.inject.ProvisionException;
 import org.apache.druid.query.DruidProcessingConfig;
 import org.apache.druid.utils.JvmUtils;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
 
 public class DruidProcessingModuleTest
 {
 
-  @Test(expected = ProvisionException.class)
+  @Test
   public void testMemoryCheckThrowsException()
   {
-    // JDK 9 and above do not support checking for direct memory size
-    // so this test only validates functionality for Java 8.
-    try {
-      JvmUtils.getRuntimeInfo().getDirectMemorySizeBytes();
-    }
-    catch (UnsupportedOperationException e) {
-      Assume.assumeNoException(e);
-    }
+    org.junit.jupiter.api.Assertions.assertThrows(ProvisionException.class, () -> {
+      // JDK 9 and above do not support checking for direct memory size
+      // so this test only validates functionality for Java 8.
+      try {
+        JvmUtils.getRuntimeInfo().getDirectMemorySizeBytes();
+      }
+      catch (UnsupportedOperationException e) {
+        Assumptions.assumeTrue(false, e::getMessage);
+      }
 
-    DruidProcessingModule module = new DruidProcessingModule();
-    module.getIntermediateResultsPool(
-        new DruidProcessingConfig()
-        {
-          @Override
-          public String getFormatString()
+      DruidProcessingModule module = new DruidProcessingModule();
+      module.getIntermediateResultsPool(
+          new DruidProcessingConfig()
           {
-            return "test";
-          }
+            @Override
+            public String getFormatString()
+            {
+              return "test";
+            }
 
-          @Override
-          public int intermediateComputeSizeBytes()
-          {
-            return Integer.MAX_VALUE;
-          }
-        },
-        JvmUtils.getRuntimeInfo()
-    );
+            @Override
+            public int intermediateComputeSizeBytes()
+            {
+              return Integer.MAX_VALUE;
+            }
+          },
+          JvmUtils.getRuntimeInfo()
+      );
+    });
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/guice/DruidProcessingModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/DruidProcessingModuleTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.guice;
 import com.google.inject.ProvisionException;
 import org.apache.druid.query.DruidProcessingConfig;
 import org.apache.druid.utils.JvmUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +33,7 @@ public class DruidProcessingModuleTest
   @Test
   public void testMemoryCheckThrowsException()
   {
-    org.junit.jupiter.api.Assertions.assertThrows(ProvisionException.class, () -> {
+    Assertions.assertThrows(ProvisionException.class, () -> {
       // JDK 9 and above do not support checking for direct memory size
       // so this test only validates functionality for Java 8.
       try {

--- a/server/src/test/java/org/apache/druid/guice/DruidProcessingModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/DruidProcessingModuleTest.java
@@ -33,16 +33,16 @@ public class DruidProcessingModuleTest
   @Test
   public void testMemoryCheckThrowsException()
   {
-    Assertions.assertThrows(ProvisionException.class, () -> {
-      // JDK 9 and above do not support checking for direct memory size
-      // so this test only validates functionality for Java 8.
-      try {
-        JvmUtils.getRuntimeInfo().getDirectMemorySizeBytes();
-      }
-      catch (UnsupportedOperationException e) {
-        Assumptions.assumeTrue(false, e::getMessage);
-      }
+    // JDK 9 and above do not support checking for direct memory size
+    // so this test only validates functionality for Java 8.
+    try {
+      JvmUtils.getRuntimeInfo().getDirectMemorySizeBytes();
+    }
+    catch (UnsupportedOperationException e) {
+      Assumptions.assumeTrue(false, e::getMessage);
+    }
 
+    Assertions.assertThrows(ProvisionException.class, () -> {
       DruidProcessingModule module = new DruidProcessingModule();
       module.getIntermediateResultsPool(
           new DruidProcessingConfig()
@@ -81,4 +81,3 @@ public class DruidProcessingModuleTest
     module.getIntermediateResultsPool(config, JvmUtils.getRuntimeInfo());
   }
 }
-

--- a/server/src/test/java/org/apache/druid/guice/JavaScriptModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/JavaScriptModuleTest.java
@@ -25,8 +25,8 @@ import com.google.inject.Injector;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import org.apache.druid.js.JavaScriptConfig;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -36,7 +36,7 @@ public class JavaScriptModuleTest
   public void testInjectionDefault()
   {
     JavaScriptConfig config = makeInjectorWithProperties(new Properties()).getInstance(JavaScriptConfig.class);
-    Assert.assertFalse(config.isEnabled());
+    Assertions.assertFalse(config.isEnabled());
   }
 
   @Test
@@ -45,7 +45,7 @@ public class JavaScriptModuleTest
     final Properties props = new Properties();
     props.setProperty("druid.javascript.enabled", "true");
     JavaScriptConfig config = makeInjectorWithProperties(props).getInstance(JavaScriptConfig.class);
-    Assert.assertTrue(config.isEnabled());
+    Assertions.assertTrue(config.isEnabled());
   }
 
   private Injector makeInjectorWithProperties(final Properties props)

--- a/server/src/test/java/org/apache/druid/guice/JoinableFactoryModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/JoinableFactoryModuleTest.java
@@ -41,9 +41,9 @@ import org.apache.druid.segment.join.NoopDataSource;
 import org.apache.druid.segment.join.NoopJoinableFactory;
 import org.apache.druid.server.SegmentManager;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
@@ -53,7 +53,7 @@ public class JoinableFactoryModuleTest
 {
   private Injector injector;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     injector = makeInjectorWithProperties();
@@ -63,9 +63,9 @@ public class JoinableFactoryModuleTest
   public void testInjectJoinableFactoryIsSingleton()
   {
     JoinableFactory factory = injector.getInstance(JoinableFactory.class);
-    Assert.assertEquals(MapJoinableFactory.class, factory.getClass());
+    Assertions.assertEquals(MapJoinableFactory.class, factory.getClass());
     JoinableFactory otherFactory = injector.getInstance(JoinableFactory.class);
-    Assert.assertSame(factory, otherFactory);
+    Assertions.assertSame(factory, otherFactory);
   }
 
   @Test
@@ -73,7 +73,7 @@ public class JoinableFactoryModuleTest
   {
     final Set<JoinableFactory> factories =
         injector.getInstance(Key.get(new TypeLiteral<>() {}));
-    Assert.assertEquals(JoinableFactoryModule.FACTORY_MAPPINGS.size(), factories.size());
+    Assertions.assertEquals(JoinableFactoryModule.FACTORY_MAPPINGS.size(), factories.size());
     Map<Class<? extends JoinableFactory>, Class<? extends DataSource>> joinableFactoriesMappings = injector.getInstance(
         Key.get(new TypeLiteral<>() {})
     );
@@ -94,8 +94,8 @@ public class JoinableFactoryModuleTest
     );
     Set<JoinableFactory> factories = injector.getInstance(Key.get(new TypeLiteral<>() {}));
 
-    Assert.assertEquals(JoinableFactoryModule.FACTORY_MAPPINGS.size() + 1, factories.size());
-    Assert.assertEquals(NoopDataSource.class, joinableFactoriesMappings.get(NoopJoinableFactory.class));
+    Assertions.assertEquals(JoinableFactoryModule.FACTORY_MAPPINGS.size() + 1, factories.size());
+    Assertions.assertEquals(NoopDataSource.class, joinableFactoriesMappings.get(NoopJoinableFactory.class));
     assertDefaultFactories(joinableFactoriesMappings);
   }
 
@@ -103,9 +103,9 @@ public class JoinableFactoryModuleTest
       Map<Class<? extends JoinableFactory>, Class<? extends DataSource>> joinableFactoriesMappings
   )
   {
-    Assert.assertEquals(LookupDataSource.class, joinableFactoriesMappings.get(LookupJoinableFactory.class));
-    Assert.assertEquals(InlineDataSource.class, joinableFactoriesMappings.get(InlineJoinableFactory.class));
-    Assert.assertEquals(
+    Assertions.assertEquals(LookupDataSource.class, joinableFactoriesMappings.get(LookupJoinableFactory.class));
+    Assertions.assertEquals(InlineDataSource.class, joinableFactoriesMappings.get(InlineJoinableFactory.class));
+    Assertions.assertEquals(
         GlobalTableDataSource.class,
         joinableFactoriesMappings.get(BroadcastTableJoinableFactory.class)
     );

--- a/server/src/test/java/org/apache/druid/guice/JsonConfigTesterBase.java
+++ b/server/src/test/java/org/apache/druid/guice/JsonConfigTesterBase.java
@@ -28,9 +28,9 @@ import com.google.inject.name.Names;
 import org.apache.druid.initialization.Initialization;
 import org.apache.druid.java.util.common.StringUtils;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -109,7 +109,7 @@ public abstract class JsonConfigTesterBase<T>
           value = field.get(config).toString();
         }
 
-        Assert.assertEquals(propertyValues.get(propertyKey), value);
+        Assertions.assertEquals(propertyValues.get(propertyKey), value);
         ++assertions;
       }
     }
@@ -118,7 +118,7 @@ public abstract class JsonConfigTesterBase<T>
   protected JsonConfigurator configurator;
   protected JsonConfigProvider<T> configProvider;
 
-  @Before
+  @BeforeEach
   public void setup() throws IllegalAccessException
   {
     assertions = 0;
@@ -157,7 +157,7 @@ public abstract class JsonConfigTesterBase<T>
   {
     configProvider.inject(testProperties, configurator);
     validateEntries(configProvider.get());
-    Assert.assertEquals(propertyValues.size(), assertions);
+    Assertions.assertEquals(propertyValues.size(), assertions);
   }
 
 

--- a/server/src/test/java/org/apache/druid/guice/JsonConfigTesterBaseTest.java
+++ b/server/src/test/java/org/apache/druid/guice/JsonConfigTesterBaseTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.guice;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
@@ -36,14 +36,14 @@ public final class JsonConfigTesterBaseTest
   @Test
   public void defaultTestPropertiesForSample()
   {
-    Assert.assertEquals("0", testProperties.getProperty("druid.test.prefix.primitiveInt"));
-    Assert.assertEquals("false", testProperties.getProperty("druid.test.prefix.primitiveBoolean"));
-    Assert.assertTrue(!testProperties.getProperty("druid.test.prefix.text").isEmpty());
-    Assert.assertEquals("[]", testProperties.getProperty("druid.test.prefix.list"));
-    Assert.assertEquals("[]", testProperties.getProperty("druid.test.prefix.set"));
-    Assert.assertEquals("{}", testProperties.getProperty("druid.test.prefix.map"));
+    Assertions.assertEquals("0", testProperties.getProperty("druid.test.prefix.primitiveInt"));
+    Assertions.assertEquals("false", testProperties.getProperty("druid.test.prefix.primitiveBoolean"));
+    Assertions.assertTrue(!testProperties.getProperty("druid.test.prefix.text").isEmpty());
+    Assertions.assertEquals("[]", testProperties.getProperty("druid.test.prefix.list"));
+    Assertions.assertEquals("[]", testProperties.getProperty("druid.test.prefix.set"));
+    Assertions.assertEquals("{}", testProperties.getProperty("druid.test.prefix.map"));
     for (Map.Entry entry : System.getProperties().entrySet()) {
-      Assert.assertEquals(entry.getValue(), testProperties.getProperty(String.valueOf(entry.getKey())));
+      Assertions.assertEquals(entry.getValue(), testProperties.getProperty(String.valueOf(entry.getKey())));
     }
   }
 
@@ -60,24 +60,24 @@ public final class JsonConfigTesterBaseTest
     configProvider.inject(testProperties, configurator);
     Sample results = configProvider.get();
 
-    Assert.assertEquals(1, results.getPrimitiveInt());
-    Assert.assertTrue(results.getPrimitiveBoolean());
-    Assert.assertEquals("foo", results.getText());
+    Assertions.assertEquals(1, results.getPrimitiveInt());
+    Assertions.assertTrue(results.getPrimitiveBoolean());
+    Assertions.assertEquals("foo", results.getText());
 
     List<String> list = results.getList();
-    Assert.assertEquals(2, list.size());
-    Assert.assertEquals("one", list.get(0));
-    Assert.assertEquals("two", list.get(1));
+    Assertions.assertEquals(2, list.size());
+    Assertions.assertEquals("one", list.get(0));
+    Assertions.assertEquals("two", list.get(1));
 
     Set<String> set = results.getSet();
-    Assert.assertEquals(2, set.size());
-    Assert.assertTrue(set.contains("three"));
-    Assert.assertTrue(set.contains("four"));
+    Assertions.assertEquals(2, set.size());
+    Assertions.assertTrue(set.contains("three"));
+    Assertions.assertTrue(set.contains("four"));
 
     Map<String, String> map = results.getMap();
-    Assert.assertEquals(2, map.size());
-    Assert.assertEquals("v1", map.get("k1"));
-    Assert.assertEquals("v2", map.get("k2"));
+    Assertions.assertEquals(2, map.size());
+    Assertions.assertEquals("v1", map.get("k1"));
+    Assertions.assertEquals("v2", map.get("k2"));
   }
 
   public static class Sample

--- a/server/src/test/java/org/apache/druid/guice/LocalDataStorageDruidModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/LocalDataStorageDruidModuleTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.segment.loading.OmniDataSegmentKiller;
 import org.apache.druid.segment.loading.RandomStorageLocationSelectorStrategy;
 import org.apache.druid.segment.loading.StorageLocation;
 import org.apache.druid.segment.loading.StorageLocationSelectorStrategy;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -40,8 +40,8 @@ public class LocalDataStorageDruidModuleTest
   {
     Injector injector = createInjector();
     OmniDataSegmentKiller killer = injector.getInstance(OmniDataSegmentKiller.class);
-    Assert.assertTrue(killer.getKillers().containsKey(LocalDataStorageDruidModule.SCHEME));
-    Assert.assertSame(
+    Assertions.assertTrue(killer.getKillers().containsKey(LocalDataStorageDruidModule.SCHEME));
+    Assertions.assertSame(
         killer.getKillers().get(LocalDataStorageDruidModule.SCHEME).get(),
         killer.getKillers().get(LocalDataStorageDruidModule.SCHEME).get()
     );

--- a/server/src/test/java/org/apache/druid/guice/QueryableModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/QueryableModuleTest.java
@@ -36,8 +36,8 @@ import org.apache.druid.server.log.NoopRequestLoggerProvider;
 import org.apache.druid.server.log.RequestLogger;
 import org.apache.druid.server.log.RequestLoggerProvider;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -52,9 +52,9 @@ public class QueryableModuleTest
     properties.setProperty("druid.request.logging.feed", "requestlog");
     final Injector injector = makeInjector(properties);
     RequestLoggerProvider emittingRequestLoggerProvider = injector.getInstance(RequestLoggerProvider.class);
-    Assert.assertTrue(emittingRequestLoggerProvider instanceof EmittingRequestLoggerProvider);
+    Assertions.assertTrue(emittingRequestLoggerProvider instanceof EmittingRequestLoggerProvider);
     RequestLogger requestLogger = emittingRequestLoggerProvider.get();
-    Assert.assertTrue(requestLogger instanceof EmittingRequestLogger);
+    Assertions.assertTrue(requestLogger instanceof EmittingRequestLogger);
   }
 
   @Test
@@ -63,9 +63,9 @@ public class QueryableModuleTest
     Properties properties = new Properties();
     final Injector injector = makeInjector(properties);
     RequestLoggerProvider emittingRequestLoggerProvider = injector.getInstance(RequestLoggerProvider.class);
-    Assert.assertTrue(emittingRequestLoggerProvider instanceof NoopRequestLoggerProvider);
+    Assertions.assertTrue(emittingRequestLoggerProvider instanceof NoopRequestLoggerProvider);
     RequestLogger requestLogger = emittingRequestLoggerProvider.get();
-    Assert.assertTrue(requestLogger instanceof NoopRequestLogger);
+    Assertions.assertTrue(requestLogger instanceof NoopRequestLogger);
   }
 
 

--- a/server/src/test/java/org/apache/druid/guice/StorageNodeModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/StorageNodeModuleTest.java
@@ -37,16 +37,20 @@ import org.apache.druid.segment.loading.StorageLocationConfig;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.ServerType;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.util.Collections;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class StorageNodeModuleTest
 {
   private static final boolean INJECT_SERVER_TYPE_CONFIG = true;
@@ -61,24 +65,16 @@ public class StorageNodeModuleTest
   private StorageLocationConfig storageLocation;
 
   private StorageNodeModule target;
-  private AutoCloseable mocks;
 
   @BeforeEach
   public void setUp()
   {
-    mocks = MockitoAnnotations.openMocks(this);
     self = new DruidNode("test", "test-host", true, 80, 443, false, true);
     serverTypeConfig = new ServerTypeConfig(ServerType.HISTORICAL);
 
-    Mockito.when(segmentLoaderConfig.getLocations()).thenReturn(Collections.singletonList(storageLocation));
+    Mockito.lenient().when(segmentLoaderConfig.getLocations()).thenReturn(Collections.singletonList(storageLocation));
 
     target = new StorageNodeModule();
-  }
-
-  @AfterEach
-  public void tearDown() throws Exception
-  {
-    mocks.close();
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/guice/StorageNodeModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/StorageNodeModuleTest.java
@@ -37,17 +37,16 @@ import org.apache.druid.segment.loading.StorageLocationConfig;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.ServerType;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 
 import java.util.Collections;
 
-@RunWith(MockitoJUnitRunner.class)
 public class StorageNodeModuleTest
 {
   private static final boolean INJECT_SERVER_TYPE_CONFIG = true;
@@ -62,10 +61,12 @@ public class StorageNodeModuleTest
   private StorageLocationConfig storageLocation;
 
   private StorageNodeModule target;
+  private AutoCloseable mocks;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
+    mocks = MockitoAnnotations.openMocks(this);
     self = new DruidNode("test", "test-host", true, 80, 443, false, true);
     serverTypeConfig = new ServerTypeConfig(ServerType.HISTORICAL);
 
@@ -74,14 +75,20 @@ public class StorageNodeModuleTest
     target = new StorageNodeModule();
   }
 
+  @AfterEach
+  public void tearDown() throws Exception
+  {
+    mocks.close();
+  }
+
   @Test
   public void testIsSegmentCacheConfiguredIsInjected()
   {
     Boolean isSegmentCacheConfigured = injector().getInstance(
         Key.get(Boolean.class, Names.named(StorageNodeModule.IS_SEGMENT_CACHE_CONFIGURED))
     );
-    Assert.assertNotNull(isSegmentCacheConfigured);
-    Assert.assertTrue(isSegmentCacheConfigured);
+    Assertions.assertNotNull(isSegmentCacheConfigured);
+    Assertions.assertTrue(isSegmentCacheConfigured);
   }
 
   @Test
@@ -91,8 +98,8 @@ public class StorageNodeModuleTest
     Boolean isSegmentCacheConfigured = injector().getInstance(
         Key.get(Boolean.class, Names.named(StorageNodeModule.IS_SEGMENT_CACHE_CONFIGURED))
     );
-    Assert.assertNotNull(isSegmentCacheConfigured);
-    Assert.assertFalse(isSegmentCacheConfigured);
+    Assertions.assertNotNull(isSegmentCacheConfigured);
+    Assertions.assertFalse(isSegmentCacheConfigured);
   }
 
   @Test
@@ -123,18 +130,18 @@ public class StorageNodeModuleTest
     final Injector injector = injector();
 
     DataNodeService dataNodeService = injector.getInstance(DataNodeService.class);
-    Assert.assertNotNull(dataNodeService);
+    Assertions.assertNotNull(dataNodeService);
 
     DataNodeService other = injector.getInstance(DataNodeService.class);
-    Assert.assertSame(dataNodeService, other);
+    Assertions.assertSame(dataNodeService, other);
   }
 
   @Test
   public void getDataNodeServiceIsInjectedAndDiscoverable()
   {
     DataNodeService dataNodeService = injector().getInstance(DataNodeService.class);
-    Assert.assertNotNull(dataNodeService);
-    Assert.assertTrue(dataNodeService.isDiscoverable());
+    Assertions.assertNotNull(dataNodeService);
+    Assertions.assertTrue(dataNodeService.isDiscoverable());
   }
 
   @Test
@@ -143,8 +150,8 @@ public class StorageNodeModuleTest
     mockSegmentCacheNotConfigured();
     serverTypeConfig = new ServerTypeConfig(ServerType.BROKER);
     DataNodeService dataNodeService = injector().getInstance(DataNodeService.class);
-    Assert.assertNotNull(dataNodeService);
-    Assert.assertFalse(dataNodeService.isDiscoverable());
+    Assertions.assertNotNull(dataNodeService);
+    Assertions.assertFalse(dataNodeService.isDiscoverable());
   }
 
   @Test
@@ -152,10 +159,10 @@ public class StorageNodeModuleTest
   {
     final Injector injector = injector();
     DruidServerMetadata druidServerMetadata = injector.getInstance(DruidServerMetadata.class);
-    Assert.assertNotNull(druidServerMetadata);
+    Assertions.assertNotNull(druidServerMetadata);
 
     DruidServerMetadata other = injector.getInstance(DruidServerMetadata.class);
-    Assert.assertSame(druidServerMetadata, other);
+    Assertions.assertSame(druidServerMetadata, other);
   }
 
   @Test
@@ -182,7 +189,7 @@ public class StorageNodeModuleTest
         Key.get(StorageLoadingThreadPool.class, EphemeralStorageLoading.class)
     );
     try {
-      Assert.assertTrue(pool.isAvailable());
+      Assertions.assertTrue(pool.isAvailable());
     }
     finally {
       pool.stop();

--- a/server/src/test/java/org/apache/druid/guice/security/DruidAuthModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/security/DruidAuthModuleTest.java
@@ -30,9 +30,9 @@ import org.apache.druid.guice.JsonConfigurator;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.jackson.JacksonModule;
 import org.apache.druid.server.security.AuthConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -41,7 +41,7 @@ public class DruidAuthModuleTest
   private Injector injector;
   private DruidAuthModule authModule;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     authModule = new DruidAuthModule();
@@ -60,8 +60,8 @@ public class DruidAuthModuleTest
   {
     AuthConfig config1 = injector.getInstance(AuthConfig.class);
     AuthConfig config2 = injector.getInstance(AuthConfig.class);
-    Assert.assertNotNull(config1);
-    Assert.assertSame(config1, config2);
+    Assertions.assertNotNull(config1);
+    Assertions.assertSame(config1, config2);
   }
 
   @Test
@@ -69,12 +69,12 @@ public class DruidAuthModuleTest
   {
     Properties properties = new Properties();
     final AuthConfig authConfig = injectProperties(properties);
-    Assert.assertNotNull(authConfig);
-    Assert.assertNull(authConfig.getAuthenticatorChain());
-    Assert.assertNull(authConfig.getAuthorizers());
-    Assert.assertTrue(authConfig.getUnsecuredPaths().isEmpty());
-    Assert.assertFalse(authConfig.isAllowUnauthenticatedHttpOptions());
-    Assert.assertFalse(authConfig.authorizeQueryContextParams());
+    Assertions.assertNotNull(authConfig);
+    Assertions.assertNull(authConfig.getAuthenticatorChain());
+    Assertions.assertNull(authConfig.getAuthorizers());
+    Assertions.assertTrue(authConfig.getUnsecuredPaths().isEmpty());
+    Assertions.assertFalse(authConfig.isAllowUnauthenticatedHttpOptions());
+    Assertions.assertFalse(authConfig.authorizeQueryContextParams());
   }
 
   @Test
@@ -88,11 +88,11 @@ public class DruidAuthModuleTest
     properties.setProperty("druid.auth.authorizeQueryContextParams", "true");
 
     final AuthConfig authConfig = injectProperties(properties);
-    Assert.assertNotNull(authConfig);
-    Assert.assertEquals(ImmutableList.of("chain", "of", "authenticators"), authConfig.getAuthenticatorChain());
-    Assert.assertEquals(ImmutableList.of("authorizers", "list"), authConfig.getAuthorizers());
-    Assert.assertEquals(ImmutableList.of("path1", "path2"), authConfig.getUnsecuredPaths());
-    Assert.assertTrue(authConfig.authorizeQueryContextParams());
+    Assertions.assertNotNull(authConfig);
+    Assertions.assertEquals(ImmutableList.of("chain", "of", "authenticators"), authConfig.getAuthenticatorChain());
+    Assertions.assertEquals(ImmutableList.of("authorizers", "list"), authConfig.getAuthorizers());
+    Assertions.assertEquals(ImmutableList.of("path1", "path2"), authConfig.getUnsecuredPaths());
+    Assertions.assertTrue(authConfig.authorizeQueryContextParams());
   }
 
   private AuthConfig injectProperties(Properties properties)

--- a/server/src/test/java/org/apache/druid/guice/security/PolicyModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/security/PolicyModuleTest.java
@@ -33,8 +33,8 @@ import org.apache.druid.query.policy.NoopPolicyEnforcer;
 import org.apache.druid.query.policy.PolicyEnforcer;
 import org.apache.druid.query.policy.RestrictAllTablesPolicyEnforcer;
 import org.apache.druid.query.policy.RowFilterPolicy;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -50,8 +50,8 @@ public class PolicyModuleTest
         new ConfigModule(),
         new PolicyModule()
     ).getInstance(Key.get(PolicyEnforcer.class));
-    Assert.assertNotNull(policyEnforcer);
-    Assert.assertTrue(policyEnforcer instanceof NoopPolicyEnforcer);
+    Assertions.assertNotNull(policyEnforcer);
+    Assertions.assertTrue(policyEnforcer instanceof NoopPolicyEnforcer);
   }
 
   @Test
@@ -65,11 +65,11 @@ public class PolicyModuleTest
         new ConfigModule(),
         new PolicyModule()
     );
-    ProvisionException e = Assert.assertThrows(
+    ProvisionException e = Assertions.assertThrows(
         ProvisionException.class,
         () -> injector.getInstance(Key.get(PolicyEnforcer.class))
     );
-    Assert.assertTrue(e.getCause()
+    Assertions.assertTrue(e.getCause()
                        .getMessage()
                        .contains(
                            "Could not resolve type id 'unrecognizedType' as a subtype of `org.apache.druid.query.policy.PolicyEnforcer`"));
@@ -88,8 +88,8 @@ public class PolicyModuleTest
         new PolicyModule()
     ).getInstance(Key.get(PolicyEnforcer.class));
 
-    Assert.assertNotNull(policyEnforcer);
-    Assert.assertEquals(new RestrictAllTablesPolicyEnforcer(null), policyEnforcer);
+    Assertions.assertNotNull(policyEnforcer);
+    Assertions.assertEquals(new RestrictAllTablesPolicyEnforcer(null), policyEnforcer);
   }
 
   @Test
@@ -109,12 +109,12 @@ public class PolicyModuleTest
         new PolicyModule()
     ).getInstance(Key.get(PolicyEnforcer.class));
 
-    Assert.assertNotNull(policyEnforcer);
-    Assert.assertEquals(new RestrictAllTablesPolicyEnforcer(ImmutableList.of(
+    Assertions.assertNotNull(policyEnforcer);
+    Assertions.assertEquals(new RestrictAllTablesPolicyEnforcer(ImmutableList.of(
         "some-policy-class",
         "org.apache.druid.query.policy.NoRestrictionPolicy"
     )), policyEnforcer);
-    Assert.assertTrue(policyEnforcer.validate(NoRestrictionPolicy.instance()));
-    Assert.assertFalse(policyEnforcer.validate(RowFilterPolicy.from(new NullFilter("some-col", null))));
+    Assertions.assertTrue(policyEnforcer.validate(NoRestrictionPolicy.instance()));
+    Assertions.assertFalse(policyEnforcer.validate(RowFilterPolicy.from(new NullFilter("some-col", null))));
   }
 }

--- a/server/src/test/java/org/apache/druid/indexing/ClientCompactQueryTuningConfigTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/ClientCompactQueryTuningConfigTest.java
@@ -23,7 +23,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.client.indexing.ClientCompactionTaskQueryTuningConfig;
 import org.apache.druid.segment.IndexSpec;
 import org.apache.druid.segment.data.CompressionStrategy;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ClientCompactQueryTuningConfigTest
 {

--- a/server/src/test/java/org/apache/druid/indexing/IndexingWorkerInfoTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/IndexingWorkerInfoTest.java
@@ -21,7 +21,7 @@ package org.apache.druid.indexing;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.client.indexing.IndexingWorkerInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IndexingWorkerInfoTest
 {

--- a/server/src/test/java/org/apache/druid/indexing/IndexingWorkerTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/IndexingWorkerTest.java
@@ -21,7 +21,7 @@ package org.apache.druid.indexing;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.client.indexing.IndexingWorker;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IndexingWorkerTest
 {

--- a/server/src/test/java/org/apache/druid/indexing/NoopSupervisorSpecTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/NoopSupervisorSpecTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.indexing;
 import org.apache.druid.indexing.overlord.supervisor.NoopSupervisorSpec;
 import org.apache.druid.indexing.overlord.supervisor.Supervisor;
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.SupervisorTaskAutoScaler;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -37,18 +37,18 @@ public class NoopSupervisorSpecTest
       NoopSupervisorSpec noopSupervisorSpec = new NoopSupervisorSpec(null, Collections.singletonList("datasource1"));
       Supervisor supervisor = noopSupervisorSpec.createSupervisor();
       SupervisorTaskAutoScaler autoscaler = noopSupervisorSpec.createAutoscaler(supervisor);
-      Assert.assertNull(autoscaler);
+      Assertions.assertNull(autoscaler);
     }
     catch (Exception ex) {
       e = ex;
     }
-    Assert.assertNull(e);
+    Assertions.assertNull(e);
   }
 
   @Test
   public void testInputSourceResources()
   {
     NoopSupervisorSpec noopSupervisorSpec = new NoopSupervisorSpec(null, Collections.singletonList("datasource1"));
-    Assert.assertTrue(noopSupervisorSpec.getInputSourceResources().isEmpty());
+    Assertions.assertTrue(noopSupervisorSpec.getInputSourceResources().isEmpty());
   }
 }

--- a/server/src/test/java/org/apache/druid/indexing/overlord/SegmentCreateRequestTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/SegmentCreateRequestTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.indexing.overlord;
 
 import org.apache.druid.timeline.partition.NumberedPartialShardSpec;
 import org.apache.druid.timeline.partition.PartialShardSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SegmentCreateRequestTest
 {
@@ -38,10 +38,10 @@ public class SegmentCreateRequestTest
         partialShardSpec,
         null
     );
-    Assert.assertEquals("sequence", request.getSequenceName());
-    Assert.assertEquals("", request.getPreviousSegmentId());
-    Assert.assertEquals("version", request.getVersion());
-    Assert.assertEquals(partialShardSpec, request.getPartialShardSpec());
+    Assertions.assertEquals("sequence", request.getSequenceName());
+    Assertions.assertEquals("", request.getPreviousSegmentId());
+    Assertions.assertEquals("version", request.getVersion());
+    Assertions.assertEquals(partialShardSpec, request.getPartialShardSpec());
   }
 
 }

--- a/server/src/test/java/org/apache/druid/indexing/overlord/SegmentPublishResultTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/SegmentPublishResultTest.java
@@ -27,8 +27,8 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.DataSegment.PruneSpecsHolder;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -49,7 +49,7 @@ public class SegmentPublishResultTest
 
     final String json = objectMapper.writeValueAsString(original);
     final SegmentPublishResult fromJson = objectMapper.readValue(json, SegmentPublishResult.class);
-    Assert.assertEquals(original, fromJson);
+    Assertions.assertEquals(original, fromJson);
   }
 
   @Test
@@ -59,7 +59,7 @@ public class SegmentPublishResultTest
 
     final String json = objectMapper.writeValueAsString(original);
     final SegmentPublishResult fromJson = objectMapper.readValue(json, SegmentPublishResult.class);
-    Assert.assertEquals(original, fromJson);
+    Assertions.assertEquals(original, fromJson);
   }
 
   private static DataSegment segment(Interval interval)

--- a/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/LagStatsTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/LagStatsTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.indexing.overlord.supervisor;
 
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.AggregateFunction;
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.LagStats;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LagStatsTest
 {
@@ -31,9 +31,9 @@ public class LagStatsTest
   {
     LagStats lagStats = new LagStats(1, 2, 3);
 
-    Assert.assertEquals(1, lagStats.getMetric(AggregateFunction.MAX));
-    Assert.assertEquals(2, lagStats.getMetric(AggregateFunction.SUM));
-    Assert.assertEquals(3, lagStats.getMetric(AggregateFunction.AVERAGE));
-    Assert.assertEquals(AggregateFunction.SUM, lagStats.getAggregateForScaling());
+    Assertions.assertEquals(1, lagStats.getMetric(AggregateFunction.MAX));
+    Assertions.assertEquals(2, lagStats.getMetric(AggregateFunction.SUM));
+    Assertions.assertEquals(3, lagStats.getMetric(AggregateFunction.AVERAGE));
+    Assertions.assertEquals(AggregateFunction.SUM, lagStats.getAggregateForScaling());
   }
 }

--- a/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/StreamSupervisorTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/StreamSupervisorTest.java
@@ -22,10 +22,11 @@ package org.apache.druid.indexing.overlord.supervisor;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.indexing.overlord.DataSourceMetadata;
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.LagStats;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.util.concurrent.Future;
 
 public class StreamSupervisorTest
@@ -92,11 +93,11 @@ public class StreamSupervisorTest
       }
     };
 
-    final Exception ex = Assert.assertThrows(
+    final Exception ex = Assertions.assertThrows(
         UnsupportedOperationException.class,
         () -> streamSupervisor.handoffTaskGroupsEarly(ImmutableList.of(1))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Supervisor does not have the feature to handoff task groups early implemented",
         ex.getMessage()
     );
@@ -166,9 +167,9 @@ public class StreamSupervisorTest
     };
 
     Future<Void> stopAsyncFuture = streamSupervisor.stopAsync();
-    Assert.assertTrue(stopAsyncFuture.isDone());
+    Assertions.assertTrue(stopAsyncFuture.isDone());
 
     // stop should be called by stopAsync
-    Assert.assertEquals(SupervisorStateManager.BasicState.STOPPING, streamSupervisor.getState());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.STOPPING, streamSupervisor.getState());
   }
 }

--- a/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpecTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpecTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.indexing.overlord.supervisor;
 
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.DruidExceptionMatcher;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -65,7 +65,7 @@ public class SupervisorSpecTest
   public void test()
   {
     DruidExceptionMatcher.assertThat(
-        Assert.assertThrows(DruidException.class, SUPERVISOR_SPEC::getInputSourceResources),
+        Assertions.assertThrows(DruidException.class, SUPERVISOR_SPEC::getInputSourceResources),
         DruidExceptionMatcher.unsupported().expectMessageIs(
             "Supervisor type[abc] does not support input source based security"
         )

--- a/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStateManagerTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStateManagerTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.indexing.overlord.supervisor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -40,17 +40,17 @@ public class SupervisorStateManagerTest
         false
     );
 
-    Assert.assertFalse(stateManagerConfig.isIdleConfigEnabled());
-    Assert.assertEquals(600000, stateManagerConfig.getInactiveAfterMillis());
+    Assertions.assertFalse(stateManagerConfig.isIdleConfigEnabled());
+    Assertions.assertEquals(600000, stateManagerConfig.getInactiveAfterMillis());
 
     supervisorStateManager.markRunFinished();
 
-    Assert.assertEquals(SupervisorStateManager.BasicState.RUNNING, supervisorStateManager.getSupervisorState());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.RUNNING, supervisorStateManager.getSupervisorState());
 
     supervisorStateManager.maybeSetState(SupervisorStateManager.BasicState.IDLE);
     supervisorStateManager.markRunFinished();
 
-    Assert.assertEquals(SupervisorStateManager.BasicState.IDLE, supervisorStateManager.getSupervisorState());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.IDLE, supervisorStateManager.getSupervisorState());
   }
 
   @Test
@@ -63,8 +63,8 @@ public class SupervisorStateManagerTest
     );
     stateManagerConfig = mapper.convertValue(config, SupervisorStateManagerConfig.class);
 
-    Assert.assertTrue(stateManagerConfig.isIdleConfigEnabled());
-    Assert.assertEquals(60000, stateManagerConfig.getInactiveAfterMillis());
+    Assertions.assertTrue(stateManagerConfig.isIdleConfigEnabled());
+    Assertions.assertEquals(60000, stateManagerConfig.getInactiveAfterMillis());
   }
 
   @Test
@@ -77,22 +77,22 @@ public class SupervisorStateManagerTest
     );
 
     // Start in PENDING state
-    Assert.assertEquals(SupervisorStateManager.BasicState.PENDING, supervisorStateManager.getSupervisorState());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.PENDING, supervisorStateManager.getSupervisorState());
 
     // Transition to STOPPING
     supervisorStateManager.maybeSetState(SupervisorStateManager.BasicState.STOPPING);
-    Assert.assertEquals(SupervisorStateManager.BasicState.STOPPING, supervisorStateManager.getSupervisorState());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.STOPPING, supervisorStateManager.getSupervisorState());
 
     // Attempt to transition out of STOPPING should be ignored
     supervisorStateManager.maybeSetState(SupervisorStateManager.BasicState.RUNNING);
-    Assert.assertEquals(SupervisorStateManager.BasicState.STOPPING, supervisorStateManager.getSupervisorState());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.STOPPING, supervisorStateManager.getSupervisorState());
 
     supervisorStateManager.maybeSetState(SupervisorStateManager.BasicState.IDLE);
-    Assert.assertEquals(SupervisorStateManager.BasicState.STOPPING, supervisorStateManager.getSupervisorState());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.STOPPING, supervisorStateManager.getSupervisorState());
 
     // Cannot transition to COMPLETED from STOPPING
     supervisorStateManager.maybeSetState(SupervisorStateManager.BasicState.COMPLETED);
-    Assert.assertEquals(SupervisorStateManager.BasicState.STOPPING, supervisorStateManager.getSupervisorState());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.STOPPING, supervisorStateManager.getSupervisorState());
   }
 
   @Test
@@ -106,8 +106,8 @@ public class SupervisorStateManagerTest
 
     supervisorStateManager.maybeSetState(SupervisorStateManager.BasicState.COMPLETED);
 
-    Assert.assertTrue(supervisorStateManager.isHealthy());
-    Assert.assertEquals(SupervisorStateManager.BasicState.COMPLETED, supervisorStateManager.getSupervisorState());
+    Assertions.assertTrue(supervisorStateManager.isHealthy());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.COMPLETED, supervisorStateManager.getSupervisorState());
   }
 
   @Test
@@ -121,7 +121,7 @@ public class SupervisorStateManagerTest
 
     supervisorStateManager.maybeSetState(SupervisorStateManager.BasicState.COMPLETED);
 
-    Assert.assertFalse(SupervisorStateManager.BasicState.COMPLETED.isFirstRunOnly());
+    Assertions.assertFalse(SupervisorStateManager.BasicState.COMPLETED.isFirstRunOnly());
   }
 
   @Test
@@ -136,6 +136,6 @@ public class SupervisorStateManagerTest
     supervisorStateManager.maybeSetState(SupervisorStateManager.BasicState.COMPLETED);
     supervisorStateManager.markRunFinished();
 
-    Assert.assertEquals(SupervisorStateManager.BasicState.COMPLETED, supervisorStateManager.getSupervisorState());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.COMPLETED, supervisorStateManager.getSupervisorState());
   }
 }

--- a/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatusTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatusTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.indexing.overlord.supervisor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -43,7 +43,7 @@ public class SupervisorStatusTest
                                                      .build();
     final String serialized = mapper.writeValueAsString(supervisorStatus);
     final SupervisorStatus deserialized = mapper.readValue(serialized, SupervisorStatus.class);
-    Assert.assertEquals(supervisorStatus, deserialized);
+    Assertions.assertEquals(supervisorStatus, deserialized);
   }
 
   @Test
@@ -61,8 +61,8 @@ public class SupervisorStatusTest
                   + "}";
     final ObjectMapper mapper = new ObjectMapper();
     final SupervisorStatus deserialized = mapper.readValue(json, SupervisorStatus.class);
-    Assert.assertEquals("wikipedia", deserialized.getId());
-    Assert.assertEquals("wikipedia", deserialized.getDataSource());
+    Assertions.assertEquals("wikipedia", deserialized.getId());
+    Assertions.assertEquals("wikipedia", deserialized.getDataSource());
   }
 
   @Test
@@ -80,11 +80,11 @@ public class SupervisorStatusTest
                   + "}";
     final ObjectMapper mapper = new ObjectMapper();
     final SupervisorStatus deserialized = mapper.readValue(json, SupervisorStatus.class);
-    Assert.assertNotNull(deserialized);
-    Assert.assertEquals("wikipedia_supervisor", deserialized.getId());
-    Assert.assertEquals("wikipedia", deserialized.getDataSource());
+    Assertions.assertNotNull(deserialized);
+    Assertions.assertEquals("wikipedia_supervisor", deserialized.getId());
+    Assertions.assertEquals("wikipedia", deserialized.getDataSource());
     final String serialized = mapper.writeValueAsString(deserialized);
-    Assert.assertTrue(serialized.contains("\"source\""));
-    Assert.assertEquals(json, serialized);
+    Assertions.assertTrue(serialized.contains("\"source\""));
+    Assertions.assertEquals(json, serialized);
   }
 }

--- a/server/src/test/java/org/apache/druid/indexing/worker/config/WorkerConfigTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/worker/config/WorkerConfigTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.indexing.worker.config;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -36,8 +36,8 @@ public class WorkerConfigTest
         .setBaseTaskDirs(Arrays.asList("1", "2", "another"))
         .build();
 
-    Assert.assertEquals(10, config.getCapacity());
-    Assert.assertEquals(100_000_000L, config.getBaseTaskDirSize());
-    Assert.assertEquals(Arrays.asList("1", "2", "another"), config.getBaseTaskDirs());
+    Assertions.assertEquals(10, config.getCapacity());
+    Assertions.assertEquals(100_000_000L, config.getBaseTaskDirSize());
+    Assertions.assertEquals(Arrays.asList("1", "2", "another"), config.getBaseTaskDirs());
   }
 }

--- a/server/src/test/java/org/apache/druid/initialization/ZkPathsConfigTest.java
+++ b/server/src/test/java/org/apache/druid/initialization/ZkPathsConfigTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.guice.JsonConfigurator;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.server.initialization.ZkPathsConfig;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -58,13 +58,13 @@ public class ZkPathsConfigTest extends JsonConfigTesterBase<ZkPathsConfig>
 
     ZkPathsConfig zkPathsConfigObj = zkPathsConfig.get();
     validateEntries(zkPathsConfigObj);
-    Assert.assertEquals(propertyValues.size(), assertions);
+    Assertions.assertEquals(propertyValues.size(), assertions);
 
     ObjectMapper jsonMapper = injector.getProvider(Key.get(ObjectMapper.class, Json.class)).get();
     String jsonVersion = jsonMapper.writeValueAsString(zkPathsConfigObj);
 
     ZkPathsConfig zkPathsConfigObjDeSer = jsonMapper.readValue(jsonVersion, ZkPathsConfig.class);
 
-    Assert.assertEquals(zkPathsConfigObj, zkPathsConfigObjDeSer);
+    Assertions.assertEquals(zkPathsConfigObj, zkPathsConfigObjDeSer);
   }
 }

--- a/server/src/test/java/org/apache/druid/metadata/BasicDataSourceExtTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/BasicDataSourceExtTest.java
@@ -23,8 +23,8 @@ import org.apache.commons.dbcp2.ConnectionFactory;
 import org.assertj.core.util.Lists;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.sql.Driver;
 import java.util.List;
@@ -73,17 +73,17 @@ public class BasicDataSourceExtTest
     expectedProps.put("user", connectorConfig.getUser());
 
 
-    Assert.assertNull(connectionFactory.createConnection());
-    Assert.assertEquals(connectorConfig.getConnectURI(), uriArg.getValue());
+    Assertions.assertNull(connectionFactory.createConnection());
+    Assertions.assertEquals(connectorConfig.getConnectURI(), uriArg.getValue());
 
     expectedProps.put("password", "pwd1");
-    Assert.assertEquals(expectedProps, propsArg.getValue());
+    Assertions.assertEquals(expectedProps, propsArg.getValue());
 
-    Assert.assertNull(connectionFactory.createConnection());
-    Assert.assertEquals(connectorConfig.getConnectURI(), uriArg.getValue());
+    Assertions.assertNull(connectionFactory.createConnection());
+    Assertions.assertEquals(connectorConfig.getConnectURI(), uriArg.getValue());
 
     expectedProps.put("password", "pwd2");
-    Assert.assertEquals(expectedProps, propsArg.getValue());
+    Assertions.assertEquals(expectedProps, propsArg.getValue());
   }
 
   @Test
@@ -93,7 +93,7 @@ public class BasicDataSourceExtTest
     Properties expectedProps = new Properties();
 
     basicDataSourceExt.setConnectionProperties("");
-    Assert.assertEquals(expectedProps, basicDataSourceExt.getConnectionProperties());
+    Assertions.assertEquals(expectedProps, basicDataSourceExt.getConnectionProperties());
 
     basicDataSourceExt.setConnectionProperties("p0;p1=v1;p2=v2;p3=v3");
     basicDataSourceExt.addConnectionProperty("p4", "v4");
@@ -106,7 +106,7 @@ public class BasicDataSourceExtTest
     expectedProps.put("p3", "v3");
     expectedProps.put("p4", "v4");
 
-    Assert.assertEquals(expectedProps, basicDataSourceExt.getConnectionProperties());
+    Assertions.assertEquals(expectedProps, basicDataSourceExt.getConnectionProperties());
 
 
   }

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorMarkUsedTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorMarkUsedTest.java
@@ -39,10 +39,10 @@ import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.List;
 import java.util.Map;
@@ -57,7 +57,7 @@ import java.util.Set;
  */
 public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSqlMetadataStorageCoordinatorTestBase
 {
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule
       = new TestDerbyConnector.DerbyConnectorRule();
   
@@ -68,7 +68,7 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
   private final DataSegment wikiSegment2 =
       CreateDataSegments.ofDatasource(TestDataSource.WIKI).startingAt("2012-01-05").eachOfSizeInMb(500).get(0);
   
-  @Before
+  @BeforeEach
   public void setup()
   {
     derbyConnector = derbyConnectorRule.getConnector();
@@ -135,17 +135,17 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
     );
 
     
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
-    Assert.assertEquals(2, storageCoordinator.markNonOvershadowedSegmentsAsUsed(TestDataSource.KOALA, segmentIds));
+    Assertions.assertEquals(2, storageCoordinator.markNonOvershadowedSegmentsAsUsed(TestDataSource.KOALA, segmentIds));
     
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(koalaSegment1, koalaSegment2),
         retrieveAllUsedSegments(TestDataSource.KOALA)
     );
@@ -177,11 +177,11 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
 
     publishUnusedSegments(koalaSegment1, koalaSegment2, koalaSegment3);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2,
         storageCoordinator.markNonOvershadowedSegmentsAsUsed(
             TestDataSource.KOALA,
@@ -190,11 +190,11 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(koalaSegment1, koalaSegment2),
         retrieveAllUsedSegments(TestDataSource.KOALA)
     );
@@ -226,11 +226,11 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
 
     publishUnusedSegments(koalaSegment1, koalaSegment2, koalaSegment3);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         storageCoordinator.markNonOvershadowedSegmentsAsUsed(
             TestDataSource.KOALA,
@@ -239,7 +239,7 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
@@ -271,11 +271,11 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
 
     publishUnusedSegments(koalaSegment1, koalaSegment2, koalaSegment3);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         storageCoordinator.markNonOvershadowedSegmentsAsUsed(
             TestDataSource.KOALA,
@@ -284,7 +284,7 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
@@ -317,11 +317,11 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
     publishUnusedSegments(koalaSegment1, koalaSegment2, koalaSegment3);
 
     
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2,
         storageCoordinator.markNonOvershadowedSegmentsAsUsed(
             TestDataSource.KOALA,
@@ -331,11 +331,11 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
     );
     
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(koalaSegment1, koalaSegment2),
         retrieveAllUsedSegments(TestDataSource.KOALA)
     );
@@ -368,11 +368,11 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
     publishUnusedSegments(koalaSegment1, koalaSegment2, koalaSegment3);
 
     
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         storageCoordinator.markNonOvershadowedSegmentsAsUsed(
             TestDataSource.KOALA,
@@ -382,7 +382,7 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
     );
     
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
@@ -399,13 +399,13 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
     publishUnusedSegments(koalaSegment1, koalaSegment2);
     final Set<SegmentId> segmentIds = Set.of(koalaSegment1.getId(), koalaSegment2.getId());
     
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
 
     DruidExceptionMatcher.assertThat(
-        Assert.assertThrows(
+        Assertions.assertThrows(
             DruidException.class,
             () -> storageCoordinator.markNonOvershadowedSegmentsAsUsed("wrongDataSource", segmentIds)
         ),
@@ -425,13 +425,13 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
 
     final Set<SegmentId> segmentIds = Set.of(koalaSegment1.getId(), koalaSegment2.getId());
     
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
 
     DruidExceptionMatcher.assertThat(
-        Assert.assertThrows(
+        Assertions.assertThrows(
             DruidException.class,
             () -> storageCoordinator.markNonOvershadowedSegmentsAsUsed(TestDataSource.KOALA, segmentIds)
         ),
@@ -465,19 +465,19 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
     final Interval theInterval = Intervals.of("2017-10-15T00:00:00.000/2017-10-18T00:00:00.000");
 
     
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
 
     // 2 out of 3 segments match the interval
-    Assert.assertEquals(2, storageCoordinator.markNonOvershadowedSegmentsAsUsed(TestDataSource.KOALA, theInterval, null));
+    Assertions.assertEquals(2, storageCoordinator.markNonOvershadowedSegmentsAsUsed(TestDataSource.KOALA, theInterval, null));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(koalaSegment1, koalaSegment2),
         retrieveAllUsedSegments(TestDataSource.KOALA)
     );
@@ -513,19 +513,19 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
     final Interval theInterval = Intervals.of("2017-10-16T00:00:00.000/2017-10-20T00:00:00.000");
 
     
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
 
     // 1 out of 3 segments match the interval, other 2 overlap, only the segment fully contained will be marked unused
-    Assert.assertEquals(1, storageCoordinator.markNonOvershadowedSegmentsAsUsed(TestDataSource.KOALA, theInterval, null));
+    Assertions.assertEquals(1, storageCoordinator.markNonOvershadowedSegmentsAsUsed(TestDataSource.KOALA, theInterval, null));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments(TestDataSource.WIKI)
     );
-    Assert.assertEquals(Set.of(koalaSegment2), retrieveAllUsedSegments(TestDataSource.KOALA));
+    Assertions.assertEquals(Set.of(koalaSegment2), retrieveAllUsedSegments(TestDataSource.KOALA));
   }
 
   @Test
@@ -537,7 +537,7 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
         TestDataSource.WIKI,
         Set.of(wikiSegment1.getId(), wikiSegment2.getId())
     );
-    Assert.assertEquals(2, numChangedSegments);
+    Assertions.assertEquals(2, numChangedSegments);
 
     // Publish an unused segment with used_status_last_updated 2 hours ago
     final DataSegment koalaSegment1 = createSegment(
@@ -571,7 +571,7 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
     );
     publishUnusedSegments(koalaSegment3);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(wikiSegment2.getInterval()),
         storageCoordinator.getUnusedSegmentIntervals(
             TestDataSource.WIKI,
@@ -583,7 +583,7 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
     );
 
     // Test the DateTime maxEndTime argument of getUnusedSegmentIntervals
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(wikiSegment2.getInterval()),
         storageCoordinator.getUnusedSegmentIntervals(
             TestDataSource.WIKI,
@@ -593,7 +593,7 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
             DateTimes.COMPARE_DATE_AS_STRING_MAX
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(wikiSegment1.getInterval()),
         storageCoordinator.getUnusedSegmentIntervals(
             TestDataSource.WIKI,
@@ -603,7 +603,7 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
             DateTimes.COMPARE_DATE_AS_STRING_MAX
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(),
         storageCoordinator.getUnusedSegmentIntervals(
             TestDataSource.WIKI,
@@ -614,7 +614,7 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(wikiSegment2.getInterval(), wikiSegment1.getInterval()),
         storageCoordinator.getUnusedSegmentIntervals(
             TestDataSource.WIKI,
@@ -628,7 +628,7 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
     // Test a buffer period that should exclude some segments
 
     // The wikipedia datasource has segments generated with last used time equal to roughly the time of test run. None of these segments should be selected with a bufer period of 1 day
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(),
         storageCoordinator.getUnusedSegmentIntervals(
             TestDataSource.WIKI,
@@ -642,7 +642,7 @@ public class IndexerSQLMetadataStorageCoordinatorMarkUsedTest extends IndexerSql
     // koalaSegment3 has a null used_status_last_updated which should mean getUnusedSegmentIntervals never returns it
     // koalaSegment2 has a used_status_last_updated older than 1 day which means it should be returned
     // The last of the 3 segments in koala has a used_status_last_updated date less than one day and should not be returned
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(koalaSegment2.getInterval()),
         storageCoordinator.getUnusedSegmentIntervals(
             TestDataSource.KOALA,

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorReadOnlyTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorReadOnlyTest.java
@@ -43,14 +43,14 @@ import org.apache.druid.server.coordinator.simulate.BlockingExecutorService;
 import org.apache.druid.server.coordinator.simulate.TestDruidLeaderSelector;
 import org.apache.druid.server.coordinator.simulate.WrappingScheduledExecutorService;
 import org.apache.druid.timeline.partition.NumberedPartialShardSpec;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
 import java.util.Map;
@@ -60,10 +60,11 @@ import java.util.Set;
  * Unit tests to verify behaviour of {@link IndexerSQLMetadataStorageCoordinator}
  * on the Coordinator for read-only purposes.
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "cacheMode = {0}")
+@MethodSource("testParameters")
 public class IndexerSQLMetadataStorageCoordinatorReadOnlyTest extends IndexerSqlMetadataStorageCoordinatorTestBase
 {
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule
       = new TestDerbyConnector.DerbyConnectorRule();
 
@@ -77,7 +78,6 @@ public class IndexerSQLMetadataStorageCoordinatorReadOnlyTest extends IndexerSql
 
   private final SegmentMetadataCache.UsageMode cacheMode;
 
-  @Parameterized.Parameters(name = "cacheMode = {0}")
   public static Object[][] testParameters()
   {
     return new Object[][]{
@@ -92,7 +92,7 @@ public class IndexerSQLMetadataStorageCoordinatorReadOnlyTest extends IndexerSql
     this.cacheMode = cacheMode;
   }
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     derbyConnector = derbyConnectorRule.getConnector();
@@ -132,7 +132,7 @@ public class IndexerSQLMetadataStorageCoordinatorReadOnlyTest extends IndexerSql
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     segmentMetadataCache.stopBeingLeader();
@@ -286,12 +286,12 @@ public class IndexerSQLMetadataStorageCoordinatorReadOnlyTest extends IndexerSql
   @Test
   public void test_retrieveSegmentForId_returnsSegment_ifPresent()
   {
-    Assert.assertNull(
+    Assertions.assertNull(
         readOnlyStorage.retrieveSegmentForId(defaultSegment.getId())
     );
 
     readWriteStorage.commitSegments(Set.of(defaultSegment), null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         defaultSegment,
         readOnlyStorage.retrieveSegmentForId(defaultSegment.getId())
     );
@@ -300,12 +300,12 @@ public class IndexerSQLMetadataStorageCoordinatorReadOnlyTest extends IndexerSql
   @Test
   public void test_retrieveUsedSegmentForId_returnsSegment_ifPresent()
   {
-    Assert.assertNull(
+    Assertions.assertNull(
         readOnlyStorage.retrieveUsedSegmentForId(defaultSegment.getId())
     );
 
     readWriteStorage.commitSegments(Set.of(defaultSegment), null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         defaultSegment,
         readOnlyStorage.retrieveUsedSegmentForId(defaultSegment.getId())
     );
@@ -314,22 +314,22 @@ public class IndexerSQLMetadataStorageCoordinatorReadOnlyTest extends IndexerSql
   @Test
   public void test_retrieveAllUsedSegments_returnsSegments_ifPresent()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(),
         readOnlyStorage.retrieveAllUsedSegments(defaultSegment.getDataSource(), Segments.INCLUDING_OVERSHADOWED)
     );
 
     readWriteStorage.commitSegments(Set.of(defaultSegment), null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(defaultSegment),
         readOnlyStorage.retrieveAllUsedSegments(defaultSegment.getDataSource(), Segments.INCLUDING_OVERSHADOWED)
     );
   }
 
-  private static void verifyThrowsDefensiveException(ThrowingRunnable runnable)
+  private static void verifyThrowsDefensiveException(Executable runnable)
   {
     DruidExceptionMatcher.assertThat(
-        Assert.assertThrows(DruidException.class, runnable),
+        Assertions.assertThrows(DruidException.class, runnable),
         DruidExceptionMatcher.defensive().expectMessageIs(
             "Only Overlord can perform write transactions on segment metadata."
         )

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -81,18 +81,16 @@ import org.apache.druid.timeline.partition.PartitionIds;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.apache.druid.timeline.partition.SingleDimensionShardSpec;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
-import org.assertj.core.api.Assertions;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -110,11 +108,12 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "cacheMode = {0}")
+@MethodSource("testParameters")
 public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadataStorageCoordinatorTestBase
 {
   private static final String SUPERVISOR_ID = "supervisor";
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
 
   private TestDruidLeaderSelector leaderSelector;
@@ -126,7 +125,11 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
   private final SegmentMetadataCache.UsageMode cacheMode;
 
-  @Parameterized.Parameters(name = "cacheMode = {0}")
+  public IndexerSQLMetadataStorageCoordinatorTest(SegmentMetadataCache.UsageMode cacheMode)
+  {
+    this.cacheMode = cacheMode;
+  }
+
   public static Object[][] testParameters()
   {
     return new Object[][]{
@@ -136,12 +139,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     };
   }
 
-  public IndexerSQLMetadataStorageCoordinatorTest(SegmentMetadataCache.UsageMode cacheMode)
-  {
-    this.cacheMode = cacheMode;
-  }
-
-  @Before
+  @BeforeEach
   public void setUp()
   {
     derbyConnector = derbyConnectorRule.getConnector();
@@ -242,7 +240,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     };
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     segmentMetadataCache.stopBeingLeader();
@@ -395,7 +393,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     // Commit the segment and verify the results
     SegmentPublishResult commitResult
         = coordinator.commitAppendSegments(appendSegments, segmentToReplaceLock, taskAllocatorId, null);
-    Assert.assertTrue(commitResult.isSuccess());
+    Assertions.assertTrue(commitResult.isSuccess());
 
     Set<DataSegment> allCommittedSegments
         = new HashSet<>(retrieveUsedSegments(derbyConnectorRule.metadataTablesConfigSupplier().get()));
@@ -404,14 +402,14 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         allCommittedSegments.stream().map(DataSegment::getId).map(SegmentId::toString).collect(Collectors.toSet())
     );
     // Verify the segments present in the metadata store
-    Assert.assertTrue(allCommittedSegments.containsAll(appendSegments));
+    Assertions.assertTrue(allCommittedSegments.containsAll(appendSegments));
     for (DataSegment segment : appendSegments) {
-      Assert.assertNull(upgradedFromSegmentIdMap.get(segment.getId().toString()));
+      Assertions.assertNull(upgradedFromSegmentIdMap.get(segment.getId().toString()));
     }
     allCommittedSegments.removeAll(appendSegments);
 
     // Verify the commit of upgraded pending segments
-    Assert.assertEquals(appendSegments.size(), allCommittedSegments.size());
+    Assertions.assertEquals(appendSegments.size(), allCommittedSegments.size());
     Map<String, DataSegment> segmentMap = new HashMap<>();
     for (DataSegment segment : appendSegments) {
       segmentMap.put(segment.getId().toString(), segment);
@@ -420,9 +418,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       for (PendingSegmentRecord pendingSegmentRecord : pendingSegmentsForTask) {
         if (pendingSegmentRecord.getId().asSegmentId().toString().equals(segment.getId().toString())) {
           DataSegment upgradedFromSegment = segmentMap.get(pendingSegmentRecord.getUpgradedFromSegmentId());
-          Assert.assertNotNull(upgradedFromSegment);
-          Assert.assertEquals(segment.getLoadSpec(), upgradedFromSegment.getLoadSpec());
-          Assert.assertEquals(
+          Assertions.assertNotNull(upgradedFromSegment);
+          Assertions.assertEquals(segment.getLoadSpec(), upgradedFromSegment.getLoadSpec());
+          Assertions.assertEquals(
               pendingSegmentRecord.getUpgradedFromSegmentId(),
               upgradedFromSegmentIdMap.get(segment.getId().toString())
           );
@@ -439,11 +437,11 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         replaceTaskId,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(expectedUpgradeSegmentIds, observedSegmentToLock.keySet());
+    Assertions.assertEquals(expectedUpgradeSegmentIds, observedSegmentToLock.keySet());
 
     final Set<String> observedLockVersions = new HashSet<>(observedSegmentToLock.values());
-    Assert.assertEquals(1, observedLockVersions.size());
-    Assert.assertEquals(replaceLock.getVersion(), Iterables.getOnlyElement(observedLockVersions));
+    Assertions.assertEquals(1, observedLockVersions.size());
+    Assertions.assertEquals(replaceLock.getVersion(), Iterables.getOnlyElement(observedLockVersions));
   }
 
   /**
@@ -508,7 +506,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         taskAllocatorId,
         null
     );
-    Assert.assertTrue(commitResult.isSuccess());
+    Assertions.assertTrue(commitResult.isSuccess());
 
     final Set<DataSegment> allCommittedSegments
         = new HashSet<>(retrieveUsedSegments(derbyConnectorRule.metadataTablesConfigSupplier().get()));
@@ -518,8 +516,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     // The original append segment is published as-is, retaining its DimensionValueSetShardSpec.
-    Assert.assertTrue(allCommittedSegments.contains(appendSegment));
-    Assert.assertTrue(appendSegment.getShardSpec() instanceof DimensionValueSetShardSpec);
+    Assertions.assertTrue(allCommittedSegments.contains(appendSegment));
+    Assertions.assertTrue(appendSegment.getShardSpec() instanceof DimensionValueSetShardSpec);
 
     // Find the upgraded copy (the one whose upgradedFromSegmentId points back to the append segment).
     DataSegment upgradedSegment = null;
@@ -528,22 +526,22 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         upgradedSegment = segment;
       }
     }
-    Assert.assertNotNull("Expected an upgraded copy of the append segment", upgradedSegment);
+    Assertions.assertNotNull(upgradedSegment, "Expected an upgraded copy of the append segment");
 
     // The upgraded copy is published under the replace version, with the pending segment's partition number and core
     // partitions, but it preserves the original DimensionValueSetShardSpec (and partitionDimensionValues).
-    Assert.assertEquals(upgradedVersion, upgradedSegment.getVersion());
-    Assert.assertTrue(
-        "upgraded append segment should preserve DimensionValueSetShardSpec",
-        upgradedSegment.getShardSpec() instanceof DimensionValueSetShardSpec
+    Assertions.assertEquals(upgradedVersion, upgradedSegment.getVersion());
+    Assertions.assertTrue(
+        upgradedSegment.getShardSpec() instanceof DimensionValueSetShardSpec,
+        "upgraded append segment should preserve DimensionValueSetShardSpec"
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         partitionDimensionValues,
         ((DimensionValueSetShardSpec) upgradedSegment.getShardSpec()).getPartitionDimensionValues()
     );
     // Partition number and core partitions come from the (numbered) pending segment.
-    Assert.assertEquals(5, upgradedSegment.getShardSpec().getPartitionNum());
-    Assert.assertEquals(8, upgradedSegment.getShardSpec().getNumCorePartitions());
+    Assertions.assertEquals(5, upgradedSegment.getShardSpec().getPartitionNum());
+    Assertions.assertEquals(8, upgradedSegment.getShardSpec().getNumCorePartitions());
   }
 
   @Test
@@ -600,7 +598,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       replacingSegments.add(segment);
     }
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> coordinator.commitReplaceSegments(replacingSegments, ImmutableSet.of(replaceLock), null)
     );
@@ -676,9 +674,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       replacingSegments.add(segment);
     }
 
-    Assert.assertTrue(coordinator.commitReplaceSegments(replacingSegments, Set.of(replaceLock), null).isSuccess());
+    Assertions.assertTrue(coordinator.commitReplaceSegments(replacingSegments, Set.of(replaceLock), null).isSuccess());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2L * segmentsAppendedWithReplaceLock.size() + replacingSegments.size(),
         retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get()).size()
     );
@@ -691,25 +689,25 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         usedSegments.stream().map(DataSegment::getId).map(SegmentId::toString).collect(Collectors.toSet())
     );
 
-    Assert.assertTrue(usedSegments.containsAll(segmentsAppendedWithReplaceLock));
+    Assertions.assertTrue(usedSegments.containsAll(segmentsAppendedWithReplaceLock));
     for (DataSegment appendSegment : segmentsAppendedWithReplaceLock) {
-      Assert.assertNull(upgradedFromSegmentIdMap.get(appendSegment.getId().toString()));
+      Assertions.assertNull(upgradedFromSegmentIdMap.get(appendSegment.getId().toString()));
     }
     usedSegments.removeAll(segmentsAppendedWithReplaceLock);
-    Assert.assertEquals(usedSegments, coordinator.retrieveAllUsedSegments("foo", Segments.ONLY_VISIBLE));
+    Assertions.assertEquals(usedSegments, coordinator.retrieveAllUsedSegments("foo", Segments.ONLY_VISIBLE));
 
-    Assert.assertTrue(usedSegments.containsAll(replacingSegments));
+    Assertions.assertTrue(usedSegments.containsAll(replacingSegments));
     for (DataSegment replaceSegment : replacingSegments) {
-      Assert.assertNull(upgradedFromSegmentIdMap.get(replaceSegment.getId().toString()));
+      Assertions.assertNull(upgradedFromSegmentIdMap.get(replaceSegment.getId().toString()));
     }
     usedSegments.removeAll(replacingSegments);
 
-    Assert.assertEquals(segmentsAppendedWithReplaceLock.size(), usedSegments.size());
+    Assertions.assertEquals(segmentsAppendedWithReplaceLock.size(), usedSegments.size());
     for (DataSegment segmentReplicaWithNewVersion : usedSegments) {
       boolean hasBeenCarriedForward = false;
       for (DataSegment appendedSegment : segmentsAppendedWithReplaceLock) {
         if (appendedSegment.getLoadSpec().equals(segmentReplicaWithNewVersion.getLoadSpec())) {
-          Assert.assertEquals(
+          Assertions.assertEquals(
               appendedSegment.getId().toString(),
               upgradedFromSegmentIdMap.get(segmentReplicaWithNewVersion.getId().toString())
           );
@@ -717,25 +715,25 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
           break;
         }
       }
-      Assert.assertTrue(hasBeenCarriedForward);
+      Assertions.assertTrue(hasBeenCarriedForward);
     }
 
     List<PendingSegmentRecord> pendingSegmentsInInterval =
         coordinator.getPendingSegments("foo", Intervals.of("2023-01-01/2023-02-01"));
-    Assert.assertEquals(2, pendingSegmentsInInterval.size());
+    Assertions.assertEquals(2, pendingSegmentsInInterval.size());
     final SegmentId rootPendingSegmentId = pendingSegmentInInterval.getId().asSegmentId();
     if (pendingSegmentsInInterval.get(0).getUpgradedFromSegmentId() == null) {
-      Assert.assertEquals(rootPendingSegmentId, pendingSegmentsInInterval.get(0).getId().asSegmentId());
-      Assert.assertEquals(rootPendingSegmentId.toString(), pendingSegmentsInInterval.get(1).getUpgradedFromSegmentId());
+      Assertions.assertEquals(rootPendingSegmentId, pendingSegmentsInInterval.get(0).getId().asSegmentId());
+      Assertions.assertEquals(rootPendingSegmentId.toString(), pendingSegmentsInInterval.get(1).getUpgradedFromSegmentId());
     } else {
-      Assert.assertEquals(rootPendingSegmentId, pendingSegmentsInInterval.get(1).getId().asSegmentId());
-      Assert.assertEquals(rootPendingSegmentId.toString(), pendingSegmentsInInterval.get(0).getUpgradedFromSegmentId());
+      Assertions.assertEquals(rootPendingSegmentId, pendingSegmentsInInterval.get(1).getId().asSegmentId());
+      Assertions.assertEquals(rootPendingSegmentId.toString(), pendingSegmentsInInterval.get(0).getUpgradedFromSegmentId());
     }
 
     List<PendingSegmentRecord> pendingSegmentsOutsideInterval =
         coordinator.getPendingSegments("foo", Intervals.of("2023-04-01/2023-05-01"));
-    Assert.assertEquals(1, pendingSegmentsOutsideInterval.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, pendingSegmentsOutsideInterval.size());
+    Assertions.assertEquals(
         pendingSegmentOutsideInterval.getId().asSegmentId(), pendingSegmentsOutsideInterval.get(0).getId().asSegmentId()
     );
   }
@@ -785,7 +783,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
           )
       );
     }
-    Assert.assertTrue(coordinator.commitReplaceSegments(replacingSegments, Set.of(replaceLock), null).isSuccess());
+    Assertions.assertTrue(coordinator.commitReplaceSegments(replacingSegments, Set.of(replaceLock), null).isSuccess());
 
     final Set<DataSegment> usedSegments
         = new HashSet<>(retrieveUsedSegments(derbyConnectorRule.metadataTablesConfigSupplier().get()));
@@ -801,16 +799,16 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         upgradedSegment = segment;
       }
     }
-    Assert.assertNotNull("Expected an upgraded published segment", upgradedSegment);
+    Assertions.assertNotNull(upgradedSegment, "Expected an upgraded published segment");
 
     // The upgraded published segment is re-versioned to the replace version but keeps its DimensionValueSetShardSpec
     // (and partitionDimensionValues), so it remains prunable by the broker.
-    Assert.assertEquals("2023-02-01", upgradedSegment.getVersion());
-    Assert.assertTrue(
-        "upgraded published segment should preserve DimensionValueSetShardSpec",
-        upgradedSegment.getShardSpec() instanceof DimensionValueSetShardSpec
+    Assertions.assertEquals("2023-02-01", upgradedSegment.getVersion());
+    Assertions.assertTrue(
+        upgradedSegment.getShardSpec() instanceof DimensionValueSetShardSpec,
+        "upgraded published segment should preserve DimensionValueSetShardSpec"
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         partitionDimensionValues,
         ((DimensionValueSetShardSpec) upgradedSegment.getShardSpec()).getPartitionDimensionValues()
     );
@@ -887,9 +885,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       replacingSegments.add(segment);
     }
 
-    Assert.assertTrue(coordinator.commitReplaceSegments(replacingSegments, Set.of(replaceLock), null).isSuccess());
+    Assertions.assertTrue(coordinator.commitReplaceSegments(replacingSegments, Set.of(replaceLock), null).isSuccess());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2L * segmentsAppendedWithReplaceLock.size() + replacingSegments.size(),
         retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get()).size()
     );
@@ -902,30 +900,30 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         usedSegments.stream().map(DataSegment::getId).map(SegmentId::toString).collect(Collectors.toSet())
     );
 
-    Assert.assertTrue(usedSegments.containsAll(segmentsAppendedWithReplaceLock));
+    Assertions.assertTrue(usedSegments.containsAll(segmentsAppendedWithReplaceLock));
     for (DataSegment appendSegment : segmentsAppendedWithReplaceLock) {
-      Assert.assertNull(upgradedFromSegmentIdMap.get(appendSegment.getId().toString()));
+      Assertions.assertNull(upgradedFromSegmentIdMap.get(appendSegment.getId().toString()));
     }
     usedSegments.removeAll(segmentsAppendedWithReplaceLock);
 
     Set<DataSegment> fetched = coordinator.retrieveAllUsedSegments("foo", Segments.ONLY_VISIBLE);
-    Assert.assertEquals(usedSegments, fetched);
+    Assertions.assertEquals(usedSegments, fetched);
     // all segments have the same corePartitions, exactly the size of replaced + appended
     List<ShardSpec> shardSpecs = fetched.stream().map(DataSegment::getShardSpec).toList();
-    Assert.assertTrue(shardSpecs.stream().allMatch(s -> s.getNumCorePartitions() == usedSegments.size()));
-    Assert.assertTrue(shardSpecs.stream().allMatch(s -> s instanceof DimensionRangeShardSpec));
-    Assert.assertTrue(usedSegments.containsAll(replacingSegments));
+    Assertions.assertTrue(shardSpecs.stream().allMatch(s -> s.getNumCorePartitions() == usedSegments.size()));
+    Assertions.assertTrue(shardSpecs.stream().allMatch(s -> s instanceof DimensionRangeShardSpec));
+    Assertions.assertTrue(usedSegments.containsAll(replacingSegments));
     for (DataSegment replaceSegment : replacingSegments) {
-      Assert.assertNull(upgradedFromSegmentIdMap.get(replaceSegment.getId().toString()));
+      Assertions.assertNull(upgradedFromSegmentIdMap.get(replaceSegment.getId().toString()));
     }
     usedSegments.removeAll(replacingSegments);
 
-    Assert.assertEquals(segmentsAppendedWithReplaceLock.size(), usedSegments.size());
+    Assertions.assertEquals(segmentsAppendedWithReplaceLock.size(), usedSegments.size());
     for (DataSegment segmentReplicaWithNewVersion : usedSegments) {
       boolean hasBeenCarriedForward = false;
       for (DataSegment appendedSegment : segmentsAppendedWithReplaceLock) {
         if (appendedSegment.getLoadSpec().equals(segmentReplicaWithNewVersion.getLoadSpec())) {
-          Assert.assertEquals(
+          Assertions.assertEquals(
               appendedSegment.getId().toString(),
               upgradedFromSegmentIdMap.get(segmentReplicaWithNewVersion.getId().toString())
           );
@@ -933,25 +931,25 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
           break;
         }
       }
-      Assert.assertTrue(hasBeenCarriedForward);
+      Assertions.assertTrue(hasBeenCarriedForward);
     }
 
     List<PendingSegmentRecord> pendingSegmentsInInterval =
         coordinator.getPendingSegments("foo", Intervals.of("2023-01-01/2023-02-01"));
-    Assert.assertEquals(2, pendingSegmentsInInterval.size());
+    Assertions.assertEquals(2, pendingSegmentsInInterval.size());
     final SegmentId rootPendingSegmentId = pendingSegmentInInterval.getId().asSegmentId();
     if (pendingSegmentsInInterval.get(0).getUpgradedFromSegmentId() == null) {
-      Assert.assertEquals(rootPendingSegmentId, pendingSegmentsInInterval.get(0).getId().asSegmentId());
-      Assert.assertEquals(rootPendingSegmentId.toString(), pendingSegmentsInInterval.get(1).getUpgradedFromSegmentId());
+      Assertions.assertEquals(rootPendingSegmentId, pendingSegmentsInInterval.get(0).getId().asSegmentId());
+      Assertions.assertEquals(rootPendingSegmentId.toString(), pendingSegmentsInInterval.get(1).getUpgradedFromSegmentId());
     } else {
-      Assert.assertEquals(rootPendingSegmentId, pendingSegmentsInInterval.get(1).getId().asSegmentId());
-      Assert.assertEquals(rootPendingSegmentId.toString(), pendingSegmentsInInterval.get(0).getUpgradedFromSegmentId());
+      Assertions.assertEquals(rootPendingSegmentId, pendingSegmentsInInterval.get(1).getId().asSegmentId());
+      Assertions.assertEquals(rootPendingSegmentId.toString(), pendingSegmentsInInterval.get(0).getUpgradedFromSegmentId());
     }
 
     List<PendingSegmentRecord> pendingSegmentsOutsideInterval =
         coordinator.getPendingSegments("foo", Intervals.of("2023-04-01/2023-05-01"));
-    Assert.assertEquals(1, pendingSegmentsOutsideInterval.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, pendingSegmentsOutsideInterval.size());
+    Assertions.assertEquals(
         pendingSegmentOutsideInterval.getId().asSegmentId(), pendingSegmentsOutsideInterval.get(0).getId().asSegmentId()
     );
   }
@@ -978,7 +976,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         List.of(pendingSegment0, pendingSegment0, pendingSegment1, pendingSegment1, pendingSegment1),
         true
     );
-    Assert.assertEquals(2, actualInserted);
+    Assertions.assertEquals(2, actualInserted);
   }
 
   @Test
@@ -986,7 +984,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
     for (DataSegment segment : SEGMENTS) {
-      Assert.assertArrayEquals(
+      Assertions.assertArrayEquals(
           mapper.writeValueAsString(segment).getBytes(StandardCharsets.UTF_8),
           derbyConnector.lookup(
               derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
@@ -997,13 +995,13 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       );
     }
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(defaultSegment.getId().toString(), defaultSegment2.getId().toString()),
         retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get())
     );
 
     // Should not update dataSource metadata.
-    Assert.assertEquals(0, metadataUpdateCounter.get());
+    Assertions.assertEquals(0, metadataUpdateCounter.get());
   }
 
   @Test
@@ -1028,7 +1026,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     coordinator.commitSegments(segments, null);
     for (DataSegment segment : segments) {
-      Assert.assertArrayEquals(
+      Assertions.assertArrayEquals(
           mapper.writeValueAsString(segment).getBytes(StandardCharsets.UTF_8),
           derbyConnector.lookup(
               derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
@@ -1044,10 +1042,10 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
                                       .sorted(Comparator.naturalOrder())
                                       .collect(Collectors.toList());
 
-    Assert.assertEquals(segmentIds, retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get()));
+    Assertions.assertEquals(segmentIds, retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get()));
 
     // Should not update dataSource metadata.
-    Assert.assertEquals(0, metadataUpdateCounter.get());
+    Assertions.assertEquals(0, metadataUpdateCounter.get());
   }
 
   @Test
@@ -1058,7 +1056,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     coordinator.commitSegments(segments, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
 
     for (DataSegment segment : segments) {
-      Assert.assertArrayEquals(
+      Assertions.assertArrayEquals(
           mapper.writeValueAsString(segment).getBytes(StandardCharsets.UTF_8),
           derbyConnector.lookup(
               derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
@@ -1069,7 +1067,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       );
     }
 
-    Assert.assertEquals(ImmutableList.of(defaultSegment4.getId().toString()), retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get()));
+    Assertions.assertEquals(ImmutableList.of(defaultSegment4.getId().toString()), retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get()));
   }
 
   @Test
@@ -1083,9 +1081,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
-    Assert.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(defaultSegment)), result1);
+    Assertions.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(defaultSegment)), result1);
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         mapper.writeValueAsString(defaultSegment).getBytes(StandardCharsets.UTF_8),
         derbyConnector.lookup(
             derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
@@ -1103,9 +1101,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
-    Assert.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(defaultSegment2)), result2);
+    Assertions.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(defaultSegment2)), result2);
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         mapper.writeValueAsString(defaultSegment2).getBytes(StandardCharsets.UTF_8),
         derbyConnector.lookup(
             derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
@@ -1116,13 +1114,13 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     // Examine metadata.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
 
     // Should only be tried once per call.
-    Assert.assertEquals(2, metadataUpdateCounter.get());
+    Assertions.assertEquals(2, metadataUpdateCounter.get());
   }
 
   @Test
@@ -1166,7 +1164,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
-    Assert.assertEquals(SegmentPublishResult.retryableFailure("this failure can be retried"), result1);
+    Assertions.assertEquals(SegmentPublishResult.retryableFailure("this failure can be retried"), result1);
 
     final SegmentPublishResult resultOnRetry = failOnceCoordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
@@ -1175,9 +1173,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
-    Assert.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(defaultSegment)), resultOnRetry);
+    Assertions.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(defaultSegment)), resultOnRetry);
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         mapper.writeValueAsString(defaultSegment).getBytes(StandardCharsets.UTF_8),
         derbyConnector.lookup(
             derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
@@ -1198,7 +1196,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
-    Assert.assertEquals(SegmentPublishResult.retryableFailure("this failure can be retried"), result2);
+    Assertions.assertEquals(SegmentPublishResult.retryableFailure("this failure can be retried"), result2);
 
     final SegmentPublishResult resultOnRetry2 = failOnceCoordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment2),
@@ -1207,9 +1205,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
-    Assert.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(defaultSegment2)), resultOnRetry2);
+    Assertions.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(defaultSegment2)), resultOnRetry2);
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         mapper.writeValueAsString(defaultSegment2).getBytes(StandardCharsets.UTF_8),
         derbyConnector.lookup(
             derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
@@ -1220,13 +1218,13 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     // Examine metadata.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         failOnceCoordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
 
     // Should be tried twice per call.
-    Assert.assertEquals(4, metadataUpdateCounter.get());
+    Assertions.assertEquals(4, metadataUpdateCounter.get());
   }
 
   @Test
@@ -1239,7 +1237,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SegmentPublishResult.retryableFailure(
             "The new start metadata state[ObjectMetadata{theObject={foo=bar}}] is ahead of the last committed"
             + " end state[null]. Try resetting the supervisor."
@@ -1248,7 +1246,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     // Should only be tried once.
-    Assert.assertEquals(1, metadataUpdateCounter.get());
+    Assertions.assertEquals(1, metadataUpdateCounter.get());
   }
 
   @Test
@@ -1261,7 +1259,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
-    Assert.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(defaultSegment)), result1);
+    Assertions.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(defaultSegment)), result1);
 
     final SegmentPublishResult result2 = coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment2),
@@ -1270,7 +1268,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SegmentPublishResult.fail(
             "Stored metadata state[ObjectMetadata{theObject={foo=baz}}] has already been updated by other tasks"
             + " and has diverged from the expected start metadata state[ObjectMetadata{theObject=null}]."
@@ -1281,14 +1279,14 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     // Should only be tried once per call.
-    Assert.assertEquals(2, metadataUpdateCounter.get());
+    Assertions.assertEquals(2, metadataUpdateCounter.get());
   }
 
   @Test
   public void test_commitSegmentsAndMetadata_isAtomic()
   {
     final String dataSource = defaultSegment.getDataSource();
-    Assert.assertNull(coordinator.retrieveDataSourceMetadata(dataSource));
+    Assertions.assertNull(coordinator.retrieveDataSourceMetadata(dataSource));
 
     // Create an instance which fails to insert segments but updates metadata successfully
     final AtomicBoolean isMetadataUpdated = new AtomicBoolean(false);
@@ -1326,31 +1324,28 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       }
     };
 
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
-            RuntimeException.class,
-            () -> storageCoordinator.commitSegmentsAndMetadata(
-                Set.of(defaultSegment),
-                SUPERVISOR_ID,
-                new ObjectMetadata(null),
-                new ObjectMetadata(Map.of("foo", "baz")),
-                null
-            )
-        ),
-        ExceptionMatcher.of(RuntimeException.class)
-                        .expectMessageIs("java.lang.RuntimeException: Fail segment insert")
+    ExceptionMatcher.of(RuntimeException.class).expectMessageIs(
+        "java.lang.RuntimeException: Fail segment insert"
+    ).assertThrowsAndMatches(
+        () -> storageCoordinator.commitSegmentsAndMetadata(
+            Set.of(defaultSegment),
+            SUPERVISOR_ID,
+            new ObjectMetadata(null),
+            new ObjectMetadata(Map.of("foo", "baz")),
+            null
+        )
     );
 
     // Verify that the datasource metadata update succeeded but was rolled back
-    Assert.assertTrue(isMetadataUpdated.get());
-    Assert.assertNull(coordinator.retrieveDataSourceMetadata(dataSource));
+    Assertions.assertTrue(isMetadataUpdated.get());
+    Assertions.assertNull(coordinator.retrieveDataSourceMetadata(dataSource));
   }
 
   @Test
   public void testRetrieveUsedSegmentForId()
   {
     coordinator.commitSegments(Set.of(defaultSegment), null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         defaultSegment,
         coordinator.retrieveUsedSegmentForId(defaultSegment.getId())
     );
@@ -1361,7 +1356,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     coordinator.commitSegments(Set.of(defaultSegment), null);
     coordinator.markSegmentAsUnused(defaultSegment.getId());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         defaultSegment,
         coordinator.retrieveSegmentForId(defaultSegment.getId())
     );
@@ -1370,7 +1365,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   @Test
   public void testCleanUpgradeSegmentsTableForTask()
   {
-    Assume.assumeFalse(isCacheEnabled());
+    Assumptions.assumeFalse(isCacheEnabled());
 
     final String taskToClean = "taskToClean";
     final ReplaceTaskLock replaceLockToClean = new ReplaceTaskLock(
@@ -1394,11 +1389,11 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     // Unrelated task should not result in clean up
-    Assert.assertEquals(0, coordinator.deleteUpgradeSegmentsForTask("someRandomTask"));
+    Assertions.assertEquals(0, coordinator.deleteUpgradeSegmentsForTask("someRandomTask"));
     // The two segment entries are deleted
-    Assert.assertEquals(2, coordinator.deleteUpgradeSegmentsForTask(taskToClean));
+    Assertions.assertEquals(2, coordinator.deleteUpgradeSegmentsForTask(taskToClean));
     // Nothing further to delete
-    Assert.assertEquals(0, coordinator.deleteUpgradeSegmentsForTask(taskToClean));
+    Assertions.assertEquals(0, coordinator.deleteUpgradeSegmentsForTask(taskToClean));
   }
 
   @Test
@@ -1411,7 +1406,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
-    Assert.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(defaultSegment)), result1);
+    Assertions.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(defaultSegment)), result1);
 
     final SegmentPublishResult result2 = coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment2),
@@ -1420,7 +1415,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new ObjectMetadata(ImmutableMap.of("foo", "baz")),
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SegmentPublishResult.fail(
             "Stored metadata state[ObjectMetadata{theObject={foo=baz}}] has already been updated by other tasks"
             + " and has diverged from the expected start metadata state[ObjectMetadata{theObject={foo=qux}}]."
@@ -1431,14 +1426,14 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     // Should only be tried once per call.
-    Assert.assertEquals(2, metadataUpdateCounter.get());
+    Assertions.assertEquals(2, metadataUpdateCounter.get());
   }
 
   @Test
   public void testSimpleUsedList()
   {
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SEGMENTS,
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
@@ -1456,7 +1451,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
     coordinator.commitSegments(ImmutableSet.of(defaultSegment3), new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
 
-    Assertions.assertThat(
+    org.assertj.core.api.Assertions.assertThat(
         coordinator.retrieveUsedSegmentsForIntervals(
             defaultSegment.getDataSource(),
             ImmutableList.of(defaultSegment.getInterval()),
@@ -1464,7 +1459,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         )
     ).containsOnlyOnce(SEGMENTS.toArray(new DataSegment[0]));
 
-    Assertions.assertThat(
+    org.assertj.core.api.Assertions.assertThat(
         coordinator.retrieveUsedSegmentsForIntervals(
             defaultSegment.getDataSource(),
             ImmutableList.of(defaultSegment3.getInterval()),
@@ -1472,7 +1467,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         )
     ).containsOnlyOnce(defaultSegment3);
 
-    Assertions.assertThat(
+    org.assertj.core.api.Assertions.assertThat(
         coordinator.retrieveUsedSegmentsForIntervals(
             defaultSegment.getDataSource(),
             ImmutableList.of(defaultSegment.getInterval(), defaultSegment3.getInterval()),
@@ -1481,7 +1476,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     ).containsOnlyOnce(defaultSegment, defaultSegment2, defaultSegment3);
 
     //case to check no duplication if two intervals overlapped with the interval of same segment.
-    Assertions.assertThat(
+    org.assertj.core.api.Assertions.assertThat(
         coordinator.retrieveUsedSegmentsForIntervals(
             defaultSegment.getDataSource(),
             ImmutableList.of(
@@ -1505,8 +1500,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         Segments.ONLY_VISIBLE
     );
 
-    Assert.assertEquals(segments.size(), actualUsedSegments.size());
-    Assert.assertTrue(actualUsedSegments.containsAll(segments));
+    Assertions.assertEquals(segments.size(), actualUsedSegments.size());
+    Assertions.assertTrue(actualUsedSegments.containsAll(segments));
   }
 
   @Test
@@ -1515,7 +1510,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     final List<DataSegment> segments = createAndGetUsedYearSegments(1905, 1910);
 
     final Interval outOfRangeInterval = Intervals.of("1700/1800");
-    Assert.assertTrue(segments.stream()
+    Assertions.assertTrue(segments.stream()
                               .anyMatch(segment -> !segment.getInterval().overlaps(outOfRangeInterval)));
 
     final Collection<DataSegment> actualUsedSegments = coordinator.retrieveUsedSegmentsForIntervals(
@@ -1524,7 +1519,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         Segments.ONLY_VISIBLE
     );
 
-    Assert.assertEquals(0, actualUsedSegments.size());
+    Assertions.assertEquals(0, actualUsedSegments.size());
   }
 
   @Test
@@ -1537,8 +1532,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         Segments.ONLY_VISIBLE
     );
 
-    Assert.assertEquals(segments.size(), actualUsedSegments.size());
-    Assert.assertTrue(actualUsedSegments.containsAll(segments));
+    Assertions.assertEquals(segments.size(), actualUsedSegments.size());
+    Assertions.assertTrue(actualUsedSegments.containsAll(segments));
   }
 
   @Test
@@ -1554,8 +1549,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null
     );
 
-    Assert.assertEquals(segments.size(), actualUnusedSegments.size());
-    Assert.assertTrue(actualUnusedSegments.containsAll(segments));
+    Assertions.assertEquals(segments.size(), actualUnusedSegments.size());
+    Assertions.assertTrue(actualUnusedSegments.containsAll(segments));
   }
 
   @Test
@@ -1572,8 +1567,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null
     );
 
-    Assert.assertEquals(requestedLimit, actualUnusedSegments.size());
-    Assert.assertTrue(actualUnusedSegments.containsAll(segments));
+    Assertions.assertEquals(requestedLimit, actualUnusedSegments.size());
+    Assertions.assertTrue(actualUnusedSegments.containsAll(segments));
   }
 
   @Test
@@ -1590,8 +1585,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null
     );
 
-    Assert.assertEquals(requestedLimit, actualUnusedSegments.size());
-    Assert.assertTrue(actualUnusedSegments.containsAll(segments.stream().limit(requestedLimit).toList()));
+    Assertions.assertEquals(requestedLimit, actualUnusedSegments.size());
+    Assertions.assertTrue(actualUnusedSegments.containsAll(segments.stream().limit(requestedLimit).toList()));
   }
 
   @Test
@@ -1607,8 +1602,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         limit,
         null
     );
-    Assert.assertEquals(segments.size(), actualUnusedSegments.size());
-    Assert.assertTrue(actualUnusedSegments.containsAll(segments));
+    Assertions.assertEquals(segments.size(), actualUnusedSegments.size());
+    Assertions.assertTrue(actualUnusedSegments.containsAll(segments));
   }
 
   @Test
@@ -1618,7 +1613,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     markAllSegmentsUnused(new HashSet<>(segments), DateTimes.nowUtc());
 
     final Interval outOfRangeInterval = Intervals.of("1700/1800");
-    Assert.assertTrue(segments.stream()
+    Assertions.assertTrue(segments.stream()
                               .anyMatch(segment -> !segment.getInterval().overlaps(outOfRangeInterval)));
     final int limit = segments.size() + 1;
 
@@ -1628,7 +1623,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         limit,
         null
     );
-    Assert.assertEquals(0, actualUnusedSegments.size());
+    Assertions.assertEquals(0, actualUnusedSegments.size());
   }
 
   @Test
@@ -1646,8 +1641,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(segments.size(), actualUnusedSegments.size());
-    Assert.assertTrue(segments.containsAll(actualUnusedSegments));
+    Assertions.assertEquals(segments.size(), actualUnusedSegments.size());
+    Assertions.assertTrue(segments.containsAll(actualUnusedSegments));
 
     final ImmutableList<DataSegmentPlus> actualUnusedSegmentsPlus = retrieveUnusedSegmentsPlus(
         segments.stream().map(DataSegment::getInterval).collect(Collectors.toList()),
@@ -1657,7 +1652,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(segments.size(), actualUnusedSegmentsPlus.size());
+    Assertions.assertEquals(segments.size(), actualUnusedSegmentsPlus.size());
     verifyContainsAllSegmentsPlus(segments, actualUnusedSegmentsPlus, usedStatusLastUpdatedTime);
   }
 
@@ -1676,8 +1671,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(segments.size(), actualUnusedSegments.size());
-    Assert.assertTrue(segments.containsAll(actualUnusedSegments));
+    Assertions.assertEquals(segments.size(), actualUnusedSegments.size());
+    Assertions.assertTrue(segments.containsAll(actualUnusedSegments));
 
     final ImmutableList<DataSegmentPlus> actualUnusedSegmentsPlus = retrieveUnusedSegmentsPlus(
         ImmutableList.of(),
@@ -1687,7 +1682,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(segments.size(), actualUnusedSegmentsPlus.size());
+    Assertions.assertEquals(segments.size(), actualUnusedSegmentsPlus.size());
     verifyContainsAllSegmentsPlus(segments, actualUnusedSegmentsPlus, usedStatusLastUpdatedTime);
   }
 
@@ -1710,8 +1705,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(expectedSegmentsAscOrder.size(), actualUnusedSegments.size());
-    Assert.assertTrue(expectedSegmentsAscOrder.containsAll(actualUnusedSegments));
+    Assertions.assertEquals(expectedSegmentsAscOrder.size(), actualUnusedSegments.size());
+    Assertions.assertTrue(expectedSegmentsAscOrder.containsAll(actualUnusedSegments));
 
     ImmutableList<DataSegmentPlus> actualUnusedSegmentsPlus = retrieveUnusedSegmentsPlus(
         ImmutableList.of(),
@@ -1721,7 +1716,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(expectedSegmentsAscOrder.size(), actualUnusedSegmentsPlus.size());
+    Assertions.assertEquals(expectedSegmentsAscOrder.size(), actualUnusedSegmentsPlus.size());
     verifyContainsAllSegmentsPlus(expectedSegmentsAscOrder, actualUnusedSegmentsPlus, usedStatusLastUpdatedTime);
 
     actualUnusedSegments = retrieveUnusedSegments(
@@ -1732,8 +1727,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(expectedSegmentsAscOrder.size(), actualUnusedSegments.size());
-    Assert.assertEquals(expectedSegmentsAscOrder, actualUnusedSegments);
+    Assertions.assertEquals(expectedSegmentsAscOrder.size(), actualUnusedSegments.size());
+    Assertions.assertEquals(expectedSegmentsAscOrder, actualUnusedSegments);
 
     actualUnusedSegmentsPlus = retrieveUnusedSegmentsPlus(
         ImmutableList.of(),
@@ -1743,7 +1738,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(expectedSegmentsAscOrder.size(), actualUnusedSegmentsPlus.size());
+    Assertions.assertEquals(expectedSegmentsAscOrder.size(), actualUnusedSegmentsPlus.size());
     verifyEqualsAllSegmentsPlus(expectedSegmentsAscOrder, actualUnusedSegmentsPlus, usedStatusLastUpdatedTime);
 
     final List<DataSegment> expectedSegmentsDescOrder = segments.stream()
@@ -1759,8 +1754,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(expectedSegmentsDescOrder.size(), actualUnusedSegments.size());
-    Assert.assertEquals(expectedSegmentsDescOrder, actualUnusedSegments);
+    Assertions.assertEquals(expectedSegmentsDescOrder.size(), actualUnusedSegments.size());
+    Assertions.assertEquals(expectedSegmentsDescOrder, actualUnusedSegments);
 
     actualUnusedSegmentsPlus = retrieveUnusedSegmentsPlus(
         ImmutableList.of(),
@@ -1770,7 +1765,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(expectedSegmentsDescOrder.size(), actualUnusedSegmentsPlus.size());
+    Assertions.assertEquals(expectedSegmentsDescOrder.size(), actualUnusedSegmentsPlus.size());
     verifyEqualsAllSegmentsPlus(expectedSegmentsDescOrder, actualUnusedSegmentsPlus, usedStatusLastUpdatedTime);
   }
 
@@ -1789,8 +1784,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(segments.size(), actualUnusedSegments.size());
-    Assert.assertTrue(segments.containsAll(actualUnusedSegments));
+    Assertions.assertEquals(segments.size(), actualUnusedSegments.size());
+    Assertions.assertTrue(segments.containsAll(actualUnusedSegments));
 
     final ImmutableList<DataSegmentPlus> actualUnusedSegmentsPlus = retrieveUnusedSegmentsPlus(
         ImmutableList.of(),
@@ -1800,7 +1795,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(segments.size(), actualUnusedSegmentsPlus.size());
+    Assertions.assertEquals(segments.size(), actualUnusedSegmentsPlus.size());
     verifyContainsAllSegmentsPlus(segments, actualUnusedSegmentsPlus, usedStatusLastUpdatedTime);
   }
 
@@ -1821,8 +1816,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
     final List<DataSegment> expectedSegments = segments.stream().limit(requestedLimit).collect(Collectors.toList());
-    Assert.assertEquals(requestedLimit, actualUnusedSegments.size());
-    Assert.assertTrue(actualUnusedSegments.containsAll(expectedSegments));
+    Assertions.assertEquals(requestedLimit, actualUnusedSegments.size());
+    Assertions.assertTrue(actualUnusedSegments.containsAll(expectedSegments));
 
     final ImmutableList<DataSegmentPlus> actualUnusedSegmentsPlus = retrieveUnusedSegmentsPlus(
         ImmutableList.of(),
@@ -1832,7 +1827,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(requestedLimit, actualUnusedSegmentsPlus.size());
+    Assertions.assertEquals(requestedLimit, actualUnusedSegmentsPlus.size());
     verifyContainsAllSegmentsPlus(expectedSegments, actualUnusedSegmentsPlus, usedStatusLastUpdatedTime);
   }
 
@@ -1857,8 +1852,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(segments.size() - 5, actualUnusedSegments.size());
-    Assert.assertEquals(actualUnusedSegments, expectedSegments);
+    Assertions.assertEquals(segments.size() - 5, actualUnusedSegments.size());
+    Assertions.assertEquals(actualUnusedSegments, expectedSegments);
 
     final ImmutableList<DataSegmentPlus> actualUnusedSegmentsPlus = retrieveUnusedSegmentsPlus(
         ImmutableList.of(),
@@ -1868,7 +1863,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(segments.size() - 5, actualUnusedSegmentsPlus.size());
+    Assertions.assertEquals(segments.size() - 5, actualUnusedSegmentsPlus.size());
     verifyEqualsAllSegmentsPlus(expectedSegments, actualUnusedSegmentsPlus, usedStatusLastUpdatedTime);
   }
 
@@ -1893,8 +1888,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(requestedLimit - 4, actualUnusedSegments.size());
-    Assert.assertEquals(actualUnusedSegments, expectedSegments);
+    Assertions.assertEquals(requestedLimit - 4, actualUnusedSegments.size());
+    Assertions.assertEquals(actualUnusedSegments, expectedSegments);
 
     final ImmutableList<DataSegmentPlus> actualUnusedSegmentsPlus = retrieveUnusedSegmentsPlus(
         segments.stream().map(DataSegment::getInterval).collect(Collectors.toList()),
@@ -1904,7 +1899,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(requestedLimit - 4, actualUnusedSegmentsPlus.size());
+    Assertions.assertEquals(requestedLimit - 4, actualUnusedSegmentsPlus.size());
     verifyEqualsAllSegmentsPlus(expectedSegments, actualUnusedSegmentsPlus, usedStatusLastUpdatedTime);
   }
 
@@ -1923,8 +1918,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(segments.size(), actualUnusedSegments.size());
-    Assert.assertTrue(actualUnusedSegments.containsAll(segments));
+    Assertions.assertEquals(segments.size(), actualUnusedSegments.size());
+    Assertions.assertTrue(actualUnusedSegments.containsAll(segments));
 
     final ImmutableList<DataSegmentPlus> actualUnusedSegmentsPlus = retrieveUnusedSegmentsPlus(
         segments.stream().map(DataSegment::getInterval).collect(Collectors.toList()),
@@ -1934,7 +1929,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(segments.size(), actualUnusedSegmentsPlus.size());
+    Assertions.assertEquals(segments.size(), actualUnusedSegmentsPlus.size());
     verifyContainsAllSegmentsPlus(segments, actualUnusedSegmentsPlus, usedStatusLastUpdatedTime);
   }
 
@@ -1945,7 +1940,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     markAllSegmentsUnused(new HashSet<>(segments), DateTimes.nowUtc());
 
     final Interval outOfRangeInterval = Intervals.of("1700/1800");
-    Assert.assertTrue(segments.stream()
+    Assertions.assertTrue(segments.stream()
                               .anyMatch(segment -> !segment.getInterval().overlaps(outOfRangeInterval)));
 
     final ImmutableList<DataSegment> actualUnusedSegments = retrieveUnusedSegments(
@@ -1956,7 +1951,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
          null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(0, actualUnusedSegments.size());
+    Assertions.assertEquals(0, actualUnusedSegments.size());
 
     final ImmutableList<DataSegmentPlus> actualUnusedSegmentsPlus = retrieveUnusedSegmentsPlus(
         ImmutableList.of(outOfRangeInterval),
@@ -1966,7 +1961,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(0, actualUnusedSegmentsPlus.size());
+    Assertions.assertEquals(0, actualUnusedSegmentsPlus.size());
   }
 
   @Test
@@ -1986,7 +1981,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         DateTimes.nowUtc(),
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(5, actualUnusedSegments1.size());
+    Assertions.assertEquals(5, actualUnusedSegments1.size());
 
     ImmutableList<DataSegmentPlus> actualUnusedSegmentsPlus = retrieveUnusedSegmentsPlus(
         ImmutableList.of(interval),
@@ -1996,7 +1991,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         DateTimes.nowUtc(),
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(5, actualUnusedSegmentsPlus.size());
+    Assertions.assertEquals(5, actualUnusedSegmentsPlus.size());
 
     final ImmutableList<DataSegment> actualUnusedSegments2 = retrieveUnusedSegments(
         ImmutableList.of(interval),
@@ -2006,7 +2001,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         DateTimes.nowUtc().minusHours(1),
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(0, actualUnusedSegments2.size());
+    Assertions.assertEquals(0, actualUnusedSegments2.size());
 
     actualUnusedSegmentsPlus = retrieveUnusedSegmentsPlus(
         ImmutableList.of(interval),
@@ -2016,7 +2011,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         DateTimes.nowUtc().minusHours(1),
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(0, actualUnusedSegmentsPlus.size());
+    Assertions.assertEquals(0, actualUnusedSegmentsPlus.size());
   }
 
   @Test
@@ -2051,7 +2046,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         maxUsedStatusLastUpdatedTime1,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(oddYearSegments.size(), actualUnusedSegments1.size());
+    Assertions.assertEquals(oddYearSegments.size(), actualUnusedSegments1.size());
 
     final ImmutableList<DataSegmentPlus> actualUnusedSegmentsPlus1 = retrieveUnusedSegmentsPlus(
         ImmutableList.of(interval),
@@ -2061,7 +2056,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         maxUsedStatusLastUpdatedTime1,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(oddYearSegments.size(), actualUnusedSegmentsPlus1.size());
+    Assertions.assertEquals(oddYearSegments.size(), actualUnusedSegmentsPlus1.size());
 
     final ImmutableList<DataSegment> actualUnusedSegments2 = retrieveUnusedSegments(
         ImmutableList.of(interval),
@@ -2071,7 +2066,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         maxUsedStatusLastUpdatedTime2,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(segments.size(), actualUnusedSegments2.size());
+    Assertions.assertEquals(segments.size(), actualUnusedSegments2.size());
 
     final ImmutableList<DataSegmentPlus> actualUnusedSegmentsPlus2 = retrieveUnusedSegmentsPlus(
         ImmutableList.of(interval),
@@ -2081,7 +2076,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         maxUsedStatusLastUpdatedTime2,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(segments.size(), actualUnusedSegmentsPlus2.size());
+    Assertions.assertEquals(segments.size(), actualUnusedSegmentsPlus2.size());
   }
 
   @Test
@@ -2089,7 +2084,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
     markAllSegmentsUnused();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SEGMENTS,
         ImmutableSet.copyOf(
             coordinator.retrieveUnusedSegmentsForInterval(
@@ -2133,11 +2128,11 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     final ImmutableSet<DataSegment> unusedSegments = ImmutableSet.of(segment1, segment2, segment3, segment4);
-    Assert.assertEquals(unusedSegments, coordinator.commitSegments(unusedSegments, null));
+    Assertions.assertEquals(unusedSegments, coordinator.commitSegments(unusedSegments, null));
     markAllSegmentsUnused(unusedSegments, DateTimes.nowUtc());
 
     for (DataSegment unusedSegment : unusedSegments) {
-      Assertions.assertThat(
+      org.assertj.core.api.Assertions.assertThat(
           coordinator.retrieveUnusedSegmentsForInterval(
               TestDataSource.WIKI,
               Intervals.of("2023-01-01/2023-01-04"),
@@ -2148,7 +2143,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       ).contains(unusedSegment);
     }
 
-    Assertions.assertThat(
+    org.assertj.core.api.Assertions.assertThat(
         coordinator.retrieveUnusedSegmentsForInterval(
             TestDataSource.WIKI,
             Intervals.of("2023-01-01/2023-01-04"),
@@ -2158,7 +2153,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         )
     ).contains(segment1, segment2);
 
-    Assertions.assertThat(
+    org.assertj.core.api.Assertions.assertThat(
         coordinator.retrieveUnusedSegmentsForInterval(
             TestDataSource.WIKI,
             Intervals.of("2023-01-01/2023-01-04"),
@@ -2168,7 +2163,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         )
     ).containsAll(unusedSegments);
 
-    Assertions.assertThat(
+    org.assertj.core.api.Assertions.assertThat(
         coordinator.retrieveUnusedSegmentsForInterval(
             TestDataSource.WIKI,
             Intervals.of("2023-01-01/2023-01-04"),
@@ -2194,8 +2189,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
             null
         )
     );
-    Assert.assertEquals(limit, retreivedUnusedSegments.size());
-    Assert.assertTrue(SEGMENTS.containsAll(retreivedUnusedSegments));
+    Assertions.assertEquals(limit, retreivedUnusedSegments.size());
+    Assertions.assertTrue(SEGMENTS.containsAll(retreivedUnusedSegments));
   }
 
   @Test
@@ -2208,7 +2203,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     markAllSegmentsUnused(Set.of(defaultSegment, defaultSegment2, defaultSegment3), now.minusHours(1));
 
     // Verify that query for overlapping interval does not return the segments
-    Assert.assertTrue(
+    Assertions.assertTrue(
         coordinator.retrieveUnusedSegmentsWithExactInterval(
             dataSource,
             Intervals.ETERNITY,
@@ -2218,7 +2213,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     // Verify that query for exact interval returns the segments
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(toSegmentPlusUpgradedId(defaultSegment3, null)),
         coordinator.retrieveUnusedSegmentsWithExactInterval(
             dataSource,
@@ -2228,8 +2223,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         )
     );
 
-    Assert.assertEquals(defaultSegment.getInterval(), defaultSegment2.getInterval());
-    Assert.assertEquals(
+    Assertions.assertEquals(defaultSegment.getInterval(), defaultSegment2.getInterval());
+    Assertions.assertEquals(
         Set.of(toSegmentPlusUpgradedId(defaultSegment, null), toSegmentPlusUpgradedId(defaultSegment2, null)),
         Set.copyOf(
             coordinator.retrieveUnusedSegmentsWithExactInterval(
@@ -2242,7 +2237,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     // Verify that query with limit 1 returns only 1 result
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         coordinator.retrieveUnusedSegmentsWithExactInterval(
             dataSource,
@@ -2259,22 +2254,22 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     final String dataSource = defaultSegment.getDataSource();
     coordinator.commitSegments(Set.of(defaultSegment, defaultSegment3), null);
 
-    Assert.assertTrue(coordinator.retrieveSomeUnusedSegmentIntervals(dataSource, 100).isEmpty());
+    Assertions.assertTrue(coordinator.retrieveSomeUnusedSegmentIntervals(dataSource, 100).isEmpty());
 
     markAllSegmentsUnused(Set.of(defaultSegment), DateTimes.nowUtc().minusHours(1));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(defaultSegment.getInterval()),
         coordinator.retrieveSomeUnusedSegmentIntervals(dataSource, 100)
     );
 
     markAllSegmentsUnused(Set.of(defaultSegment3), DateTimes.nowUtc().minusHours(1));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(defaultSegment.getInterval(), defaultSegment3.getInterval()),
         Set.copyOf(coordinator.retrieveSomeUnusedSegmentIntervals(dataSource, 100))
     );
 
     // Verify retrieve with limit 1 returns only 1 interval
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         coordinator.retrieveSomeUnusedSegmentIntervals(dataSource, 1).size()
     );
@@ -2288,16 +2283,16 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     final DateTime maxUpdatedTime = DateTimes.nowUtc();
 
-    Assert.assertTrue(coordinator.retrieveSomeUnusedSegmentIntervals(maxUpdatedTime, 100, 100).isEmpty());
+    Assertions.assertTrue(coordinator.retrieveSomeUnusedSegmentIntervals(maxUpdatedTime, 100, 100).isEmpty());
 
     markAllSegmentsUnused(Set.of(defaultSegment), DateTimes.nowUtc().minusHours(1));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Map.of(new DatasourceInterval(dataSource, defaultSegment.getInterval()), 1),
         coordinator.retrieveSomeUnusedSegmentIntervals(maxUpdatedTime, 100, 100)
     );
 
     markAllSegmentsUnused(Set.of(defaultSegment3), DateTimes.nowUtc().minusHours(1));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Map.of(
             new DatasourceInterval(dataSource, defaultSegment.getInterval()), 1,
             new DatasourceInterval(dataSource, defaultSegment3.getInterval()), 1
@@ -2306,7 +2301,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     // Verify retrieve with limit 1 returns only 1 interval
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         coordinator.retrieveSomeUnusedSegmentIntervals(maxUpdatedTime, 1, 1).size()
     );
@@ -2317,7 +2312,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     coordinator.commitSegments(Set.of(defaultSegment), null);
     coordinator.commitSegments(Set.of(hugeTimeRangeSegment1), null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of("fooDataSource", "hugeTimeRangeDataSource"),
         coordinator.retrieveAllDatasourceNames()
     );
@@ -2334,7 +2329,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
             Segments.ONLY_VISIBLE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SEGMENTS,
         actualSegments
     );
@@ -2345,7 +2340,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   public void testUsedOverlapHigh()
   {
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SEGMENTS,
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
@@ -2361,7 +2356,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   public void testUsedOutOfBoundsLow()
   {
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
-    Assert.assertTrue(
+    Assertions.assertTrue(
         coordinator.retrieveUsedSegmentsForInterval(
             defaultSegment.getDataSource(),
             new Interval(defaultSegment.getInterval().getStart().minus(1), defaultSegment.getInterval().getStart()),
@@ -2375,7 +2370,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   public void testUsedOutOfBoundsHigh()
   {
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
-    Assert.assertTrue(
+    Assertions.assertTrue(
         coordinator.retrieveUsedSegmentsForInterval(
             defaultSegment.getDataSource(),
             new Interval(defaultSegment.getInterval().getEnd(), defaultSegment.getInterval().getEnd().plusDays(10)),
@@ -2388,7 +2383,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   public void testUsedWithinBoundsEnd()
   {
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SEGMENTS,
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
@@ -2404,7 +2399,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   public void testUsedOverlapEnd()
   {
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SEGMENTS,
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
@@ -2421,7 +2416,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
     markAllSegmentsUnused();
-    Assert.assertTrue(
+    Assertions.assertTrue(
         coordinator.retrieveUnusedSegmentsForInterval(
             defaultSegment.getDataSource(),
             new Interval(
@@ -2439,7 +2434,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
     markAllSegmentsUnused();
-    Assert.assertTrue(
+    Assertions.assertTrue(
         coordinator.retrieveUnusedSegmentsForInterval(
             defaultSegment.getDataSource(),
             new Interval(defaultSegment.getInterval().getStart().plus(1), defaultSegment.getInterval().getEnd()),
@@ -2455,7 +2450,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
     markAllSegmentsUnused();
-    Assert.assertTrue(
+    Assertions.assertTrue(
         coordinator.retrieveUnusedSegmentsForInterval(
             defaultSegment.getDataSource(),
             new Interval(defaultSegment.getInterval().getStart(), defaultSegment.getInterval().getEnd().minus(1)),
@@ -2470,7 +2465,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
     markAllSegmentsUnused();
-    Assert.assertTrue(
+    Assertions.assertTrue(
         coordinator.retrieveUnusedSegmentsForInterval(
             defaultSegment.getDataSource(),
             defaultSegment.getInterval().withStart(defaultSegment.getInterval().getEnd().minus(1)),
@@ -2485,7 +2480,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
     markAllSegmentsUnused();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SEGMENTS,
         ImmutableSet.copyOf(
             coordinator.retrieveUnusedSegmentsForInterval(
@@ -2503,7 +2498,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
     markAllSegmentsUnused();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SEGMENTS,
         ImmutableSet.copyOf(
             coordinator.retrieveUnusedSegmentsForInterval(
@@ -2514,7 +2509,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
             )
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SEGMENTS,
         ImmutableSet.copyOf(
             coordinator.retrieveUnusedSegmentsForInterval(
@@ -2532,7 +2527,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   {
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
     markAllSegmentsUnused();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SEGMENTS,
         ImmutableSet.copyOf(
             coordinator.retrieveUnusedSegmentsForInterval(
@@ -2543,7 +2538,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
             )
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SEGMENTS,
         ImmutableSet.copyOf(
             coordinator.retrieveUnusedSegmentsForInterval(
@@ -2568,7 +2563,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(hugeTimeRangeSegment1, hugeTimeRangeSegment2, hugeTimeRangeSegment3),
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForIntervals(
@@ -2592,7 +2587,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(hugeTimeRangeSegment2),
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
@@ -2616,7 +2611,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(hugeTimeRangeSegment2),
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
@@ -2638,7 +2633,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(eternitySegment),
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
@@ -2661,7 +2656,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(eternitySegment, numberedSegment0of0),
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
@@ -2683,7 +2678,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(firstHalfEternityRangeSegment),
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
@@ -2706,7 +2701,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(numberedSegment0of0, firstHalfEternityRangeSegment),
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
@@ -2728,7 +2723,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(secondHalfEternityRangeSegment),
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
@@ -2744,7 +2739,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   public void testLargeIntervalWithStringComparison()
   {
     // Known Issue when not using cache: https://github.com/apache/druid/issues/12860
-    Assume.assumeTrue(isCacheEnabled());
+    Assumptions.assumeTrue(isCacheEnabled());
 
     coordinator.commitSegments(
         ImmutableSet.of(
@@ -2753,7 +2748,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(hugeTimeRangeSegment4),
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
@@ -2776,7 +2771,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(numberedSegment0of0, secondHalfEternityRangeSegment),
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
@@ -2799,15 +2794,15 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
 
-    Assert.assertFalse("deleteInvalidDataSourceMetadata", coordinator.deleteDataSourceMetadata("nonExistentSupervisor"));
-    Assert.assertTrue("deleteValidDataSourceMetadata", coordinator.deleteDataSourceMetadata(SUPERVISOR_ID));
+    Assertions.assertFalse(coordinator.deleteDataSourceMetadata("nonExistentSupervisor"), "deleteInvalidDataSourceMetadata");
+    Assertions.assertTrue(coordinator.deleteDataSourceMetadata(SUPERVISOR_ID), "deleteValidDataSourceMetadata");
 
-    Assert.assertNull("getDataSourceMetadataNullAfterDelete", coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID));
+    Assertions.assertNull(coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID), "getDataSourceMetadataNullAfterDelete");
   }
 
   @Test
@@ -2817,7 +2812,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
 
     // check segments Published
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SEGMENTS,
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
@@ -2831,7 +2826,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     coordinator.deleteSegments(SEGMENTS);
 
     // check segments removed
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
@@ -2846,13 +2841,13 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   @Test
   public void testUpdateSegmentsInMetaDataStorage()
   {
-    Assume.assumeFalse(isCacheEnabled());
+    Assumptions.assumeFalse(isCacheEnabled());
 
     // Published segments to MetaDataStorage
     coordinator.commitSegments(SEGMENTS, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
 
     // check segments Published
-    Assert.assertEquals(
+    Assertions.assertEquals(
             SEGMENTS,
             ImmutableSet.copyOf(
                     coordinator.retrieveUsedSegmentsForInterval(
@@ -2871,18 +2866,18 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
             defaultSegment.getInterval(),
             Segments.ONLY_VISIBLE);
 
-    Assert.assertEquals(SEGMENTS.size(), updated.size());
+    Assertions.assertEquals(SEGMENTS.size(), updated.size());
 
     DataSegment defaultAfterUpdate = updated.stream().filter(s -> s.equals(defaultSegment)).findFirst().get();
     DataSegment default2AfterUpdate = updated.stream().filter(s -> s.equals(defaultSegment2)).findFirst().get();
 
-    Assert.assertNotNull(defaultAfterUpdate);
-    Assert.assertNotNull(default2AfterUpdate);
+    Assertions.assertNotNull(defaultAfterUpdate);
+    Assertions.assertNotNull(default2AfterUpdate);
 
     // check that default did not change
-    Assert.assertEquals(defaultSegment.getSize(), defaultAfterUpdate.getSize());
+    Assertions.assertEquals(defaultSegment.getSize(), defaultAfterUpdate.getSize());
     // but that default 2 did change
-    Assert.assertEquals(defaultSegment2WithBiggerSize.getSize(), default2AfterUpdate.getSize());
+    Assertions.assertEquals(defaultSegment2WithBiggerSize.getSize(), default2AfterUpdate.getSize());
   }
 
   @Test
@@ -2914,7 +2909,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     coordinator.commitSegments(segments, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
 
     for (DataSegment segment : segments) {
-      Assert.assertArrayEquals(
+      Assertions.assertArrayEquals(
           mapper.writeValueAsString(segment).getBytes(StandardCharsets.UTF_8),
           derbyConnector.lookup(
               derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
@@ -2925,13 +2920,13 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       );
     }
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         segments.stream().map(segment -> segment.getId().toString()).collect(Collectors.toList()),
         retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get())
     );
 
     // Should not update dataSource metadata.
-    Assert.assertEquals(0, metadataUpdateCounter.get());
+    Assertions.assertEquals(0, metadataUpdateCounter.get());
   }
 
   @Test
@@ -2951,7 +2946,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null
     );
 
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version", identifier.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version", identifier.toString());
 
     final SegmentIdWithShardSpec identifier1 = allocatePendingSegment(
         dataSource,
@@ -2964,7 +2959,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null
     );
 
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_1", identifier1.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_1", identifier1.toString());
 
     final SegmentIdWithShardSpec identifier2 = allocatePendingSegment(
         dataSource,
@@ -2977,7 +2972,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null
     );
 
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_2", identifier2.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_2", identifier2.toString());
 
     final SegmentIdWithShardSpec identifier3 = allocatePendingSegment(
         dataSource,
@@ -2990,8 +2985,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null
     );
 
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_2", identifier3.toString());
-    Assert.assertEquals(identifier2, identifier3);
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_2", identifier3.toString());
+    Assertions.assertEquals(identifier2, identifier3);
 
     final SegmentIdWithShardSpec identifier4 = allocatePendingSegment(
         dataSource,
@@ -3004,7 +2999,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null
     );
 
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_3", identifier4.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_3", identifier4.toString());
   }
 
   /**
@@ -3040,9 +3035,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         true,
         null
     );
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version", identifier.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version", identifier.toString());
     // Since there are no used core partitions yet
-    Assert.assertEquals(0, identifier.getShardSpec().getNumCorePartitions());
+    Assertions.assertEquals(0, identifier.getShardSpec().getNumCorePartitions());
 
     // simulate one more load using kafka streaming (as if previous segment was published, note different sequence name)
     final SegmentIdWithShardSpec identifier1 = allocatePendingSegment(
@@ -3055,9 +3050,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         true,
         null
     );
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_1", identifier1.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_1", identifier1.toString());
     // Since there are no used core partitions yet
-    Assert.assertEquals(0, identifier1.getShardSpec().getNumCorePartitions());
+    Assertions.assertEquals(0, identifier1.getShardSpec().getNumCorePartitions());
 
     // simulate one more load using kafka streaming (as if previous segment was published, note different sequence name)
     final SegmentIdWithShardSpec identifier2 = allocatePendingSegment(
@@ -3070,9 +3065,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         true,
         null
     );
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_2", identifier2.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_2", identifier2.toString());
     // Since there are no used core partitions yet
-    Assert.assertEquals(0, identifier2.getShardSpec().getNumCorePartitions());
+    Assertions.assertEquals(0, identifier2.getShardSpec().getNumCorePartitions());
 
     // now simulate that one compaction was done (batch) ingestion for same interval (like reindex of the previous three):
     DataSegment segment = new DataSegment(
@@ -3088,7 +3083,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
     coordinator.commitSegments(Set.of(segment), null);
     List<String> ids = retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get());
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_new", ids.get(0));
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_new", ids.get(0));
 
     // one more load on same interval:
     final SegmentIdWithShardSpec identifier3 = allocatePendingSegment(
@@ -3101,9 +3096,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         true,
         null
     );
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_new_1", identifier3.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_new_1", identifier3.toString());
     // Used segment set has 1 core partition
-    Assert.assertEquals(1, identifier3.getShardSpec().getNumCorePartitions());
+    Assertions.assertEquals(1, identifier3.getShardSpec().getNumCorePartitions());
 
     // now drop the used segment previously loaded:
     coordinator.markSegmentAsUnused(segment.getId());
@@ -3120,9 +3115,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         true,
         null
     );
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_new_2", identifier4.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_new_2", identifier4.toString());
     // Since all core partitions have been dropped
-    Assert.assertEquals(0, identifier4.getShardSpec().getNumCorePartitions());
+    Assertions.assertEquals(0, identifier4.getShardSpec().getNumCorePartitions());
   }
 
   /**
@@ -3154,7 +3149,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         true,
         null
     );
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A", identifier.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A", identifier.toString());
     // Assume it publishes; create its corresponding segment
     DataSegment segment = new DataSegment(
         "ds",
@@ -3169,7 +3164,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
     coordinator.commitSegments(Set.of(segment), null);
     List<String> ids = retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get());
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A", ids.get(0));
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A", ids.get(0));
 
 
     // 1.1) simulate one more append load  (as if previous segment was published, note different sequence name)
@@ -3183,7 +3178,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         true,
         null
     );
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A_1", identifier1.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A_1", identifier1.toString());
     // Assume it publishes; create its corresponding segment
     segment = new DataSegment(
         "ds",
@@ -3198,7 +3193,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
     coordinator.commitSegments(Set.of(segment), null);
     ids = retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get());
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A_1", ids.get(1));
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A_1", ids.get(1));
 
 
     // 1.2) simulate one more append load  (as if previous segment was published, note different sequence name)
@@ -3212,7 +3207,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         true,
         null
     );
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A_2", identifier2.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A_2", identifier2.toString());
     // Assume it publishes; create its corresponding segment
     segment = new DataSegment(
         "ds",
@@ -3231,7 +3226,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     // unused segments:
     coordinator.commitSegments(Set.of(segment), null);
     ids = retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get());
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A_2", ids.get(2));
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A_2", ids.get(2));
 
 
     // 2)
@@ -3249,7 +3244,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
     coordinator.commitSegments(Set.of(compactedSegment), null);
     ids = retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get());
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_B", ids.get(3));
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_B", ids.get(3));
     // 3) When overshadowing, segments are still marked as "used" in the segments table
     // state so far:
     // pendings: A: 0,1,2
@@ -3267,7 +3262,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         true,
         null
     );
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_B_1", identifier3.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_B_1", identifier3.toString());
     // no corresponding segment, pending aborted
     // state so far:
     // pendings: A: 0,1,2; B:1 (note that B_1 does not make it into segments since its task aborted)
@@ -3283,13 +3278,13 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     //        used segment: version = A, id = 0,1,2
     //        unused segment: version = B, id = 0
     List<String> pendings = retrievePendingSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get());
-    Assert.assertEquals(4, pendings.size());
+    Assertions.assertEquals(4, pendings.size());
 
     List<String> used = retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get());
-    Assert.assertEquals(3, used.size());
+    Assertions.assertEquals(3, used.size());
 
     List<String> unused = retrieveUnusedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get());
-    Assert.assertEquals(1, unused.size());
+    Assertions.assertEquals(1, unused.size());
 
     // Simulate one more append load
     final SegmentIdWithShardSpec identifier4 = allocatePendingSegment(
@@ -3305,7 +3300,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     // maxid = B_1 -> new partno = 2
     // versionofexistingchunk=A
     // ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A_2
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A_3", identifier4.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A_3", identifier4.toString());
     // Assume it publishes; create its corresponding segment
     segment = new DataSegment(
         "ds",
@@ -3325,7 +3320,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     //        unused segment: version = B, id = 0
     coordinator.commitSegments(Set.of(segment), null);
     ids = retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get());
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A_3", ids.get(3));
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A_3", ids.get(3));
 
   }
 
@@ -3346,7 +3341,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         true
     ).get(request);
 
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1", segmentId0.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1", segmentId0.toString());
 
     final SegmentCreateRequest request1 =
         new SegmentCreateRequest(sequenceName, segmentId0.toString(), segmentId0.getVersion(), partialShardSpec, null);
@@ -3358,7 +3353,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         true
     ).get(request1);
 
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_1", segmentId1.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_1", segmentId1.toString());
 
     final SegmentCreateRequest request2 =
         new SegmentCreateRequest(sequenceName, segmentId1.toString(), segmentId1.getVersion(), partialShardSpec, null);
@@ -3370,7 +3365,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         true
     ).get(request2);
 
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_2", segmentId2.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_2", segmentId2.toString());
 
     final SegmentCreateRequest request3 =
         new SegmentCreateRequest(sequenceName, segmentId1.toString(), segmentId1.getVersion(), partialShardSpec, null);
@@ -3382,8 +3377,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         true
     ).get(request3);
 
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_2", segmentId3.toString());
-    Assert.assertEquals(segmentId2, segmentId3);
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_2", segmentId3.toString());
+    Assertions.assertEquals(segmentId2, segmentId3);
 
     final SegmentCreateRequest request4 =
         new SegmentCreateRequest("seq1", null, "v1", partialShardSpec, null);
@@ -3395,7 +3390,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         true
     ).get(request4);
 
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_3", segmentId4.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_3", segmentId4.toString());
   }
 
   @Test
@@ -3415,7 +3410,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         false
     ).get(request);
 
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1", segmentId0.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1", segmentId0.toString());
 
     final SegmentCreateRequest request1 =
         new SegmentCreateRequest(sequenceName, segmentId0.toString(), segmentId0.getVersion(), partialShardSpec, null);
@@ -3427,7 +3422,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         false
     ).get(request1);
 
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_1", segmentId1.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_1", segmentId1.toString());
 
     final SegmentCreateRequest request2 =
         new SegmentCreateRequest(sequenceName, segmentId1.toString(), segmentId1.getVersion(), partialShardSpec, null);
@@ -3439,7 +3434,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         false
     ).get(request2);
 
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_2", segmentId2.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_2", segmentId2.toString());
 
     final SegmentCreateRequest request3 =
         new SegmentCreateRequest(sequenceName, segmentId1.toString(), segmentId1.getVersion(), partialShardSpec, null);
@@ -3451,8 +3446,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         false
     ).get(request3);
 
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_2", segmentId3.toString());
-    Assert.assertEquals(segmentId2, segmentId3);
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_2", segmentId3.toString());
+    Assertions.assertEquals(segmentId2, segmentId3);
 
     final SegmentCreateRequest request4 =
         new SegmentCreateRequest("seq1", null, "v1", partialShardSpec, null);
@@ -3464,7 +3459,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         false
     ).get(request4);
 
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_3", segmentId4.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_3", segmentId4.toString());
   }
 
   @Test
@@ -3487,7 +3482,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     coordinator.commitSegments(Set.of(segment), null);
     List<String> ids = retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get());
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A", ids.get(0));
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A", ids.get(0));
 
     // simulate one aborted append load
     final PartialShardSpec partialShardSpec = NumberedPartialShardSpec.instance();
@@ -3503,7 +3498,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         true,
         null
     );
-    Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A_1", identifier.toString());
+    Assertions.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_A_1", identifier.toString());
   }
 
   @Test
@@ -3518,9 +3513,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     final SegmentIdWithShardSpec pendingSegment
         = allocatePendingSegmentForAppendTask(wiki, firstOfJan23, taskAllocator1);
 
-    Assert.assertNotNull(pendingSegment);
-    Assert.assertEquals(appendLockVersion, pendingSegment.getVersion());
-    Assert.assertEquals(0, pendingSegment.getShardSpec().getPartitionNum());
+    Assertions.assertNotNull(pendingSegment);
+    Assertions.assertEquals(appendLockVersion, pendingSegment.getVersion());
+    Assertions.assertEquals(0, pendingSegment.getShardSpec().getPartitionNum());
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     coordinator.commitAppendSegments(Set.of(segmentV01), Map.of(), taskAllocator1, null);
@@ -3542,13 +3537,13 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         = allocatePendingSegmentForAppendTask(wiki, firstOfJan23, taskAllocator2);
 
     // Verify that the new segment gets a different version
-    Assert.assertNotNull(pendingSegment2);
-    Assert.assertEquals(appendLockVersion + "S", pendingSegment2.getVersion());
-    Assert.assertEquals(0, pendingSegment2.getShardSpec().getPartitionNum());
+    Assertions.assertNotNull(pendingSegment2);
+    Assertions.assertEquals(appendLockVersion + "S", pendingSegment2.getVersion());
+    Assertions.assertEquals(0, pendingSegment2.getShardSpec().getPartitionNum());
 
     final DataSegment segmentV02 = asSegment(pendingSegment2);
     coordinator.commitAppendSegments(Set.of(segmentV02), Map.of(), taskAllocator2, null);
-    Assert.assertNotEquals(segmentV01, segmentV02);
+    Assertions.assertNotEquals(segmentV01, segmentV02);
 
     verifyIntervalHasUsedSegments(wiki, firstOfJan23, segmentV02);
     verifyIntervalHasVisibleSegments(wiki, firstOfJan23, segmentV02);
@@ -3572,16 +3567,16 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       final SegmentIdWithShardSpec pendingSegment
           = allocatePendingSegmentForAppendTask(wiki, firstOfJan23, taskAllocatorId);
 
-      Assert.assertNotNull(pendingSegment);
-      Assert.assertEquals(expectedVersion, pendingSegment.getVersion());
-      Assert.assertEquals(expectedParitionNum, pendingSegment.getShardSpec().getPartitionNum());
+      Assertions.assertNotNull(pendingSegment);
+      Assertions.assertEquals(expectedVersion, pendingSegment.getVersion());
+      Assertions.assertEquals(expectedParitionNum, pendingSegment.getShardSpec().getPartitionNum());
 
       // Commit the segment and verify its version and partition number
       final DataSegment segment = asSegment(pendingSegment);
       coordinator.commitAppendSegments(Set.of(segment), Map.of(), taskAllocatorId, null);
 
-      Assert.assertEquals(expectedVersion, segment.getVersion());
-      Assert.assertEquals(expectedParitionNum, segment.getShardSpec().getPartitionNum());
+      Assertions.assertEquals(expectedVersion, segment.getVersion());
+      Assertions.assertEquals(expectedParitionNum, segment.getShardSpec().getPartitionNum());
 
       verifyIntervalHasUsedSegments(wiki, firstOfJan23, segment);
       verifyIntervalHasVisibleSegments(wiki, firstOfJan23, segment);
@@ -3597,7 +3592,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     // Verify that the next attempt fails
     DruidExceptionMatcher.assertThat(
-        Assert.assertThrows(
+        Assertions.assertThrows(
             DruidException.class,
             () -> allocatePendingSegmentForAppendTask(wiki, firstOfJan23, IdUtils.getRandomId())
         ),
@@ -3654,7 +3649,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         dataSource,
         new Interval(begin, secondBegin)
     );
-    Assert.assertEquals(10, numDeleted);
+    Assertions.assertEquals(10, numDeleted);
   }
 
   @Test
@@ -3675,7 +3670,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
           false,
           null
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           StringUtils.format(
               "ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version%s",
               "_" + (i + PartitionIds.NON_ROOT_GEN_START_PARTITION_ID)
@@ -3698,14 +3693,14 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       );
       final Set<DataSegment> announced = coordinator.commitSegments(toBeAnnounced, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
 
-      Assert.assertEquals(toBeAnnounced, announced);
+      Assertions.assertEquals(toBeAnnounced, announced);
     }
 
     final Collection<DataSegment> visibleSegments =
         coordinator.retrieveUsedSegmentsForInterval(dataSource, interval, Segments.ONLY_VISIBLE);
 
-    Assert.assertEquals(1, visibleSegments.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, visibleSegments.size());
+    Assertions.assertEquals(
         new DataSegment(
             dataSource,
             interval,
@@ -3746,9 +3741,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     HashBasedNumberedShardSpec shardSpec = (HashBasedNumberedShardSpec) id.getShardSpec();
-    Assert.assertEquals(0, shardSpec.getPartitionNum());
-    Assert.assertEquals(0, shardSpec.getNumCorePartitions());
-    Assert.assertEquals(5, shardSpec.getNumBuckets());
+    Assertions.assertEquals(0, shardSpec.getPartitionNum());
+    Assertions.assertEquals(0, shardSpec.getNumCorePartitions());
+    Assertions.assertEquals(5, shardSpec.getNumBuckets());
 
     coordinator.commitSegments(
         Collections.singleton(
@@ -3779,9 +3774,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     shardSpec = (HashBasedNumberedShardSpec) id.getShardSpec();
-    Assert.assertEquals(1, shardSpec.getPartitionNum());
-    Assert.assertEquals(0, shardSpec.getNumCorePartitions());
-    Assert.assertEquals(5, shardSpec.getNumBuckets());
+    Assertions.assertEquals(1, shardSpec.getPartitionNum());
+    Assertions.assertEquals(0, shardSpec.getNumCorePartitions());
+    Assertions.assertEquals(5, shardSpec.getNumBuckets());
 
     coordinator.commitSegments(
         Collections.singleton(
@@ -3812,9 +3807,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     shardSpec = (HashBasedNumberedShardSpec) id.getShardSpec();
-    Assert.assertEquals(2, shardSpec.getPartitionNum());
-    Assert.assertEquals(0, shardSpec.getNumCorePartitions());
-    Assert.assertEquals(3, shardSpec.getNumBuckets());
+    Assertions.assertEquals(2, shardSpec.getPartitionNum());
+    Assertions.assertEquals(0, shardSpec.getNumCorePartitions());
+    Assertions.assertEquals(3, shardSpec.getNumBuckets());
   }
 
   @Test
@@ -3859,7 +3854,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         false,
         null
     );
-    Assert.assertNull(id);
+    Assertions.assertNull(id);
   }
 
   @Test
@@ -3905,7 +3900,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         false,
         null
     );
-    Assert.assertNull(id);
+    Assertions.assertNull(id);
   }
 
   @Test
@@ -3919,7 +3914,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
@@ -3931,11 +3926,11 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     // Datasource should not be deleted
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
-    Assert.assertEquals(0, deletedCount);
+    Assertions.assertEquals(0, deletedCount);
   }
 
   @Test
@@ -3949,7 +3944,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
@@ -3958,10 +3953,10 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     int deletedCount = coordinator.removeDataSourceMetadataOlderThan(System.currentTimeMillis(), ImmutableSet.of());
 
     // Datasource should be deleted
-    Assert.assertNull(
+    Assertions.assertNull(
         coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
-    Assert.assertEquals(1, deletedCount);
+    Assertions.assertEquals(1, deletedCount);
   }
 
   @Test
@@ -3975,7 +3970,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
@@ -3988,11 +3983,11 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     // Datasource should not be deleted
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         coordinator.retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
-    Assert.assertEquals(0, deletedCount);
+    Assertions.assertEquals(0, deletedCount);
   }
 
   @Test
@@ -4008,7 +4003,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(existingSegment1),
         ImmutableSet.copyOf(
             coordinator.retrieveUnusedSegmentsForInterval(
@@ -4020,7 +4015,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
             )
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(),
         ImmutableSet.copyOf(
             coordinator.retrieveUnusedSegmentsForInterval(
@@ -4046,7 +4041,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(existingSegment1),
         ImmutableSet.copyOf(
             coordinator.retrieveUnusedSegmentsForInterval(
@@ -4057,7 +4052,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
             )
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(),
         ImmutableSet.copyOf(
             coordinator.retrieveUnusedSegmentsForInterval(
@@ -4077,36 +4072,36 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     List<Pair<DataSegment, String>> resultForIntervalOnTheLeft =
         coordinator.retrieveUsedSegmentsAndCreatedDates(defaultSegment.getDataSource(), Collections.singletonList(Intervals.of("2000/2001")));
-    Assert.assertTrue(resultForIntervalOnTheLeft.isEmpty());
+    Assertions.assertTrue(resultForIntervalOnTheLeft.isEmpty());
 
     List<Pair<DataSegment, String>> resultForIntervalOnTheRight =
         coordinator.retrieveUsedSegmentsAndCreatedDates(defaultSegment.getDataSource(), Collections.singletonList(Intervals.of("3000/3001")));
-    Assert.assertTrue(resultForIntervalOnTheRight.isEmpty());
+    Assertions.assertTrue(resultForIntervalOnTheRight.isEmpty());
 
     List<Pair<DataSegment, String>> resultForExactInterval =
         coordinator.retrieveUsedSegmentsAndCreatedDates(defaultSegment.getDataSource(), Collections.singletonList(defaultSegment.getInterval()));
-    Assert.assertEquals(1, resultForExactInterval.size());
-    Assert.assertEquals(defaultSegment, resultForExactInterval.get(0).lhs);
+    Assertions.assertEquals(1, resultForExactInterval.size());
+    Assertions.assertEquals(defaultSegment, resultForExactInterval.get(0).lhs);
 
     List<Pair<DataSegment, String>> resultForIntervalWithLeftOverlap =
         coordinator.retrieveUsedSegmentsAndCreatedDates(defaultSegment.getDataSource(), Collections.singletonList(Intervals.of("2000/2015-01-02")));
-    Assert.assertEquals(resultForExactInterval, resultForIntervalWithLeftOverlap);
+    Assertions.assertEquals(resultForExactInterval, resultForIntervalWithLeftOverlap);
 
     List<Pair<DataSegment, String>> resultForIntervalWithRightOverlap =
         coordinator.retrieveUsedSegmentsAndCreatedDates(defaultSegment.getDataSource(), Collections.singletonList(Intervals.of("2015-01-01/3000")));
-    Assert.assertEquals(resultForExactInterval, resultForIntervalWithRightOverlap);
+    Assertions.assertEquals(resultForExactInterval, resultForIntervalWithRightOverlap);
 
     List<Pair<DataSegment, String>> resultForEternity =
         coordinator.retrieveUsedSegmentsAndCreatedDates(defaultSegment.getDataSource(), Collections.singletonList(Intervals.ETERNITY));
-    Assert.assertEquals(resultForExactInterval, resultForEternity);
+    Assertions.assertEquals(resultForExactInterval, resultForEternity);
 
     List<Pair<DataSegment, String>> resultForFirstHalfEternity =
         coordinator.retrieveUsedSegmentsAndCreatedDates(defaultSegment.getDataSource(), Collections.singletonList(firstHalfEternityRangeSegment.getInterval()));
-    Assert.assertEquals(resultForExactInterval, resultForFirstHalfEternity);
+    Assertions.assertEquals(resultForExactInterval, resultForFirstHalfEternity);
 
     List<Pair<DataSegment, String>> resultForSecondHalfEternity =
         coordinator.retrieveUsedSegmentsAndCreatedDates(defaultSegment.getDataSource(), Collections.singletonList(secondHalfEternityRangeSegment.getInterval()));
-    Assert.assertEquals(resultForExactInterval, resultForSecondHalfEternity);
+    Assertions.assertEquals(resultForExactInterval, resultForSecondHalfEternity);
   }
 
   @Test
@@ -4129,19 +4124,19 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     List<Pair<DataSegment, String>> resultForRandomInterval =
         coordinator.retrieveUsedSegmentsAndCreatedDates(defaultSegment.getDataSource(), Collections.singletonList(defaultSegment.getInterval()));
-    Assert.assertEquals(3, resultForRandomInterval.size());
+    Assertions.assertEquals(3, resultForRandomInterval.size());
 
     List<Pair<DataSegment, String>> resultForEternity =
         coordinator.retrieveUsedSegmentsAndCreatedDates(defaultSegment.getDataSource(), Collections.singletonList(eternitySegment.getInterval()));
-    Assert.assertEquals(3, resultForEternity.size());
+    Assertions.assertEquals(3, resultForEternity.size());
 
     List<Pair<DataSegment, String>> resultForFirstHalfEternity =
         coordinator.retrieveUsedSegmentsAndCreatedDates(defaultSegment.getDataSource(), Collections.singletonList(firstHalfEternityRangeSegment.getInterval()));
-    Assert.assertEquals(3, resultForFirstHalfEternity.size());
+    Assertions.assertEquals(3, resultForFirstHalfEternity.size());
 
     List<Pair<DataSegment, String>> resultForSecondHalfEternity =
         coordinator.retrieveUsedSegmentsAndCreatedDates(defaultSegment.getDataSource(), Collections.singletonList(secondHalfEternityRangeSegment.getInterval()));
-    Assert.assertEquals(3, resultForSecondHalfEternity.size());
+    Assertions.assertEquals(3, resultForSecondHalfEternity.size());
   }
 
   @Test
@@ -4156,7 +4151,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     final Set<DataSegment> tombstones = new HashSet<>(Collections.singleton(tombstoneSegment));
-    Assert.assertTrue(coordinator.commitSegments(tombstones, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)).containsAll(tombstones));
+    Assertions.assertTrue(coordinator.commitSegments(tombstones, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)).containsAll(tombstones));
 
     // Allocate and commit a data segment by appending to the same interval
     final SegmentIdWithShardSpec identifier = allocatePendingSegment(
@@ -4170,8 +4165,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null
     );
 
-    Assert.assertEquals("wiki_2020-01-01T00:00:00.000Z_2021-01-01T00:00:00.000Z_version_1", identifier.toString());
-    Assert.assertEquals(0, identifier.getShardSpec().getNumCorePartitions());
+    Assertions.assertEquals("wiki_2020-01-01T00:00:00.000Z_2021-01-01T00:00:00.000Z_version_1", identifier.toString());
+    Assertions.assertEquals(0, identifier.getShardSpec().getNumCorePartitions());
 
     final DataSegment dataSegment = createSegment(
         interval,
@@ -4179,7 +4174,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         identifier.getShardSpec()
     );
     final Set<DataSegment> dataSegments = new HashSet<>(Collections.singleton(dataSegment));
-    Assert.assertTrue(coordinator.commitSegments(dataSegments, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)).containsAll(dataSegments));
+    Assertions.assertTrue(coordinator.commitSegments(dataSegments, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)).containsAll(dataSegments));
 
     // Mark the tombstone as unused
     markAllSegmentsUnused(tombstones, DateTimes.nowUtc());
@@ -4192,8 +4187,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     // The appended data segment will still be visible in the timeline since the
     // tombstone contains 0 core partitions
     SegmentTimeline segmentTimeline = SegmentTimeline.forSegments(allUsedSegments);
-    Assert.assertEquals(1, segmentTimeline.lookup(interval).size());
-    Assert.assertEquals(dataSegment, segmentTimeline.lookup(interval).get(0).getObject().getChunk(1).getObject());
+    Assertions.assertEquals(1, segmentTimeline.lookup(interval).size());
+    Assertions.assertEquals(dataSegment, segmentTimeline.lookup(interval).get(0).getObject().getChunk(1).getObject());
   }
 
   @Test
@@ -4211,7 +4206,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
 
     final Set<DataSegment> tombstones = new HashSet<>(Collections.singleton(tombstoneSegment));
-    Assert.assertTrue(coordinator.commitSegments(tombstones, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)).containsAll(tombstones));
+    Assertions.assertTrue(coordinator.commitSegments(tombstones, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)).containsAll(tombstones));
 
     // Allocate and commit a data segment by appending to the same interval
     final SegmentIdWithShardSpec identifier = allocatePendingSegment(
@@ -4225,8 +4220,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null
     );
 
-    Assert.assertEquals("wiki_2020-01-01T00:00:00.000Z_2021-01-01T00:00:00.000Z_version_1", identifier.toString());
-    Assert.assertEquals(1, identifier.getShardSpec().getNumCorePartitions());
+    Assertions.assertEquals("wiki_2020-01-01T00:00:00.000Z_2021-01-01T00:00:00.000Z_version_1", identifier.toString());
+    Assertions.assertEquals(1, identifier.getShardSpec().getNumCorePartitions());
 
     final DataSegment dataSegment = createSegment(
         interval,
@@ -4234,7 +4229,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         identifier.getShardSpec()
     );
     final Set<DataSegment> dataSegments = new HashSet<>(Collections.singleton(dataSegment));
-    Assert.assertTrue(coordinator.commitSegments(dataSegments, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)).containsAll(dataSegments));
+    Assertions.assertTrue(coordinator.commitSegments(dataSegments, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)).containsAll(dataSegments));
 
     // Mark the tombstone as unused
     coordinator.markSegmentAsUnused(tombstoneSegment.getId());
@@ -4247,7 +4242,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     // The appended data segment will not be visible in the timeline since the old generation
     // tombstone contains 1 core partition
     SegmentTimeline segmentTimeline = SegmentTimeline.forSegments(allUsedSegments);
-    Assert.assertEquals(0, segmentTimeline.lookup(interval).size());
+    Assertions.assertEquals(0, segmentTimeline.lookup(interval).size());
   }
 
   @Test
@@ -4302,7 +4297,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         false,
         "taskAllocatorId"
     );
-    Assert.assertNull(coordinator.retrieveSegmentForId(theId.asSegmentId()));
+    Assertions.assertNull(coordinator.retrieveSegmentForId(theId.asSegmentId()));
   }
 
   @Test
@@ -4349,7 +4344,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
             "v1"
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         unusedSegmentForExactIntervalAndVersion.getId(),
         highestUnusedId
     );
@@ -4376,7 +4371,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     segmentIds.add(defaultSegment2.getId().toString());
     segmentIds.add(defaultSegment3.getId().toString());
     segmentIds.add(defaultSegment4.getId().toString());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expected,
         coordinator.retrieveUpgradedFromSegmentIds(datasource, segmentIds)
     );
@@ -4385,7 +4380,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   @Test
   public void testRetrieveUpgradedFromSegmentIdsInBatches()
   {
-    Assume.assumeFalse(isCacheEnabled());
+    Assumptions.assumeFalse(isCacheEnabled());
 
     final int size = 500;
     final int batchSize = 100;
@@ -4422,8 +4417,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         segments.stream().map(DataSegment::getId).map(SegmentId::toString).collect(Collectors.toSet())
     );
 
-    Assert.assertEquals(400, actual.size());
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(400, actual.size());
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -4446,7 +4441,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     Set<String> upgradedIds = new HashSet<>();
     upgradedIds.add(defaultSegment.getId().toString());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expected,
         coordinator.retrieveUpgradedToSegmentIds(datasource, upgradedIds)
     );
@@ -4499,8 +4494,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         segments.stream().map(DataSegment::getId).map(SegmentId::toString).collect(Collectors.toSet())
     );
 
-    Assert.assertEquals(500, actual.size());
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(500, actual.size());
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -4579,26 +4574,26 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
                        .collect(Collectors.toSet())
     );
 
-    Assert.assertEquals(expected, observed);
+    Assertions.assertEquals(expected, observed);
   }
 
   @Test
   public void testCachedTransaction_cannotReadWhatItWrites()
   {
-    Assume.assumeTrue(isCacheEnabled());
+    Assumptions.assumeTrue(isCacheEnabled());
 
     transactionFactory.inReadWriteDatasourceTransaction(
         TestDataSource.WIKI,
         transaction -> {
           final DataSegmentPlus wikiSegment =
               CreateDataSegments.ofDatasource(TestDataSource.WIKI).updatedNow().markUsed().asPlus();
-          Assert.assertEquals(1, transaction.insertSegments(Set.of(wikiSegment)));
+          Assertions.assertEquals(1, transaction.insertSegments(Set.of(wikiSegment)));
 
           // Verify that segment is not present in cache
-          Assert.assertNull(transaction.findUsedSegment(wikiSegment.getDataSegment().getId()));
+          Assertions.assertNull(transaction.findUsedSegment(wikiSegment.getDataSegment().getId()));
 
           // Verify that segment is present in metadata store
-          Assert.assertEquals(
+          Assertions.assertEquals(
               wikiSegment.getDataSegment(),
               transaction.findSegment(wikiSegment.getDataSegment().getId())
           );
@@ -4613,9 +4608,9 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   @Test
   public void testReadOperation_usesCache_ifSynced()
   {
-    Assume.assumeTrue(isCacheEnabled());
+    Assumptions.assumeTrue(isCacheEnabled());
 
-    Assert.assertTrue(segmentMetadataCache.isSyncedForRead());
+    Assertions.assertTrue(segmentMetadataCache.isSyncedForRead());
 
     insertUsedSegments(Set.of(defaultSegment), Map.of());
     final Supplier<Set<DataSegment>> retrieveAction =
@@ -4625,10 +4620,10 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         );
 
     // Retrieve returns empty since cache is not synced with metadata store yet
-    Assert.assertTrue(retrieveAction.get().isEmpty());
+    Assertions.assertTrue(retrieveAction.get().isEmpty());
 
     refreshCache();
-    Assert.assertEquals(Set.of(defaultSegment), retrieveAction.get());
+    Assertions.assertEquals(Set.of(defaultSegment), retrieveAction.get());
 
     emitter.verifyEmitted(Metric.READ_ONLY_TRANSACTIONS, 2);
   }
@@ -4636,10 +4631,10 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   @Test
   public void testReadOperation_doesNotUseCache_ifNotSynced()
   {
-    Assume.assumeTrue(isCacheEnabled());
+    Assumptions.assumeTrue(isCacheEnabled());
 
     segmentMetadataCache.stopBeingLeader();
-    Assert.assertFalse(segmentMetadataCache.isSyncedForRead());
+    Assertions.assertFalse(segmentMetadataCache.isSyncedForRead());
 
     final Supplier<Set<DataSegment>> retrieveAction =
         () -> coordinator.retrieveAllUsedSegments(
@@ -4649,48 +4644,48 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     insertUsedSegments(Set.of(defaultSegment), Map.of());
 
-    Assert.assertEquals(Set.of(defaultSegment), retrieveAction.get());
+    Assertions.assertEquals(Set.of(defaultSegment), retrieveAction.get());
     emitter.verifyNotEmitted(Metric.READ_ONLY_TRANSACTIONS);
 
     // Become leader but cache will still not be used
     segmentMetadataCache.becomeLeader();
-    Assert.assertFalse(segmentMetadataCache.isSyncedForRead());
-    Assert.assertEquals(Set.of(defaultSegment), retrieveAction.get());
+    Assertions.assertFalse(segmentMetadataCache.isSyncedForRead());
+    Assertions.assertEquals(Set.of(defaultSegment), retrieveAction.get());
     emitter.verifyNotEmitted(Metric.READ_ONLY_TRANSACTIONS);
 
     // Sync the cache so that it becomes ready for use
     refreshCache();
     refreshCache();
-    Assert.assertTrue(segmentMetadataCache.isSyncedForRead());
-    Assert.assertEquals(Set.of(defaultSegment), retrieveAction.get());
+    Assertions.assertTrue(segmentMetadataCache.isSyncedForRead());
+    Assertions.assertEquals(Set.of(defaultSegment), retrieveAction.get());
     emitter.verifyValue(Metric.READ_ONLY_TRANSACTIONS, 1L);
   }
 
   @Test
   public void testWriteOperation_alwaysUsesCache_inModeIfSynced()
   {
-    Assume.assumeTrue(cacheMode == SegmentMetadataCache.UsageMode.IF_SYNCED);
+    Assumptions.assumeTrue(cacheMode == SegmentMetadataCache.UsageMode.IF_SYNCED);
 
     // Lose and regain leadership
     segmentMetadataCache.stopBeingLeader();
     segmentMetadataCache.becomeLeader();
 
-    Assert.assertTrue(segmentMetadataCache.isEnabled());
-    Assert.assertFalse(segmentMetadataCache.isSyncedForRead());
+    Assertions.assertTrue(segmentMetadataCache.isEnabled());
+    Assertions.assertFalse(segmentMetadataCache.isSyncedForRead());
 
     final Supplier<Set<DataSegment>> writeAction =
         () -> coordinator.commitSegments(Set.of(defaultSegment), null);
 
     // Cache is not synced yet and will be used only for write operations
-    Assert.assertEquals(Set.of(defaultSegment), writeAction.get());
+    Assertions.assertEquals(Set.of(defaultSegment), writeAction.get());
     emitter.verifyValue(Metric.WRITE_ONLY_TRANSACTIONS, 1L);
 
     // Sync the cache to use it for both read and write operations
     refreshCache();
     refreshCache();
-    Assert.assertTrue(segmentMetadataCache.isSyncedForRead());
+    Assertions.assertTrue(segmentMetadataCache.isSyncedForRead());
 
-    Assert.assertTrue(writeAction.get().isEmpty());
+    Assertions.assertTrue(writeAction.get().isEmpty());
     emitter.verifyValue(Metric.READ_WRITE_TRANSACTIONS, 1L);
   }
 
@@ -4700,7 +4695,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     String fingerprint = "vanillaFingerprint";
     CompactionState state = createTestIndexingState();
     indexingStateStorage.upsertIndexingState(TestDataSource.WIKI, fingerprint, state, DateTimes.nowUtc());
-    Assert.assertEquals(Boolean.TRUE, indexingStateStorage.isIndexingStatePending(fingerprint));
+    Assertions.assertEquals(Boolean.TRUE, indexingStateStorage.isIndexingStatePending(fingerprint));
 
     final DataSegment segment = CreateDataSegments.ofDatasource(TestDataSource.WIKI)
                                                    .startingAt("2023-01-01")
@@ -4716,7 +4711,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null
     );
 
-    Assert.assertEquals(Boolean.FALSE, indexingStateStorage.isIndexingStatePending(fingerprint));
+    Assertions.assertEquals(Boolean.FALSE, indexingStateStorage.isIndexingStatePending(fingerprint));
   }
 
   @Test
@@ -4725,7 +4720,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     String fingerprint = "replaceFingerprint";
     CompactionState state = createTestIndexingState();
     indexingStateStorage.upsertIndexingState(TestDataSource.WIKI, fingerprint, state, DateTimes.nowUtc());
-    Assert.assertEquals(Boolean.TRUE, indexingStateStorage.isIndexingStatePending(fingerprint));
+    Assertions.assertEquals(Boolean.TRUE, indexingStateStorage.isIndexingStatePending(fingerprint));
 
     final DataSegment segment = CreateDataSegments.ofDatasource(TestDataSource.WIKI)
                                                    .startingAt("2023-01-01")
@@ -4746,7 +4741,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null
     );
 
-    Assert.assertEquals(Boolean.FALSE, indexingStateStorage.isIndexingStatePending(fingerprint));
+    Assertions.assertEquals(Boolean.FALSE, indexingStateStorage.isIndexingStatePending(fingerprint));
   }
 
   @Test
@@ -4755,7 +4750,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     String fingerprint = "appendFingerprint";
     CompactionState state = createTestIndexingState();
     indexingStateStorage.upsertIndexingState(TestDataSource.WIKI, fingerprint, state, DateTimes.nowUtc());
-    Assert.assertEquals(Boolean.TRUE, indexingStateStorage.isIndexingStatePending(fingerprint));
+    Assertions.assertEquals(Boolean.TRUE, indexingStateStorage.isIndexingStatePending(fingerprint));
 
     final DataSegment segment = CreateDataSegments.ofDatasource(TestDataSource.WIKI)
                                                    .startingAt("2023-01-01")
@@ -4772,7 +4767,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         null
     );
 
-    Assert.assertEquals(Boolean.FALSE, indexingStateStorage.isIndexingStatePending(fingerprint));
+    Assertions.assertEquals(Boolean.FALSE, indexingStateStorage.isIndexingStatePending(fingerprint));
   }
 
   private CompactionState createTestIndexingState()
@@ -4860,7 +4855,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       DataSegment... expectedSegments
   )
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(expectedSegments),
         coordinator.retrieveUsedSegmentsForIntervals(dataSource, List.of(interval), Segments.INCLUDING_OVERSHADOWED)
     );
@@ -4872,7 +4867,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       DataSegment... expectedSegments
   )
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(expectedSegments),
         coordinator.retrieveUsedSegmentsForIntervals(dataSource, List.of(interval), Segments.ONLY_VISIBLE)
     );

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest.java
@@ -49,10 +49,10 @@ import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.HashBasedNumberedShardSpec;
 import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -70,11 +70,11 @@ import java.util.stream.Collectors;
 public class IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest extends
     IndexerSqlMetadataStorageCoordinatorTestBase
 {
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule =
       new TestDerbyConnector.DerbyConnectorRule(CentralizedDatasourceSchemaConfig.enabled(true));
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     derbyConnector = derbyConnectorRule.getConnector();
@@ -205,11 +205,11 @@ public class IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest extends
     // Commit the segment and verify the results
     SegmentPublishResult commitResult
         = coordinator.commitAppendSegments(appendSegments, segmentToReplaceLock, "append", segmentSchemaMapping);
-    Assert.assertTrue(commitResult.isSuccess());
-    Assert.assertEquals(appendSegments, commitResult.getSegments());
+    Assertions.assertTrue(commitResult.isSuccess());
+    Assertions.assertEquals(appendSegments, commitResult.getSegments());
 
     // Verify the segments present in the metadata store
-    Assert.assertEquals(
+    Assertions.assertEquals(
         appendSegments,
         ImmutableSet.copyOf(retrieveUsedSegments(derbyConnectorRule.metadataTablesConfigSupplier().get()))
     );
@@ -225,11 +225,11 @@ public class IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest extends
         replaceTaskId,
         derbyConnectorRule.metadataTablesConfigSupplier().get()
     );
-    Assert.assertEquals(expectedUpgradeSegmentIds, observedSegmentToLock.keySet());
+    Assertions.assertEquals(expectedUpgradeSegmentIds, observedSegmentToLock.keySet());
 
     final Set<String> observedLockVersions = new HashSet<>(observedSegmentToLock.values());
-    Assert.assertEquals(1, observedLockVersions.size());
-    Assert.assertEquals(replaceLock.getVersion(), Iterables.getOnlyElement(observedLockVersions));
+    Assertions.assertEquals(1, observedLockVersions.size());
+    Assertions.assertEquals(replaceLock.getVersion(), Iterables.getOnlyElement(observedLockVersions));
   }
 
   @Test
@@ -272,7 +272,7 @@ public class IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest extends
 
     coordinator.commitSegments(segments, segmentSchemaMapping);
     for (DataSegment segment : segments) {
-      Assert.assertArrayEquals(
+      Assertions.assertArrayEquals(
           mapper.writeValueAsString(segment).getBytes(StandardCharsets.UTF_8),
           derbyConnector.lookup(
               derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
@@ -288,10 +288,10 @@ public class IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest extends
                                       .sorted(Comparator.naturalOrder())
                                       .collect(Collectors.toList());
 
-    Assert.assertEquals(segmentIds, retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get()));
+    Assertions.assertEquals(segmentIds, retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get()));
 
     // Should not update dataSource metadata.
-    Assert.assertEquals(0, metadataUpdateCounter.get());
+    Assertions.assertEquals(0, metadataUpdateCounter.get());
 
     segmentSchemaTestUtils.verifySegmentSchema(segmentIdSchemaMap);
   }
@@ -378,7 +378,7 @@ public class IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest extends
 
     coordinator.commitSegments(segments, segmentSchemaMapping);
     for (DataSegment segment : segments) {
-      Assert.assertArrayEquals(
+      Assertions.assertArrayEquals(
           mapper.writeValueAsString(segment).getBytes(StandardCharsets.UTF_8),
           derbyConnector.lookup(
               derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
@@ -394,10 +394,10 @@ public class IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest extends
                                       .sorted(Comparator.naturalOrder())
                                       .collect(Collectors.toList());
 
-    Assert.assertEquals(segmentIds, retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get()));
+    Assertions.assertEquals(segmentIds, retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get()));
 
     // Should not update dataSource metadata.
-    Assert.assertEquals(0, metadataUpdateCounter.get());
+    Assertions.assertEquals(0, metadataUpdateCounter.get());
 
     // verify that only a single schema is created
     segmentSchemaTestUtils.verifySegmentSchema(segmentIdSchemaMap);
@@ -460,7 +460,7 @@ public class IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest extends
 
     coordinator.commitSegments(segments, segmentSchemaMapping);
     for (DataSegment segment : segments) {
-      Assert.assertArrayEquals(
+      Assertions.assertArrayEquals(
           mapper.writeValueAsString(segment).getBytes(StandardCharsets.UTF_8),
           derbyConnector.lookup(
               derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
@@ -476,10 +476,10 @@ public class IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest extends
                                       .sorted(Comparator.naturalOrder())
                                       .collect(Collectors.toList());
 
-    Assert.assertEquals(segmentIds, retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get()));
+    Assertions.assertEquals(segmentIds, retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get()));
 
     // Should not update dataSource metadata.
-    Assert.assertEquals(0, metadataUpdateCounter.get());
+    Assertions.assertEquals(0, metadataUpdateCounter.get());
 
     segmentSchemaTestUtils.verifySegmentSchema(segmentIdSchemaMap);
   }
@@ -575,20 +575,20 @@ public class IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest extends
 
     coordinator.commitReplaceSegments(replacingSegments, ImmutableSet.of(replaceLock), segmentSchemaMapping);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2L * segmentsAppendedWithReplaceLock.size() + replacingSegments.size(),
         retrieveUsedSegmentIds(derbyConnectorRule.metadataTablesConfigSupplier().get()).size()
     );
 
     final Set<DataSegment> usedSegments = new HashSet<>(retrieveUsedSegments(derbyConnectorRule.metadataTablesConfigSupplier().get()));
 
-    Assert.assertTrue(usedSegments.containsAll(segmentsAppendedWithReplaceLock));
+    Assertions.assertTrue(usedSegments.containsAll(segmentsAppendedWithReplaceLock));
     usedSegments.removeAll(segmentsAppendedWithReplaceLock);
 
-    Assert.assertTrue(usedSegments.containsAll(replacingSegments));
+    Assertions.assertTrue(usedSegments.containsAll(replacingSegments));
     usedSegments.removeAll(replacingSegments);
 
-    Assert.assertEquals(segmentsAppendedWithReplaceLock.size(), usedSegments.size());
+    Assertions.assertEquals(segmentsAppendedWithReplaceLock.size(), usedSegments.size());
     for (DataSegment segmentReplicaWithNewVersion : usedSegments) {
       boolean hasBeenCarriedForward = false;
       for (DataSegment appendedSegment : segmentsAppendedWithReplaceLock) {
@@ -600,7 +600,7 @@ public class IndexerSqlMetadataStorageCoordinatorSchemaPersistenceTest extends
       RowSignature rowSignature = RowSignature.builder().add("c6", ColumnType.FLOAT).build();
       SchemaPayload schemaPayload = new SchemaPayload(rowSignature);
       segmentIdSchemaMap.put(segmentReplicaWithNewVersion.getId(), new SchemaPayloadPlus(schemaPayload, 6L));
-      Assert.assertTrue(hasBeenCarriedForward);
+      Assertions.assertTrue(hasBeenCarriedForward);
     }
 
     segmentSchemaTestUtils.verifySegmentSchema(segmentIdSchemaMap);

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSqlMetadataStorageCoordinatorTestBase.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSqlMetadataStorageCoordinatorTestBase.java
@@ -46,13 +46,14 @@ import org.apache.druid.timeline.partition.ShardSpec;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.skife.jdbi.v2.PreparedBatch;
 import org.skife.jdbi.v2.PreparedBatchPart;
 import org.skife.jdbi.v2.ResultIterator;
 import org.skife.jdbi.v2.util.StringMapper;
 
 import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -338,7 +339,7 @@ public class IndexerSqlMetadataStorageCoordinatorTestBase
     }
     final Set<DataSegment> segmentsSet = new HashSet<>(segments);
     final Set<DataSegment> committedSegments = coordinator.commitSegments(segmentsSet, null);
-    Assert.assertTrue(committedSegments.containsAll(segmentsSet));
+    Assertions.assertTrue(committedSegments.containsAll(segmentsSet));
 
     return segments;
   }
@@ -423,7 +424,7 @@ public class IndexerSqlMetadataStorageCoordinatorTestBase
                                                                                               .getId(),
                                                                                         Function.identity()
                                                                                     ));
-    Assert.assertTrue(expectedIdToSegment.entrySet().stream().allMatch(e -> {
+    Assertions.assertTrue(expectedIdToSegment.entrySet().stream().allMatch(e -> {
       DataSegmentPlus segmentPlus = actualIdToSegmentPlus.get(e.getKey());
       return segmentPlus != null
              && !segmentPlus.getCreatedDate().isAfter(usedStatusLastUpdatedTime)
@@ -438,12 +439,12 @@ public class IndexerSqlMetadataStorageCoordinatorTestBase
       DateTime usedStatusLastUpdatedTime
   )
   {
-    Assert.assertEquals(expectedSegments.size(), actualUnusedSegmentsPlus.size());
+    Assertions.assertEquals(expectedSegments.size(), actualUnusedSegmentsPlus.size());
     for (int i = 0; i < expectedSegments.size(); i++) {
       DataSegment expectedSegment = expectedSegments.get(i);
       DataSegmentPlus actualSegmentPlus = actualUnusedSegmentsPlus.get(i);
-      Assert.assertEquals(expectedSegment.getId(), actualSegmentPlus.getDataSegment().getId());
-      Assert.assertTrue(!actualSegmentPlus.getCreatedDate().isAfter(usedStatusLastUpdatedTime)
+      Assertions.assertEquals(expectedSegment.getId(), actualSegmentPlus.getDataSegment().getId());
+      Assertions.assertTrue(!actualSegmentPlus.getCreatedDate().isAfter(usedStatusLastUpdatedTime)
                         && actualSegmentPlus.getUsedStatusLastUpdatedDate() != null
                         && actualSegmentPlus.getUsedStatusLastUpdatedDate().equals(usedStatusLastUpdatedTime));
     }
@@ -471,7 +472,7 @@ public class IndexerSqlMetadataStorageCoordinatorTestBase
   protected void markAllSegmentsUnused(Set<DataSegment> segments, DateTime usedStatusLastUpdatedTime)
   {
     for (final DataSegment segment : segments) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           1,
           segmentsTable.update(
               "UPDATE %s SET used = false, used_status_last_updated = ? WHERE id = ?",

--- a/server/src/test/java/org/apache/druid/metadata/ReplaceTaskLockTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/ReplaceTaskLockTest.java
@@ -20,7 +20,7 @@
 package org.apache.druid.metadata;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReplaceTaskLockTest
 {

--- a/server/src/test/java/org/apache/druid/metadata/SQLMetadataConnectorSchemaPersistenceTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SQLMetadataConnectorSchemaPersistenceTest.java
@@ -21,10 +21,10 @@ package org.apache.druid.metadata;
 
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.metadata.CentralizedDatasourceSchemaConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,14 +32,14 @@ import java.util.List;
 
 public class SQLMetadataConnectorSchemaPersistenceTest
 {
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule =
       new TestDerbyConnector.DerbyConnectorRule(CentralizedDatasourceSchemaConfig.enabled(true));
 
   private TestDerbyConnector connector;
   private MetadataStorageTablesConfig tablesConfig;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     connector = derbyConnectorRule.getConnector();
@@ -80,17 +80,17 @@ public class SQLMetadataConnectorSchemaPersistenceTest
     connector.getDBI().withHandle(
         handle -> {
           for (String table : tables) {
-            Assert.assertTrue(
-                StringUtils.format("table %s was not created!", table),
-                connector.tableExists(handle, table)
+            Assertions.assertTrue(
+                connector.tableExists(handle, table),
+                StringUtils.format("table %s was not created!", table)
             );
           }
 
           String taskTable = tablesConfig.getTasksTable();
           for (String column : Arrays.asList("type", "group_id")) {
-            Assert.assertTrue(
-                StringUtils.format("Tasks table column %s was not created!", column),
-                connector.tableHasColumn(taskTable, column)
+            Assertions.assertTrue(
+                connector.tableHasColumn(taskTable, column),
+                StringUtils.format("Tasks table column %s was not created!", column)
             );
           }
 
@@ -126,15 +126,15 @@ public class SQLMetadataConnectorSchemaPersistenceTest
     derbyConnectorRule.segments().update("ALTER TABLE %1$s DROP COLUMN NUM_ROWS");
 
     connector.alterSegmentTable();
-    Assert.assertTrue(connector.tableHasColumn(
+    Assertions.assertTrue(connector.tableHasColumn(
         derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
         "USED_STATUS_LAST_UPDATED"
     ));
-    Assert.assertTrue(connector.tableHasColumn(
+    Assertions.assertTrue(connector.tableHasColumn(
         derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
         "SCHEMA_FINGERPRINT"
     ));
-    Assert.assertTrue(connector.tableHasColumn(
+    Assertions.assertTrue(connector.tableHasColumn(
         derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
         "NUM_ROWS"
     ));

--- a/server/src/test/java/org/apache/druid/metadata/SQLMetadataConnectorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SQLMetadataConnectorTest.java
@@ -27,10 +27,10 @@ import com.google.common.collect.Sets;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.metadata.CentralizedDatasourceSchemaConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.exceptions.CallbackFailedException;
@@ -52,13 +52,13 @@ import java.util.stream.Collectors;
 
 public class SQLMetadataConnectorTest
 {
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
 
   private TestDerbyConnector connector;
   private MetadataStorageTablesConfig tablesConfig;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     connector = derbyConnectorRule.getConnector();
@@ -89,17 +89,17 @@ public class SQLMetadataConnectorTest
     connector.getDBI().withHandle(
         handle -> {
           for (String table : tables) {
-            Assert.assertTrue(
-                StringUtils.format("table %s was not created!", table),
-                connector.tableExists(handle, table)
+            Assertions.assertTrue(
+                connector.tableExists(handle, table),
+                StringUtils.format("table %s was not created!", table)
             );
           }
 
           String taskTable = tablesConfig.getTasksTable();
           for (String column : Arrays.asList("type", "group_id")) {
-            Assert.assertTrue(
-                StringUtils.format("Tasks table column %s was not created!", column),
-                connector.tableHasColumn(taskTable, column)
+            Assertions.assertTrue(
+                connector.tableHasColumn(taskTable, column),
+                StringUtils.format("Tasks table column %s was not created!", column)
             );
           }
 
@@ -124,9 +124,9 @@ public class SQLMetadataConnectorTest
     ).stream().map(StringUtils::toUpperCase).collect(Collectors.toSet());
 
     for (String expectedIndex : expectedIndexSet) {
-      Assert.assertTrue(
-          StringUtils.format("Failed to find the expected Index %s on entry table", expectedIndex),
-          createdIndexSet.contains(expectedIndex)
+      Assertions.assertTrue(
+          createdIndexSet.contains(expectedIndex),
+          StringUtils.format("Failed to find the expected Index %s on entry table", expectedIndex)
       );
     }
     connector.createTaskTables();
@@ -145,7 +145,7 @@ public class SQLMetadataConnectorTest
       );
     }
     catch (Exception e) {
-      Assert.fail("Index creation should never throw an exception");
+      Assertions.fail("Index creation should never throw an exception");
     }
   }
 
@@ -155,10 +155,10 @@ public class SQLMetadataConnectorTest
     String tableName = "noTable";
     try {
       Set<String> res = connector.getIndexOnTable(tableName);
-      Assert.assertEquals(0, res.size());
+      Assertions.assertEquals(0, res.size());
     }
     catch (Exception e) {
-      Assert.fail("getIndexOnTable should never throw an exception");
+      Assertions.fail("getIndexOnTable should never throw an exception");
     }
   }
 
@@ -173,17 +173,17 @@ public class SQLMetadataConnectorTest
     derbyConnectorRule.segments().update("ALTER TABLE %1$s DROP COLUMN USED_STATUS_LAST_UPDATED");
 
     connector.alterSegmentTable();
-    Assert.assertTrue(connector.tableHasColumn(
+    Assertions.assertTrue(connector.tableHasColumn(
         derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
         "USED_STATUS_LAST_UPDATED"
     ));
 
-    Assert.assertFalse(connector.tableHasColumn(
+    Assertions.assertFalse(connector.tableHasColumn(
         derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
         "SCHEMA_FINGERPRINT"
     ));
 
-    Assert.assertFalse(connector.tableHasColumn(
+    Assertions.assertFalse(connector.tableHasColumn(
         derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
         "NUM_ROWS"
     ));
@@ -199,7 +199,7 @@ public class SQLMetadataConnectorTest
     connector.createSegmentTable();
     derbyConnectorRule.segments().update("ALTER TABLE %1$s DROP COLUMN INDEXING_STATE_FINGERPRINT");
     connector.alterSegmentTable();
-    Assert.assertTrue(connector.tableHasColumn(
+    Assertions.assertTrue(connector.tableHasColumn(
         derbyConnectorRule.metadataTablesConfigSupplier().get().getSegmentsTable(),
         "INDEXING_STATE_FINGERPRINT"
     ));
@@ -211,7 +211,7 @@ public class SQLMetadataConnectorTest
     final String tableName = "test";
     connector.createConfigTable(tableName);
 
-    Assert.assertNull(connector.lookup(tableName, "name", "payload", "emperor"));
+    Assertions.assertNull(connector.lookup(tableName, "name", "payload", "emperor"));
 
     connector.insertOrUpdate(
         tableName,
@@ -220,7 +220,7 @@ public class SQLMetadataConnectorTest
         "emperor",
         StringUtils.toUtf8("penguin")
     );
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         StringUtils.toUtf8("penguin"),
         connector.lookup(tableName, "name", "payload", "emperor")
     );
@@ -233,7 +233,7 @@ public class SQLMetadataConnectorTest
         StringUtils.toUtf8("penguin chick")
     );
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         StringUtils.toUtf8("penguin chick"),
         connector.lookup(tableName, "name", "payload", "emperor")
     );
@@ -265,8 +265,8 @@ public class SQLMetadataConnectorTest
         CentralizedDatasourceSchemaConfig.create()
     );
     BasicDataSource dataSource = testSQLMetadataConnector.getDatasource();
-    Assert.assertEquals(dataSource.getMaxConnLifetimeMillis(), 1200000);
-    Assert.assertEquals(dataSource.getDefaultQueryTimeout().intValue(), 30000);
+    Assertions.assertEquals(dataSource.getMaxConnLifetimeMillis(), 1200000);
+    Assertions.assertEquals(dataSource.getDefaultQueryTimeout().intValue(), 30000);
   }
 
   @Test
@@ -281,40 +281,40 @@ public class SQLMetadataConnectorTest
     );
 
     // Transient exceptions
-    Assert.assertTrue(metadataConnector.isTransientException(new RetryTransactionException("")));
-    Assert.assertTrue(metadataConnector.isTransientException(new SQLRecoverableException()));
-    Assert.assertTrue(metadataConnector.isTransientException(new SQLTransientException()));
-    Assert.assertTrue(metadataConnector.isTransientException(new SQLTransientConnectionException()));
+    Assertions.assertTrue(metadataConnector.isTransientException(new RetryTransactionException("")));
+    Assertions.assertTrue(metadataConnector.isTransientException(new SQLRecoverableException()));
+    Assertions.assertTrue(metadataConnector.isTransientException(new SQLTransientException()));
+    Assertions.assertTrue(metadataConnector.isTransientException(new SQLTransientConnectionException()));
 
     // Non transient exceptions
-    Assert.assertFalse(metadataConnector.isTransientException(null));
-    Assert.assertFalse(metadataConnector.isTransientException(new SQLException()));
-    Assert.assertFalse(metadataConnector.isTransientException(new UnableToExecuteStatementException("")));
+    Assertions.assertFalse(metadataConnector.isTransientException(null));
+    Assertions.assertFalse(metadataConnector.isTransientException(new SQLException()));
+    Assertions.assertFalse(metadataConnector.isTransientException(new UnableToExecuteStatementException("")));
 
     // Nested transient exceptions
-    Assert.assertTrue(
+    Assertions.assertTrue(
         metadataConnector.isTransientException(
             new CallbackFailedException(new SQLTransientException())
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         metadataConnector.isTransientException(
             new UnableToObtainConnectionException(new SQLException())
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         metadataConnector.isTransientException(
             new UnableToExecuteStatementException(new SQLTransientException())
         )
     );
 
     // Nested non-transient exceptions
-    Assert.assertFalse(
+    Assertions.assertFalse(
         metadataConnector.isTransientException(
             new CallbackFailedException(new SQLException())
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         metadataConnector.isTransientException(
             new UnableToExecuteStatementException(new SQLException())
         )
@@ -457,15 +457,15 @@ public class SQLMetadataConnectorTest
                                                .stream()
                                                .filter(name -> !name.startsWith("SQL"))
                                                .collect(Collectors.toSet());
-    Assert.assertEquals(
+    Assertions.assertEquals(
+        actualIndices,
+        expectedIndices,
         StringUtils.format(
             "Received unexpected table index set for table[%s]. Got [%s], expected [%s].",
             tableName,
             actualIndices,
             expectedIndices
-        ),
-        actualIndices,
-        expectedIndices
+        )
     );
   }
 

--- a/server/src/test/java/org/apache/druid/metadata/SQLMetadataRuleManagerTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SQLMetadataRuleManagerTest.java
@@ -42,10 +42,10 @@ import org.apache.druid.server.coordinator.rules.Rule;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -53,7 +53,7 @@ import java.util.Map;
 
 public class SQLMetadataRuleManagerTest
 {
-  @org.junit.Rule
+  @org.junit.jupiter.api.extension.RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
 
   private TestDerbyConnector connector;
@@ -63,7 +63,7 @@ public class SQLMetadataRuleManagerTest
   private AuditManager auditManager;
   private final ObjectMapper mapper = new DefaultObjectMapper();
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     connector = derbyConnectorRule.getConnector();
@@ -110,9 +110,9 @@ public class SQLMetadataRuleManagerTest
     ruleManager.overrideRule(TestDataSource.WIKI, rules, createAuditInfo("override rule"));
     // New rule should be be reflected in the in memory rules map immediately after being set by user
     Map<String, List<Rule>> allRules = ruleManager.getAllRules();
-    Assert.assertEquals(1, allRules.size());
-    Assert.assertEquals(1, allRules.get(TestDataSource.WIKI).size());
-    Assert.assertEquals(rules.get(0), allRules.get(TestDataSource.WIKI).get(0));
+    Assertions.assertEquals(1, allRules.size());
+    Assertions.assertEquals(1, allRules.get(TestDataSource.WIKI).size());
+    Assertions.assertEquals(rules.get(0), allRules.get(TestDataSource.WIKI).get(0));
   }
 
   @Test
@@ -128,7 +128,7 @@ public class SQLMetadataRuleManagerTest
     ruleManager.overrideRule(TestDataSource.WIKI, rules, createAuditInfo("override rule"));
     ruleManager.overrideRule(TestDataSource.WIKI, rules, createAuditInfo("override rule"));
     ruleManager.overrideRule(TestDataSource.WIKI, rules, createAuditInfo("override rule"));
-    Assert.assertEquals(1, auditManager.fetchAuditHistory(TestDataSource.WIKI, "rules", 3).size());
+    Assertions.assertEquals(1, auditManager.fetchAuditHistory(TestDataSource.WIKI, "rules", 3).size());
   }
 
   @Test
@@ -158,21 +158,21 @@ public class SQLMetadataRuleManagerTest
         )
     );
     ruleManager.overrideRule(TestDataSource.WIKI, rules, createAuditInfo("override rule"));
-    Assert.assertEquals(3, auditManager.fetchAuditHistory(TestDataSource.WIKI, "rules", 3).size());
+    Assertions.assertEquals(3, auditManager.fetchAuditHistory(TestDataSource.WIKI, "rules", 3).size());
   }
 
   @Test
   public void testOverrideRuleWithNull()
   {
     // Datasource level rules cannot be null
-    IAE exception = Assert.assertThrows(
+    IAE exception = Assertions.assertThrows(
         IAE.class,
         () -> ruleManager.overrideRule(TestDataSource.WIKI, null, createAuditInfo("null rule"))
     );
-    Assert.assertEquals("Rules cannot be null.", exception.getMessage());
+    Assertions.assertEquals("Rules cannot be null.", exception.getMessage());
 
     // Cluster level rules cannot be null
-    exception = Assert.assertThrows(
+    exception = Assertions.assertThrows(
         IAE.class,
         () -> ruleManager.overrideRule(
             managerConfig.getDefaultRule(),
@@ -180,14 +180,14 @@ public class SQLMetadataRuleManagerTest
             createAuditInfo("null cluster rule")
         )
     );
-    Assert.assertEquals("Rules cannot be null.", exception.getMessage());
+    Assertions.assertEquals("Rules cannot be null.", exception.getMessage());
   }
 
   @Test
   public void testOverrideRuleWithEmpty()
   {
     // Cluster level rules cannot be empty
-    IAE exception = Assert.assertThrows(
+    IAE exception = Assertions.assertThrows(
         IAE.class,
         () -> ruleManager.overrideRule(
             managerConfig.getDefaultRule(),
@@ -195,10 +195,10 @@ public class SQLMetadataRuleManagerTest
             createAuditInfo("empty cluster rule")
         )
     );
-    Assert.assertEquals("Cluster-level rules cannot be empty.", exception.getMessage());
+    Assertions.assertEquals("Cluster-level rules cannot be empty.", exception.getMessage());
 
     // Datasource level rules can be empty
-    Assert.assertTrue(
+    Assertions.assertTrue(
         ruleManager.overrideRule(
             TestDataSource.WIKI,
             Collections.emptyList(),
@@ -222,19 +222,19 @@ public class SQLMetadataRuleManagerTest
     // fetch rules from metadata storage
     ruleManager.poll();
 
-    Assert.assertEquals(rules, ruleManager.getRules(TestDataSource.WIKI));
+    Assertions.assertEquals(rules, ruleManager.getRules(TestDataSource.WIKI));
 
     // verify audit entry is created
     List<AuditEntry> auditEntries = auditManager.fetchAuditHistory(TestDataSource.WIKI, "rules", null);
-    Assert.assertEquals(1, auditEntries.size());
+    Assertions.assertEquals(1, auditEntries.size());
     AuditEntry entry = auditEntries.get(0);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         rules,
         mapper.readValue(entry.getPayload().serialized(), new TypeReference<List<Rule>>() {})
     );
-    Assert.assertEquals(auditInfo, entry.getAuditInfo());
-    Assert.assertEquals(TestDataSource.WIKI, entry.getKey());
+    Assertions.assertEquals(auditInfo, entry.getAuditInfo());
+    Assertions.assertEquals(TestDataSource.WIKI, entry.getKey());
   }
 
   @Test
@@ -255,18 +255,18 @@ public class SQLMetadataRuleManagerTest
     // fetch rules from metadata storage
     ruleManager.poll();
 
-    Assert.assertEquals(rules, ruleManager.getRules(TestDataSource.WIKI));
-    Assert.assertEquals(rules, ruleManager.getRules("test_dataSource2"));
+    Assertions.assertEquals(rules, ruleManager.getRules(TestDataSource.WIKI));
+    Assertions.assertEquals(rules, ruleManager.getRules("test_dataSource2"));
 
     // test fetch audit entries
     List<AuditEntry> auditEntries = auditManager.fetchAuditHistory("rules", null);
-    Assert.assertEquals(2, auditEntries.size());
+    Assertions.assertEquals(2, auditEntries.size());
     for (AuditEntry entry : auditEntries) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           rules,
           mapper.readValue(entry.getPayload().serialized(), new TypeReference<List<Rule>>() {})
       );
-      Assert.assertEquals(auditInfo, entry.getAuditInfo());
+      Assertions.assertEquals(auditInfo, entry.getAuditInfo());
     }
   }
 
@@ -285,8 +285,8 @@ public class SQLMetadataRuleManagerTest
     // Verify that the rule was added
     ruleManager.poll();
     Map<String, List<Rule>> allRules = ruleManager.getAllRules();
-    Assert.assertEquals(1, allRules.size());
-    Assert.assertEquals(1, allRules.get(TestDataSource.WIKI).size());
+    Assertions.assertEquals(1, allRules.size());
+    Assertions.assertEquals(1, allRules.get(TestDataSource.WIKI).size());
 
     // Now delete rules
     ruleManager.removeRulesForEmptyDatasourcesOlderThan(System.currentTimeMillis());
@@ -294,7 +294,7 @@ public class SQLMetadataRuleManagerTest
     // Verify that rule was deleted
     ruleManager.poll();
     allRules = ruleManager.getAllRules();
-    Assert.assertEquals(0, allRules.size());
+    Assertions.assertEquals(0, allRules.size());
   }
 
   @Test
@@ -312,8 +312,8 @@ public class SQLMetadataRuleManagerTest
     // Verify that rule was added
     ruleManager.poll();
     Map<String, List<Rule>> allRules = ruleManager.getAllRules();
-    Assert.assertEquals(1, allRules.size());
-    Assert.assertEquals(1, allRules.get(TestDataSource.WIKI).size());
+    Assertions.assertEquals(1, allRules.size());
+    Assertions.assertEquals(1, allRules.get(TestDataSource.WIKI).size());
 
     // This will not delete the rule as the rule was created just now so it will have the created timestamp later than
     // the timestamp 2012-01-01T00:00:00Z
@@ -322,8 +322,8 @@ public class SQLMetadataRuleManagerTest
     // Verify that rule was not deleted
     ruleManager.poll();
     allRules = ruleManager.getAllRules();
-    Assert.assertEquals(1, allRules.size());
-    Assert.assertEquals(1, allRules.get(TestDataSource.WIKI).size());
+    Assertions.assertEquals(1, allRules.size());
+    Assertions.assertEquals(1, allRules.get(TestDataSource.WIKI).size());
   }
 
   @Test
@@ -341,8 +341,8 @@ public class SQLMetadataRuleManagerTest
     // Verify that rule was added
     ruleManager.poll();
     Map<String, List<Rule>> allRules = ruleManager.getAllRules();
-    Assert.assertEquals(1, allRules.size());
-    Assert.assertEquals(1, allRules.get(TestDataSource.WIKI).size());
+    Assertions.assertEquals(1, allRules.size());
+    Assertions.assertEquals(1, allRules.get(TestDataSource.WIKI).size());
 
     // Add segment metadata to segment table so that the datasource is considered active
     DataSegment dataSegment = new DataSegment(
@@ -368,8 +368,8 @@ public class SQLMetadataRuleManagerTest
     // Verify that rule was not deleted
     ruleManager.poll();
     allRules = ruleManager.getAllRules();
-    Assert.assertEquals(1, allRules.size());
-    Assert.assertEquals(1, allRules.get(TestDataSource.WIKI).size());
+    Assertions.assertEquals(1, allRules.size());
+    Assertions.assertEquals(1, allRules.get(TestDataSource.WIKI).size());
   }
 
   @Test
@@ -380,18 +380,18 @@ public class SQLMetadataRuleManagerTest
     // Verify the default rule
     ruleManager.poll();
     Map<String, List<Rule>> allRules = ruleManager.getAllRules();
-    Assert.assertEquals(1, allRules.size());
-    Assert.assertEquals(1, allRules.get("_default").size());
+    Assertions.assertEquals(1, allRules.size());
+    Assertions.assertEquals(1, allRules.get("_default").size());
     // Delete everything
     ruleManager.removeRulesForEmptyDatasourcesOlderThan(System.currentTimeMillis());
     // Verify the default rule was not deleted
     ruleManager.poll();
     allRules = ruleManager.getAllRules();
-    Assert.assertEquals(1, allRules.size());
-    Assert.assertEquals(1, allRules.get("_default").size());
+    Assertions.assertEquals(1, allRules.size());
+    Assertions.assertEquals(1, allRules.get("_default").size());
   }
 
-  @After
+  @AfterEach
   public void cleanup()
   {
     dropTable(tablesConfig.getAuditTable());

--- a/server/src/test/java/org/apache/druid/metadata/SQLMetadataRuleManagerTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SQLMetadataRuleManagerTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Collections;
 import java.util.List;
@@ -53,7 +54,7 @@ import java.util.Map;
 
 public class SQLMetadataRuleManagerTest
 {
-  @org.junit.jupiter.api.extension.RegisterExtension
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
 
   private TestDerbyConnector connector;

--- a/server/src/test/java/org/apache/druid/metadata/SQLMetadataSupervisorManagerTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SQLMetadataSupervisorManagerTest.java
@@ -31,12 +31,12 @@ import org.apache.druid.indexing.overlord.supervisor.autoscaler.SupervisorTaskAu
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Collections;
 import java.util.List;
@@ -50,16 +50,16 @@ public class SQLMetadataSupervisorManagerTest
   private MetadataStorageTablesConfig tablesConfig;
   private SQLMetadataSupervisorManager supervisorManager;
 
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
 
-  @BeforeClass
+  @BeforeAll
   public static void setupStatic()
   {
     MAPPER.registerSubtypes(TestSupervisorSpec.class);
   }
 
-  @After
+  @AfterEach
   public void cleanup()
   {
     connector.getDBI().withHandle(
@@ -69,7 +69,7 @@ public class SQLMetadataSupervisorManagerTest
     );
   }
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     connector = derbyConnectorRule.getConnector();
@@ -84,21 +84,21 @@ public class SQLMetadataSupervisorManagerTest
   {
     final String supervisor1 = "test-supervisor-1";
     final Map<String, String> data1rev1 = ImmutableMap.of("key1-1", "value1-1-1", "key1-2", "value1-2-1");
-    Assert.assertTrue(supervisorManager.getAll().isEmpty());
+    Assertions.assertTrue(supervisorManager.getAll().isEmpty());
     supervisorManager.insert(supervisor1, new TestSupervisorSpec(supervisor1, data1rev1));
     // Test that supervisor was inserted
     Map<String, List<VersionedSupervisorSpec>> supervisorSpecs = supervisorManager.getAll();
-    Assert.assertEquals(1, supervisorSpecs.size());
+    Assertions.assertEquals(1, supervisorSpecs.size());
     Map<String, SupervisorSpec> latestSpecs = supervisorManager.getLatest();
-    Assert.assertEquals(1, latestSpecs.size());
+    Assertions.assertEquals(1, latestSpecs.size());
     // Try delete. Supervisor should not be deleted as it is still active
     int deleteCount = supervisorManager.removeTerminatedSupervisorsOlderThan(System.currentTimeMillis());
     // Test that supervisor was not deleted
-    Assert.assertEquals(0, deleteCount);
+    Assertions.assertEquals(0, deleteCount);
     supervisorSpecs = supervisorManager.getAll();
-    Assert.assertEquals(1, supervisorSpecs.size());
+    Assertions.assertEquals(1, supervisorSpecs.size());
     latestSpecs = supervisorManager.getLatest();
-    Assert.assertEquals(1, latestSpecs.size());
+    Assertions.assertEquals(1, latestSpecs.size());
   }
 
   @Test
@@ -107,24 +107,24 @@ public class SQLMetadataSupervisorManagerTest
     final String supervisor1 = "test-supervisor-1";
     final String datasource1 = "datasource-1";
     final Map<String, String> data1rev1 = ImmutableMap.of("key1-1", "value1-1-1", "key1-2", "value1-2-1");
-    Assert.assertTrue(supervisorManager.getAll().isEmpty());
+    Assertions.assertTrue(supervisorManager.getAll().isEmpty());
     supervisorManager.insert(supervisor1, new TestSupervisorSpec(supervisor1, data1rev1));
     supervisorManager.insert(supervisor1, new NoopSupervisorSpec(supervisor1, ImmutableList.of(datasource1)));
     // Test that supervisor was inserted
     Map<String, List<VersionedSupervisorSpec>> supervisorSpecs = supervisorManager.getAll();
-    Assert.assertEquals(1, supervisorSpecs.size());
-    Assert.assertEquals(2, supervisorSpecs.get(supervisor1).size());
+    Assertions.assertEquals(1, supervisorSpecs.size());
+    Assertions.assertEquals(2, supervisorSpecs.get(supervisor1).size());
     Map<String, SupervisorSpec> latestSpecs = supervisorManager.getLatest();
-    Assert.assertEquals(1, latestSpecs.size());
-    Assert.assertEquals(ImmutableList.of(datasource1), ((NoopSupervisorSpec) latestSpecs.get(supervisor1)).getDataSources());
+    Assertions.assertEquals(1, latestSpecs.size());
+    Assertions.assertEquals(ImmutableList.of(datasource1), ((NoopSupervisorSpec) latestSpecs.get(supervisor1)).getDataSources());
     // Do delete. Supervisor should be deleted as it is terminated
     int deleteCount = supervisorManager.removeTerminatedSupervisorsOlderThan(System.currentTimeMillis());
     // Verify that supervisor was actually deleted
-    Assert.assertEquals(2, deleteCount);
+    Assertions.assertEquals(2, deleteCount);
     supervisorSpecs = supervisorManager.getAll();
-    Assert.assertEquals(0, supervisorSpecs.size());
+    Assertions.assertEquals(0, supervisorSpecs.size());
     latestSpecs = supervisorManager.getLatest();
-    Assert.assertEquals(0, latestSpecs.size());
+    Assertions.assertEquals(0, latestSpecs.size());
   }
 
   @Test
@@ -133,27 +133,27 @@ public class SQLMetadataSupervisorManagerTest
     final String supervisor1 = "test-supervisor-1";
     final String datasource1 = "datasource-1";
     final Map<String, String> data1rev1 = ImmutableMap.of("key1-1", "value1-1-1", "key1-2", "value1-2-1");
-    Assert.assertTrue(supervisorManager.getAll().isEmpty());
+    Assertions.assertTrue(supervisorManager.getAll().isEmpty());
     supervisorManager.insert(supervisor1, new TestSupervisorSpec(supervisor1, data1rev1));
     supervisorManager.insert(supervisor1, new NoopSupervisorSpec(supervisor1, ImmutableList.of(datasource1)));
     // Test that supervisor was inserted
     Map<String, List<VersionedSupervisorSpec>> supervisorSpecs = supervisorManager.getAll();
-    Assert.assertEquals(1, supervisorSpecs.size());
-    Assert.assertEquals(2, supervisorSpecs.get(supervisor1).size());
+    Assertions.assertEquals(1, supervisorSpecs.size());
+    Assertions.assertEquals(2, supervisorSpecs.get(supervisor1).size());
     Map<String, SupervisorSpec> latestSpecs = supervisorManager.getLatest();
-    Assert.assertEquals(1, latestSpecs.size());
-    Assert.assertEquals(ImmutableList.of(datasource1), ((NoopSupervisorSpec) latestSpecs.get(supervisor1)).getDataSources());
+    Assertions.assertEquals(1, latestSpecs.size());
+    Assertions.assertEquals(ImmutableList.of(datasource1), ((NoopSupervisorSpec) latestSpecs.get(supervisor1)).getDataSources());
     // Do delete. Supervisor should not be deleted. Supervisor is terminated but it was created just now so it's
     // created timestamp will be later than the timestamp 2012-01-01T00:00:00Z
     int deleteCount = supervisorManager.removeTerminatedSupervisorsOlderThan(DateTimes.of("2012-01-01T00:00:00Z").getMillis());
     // Verify that supervisor was not deleted
-    Assert.assertEquals(0, deleteCount);
+    Assertions.assertEquals(0, deleteCount);
     supervisorSpecs = supervisorManager.getAll();
-    Assert.assertEquals(1, supervisorSpecs.size());
-    Assert.assertEquals(2, supervisorSpecs.get(supervisor1).size());
+    Assertions.assertEquals(1, supervisorSpecs.size());
+    Assertions.assertEquals(2, supervisorSpecs.get(supervisor1).size());
     latestSpecs = supervisorManager.getLatest();
-    Assert.assertEquals(1, latestSpecs.size());
-    Assert.assertEquals(ImmutableList.of(datasource1), ((NoopSupervisorSpec) latestSpecs.get(supervisor1)).getDataSources());
+    Assertions.assertEquals(1, latestSpecs.size());
+    Assertions.assertEquals(ImmutableList.of(datasource1), ((NoopSupervisorSpec) latestSpecs.get(supervisor1)).getDataSources());
   }
 
   @Test
@@ -167,7 +167,7 @@ public class SQLMetadataSupervisorManagerTest
     final Map<String, String> data2rev1 = ImmutableMap.of("key2-1", "value2-1-1", "key2-2", "value2-2-1");
     final Map<String, String> data2rev2 = ImmutableMap.of("key2-3", "value2-3-2", "key2-4", "value2-4-2");
 
-    Assert.assertTrue(supervisorManager.getAll().isEmpty());
+    Assertions.assertTrue(supervisorManager.getAll().isEmpty());
 
     // add 2 supervisors, one revision each, and make sure the state is as expected
     supervisorManager.insert(supervisor1, new TestSupervisorSpec(supervisor1, data1rev1));
@@ -175,16 +175,16 @@ public class SQLMetadataSupervisorManagerTest
 
     Map<String, List<VersionedSupervisorSpec>> supervisorSpecs = supervisorManager.getAll();
     Map<String, SupervisorSpec> latestSpecs = supervisorManager.getLatest();
-    Assert.assertEquals(2, supervisorSpecs.size());
-    Assert.assertEquals(1, supervisorSpecs.get(supervisor1).size());
-    Assert.assertEquals(1, supervisorSpecs.get(supervisor2).size());
-    Assert.assertEquals(supervisor1, supervisorSpecs.get(supervisor1).get(0).getSpec().getId());
-    Assert.assertEquals(supervisor2, supervisorSpecs.get(supervisor2).get(0).getSpec().getId());
-    Assert.assertEquals(data1rev1, ((TestSupervisorSpec) supervisorSpecs.get(supervisor1).get(0).getSpec()).getData());
-    Assert.assertEquals(data2rev1, ((TestSupervisorSpec) supervisorSpecs.get(supervisor2).get(0).getSpec()).getData());
-    Assert.assertEquals(2, latestSpecs.size());
-    Assert.assertEquals(data1rev1, ((TestSupervisorSpec) latestSpecs.get(supervisor1)).getData());
-    Assert.assertEquals(data2rev1, ((TestSupervisorSpec) latestSpecs.get(supervisor2)).getData());
+    Assertions.assertEquals(2, supervisorSpecs.size());
+    Assertions.assertEquals(1, supervisorSpecs.get(supervisor1).size());
+    Assertions.assertEquals(1, supervisorSpecs.get(supervisor2).size());
+    Assertions.assertEquals(supervisor1, supervisorSpecs.get(supervisor1).get(0).getSpec().getId());
+    Assertions.assertEquals(supervisor2, supervisorSpecs.get(supervisor2).get(0).getSpec().getId());
+    Assertions.assertEquals(data1rev1, ((TestSupervisorSpec) supervisorSpecs.get(supervisor1).get(0).getSpec()).getData());
+    Assertions.assertEquals(data2rev1, ((TestSupervisorSpec) supervisorSpecs.get(supervisor2).get(0).getSpec()).getData());
+    Assertions.assertEquals(2, latestSpecs.size());
+    Assertions.assertEquals(data1rev1, ((TestSupervisorSpec) latestSpecs.get(supervisor1)).getData());
+    Assertions.assertEquals(data2rev1, ((TestSupervisorSpec) latestSpecs.get(supervisor2)).getData());
 
     // add more revisions to the supervisors
     supervisorManager.insert(supervisor1, new TestSupervisorSpec(supervisor1, data1rev2));
@@ -193,20 +193,20 @@ public class SQLMetadataSupervisorManagerTest
 
     supervisorSpecs = supervisorManager.getAll();
     latestSpecs = supervisorManager.getLatest();
-    Assert.assertEquals(2, supervisorSpecs.size());
-    Assert.assertEquals(3, supervisorSpecs.get(supervisor1).size());
-    Assert.assertEquals(2, supervisorSpecs.get(supervisor2).size());
+    Assertions.assertEquals(2, supervisorSpecs.size());
+    Assertions.assertEquals(3, supervisorSpecs.get(supervisor1).size());
+    Assertions.assertEquals(2, supervisorSpecs.get(supervisor2).size());
 
     // make sure getAll() returns each spec in descending order
-    Assert.assertEquals(data1rev3, ((TestSupervisorSpec) supervisorSpecs.get(supervisor1).get(0).getSpec()).getData());
-    Assert.assertEquals(data1rev2, ((TestSupervisorSpec) supervisorSpecs.get(supervisor1).get(1).getSpec()).getData());
-    Assert.assertEquals(data1rev1, ((TestSupervisorSpec) supervisorSpecs.get(supervisor1).get(2).getSpec()).getData());
-    Assert.assertEquals(data2rev2, ((TestSupervisorSpec) supervisorSpecs.get(supervisor2).get(0).getSpec()).getData());
-    Assert.assertEquals(data2rev1, ((TestSupervisorSpec) supervisorSpecs.get(supervisor2).get(1).getSpec()).getData());
+    Assertions.assertEquals(data1rev3, ((TestSupervisorSpec) supervisorSpecs.get(supervisor1).get(0).getSpec()).getData());
+    Assertions.assertEquals(data1rev2, ((TestSupervisorSpec) supervisorSpecs.get(supervisor1).get(1).getSpec()).getData());
+    Assertions.assertEquals(data1rev1, ((TestSupervisorSpec) supervisorSpecs.get(supervisor1).get(2).getSpec()).getData());
+    Assertions.assertEquals(data2rev2, ((TestSupervisorSpec) supervisorSpecs.get(supervisor2).get(0).getSpec()).getData());
+    Assertions.assertEquals(data2rev1, ((TestSupervisorSpec) supervisorSpecs.get(supervisor2).get(1).getSpec()).getData());
 
     // make sure getLatest() returns the last revision
-    Assert.assertEquals(data1rev3, ((TestSupervisorSpec) latestSpecs.get(supervisor1)).getData());
-    Assert.assertEquals(data2rev2, ((TestSupervisorSpec) latestSpecs.get(supervisor2)).getData());
+    Assertions.assertEquals(data1rev3, ((TestSupervisorSpec) latestSpecs.get(supervisor1)).getData());
+    Assertions.assertEquals(data2rev2, ((TestSupervisorSpec) latestSpecs.get(supervisor2)).getData());
   }
 
   @Test
@@ -220,8 +220,8 @@ public class SQLMetadataSupervisorManagerTest
     final Map<String, String> data2rev1 = ImmutableMap.of("key2-1", "value2-1-1", "key2-2", "value2-2-1");
     final Map<String, String> data2rev2 = ImmutableMap.of("key2-3", "value2-3-2", "key2-4", "value2-4-2");
 
-    Assert.assertTrue(supervisorManager.getAllForId(supervisor1, null).isEmpty());
-    Assert.assertTrue(supervisorManager.getAllForId(supervisor2, null).isEmpty());
+    Assertions.assertTrue(supervisorManager.getAllForId(supervisor1, null).isEmpty());
+    Assertions.assertTrue(supervisorManager.getAllForId(supervisor2, null).isEmpty());
 
     // add 2 supervisors, with revisions
     supervisorManager.insert(supervisor1, new TestSupervisorSpec(supervisor1, data1rev1));
@@ -233,14 +233,14 @@ public class SQLMetadataSupervisorManagerTest
     List<VersionedSupervisorSpec> supervisor1Specs = supervisorManager.getAllForId(supervisor1, null);
     List<VersionedSupervisorSpec> supervisor2Specs = supervisorManager.getAllForId(supervisor2, null);
 
-    Assert.assertEquals(3, supervisor1Specs.size());
-    Assert.assertEquals(2, supervisor2Specs.size());
+    Assertions.assertEquals(3, supervisor1Specs.size());
+    Assertions.assertEquals(2, supervisor2Specs.size());
     // make sure getAll() returns each spec in descending order
-    Assert.assertEquals(data1rev3, ((TestSupervisorSpec) supervisor1Specs.get(0).getSpec()).getData());
-    Assert.assertEquals(data1rev2, ((TestSupervisorSpec) supervisor1Specs.get(1).getSpec()).getData());
-    Assert.assertEquals(data1rev1, ((TestSupervisorSpec) supervisor1Specs.get(2).getSpec()).getData());
-    Assert.assertEquals(data2rev2, ((TestSupervisorSpec) supervisor2Specs.get(0).getSpec()).getData());
-    Assert.assertEquals(data2rev1, ((TestSupervisorSpec) supervisor2Specs.get(1).getSpec()).getData());
+    Assertions.assertEquals(data1rev3, ((TestSupervisorSpec) supervisor1Specs.get(0).getSpec()).getData());
+    Assertions.assertEquals(data1rev2, ((TestSupervisorSpec) supervisor1Specs.get(1).getSpec()).getData());
+    Assertions.assertEquals(data1rev1, ((TestSupervisorSpec) supervisor1Specs.get(2).getSpec()).getData());
+    Assertions.assertEquals(data2rev2, ((TestSupervisorSpec) supervisor2Specs.get(0).getSpec()).getData());
+    Assertions.assertEquals(data2rev1, ((TestSupervisorSpec) supervisor2Specs.get(1).getSpec()).getData());
   }
 
   @Test
@@ -257,18 +257,18 @@ public class SQLMetadataSupervisorManagerTest
 
     final Map<String, List<VersionedSupervisorSpec>> allSpecs = supervisorManager.getAll();
 
-    Assert.assertEquals(2, allSpecs.size());
+    Assertions.assertEquals(2, allSpecs.size());
     List<VersionedSupervisorSpec> specs = allSpecs.get(supervisor1);
-    Assert.assertEquals(2, specs.size());
-    Assert.assertEquals(new TestSupervisorSpec(supervisor1, data1rev2), specs.get(0).getSpec());
-    Assert.assertEquals(new TestSupervisorSpec(supervisor1, data1rev1), specs.get(1).getSpec());
+    Assertions.assertEquals(2, specs.size());
+    Assertions.assertEquals(new TestSupervisorSpec(supervisor1, data1rev2), specs.get(0).getSpec());
+    Assertions.assertEquals(new TestSupervisorSpec(supervisor1, data1rev1), specs.get(1).getSpec());
 
     specs = allSpecs.get(supervisor2);
-    Assert.assertEquals(1, specs.size());
-    Assert.assertNull(specs.get(0).getSpec());
+    Assertions.assertEquals(1, specs.size());
+    Assertions.assertNull(specs.get(0).getSpec());
 
     Map<String, SupervisorSpec> latestSupervisorSpec = supervisorManager.getLatest();
-    Assert.assertEquals(1, latestSupervisorSpec.size());
+    Assertions.assertEquals(1, latestSupervisorSpec.size());
   }
 
   @Test
@@ -278,7 +278,7 @@ public class SQLMetadataSupervisorManagerTest
     final String datasource1 = "datasource-1";
     final String supervisor2 = "test-supervisor-2";
     final Map<String, String> data1rev1 = ImmutableMap.of("key1-1", "value1-1-1", "key1-2", "value1-2-1");
-    Assert.assertTrue(supervisorManager.getAll().isEmpty());
+    Assertions.assertTrue(supervisorManager.getAll().isEmpty());
     supervisorManager.insert(supervisor1, new TestSupervisorSpec(supervisor1, data1rev1));
     // supervisor1 is terminated
     supervisorManager.insert(supervisor1, new NoopSupervisorSpec(supervisor1, ImmutableList.of(datasource1)));
@@ -286,8 +286,8 @@ public class SQLMetadataSupervisorManagerTest
     supervisorManager.insert(supervisor2, new TestSupervisorSpec(supervisor2, data1rev1));
     // get latest active should only return supervisor2
     Map<String, SupervisorSpec> actual = supervisorManager.getLatestActiveOnly();
-    Assert.assertEquals(1, actual.size());
-    Assert.assertTrue(actual.containsKey(supervisor2));
+    Assertions.assertEquals(1, actual.size());
+    Assertions.assertTrue(actual.containsKey(supervisor2));
   }
 
 
@@ -298,7 +298,7 @@ public class SQLMetadataSupervisorManagerTest
     final String datasource1 = "datasource-1";
     final String supervisor2 = "test-supervisor-2";
     final Map<String, String> data1rev1 = ImmutableMap.of("key1-1", "value1-1-1", "key1-2", "value1-2-1");
-    Assert.assertTrue(supervisorManager.getAll().isEmpty());
+    Assertions.assertTrue(supervisorManager.getAll().isEmpty());
     supervisorManager.insert(supervisor1, new TestSupervisorSpec(supervisor1, data1rev1));
     // supervisor1 is terminated
     supervisorManager.insert(supervisor1, new NoopSupervisorSpec(supervisor1, ImmutableList.of(datasource1)));
@@ -306,8 +306,8 @@ public class SQLMetadataSupervisorManagerTest
     supervisorManager.insert(supervisor2, new TestSupervisorSpec(supervisor2, data1rev1));
     // get latest terminated should only return supervisor1
     Map<String, SupervisorSpec> actual = supervisorManager.getLatestTerminatedOnly();
-    Assert.assertEquals(1, actual.size());
-    Assert.assertTrue(actual.containsKey(supervisor1));
+    Assertions.assertEquals(1, actual.size());
+    Assertions.assertTrue(actual.containsKey(supervisor1));
   }
 
   @Test
@@ -318,7 +318,7 @@ public class SQLMetadataSupervisorManagerTest
     final Map<String, String> data1rev2 = ImmutableMap.of("key1-1", "value1-1-2", "key1-2", "value1-2-2");
     final Map<String, String> data1rev3 = ImmutableMap.of("key1-1", "value1-1-3", "key1-2", "value1-2-3");
 
-    Assert.assertTrue(supervisorManager.getAll().isEmpty());
+    Assertions.assertTrue(supervisorManager.getAll().isEmpty());
 
     // Insert 3 versions
     supervisorManager.insert(supervisor1, new TestSupervisorSpec(supervisor1, data1rev1));
@@ -327,40 +327,40 @@ public class SQLMetadataSupervisorManagerTest
 
     // Test with limit=2
     List<VersionedSupervisorSpec> limitedResults = supervisorManager.getAllForId(supervisor1, 2);
-    Assert.assertEquals(2, limitedResults.size());
+    Assertions.assertEquals(2, limitedResults.size());
     // Results should be in descending order (newest first)
-    Assert.assertEquals(data1rev3, ((TestSupervisorSpec) limitedResults.get(0).getSpec()).getData());
-    Assert.assertEquals(data1rev2, ((TestSupervisorSpec) limitedResults.get(1).getSpec()).getData());
+    Assertions.assertEquals(data1rev3, ((TestSupervisorSpec) limitedResults.get(0).getSpec()).getData());
+    Assertions.assertEquals(data1rev2, ((TestSupervisorSpec) limitedResults.get(1).getSpec()).getData());
 
     // Test with limit=1
     limitedResults = supervisorManager.getAllForId(supervisor1, 1);
-    Assert.assertEquals(1, limitedResults.size());
-    Assert.assertEquals(data1rev3, ((TestSupervisorSpec) limitedResults.get(0).getSpec()).getData());
+    Assertions.assertEquals(1, limitedResults.size());
+    Assertions.assertEquals(data1rev3, ((TestSupervisorSpec) limitedResults.get(0).getSpec()).getData());
 
     // Test with limit=0 (should throw exception)
     try {
       supervisorManager.getAllForId(supervisor1, 0);
-      Assert.fail("Expected IllegalArgumentException for limit=0");
+      Assertions.fail("Expected IllegalArgumentException for limit=0");
     }
     catch (IllegalArgumentException e) {
-      Assert.assertEquals("Limit must be greater than zero if set", e.getMessage());
+      Assertions.assertEquals("Limit must be greater than zero if set", e.getMessage());
     }
 
     // Test with limit=null (should return all)
     List<VersionedSupervisorSpec> allResults = supervisorManager.getAllForId(supervisor1, null);
-    Assert.assertEquals(3, allResults.size());
+    Assertions.assertEquals(3, allResults.size());
 
     // Test with limit larger than available records
     limitedResults = supervisorManager.getAllForId(supervisor1, 10);
-    Assert.assertEquals(3, limitedResults.size());
+    Assertions.assertEquals(3, limitedResults.size());
 
     // Test with negative limit (should throw exception)
     try {
       supervisorManager.getAllForId(supervisor1, -1);
-      Assert.fail("Expected IllegalArgumentException for limit=-1");
+      Assertions.fail("Expected IllegalArgumentException for limit=-1");
     }
     catch (IllegalArgumentException e) {
-      Assert.assertEquals("Limit must be greater than zero if set", e.getMessage());
+      Assertions.assertEquals("Limit must be greater than zero if set", e.getMessage());
     }
   }
 

--- a/server/src/test/java/org/apache/druid/metadata/SortOrderTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SortOrderTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.metadata;
 
 import org.apache.druid.error.DruidExceptionMatcher;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SortOrderTest
 {
@@ -29,23 +29,23 @@ public class SortOrderTest
   @Test
   public void testAsc()
   {
-    Assert.assertEquals(SortOrder.ASC, SortOrder.fromValue("asc"));
-    Assert.assertEquals("ASC", SortOrder.fromValue("asc").toString());
-    Assert.assertEquals(SortOrder.ASC, SortOrder.fromValue("ASC"));
-    Assert.assertEquals("ASC", SortOrder.fromValue("ASC").toString());
-    Assert.assertEquals(SortOrder.ASC, SortOrder.fromValue("AsC"));
-    Assert.assertEquals("ASC", SortOrder.fromValue("AsC").toString());
+    Assertions.assertEquals(SortOrder.ASC, SortOrder.fromValue("asc"));
+    Assertions.assertEquals("ASC", SortOrder.fromValue("asc").toString());
+    Assertions.assertEquals(SortOrder.ASC, SortOrder.fromValue("ASC"));
+    Assertions.assertEquals("ASC", SortOrder.fromValue("ASC").toString());
+    Assertions.assertEquals(SortOrder.ASC, SortOrder.fromValue("AsC"));
+    Assertions.assertEquals("ASC", SortOrder.fromValue("AsC").toString());
   }
 
   @Test
   public void testDesc()
   {
-    Assert.assertEquals(SortOrder.DESC, SortOrder.fromValue("desc"));
-    Assert.assertEquals("DESC", SortOrder.fromValue("desc").toString());
-    Assert.assertEquals(SortOrder.DESC, SortOrder.fromValue("DESC"));
-    Assert.assertEquals("DESC", SortOrder.fromValue("DESC").toString());
-    Assert.assertEquals(SortOrder.DESC, SortOrder.fromValue("DesC"));
-    Assert.assertEquals("DESC", SortOrder.fromValue("DesC").toString());
+    Assertions.assertEquals(SortOrder.DESC, SortOrder.fromValue("desc"));
+    Assertions.assertEquals("DESC", SortOrder.fromValue("desc").toString());
+    Assertions.assertEquals(SortOrder.DESC, SortOrder.fromValue("DESC"));
+    Assertions.assertEquals("DESC", SortOrder.fromValue("DESC").toString());
+    Assertions.assertEquals(SortOrder.DESC, SortOrder.fromValue("DesC"));
+    Assertions.assertEquals("DESC", SortOrder.fromValue("DesC").toString());
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerProviderTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerProviderTest.java
@@ -28,15 +28,15 @@ import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.metadata.CentralizedDatasourceSchemaConfig;
 import org.apache.druid.segment.metadata.SegmentSchemaCache;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Locale;
 
 public class SqlSegmentsMetadataManagerProviderTest
 {
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule
       = new TestDerbyConnector.DerbyConnectorRule();
 
@@ -61,21 +61,21 @@ public class SqlSegmentsMetadataManagerProviderTest
         NoopServiceEmitter.instance()
     );
     SegmentsMetadataManager manager = provider.get();
-    Assert.assertTrue(manager instanceof SqlSegmentsMetadataManagerV2);
+    Assertions.assertTrue(manager instanceof SqlSegmentsMetadataManagerV2);
 
     final MetadataStorageTablesConfig storageConfig = derbyConnectorRule.metadataTablesConfigSupplier().get();
     final String segmentsTable = storageConfig.getSegmentsTable();
     final String upgradeSegmentsTable = storageConfig.getUpgradeSegmentsTable();
 
     // Verify that the tables do not exist yet
-    Assert.assertFalse(tableExists(segmentsTable, connector));
-    Assert.assertFalse(tableExists(upgradeSegmentsTable, connector));
+    Assertions.assertFalse(tableExists(segmentsTable, connector));
+    Assertions.assertFalse(tableExists(upgradeSegmentsTable, connector));
 
     lifecycle.start();
 
     // Verify that tables have now been created
-    Assert.assertTrue(tableExists(segmentsTable, connector));
-    Assert.assertTrue(tableExists(upgradeSegmentsTable, connector));
+    Assertions.assertTrue(tableExists(segmentsTable, connector));
+    Assertions.assertTrue(tableExists(upgradeSegmentsTable, connector));
 
     lifecycle.stop();
   }

--- a/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerSchemaPollTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerSchemaPollTest.java
@@ -34,23 +34,25 @@ import org.apache.druid.segment.metadata.SegmentSchemaCache;
 import org.apache.druid.segment.metadata.SegmentSchemaManager;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class SqlSegmentsMetadataManagerSchemaPollTest extends SqlSegmentsMetadataManagerTestBase
 {
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule =
       new TestDerbyConnector.DerbyConnectorRule(CentralizedDatasourceSchemaConfig.enabled(true));
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     setUp(derbyConnectorRule);
@@ -65,13 +67,14 @@ public class SqlSegmentsMetadataManagerSchemaPollTest extends SqlSegmentsMetadat
     publishSegment(segment2);
   }
 
-  @After
+  @AfterEach
   public void teardown()
   {
     teardownManager();
   }
 
-  @Test(timeout = 60_000)
+  @Test
+  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS)
   public void testPollSegmentAndSchema()
   {
     List<SegmentSchemaManager.SegmentSchemaMetadataPlus> list = new ArrayList<>();
@@ -122,36 +125,36 @@ public class SqlSegmentsMetadataManagerSchemaPollTest extends SqlSegmentsMetadat
 
     sqlSegmentsMetadataManager.start();
     DataSourcesSnapshot dataSourcesSnapshot = sqlSegmentsMetadataManager.getLatestDataSourcesSnapshot();
-    Assert.assertNull(dataSourcesSnapshot);
-    Assert.assertFalse(segmentSchemaCache.getSchemaForSegment(segment1.getId()).isPresent());
-    Assert.assertFalse(segmentSchemaCache.getSchemaForSegment(segment2.getId()).isPresent());
-    Assert.assertFalse(segmentSchemaCache.isInitialized());
+    Assertions.assertNull(dataSourcesSnapshot);
+    Assertions.assertFalse(segmentSchemaCache.getSchemaForSegment(segment1.getId()).isPresent());
+    Assertions.assertFalse(segmentSchemaCache.getSchemaForSegment(segment2.getId()).isPresent());
+    Assertions.assertFalse(segmentSchemaCache.isInitialized());
 
     sqlSegmentsMetadataManager.startPollingDatabasePeriodically();
-    Assert.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
+    Assertions.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
     // This call make sure that the first poll is completed
     sqlSegmentsMetadataManager.useLatestSnapshotIfWithinDelay();
-    Assert.assertTrue(sqlSegmentsMetadataManager.getLatestDatabasePoll() instanceof SqlSegmentsMetadataManager.PeriodicDatabasePoll);
-    Assert.assertTrue(segmentSchemaCache.isInitialized());
-    Assert.assertTrue(segmentSchemaCache.getSchemaForSegment(segment1.getId()).isPresent());
-    Assert.assertTrue(segmentSchemaCache.getSchemaForSegment(segment2.getId()).isPresent());
+    Assertions.assertTrue(sqlSegmentsMetadataManager.getLatestDatabasePoll() instanceof SqlSegmentsMetadataManager.PeriodicDatabasePoll);
+    Assertions.assertTrue(segmentSchemaCache.isInitialized());
+    Assertions.assertTrue(segmentSchemaCache.getSchemaForSegment(segment1.getId()).isPresent());
+    Assertions.assertTrue(segmentSchemaCache.getSchemaForSegment(segment2.getId()).isPresent());
 
-    Assert.assertEquals(schemaMetadata1, segmentSchemaCache.getSchemaForSegment(segment1.getId()).get());
-    Assert.assertEquals(schemaMetadata2, segmentSchemaCache.getSchemaForSegment(segment2.getId()).get());
+    Assertions.assertEquals(schemaMetadata1, segmentSchemaCache.getSchemaForSegment(segment1.getId()).get());
+    Assertions.assertEquals(schemaMetadata2, segmentSchemaCache.getSchemaForSegment(segment2.getId()).get());
 
     dataSourcesSnapshot = sqlSegmentsMetadataManager.getLatestDataSourcesSnapshot();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("wikipedia"),
         dataSourcesSnapshot.getDataSourcesWithAllUsedSegments()
                            .stream()
                            .map(ImmutableDruidDataSource::getName)
                            .collect(Collectors.toList())
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(segment1, segment2),
         ImmutableSet.copyOf(dataSourcesSnapshot.getDataSource("wikipedia").getSegments())
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(segment1, segment2),
         ImmutableSet.copyOf(dataSourcesSnapshot.iterateAllUsedSegmentsInSnapshot())
     );
@@ -206,9 +209,9 @@ public class SqlSegmentsMetadataManagerSchemaPollTest extends SqlSegmentsMetadat
 
     sqlSegmentsMetadataManager.start();
     sqlSegmentsMetadataManager.poll();
-    Assert.assertTrue(segmentSchemaCache.isInitialized());
-    Assert.assertFalse(segmentSchemaCache.getSchemaForSegment(segment1.getId()).isPresent());
-    Assert.assertFalse(segmentSchemaCache.getSchemaForSegment(segment2.getId()).isPresent());
+    Assertions.assertTrue(segmentSchemaCache.isInitialized());
+    Assertions.assertFalse(segmentSchemaCache.getSchemaForSegment(segment1.getId()).isPresent());
+    Assertions.assertFalse(segmentSchemaCache.getSchemaForSegment(segment2.getId()).isPresent());
 
     list.clear();
     list.add(
@@ -234,8 +237,8 @@ public class SqlSegmentsMetadataManagerSchemaPollTest extends SqlSegmentsMetadat
     segmentSchemaManager.persistSchemaAndUpdateSegmentsTable("wikipedia", list, CentralizedDatasourceSchemaConfig.SCHEMA_VERSION);
 
     sqlSegmentsMetadataManager.poll();
-    Assert.assertTrue(segmentSchemaCache.isInitialized());
-    Assert.assertTrue(segmentSchemaCache.getSchemaForSegment(segment1.getId()).isPresent());
-    Assert.assertTrue(segmentSchemaCache.getSchemaForSegment(segment2.getId()).isPresent());
+    Assertions.assertTrue(segmentSchemaCache.isInitialized());
+    Assertions.assertTrue(segmentSchemaCache.getSchemaForSegment(segment1.getId()).isPresent());
+    Assertions.assertTrue(segmentSchemaCache.getSchemaForSegment(segment2.getId()).isPresent());
   }
 }

--- a/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerSchemaPollTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerSchemaPollTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.ArrayList;
@@ -74,7 +75,7 @@ public class SqlSegmentsMetadataManagerSchemaPollTest extends SqlSegmentsMetadat
   }
 
   @Test
-  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testPollSegmentAndSchema()
   {
     List<SegmentSchemaManager.SegmentSchemaMetadataPlus> list = new ArrayList<>();

--- a/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerTest.java
@@ -38,13 +38,15 @@ import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.assertj.core.util.Sets;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTestBase
@@ -68,7 +70,7 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
     );
   }
 
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule
       = new TestDerbyConnector.DerbyConnectorRule();
 
@@ -91,13 +93,13 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
     publishSegment(wikiSegment2);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     setUp(derbyConnectorRule);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     teardownManager();
@@ -108,8 +110,8 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
   {
     sqlSegmentsMetadataManager.startPollingDatabasePeriodically();
     sqlSegmentsMetadataManager.poll();
-    Assert.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
-    Assert.assertTrue(
+    Assertions.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
+    Assertions.assertTrue(
         sqlSegmentsMetadataManager
             .getRecentDataSourcesSnapshot()
             .getDataSourcesWithAllUsedSegments()
@@ -122,25 +124,25 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
   {
     publishWikiSegments();
     DataSourcesSnapshot dataSourcesSnapshot = sqlSegmentsMetadataManager.getLatestDataSourcesSnapshot();
-    Assert.assertNull(dataSourcesSnapshot);
+    Assertions.assertNull(dataSourcesSnapshot);
     sqlSegmentsMetadataManager.startPollingDatabasePeriodically();
-    Assert.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
+    Assertions.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
     // This call make sure that the first poll is completed
     sqlSegmentsMetadataManager.useLatestSnapshotIfWithinDelay();
-    Assert.assertTrue(sqlSegmentsMetadataManager.getLatestDatabasePoll() instanceof SqlSegmentsMetadataManager.PeriodicDatabasePoll);
+    Assertions.assertTrue(sqlSegmentsMetadataManager.getLatestDatabasePoll() instanceof SqlSegmentsMetadataManager.PeriodicDatabasePoll);
     dataSourcesSnapshot = sqlSegmentsMetadataManager.getLatestDataSourcesSnapshot();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(TestDataSource.WIKI),
         dataSourcesSnapshot.getDataSourcesWithAllUsedSegments()
                            .stream()
                            .map(ImmutableDruidDataSource::getName)
                            .collect(Collectors.toList())
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(wikiSegment1, wikiSegment2),
         ImmutableSet.copyOf(dataSourcesSnapshot.getDataSource(TestDataSource.WIKI).getSegments())
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments()
     );
@@ -151,45 +153,46 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
   {
     publishWikiSegments();
     DataSourcesSnapshot dataSourcesSnapshot = sqlSegmentsMetadataManager.getLatestDataSourcesSnapshot();
-    Assert.assertNull(dataSourcesSnapshot);
+    Assertions.assertNull(dataSourcesSnapshot);
     // This should return false and not wait/poll anything as we did not schedule periodic poll
-    Assert.assertFalse(sqlSegmentsMetadataManager.useLatestSnapshotIfWithinDelay());
-    Assert.assertNull(dataSourcesSnapshot);
+    Assertions.assertFalse(sqlSegmentsMetadataManager.useLatestSnapshotIfWithinDelay());
+    Assertions.assertNull(dataSourcesSnapshot);
     // This call will force on demand poll
     sqlSegmentsMetadataManager.forceOrWaitOngoingDatabasePoll();
-    Assert.assertFalse(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
-    Assert.assertTrue(sqlSegmentsMetadataManager.getLatestDatabasePoll() instanceof SqlSegmentsMetadataManager.OnDemandDatabasePoll);
+    Assertions.assertFalse(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
+    Assertions.assertTrue(sqlSegmentsMetadataManager.getLatestDatabasePoll() instanceof SqlSegmentsMetadataManager.OnDemandDatabasePoll);
     dataSourcesSnapshot = sqlSegmentsMetadataManager.getLatestDataSourcesSnapshot();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(TestDataSource.WIKI),
         dataSourcesSnapshot.getDataSourcesWithAllUsedSegments()
                            .stream()
                            .map(ImmutableDruidDataSource::getName)
                            .collect(Collectors.toList())
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(wikiSegment1, wikiSegment2),
         ImmutableSet.copyOf(dataSourcesSnapshot.getDataSource(TestDataSource.WIKI).getSegments())
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments()
     );
   }
 
-  @Test(timeout = 60_000)
+  @Test
+  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS)
   public void testPollPeriodicallyAndOnDemandInterleave() throws Exception
   {
     publishWikiSegments();
     DataSourcesSnapshot dataSourcesSnapshot = sqlSegmentsMetadataManager.getLatestDataSourcesSnapshot();
-    Assert.assertNull(dataSourcesSnapshot);
+    Assertions.assertNull(dataSourcesSnapshot);
     sqlSegmentsMetadataManager.startPollingDatabasePeriodically();
-    Assert.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
+    Assertions.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
     // This call make sure that the first poll is completed
     sqlSegmentsMetadataManager.useLatestSnapshotIfWithinDelay();
-    Assert.assertTrue(sqlSegmentsMetadataManager.getLatestDatabasePoll() instanceof SqlSegmentsMetadataManager.PeriodicDatabasePoll);
+    Assertions.assertTrue(sqlSegmentsMetadataManager.getLatestDatabasePoll() instanceof SqlSegmentsMetadataManager.PeriodicDatabasePoll);
     dataSourcesSnapshot = sqlSegmentsMetadataManager.getLatestDataSourcesSnapshot();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(TestDataSource.WIKI),
         dataSourcesSnapshot.getDataSourcesWithAllUsedSegments()
                            .stream()
@@ -200,11 +203,11 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
 
     // This call will force on demand poll
     sqlSegmentsMetadataManager.forceOrWaitOngoingDatabasePoll();
-    Assert.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
-    Assert.assertTrue(sqlSegmentsMetadataManager.getLatestDatabasePoll() instanceof SqlSegmentsMetadataManager.OnDemandDatabasePoll);
+    Assertions.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
+    Assertions.assertTrue(sqlSegmentsMetadataManager.getLatestDatabasePoll() instanceof SqlSegmentsMetadataManager.OnDemandDatabasePoll);
     // New datasource should now be in the snapshot since we just force on demand poll.
     dataSourcesSnapshot = sqlSegmentsMetadataManager.getLatestDataSourcesSnapshot();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(TestDataSource.KOALA, TestDataSource.WIKI),
         dataSourcesSnapshot.getDataSourcesWithAllUsedSegments()
                            .stream()
@@ -219,10 +222,10 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
     while (sqlSegmentsMetadataManager.getLatestDataSourcesSnapshot().getDataSource(newDataSource3) == null) {
       Thread.sleep(1000);
     }
-    Assert.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
-    Assert.assertTrue(sqlSegmentsMetadataManager.getLatestDatabasePoll() instanceof SqlSegmentsMetadataManager.PeriodicDatabasePoll);
+    Assertions.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
+    Assertions.assertTrue(sqlSegmentsMetadataManager.getLatestDatabasePoll() instanceof SqlSegmentsMetadataManager.PeriodicDatabasePoll);
     dataSourcesSnapshot = sqlSegmentsMetadataManager.getLatestDataSourcesSnapshot();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(TestDataSource.KOALA, "wikipedia3", TestDataSource.WIKI),
         dataSourcesSnapshot.getDataSourcesWithAllUsedSegments()
                            .stream()
@@ -236,7 +239,7 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
   {
     publishWikiSegments();
     DataSegment koalaSegment = pollThenStopThenPublishKoalaSegment();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(koalaSegment),
         Set.copyOf(sqlSegmentsMetadataManager.getRecentDataSourcesSnapshot().getDataSource(TestDataSource.KOALA).getSegments())
     );
@@ -247,7 +250,7 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
   {
     publishWikiSegments();
     DataSegment koalaSegment = pollThenStopThenPublishKoalaSegment();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(koalaSegment),
         Set.copyOf(sqlSegmentsMetadataManager.getRecentDataSourcesSnapshot().getDataSource(TestDataSource.KOALA).getSegments())
     );
@@ -258,7 +261,7 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
   {
     publishWikiSegments();
     DataSegment koalaSegment = pollThenStopThenPublishKoalaSegment();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(wikiSegment1, wikiSegment2, koalaSegment),
         ImmutableSet.copyOf(
             sqlSegmentsMetadataManager
@@ -276,7 +279,7 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
   {
     publishWikiSegments();
     DataSegment koalaSegment = pollThenStopThenPublishKoalaSegment();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(wikiSegment1, wikiSegment2, koalaSegment),
         retrieveAllUsedSegments()
     );
@@ -287,7 +290,7 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
     sqlSegmentsMetadataManager.startPollingDatabasePeriodically();
     sqlSegmentsMetadataManager.poll();
     sqlSegmentsMetadataManager.stopPollingDatabasePeriodically();
-    Assert.assertFalse(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
+    Assertions.assertFalse(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
     final DataSegment koalaSegment = createNewSegment1(TestDataSource.KOALA);
     publishSegment(koalaSegment);
     sqlSegmentsMetadataManager.startPollingDatabasePeriodically();
@@ -310,10 +313,10 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
 
     EmittingLogger.registerEmitter(new NoopServiceEmitter());
     sqlSegmentsMetadataManager.startPollingDatabasePeriodically();
-    Assert.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
+    Assertions.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
 
     DataSourcesSnapshot snapshot = sqlSegmentsMetadataManager.getRecentDataSourcesSnapshot();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TestDataSource.WIKI,
         Iterables.getOnlyElement(snapshot.getDataSourcesWithAllUsedSegments()).getName()
     );
@@ -350,18 +353,18 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
     // Poll all segments
     sqlSegmentsMetadataManager.startPollingDatabasePeriodically();
     sqlSegmentsMetadataManager.poll();
-    Assert.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
-    Assert.assertEquals(
+    Assertions.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2, koalaSegment1, koalaSegment2),
         retrieveAllUsedSegments()
     );
 
     // Mark the koala segments as unused
-    Assert.assertEquals(2, markSegmentsAsUnused(koalaSegment1.getId(), koalaSegment2.getId()));
+    Assertions.assertEquals(2, markSegmentsAsUnused(koalaSegment1.getId(), koalaSegment2.getId()));
 
     // Verify that subsequent poll only retrieves the used segments
     sqlSegmentsMetadataManager.poll();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(wikiSegment1, wikiSegment2),
         retrieveAllUsedSegments()
     );
@@ -400,7 +403,7 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
     Set<DataSegment> segments = sqlSegmentsMetadataManager
         .getRecentDataSourcesSnapshot()
         .getAllUsedNonOvershadowedSegments(TestDataSource.WIKI, theInterval);
-    Assert.assertEquals(Set.of(wikiSegment1), segments);
+    Assertions.assertEquals(Set.of(wikiSegment1), segments);
 
     final DataSegment wikiSegment3 = createSegment(
         TestDataSource.WIKI,
@@ -413,13 +416,13 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
     segments = sqlSegmentsMetadataManager
         .getRecentDataSourcesSnapshot()
         .getAllUsedNonOvershadowedSegments(TestDataSource.WIKI, theInterval);
-    Assert.assertEquals(Set.of(wikiSegment1), segments);
+    Assertions.assertEquals(Set.of(wikiSegment1), segments);
 
     // New segment is returned since we call with force poll
     segments = sqlSegmentsMetadataManager
         .forceUpdateDataSourcesSnapshot()
         .getAllUsedNonOvershadowedSegments(TestDataSource.WIKI, theInterval);
-    Assert.assertEquals(Set.of(wikiSegment1, wikiSegment3), segments);
+    Assertions.assertEquals(Set.of(wikiSegment1, wikiSegment3), segments);
   }
 
   @Test
@@ -435,9 +438,9 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
     publishUnusedSegments(koalaSegment);
     updateUsedStatusLastUpdatedToNull(koalaSegment);
 
-    Assert.assertEquals(1, getCountOfRowsWithLastUsedNull());
+    Assertions.assertEquals(1, getCountOfRowsWithLastUsedNull());
     sqlSegmentsMetadataManager.populateUsedFlagLastUpdated();
-    Assert.assertEquals(0, getCountOfRowsWithLastUsedNull());
+    Assertions.assertEquals(0, getCountOfRowsWithLastUsedNull());
   }
 
   private int getCountOfRowsWithLastUsedNull()

--- a/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Set;
@@ -180,7 +181,7 @@ public class SqlSegmentsMetadataManagerTest extends SqlSegmentsMetadataManagerTe
   }
 
   @Test
-  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testPollPeriodicallyAndOnDemandInterleave() throws Exception
   {
     publishWikiSegments();

--- a/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataQueryTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataQueryTest.java
@@ -43,10 +43,10 @@ import org.apache.druid.timeline.SegmentId;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -59,7 +59,7 @@ import java.util.stream.Collectors;
 
 public class SqlSegmentsMetadataQueryTest
 {
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule
       = new TestDerbyConnector.DerbyConnectorRule();
 
@@ -75,7 +75,7 @@ public class SqlSegmentsMetadataQueryTest
                           .withVersion(V1)
                           .eachOfSizeInMb(500);
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     derbyConnectorRule.getConnector().createSegmentTable();
@@ -86,23 +86,23 @@ public class SqlSegmentsMetadataQueryTest
   public void test_markSegmentsAsUnused()
   {
     // Check segments currently present in the metadata store
-    Assert.assertEquals(Set.copyOf(WIKI_SEGMENTS_2X5D), retrieveAllUsedSegments());
-    Assert.assertTrue(retrieveAllUnusedSegments().isEmpty());
+    Assertions.assertEquals(Set.copyOf(WIKI_SEGMENTS_2X5D), retrieveAllUsedSegments());
+    Assertions.assertTrue(retrieveAllUnusedSegments().isEmpty());
 
     // Mark segments as unused and verify the results
     final Set<DataSegment> segmentsToUpdate = Set.of(WIKI_SEGMENTS_2X5D.get(0), WIKI_SEGMENTS_2X5D.get(1));
     int numUpdatedSegments = update(
         sql -> sql.markSegmentsAsUnused(getIds(segmentsToUpdate), DateTimes.nowUtc())
     );
-    Assert.assertEquals(2, numUpdatedSegments);
-    Assert.assertEquals(segmentsToUpdate, retrieveAllUnusedSegments());
+    Assertions.assertEquals(2, numUpdatedSegments);
+    Assertions.assertEquals(segmentsToUpdate, retrieveAllUnusedSegments());
 
     // Verify that these segments are not present in used segments set
     Set<DataSegment> usedSegments = retrieveAllUsedSegments();
-    Assert.assertEquals(8, usedSegments.size());
+    Assertions.assertEquals(8, usedSegments.size());
 
     segmentsToUpdate.forEach(
-        updatedSegment -> Assert.assertFalse(usedSegments.contains(updatedSegment))
+        updatedSegment -> Assertions.assertFalse(usedSegments.contains(updatedSegment))
     );
   }
 
@@ -114,16 +114,16 @@ public class SqlSegmentsMetadataQueryTest
     int numUpdatedSegments = update(
         sql -> sql.markSegmentsAsUnused(getIds(segmentsToUpdate), DateTimes.nowUtc())
     );
-    Assert.assertEquals(2, numUpdatedSegments);
-    Assert.assertEquals(segmentsToUpdate, retrieveAllUnusedSegments());
+    Assertions.assertEquals(2, numUpdatedSegments);
+    Assertions.assertEquals(segmentsToUpdate, retrieveAllUnusedSegments());
 
     // Mark segments as used again and verify the results
     numUpdatedSegments = update(
         sql -> sql.markSegmentsAsUsed(getIds(segmentsToUpdate), DateTimes.nowUtc())
     );
-    Assert.assertEquals(2, numUpdatedSegments);
-    Assert.assertEquals(Set.copyOf(WIKI_SEGMENTS_2X5D), retrieveAllUsedSegments());
-    Assert.assertTrue(retrieveAllUnusedSegments().isEmpty());
+    Assertions.assertEquals(2, numUpdatedSegments);
+    Assertions.assertEquals(Set.copyOf(WIKI_SEGMENTS_2X5D), retrieveAllUsedSegments());
+    Assertions.assertTrue(retrieveAllUnusedSegments().isEmpty());
   }
 
   @Test
@@ -132,8 +132,8 @@ public class SqlSegmentsMetadataQueryTest
     int numUpdatedSegments = update(
         sql -> sql.markSegmentsAsUnused(Set.of(), DateTimes.nowUtc())
     );
-    Assert.assertEquals(0, numUpdatedSegments);
-    Assert.assertEquals(Set.copyOf(WIKI_SEGMENTS_2X5D), retrieveAllUsedSegments());
+    Assertions.assertEquals(0, numUpdatedSegments);
+    Assertions.assertEquals(Set.copyOf(WIKI_SEGMENTS_2X5D), retrieveAllUsedSegments());
   }
 
   @Test
@@ -142,9 +142,9 @@ public class SqlSegmentsMetadataQueryTest
     int numUpdatedSegments = update(
         sql -> sql.markSegmentsUnused(TestDataSource.WIKI, Intervals.ETERNITY, null, DateTimes.nowUtc())
     );
-    Assert.assertEquals(WIKI_SEGMENTS_2X5D.size(), numUpdatedSegments);
-    Assert.assertEquals(Set.copyOf(WIKI_SEGMENTS_2X5D), retrieveAllUnusedSegments());
-    Assert.assertTrue(retrieveAllUsedSegments().isEmpty());
+    Assertions.assertEquals(WIKI_SEGMENTS_2X5D.size(), numUpdatedSegments);
+    Assertions.assertEquals(Set.copyOf(WIKI_SEGMENTS_2X5D), retrieveAllUnusedSegments());
+    Assertions.assertTrue(retrieveAllUsedSegments().isEmpty());
   }
 
   @Test
@@ -166,9 +166,9 @@ public class SqlSegmentsMetadataQueryTest
             DateTimes.nowUtc()
         )
     );
-    Assert.assertEquals(4, numUpdatedSegments);
-    Assert.assertEquals(4, retrieveAllUnusedSegments().size());
-    Assert.assertEquals(16, retrieveAllUsedSegments().size());
+    Assertions.assertEquals(4, numUpdatedSegments);
+    Assertions.assertEquals(4, retrieveAllUnusedSegments().size());
+    Assertions.assertEquals(16, retrieveAllUsedSegments().size());
   }
 
   @Test
@@ -191,9 +191,9 @@ public class SqlSegmentsMetadataQueryTest
             DateTimes.nowUtc()
         )
     );
-    Assert.assertEquals(8, numUpdatedSegments);
-    Assert.assertEquals(8, retrieveAllUnusedSegments().size());
-    Assert.assertEquals(12, retrieveAllUsedSegments().size());
+    Assertions.assertEquals(8, numUpdatedSegments);
+    Assertions.assertEquals(8, retrieveAllUnusedSegments().size());
+    Assertions.assertEquals(12, retrieveAllUsedSegments().size());
   }
 
   @Test
@@ -215,9 +215,9 @@ public class SqlSegmentsMetadataQueryTest
             DateTimes.nowUtc()
         )
     );
-    Assert.assertEquals(8, numUpdatedSegments);
-    Assert.assertEquals(8, retrieveAllUnusedSegments().size());
-    Assert.assertEquals(12, retrieveAllUsedSegments().size());
+    Assertions.assertEquals(8, numUpdatedSegments);
+    Assertions.assertEquals(8, retrieveAllUnusedSegments().size());
+    Assertions.assertEquals(12, retrieveAllUsedSegments().size());
   }
 
   @Test
@@ -226,16 +226,16 @@ public class SqlSegmentsMetadataQueryTest
     int numUpdatedSegments = update(
         sql -> sql.markSegmentsUnused(TestDataSource.WIKI, Intervals.ETERNITY, List.of(), DateTimes.nowUtc())
     );
-    Assert.assertEquals(0, numUpdatedSegments);
-    Assert.assertEquals(Set.copyOf(WIKI_SEGMENTS_2X5D), retrieveAllUsedSegments());
-    Assert.assertTrue(retrieveAllUnusedSegments().isEmpty());
+    Assertions.assertEquals(0, numUpdatedSegments);
+    Assertions.assertEquals(Set.copyOf(WIKI_SEGMENTS_2X5D), retrieveAllUsedSegments());
+    Assertions.assertTrue(retrieveAllUnusedSegments().isEmpty());
   }
 
   @Test
   public void test_retrieveSegmentForId()
   {
     final DataSegment segmentJan1 = WIKI_SEGMENTS_2X5D.get(0);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         segmentJan1,
         read(sql -> sql.retrieveSegmentForId(segmentJan1.getId()))
     );
@@ -244,7 +244,7 @@ public class SqlSegmentsMetadataQueryTest
   @Test
   public void test_retrieveSegmentForId_returnsNull_forUnknownId()
   {
-    Assert.assertNull(
+    Assertions.assertNull(
         read(
             sql -> sql.retrieveSegmentForId(SegmentId.dummy(TestDataSource.WIKI))
         )
@@ -258,7 +258,7 @@ public class SqlSegmentsMetadataQueryTest
 
     Set<DataSegment> result = readAsSet(q -> q.retrieveUsedSegments(TestDataSource.WIKI, List.of(queryInterval)));
 
-    Assert.assertEquals(4, result.size());
+    Assertions.assertEquals(4, result.size());
     assertSegmentsOverlapInterval(result, queryInterval);
   }
 
@@ -269,13 +269,13 @@ public class SqlSegmentsMetadataQueryTest
     int numUpdatedSegments = update(
         sql -> sql.markSegmentsAsUnused(getIds(segmentsToUpdate), DateTimes.nowUtc())
     );
-    Assert.assertEquals(1, numUpdatedSegments);
+    Assertions.assertEquals(1, numUpdatedSegments);
 
     final Interval queryInterval = new Interval(JAN_1, JAN_1.plusDays(2));
 
     Set<DataSegment> result = readAsSet(q -> q.retrieveUsedSegments(TestDataSource.WIKI, List.of(queryInterval)));
 
-    Assert.assertEquals(3, result.size());
+    Assertions.assertEquals(3, result.size());
     assertSegmentsOverlapInterval(result, queryInterval);
   }
 
@@ -285,7 +285,7 @@ public class SqlSegmentsMetadataQueryTest
     Interval queryInterval = new Interval(JAN_1.plusDays(4), JAN_1.plusDays(5));
 
     Set<DataSegment> result = readAsSet(q -> q.retrieveUsedSegments(TestDataSource.WIKI, List.of(queryInterval)));
-    Assert.assertEquals(2, result.size());
+    Assertions.assertEquals(2, result.size());
     assertSegmentsOverlapInterval(result, queryInterval);
   }
 
@@ -295,9 +295,9 @@ public class SqlSegmentsMetadataQueryTest
   )
   {
     for (DataSegment segment : segments) {
-      Assert.assertTrue(
-          "Segment " + segment.getId() + " should be in interval " + interval,
-          segment.getInterval().overlaps(interval)
+      Assertions.assertTrue(
+          segment.getInterval().overlaps(interval),
+          "Segment " + segment.getId() + " should be in interval " + interval
       );
     }
   }
@@ -548,7 +548,7 @@ public class SqlSegmentsMetadataQueryTest
 
     Set<String> fingerprints = read(SqlSegmentsMetadataQuery::retrieveAllUsedIndexingStateFingerprints);
 
-    Assert.assertTrue("Should return empty set when no segments have indexing states", fingerprints.isEmpty());
+    Assertions.assertTrue(fingerprints.isEmpty(), "Should return empty set when no segments have indexing states");
   }
 
   @Test
@@ -569,7 +569,7 @@ public class SqlSegmentsMetadataQueryTest
 
     Set<String> fingerprints = read(SqlSegmentsMetadataQuery::retrieveAllUsedIndexingStateFingerprints);
 
-    Assert.assertEquals("Should return all fingerprints in the cache", Set.of("fp1", "fp2", "fp3"), fingerprints);
+    Assertions.assertEquals(Set.of("fp1", "fp2", "fp3"), fingerprints, "Should return all fingerprints in the cache");
   }
 
   @Test
@@ -586,7 +586,7 @@ public class SqlSegmentsMetadataQueryTest
 
     Set<String> fingerprints = read(SqlSegmentsMetadataQuery::retrieveAllUsedIndexingStateFingerprints);
 
-    Assert.assertEquals("Should ignore segments without indexing states", Set.of("fp1"), fingerprints);
+    Assertions.assertEquals(Set.of("fp1"), fingerprints, "Should ignore segments without indexing states");
   }
 
   @Test
@@ -596,7 +596,7 @@ public class SqlSegmentsMetadataQueryTest
 
     List<IndexingStateRecord> records = read(SqlSegmentsMetadataQuery::retrieveAllUsedIndexingStates);
 
-    Assert.assertTrue("Should return empty list when no indexing states exist", records.isEmpty());
+    Assertions.assertTrue(records.isEmpty(), "Should return empty list when no indexing states exist");
   }
 
   @Test
@@ -624,12 +624,12 @@ public class SqlSegmentsMetadataQueryTest
 
     List<IndexingStateRecord> records = read(SqlSegmentsMetadataQuery::retrieveAllUsedIndexingStates);
 
-    Assert.assertEquals("Should return all indexing states", 3, records.size());
+    Assertions.assertEquals(3, records.size(), "Should return all indexing states");
 
     Set<String> retrievedFingerprints = records.stream()
                                                 .map(IndexingStateRecord::getFingerprint)
                                                 .collect(Collectors.toSet());
-    Assert.assertEquals("Should contain all fps", Set.of("fp1", "fp2", "fp3"), retrievedFingerprints);
+    Assertions.assertEquals(Set.of("fp1", "fp2", "fp3"), retrievedFingerprints, "Should contain all fps");
 
     // Verify payloads
     Map<String, CompactionState> retrievedStates = records.stream()
@@ -637,9 +637,9 @@ public class SqlSegmentsMetadataQueryTest
             IndexingStateRecord::getFingerprint,
             IndexingStateRecord::getState
         ));
-    Assert.assertEquals("fp1 state should match", state1, retrievedStates.get("fp1"));
-    Assert.assertEquals("fp2 state should match", state2, retrievedStates.get("fp2"));
-    Assert.assertEquals("fp3 state should match", state3, retrievedStates.get("fp3"));
+    Assertions.assertEquals(state1, retrievedStates.get("fp1"), "fp1 state should match");
+    Assertions.assertEquals(state2, retrievedStates.get("fp2"), "fp2 state should match");
+    Assertions.assertEquals(state3, retrievedStates.get("fp3"), "fp3 state should match");
   }
 
   @Test
@@ -657,7 +657,7 @@ public class SqlSegmentsMetadataQueryTest
 
     List<IndexingStateRecord> records = read(SqlSegmentsMetadataQuery::retrieveAllUsedIndexingStates);
 
-    Assert.assertEquals("Should only return all indexing states", 2, records.size());
+    Assertions.assertEquals(2, records.size(), "Should only return all indexing states");
   }
 
   @Test
@@ -675,7 +675,7 @@ public class SqlSegmentsMetadataQueryTest
 
     List<IndexingStateRecord> records = read(SqlSegmentsMetadataQuery::retrieveAllUsedIndexingStates);
 
-    Assert.assertTrue("Should not return unused indexing states", records.isEmpty());
+    Assertions.assertTrue(records.isEmpty(), "Should not return unused indexing states");
   }
 
   @Test
@@ -687,7 +687,7 @@ public class SqlSegmentsMetadataQueryTest
         sql -> sql.retrieveIndexingStatesForFingerprints(Set.of())
     );
 
-    Assert.assertTrue("Should return empty list for empty input", records.isEmpty());
+    Assertions.assertTrue(records.isEmpty(), "Should return empty list for empty input");
   }
 
   @Test
@@ -706,12 +706,12 @@ public class SqlSegmentsMetadataQueryTest
         sql -> sql.retrieveIndexingStatesForFingerprints(Set.of("fp1", "fp3"))
     );
 
-    Assert.assertEquals("Should return requested fingerprints", 2, records.size());
+    Assertions.assertEquals(2, records.size(), "Should return requested fingerprints");
 
     Set<String> retrievedFingerprints = records.stream()
                                                 .map(IndexingStateRecord::getFingerprint)
                                                 .collect(Collectors.toSet());
-    Assert.assertEquals("Should contain only requested fingerprints", Set.of("fp1", "fp3"), retrievedFingerprints);
+    Assertions.assertEquals(Set.of("fp1", "fp3"), retrievedFingerprints, "Should contain only requested fingerprints");
   }
 
   @Test
@@ -734,12 +734,12 @@ public class SqlSegmentsMetadataQueryTest
         sql -> sql.retrieveIndexingStatesForFingerprints(expectedFingerprints)
     );
 
-    Assert.assertEquals("Should return all fingerprints across multiple batches", 150, records.size());
+    Assertions.assertEquals(150, records.size(), "Should return all fingerprints across multiple batches");
 
     Set<String> retrievedFingerprints = records.stream()
                                                 .map(IndexingStateRecord::getFingerprint)
                                                 .collect(Collectors.toSet());
-    Assert.assertEquals("Should contain all requested fingerprints", expectedFingerprints, retrievedFingerprints);
+    Assertions.assertEquals(expectedFingerprints, retrievedFingerprints, "Should contain all requested fingerprints");
   }
 
   @Test
@@ -756,7 +756,7 @@ public class SqlSegmentsMetadataQueryTest
         sql -> sql.retrieveIndexingStatesForFingerprints(Set.of("fp999", "fp888"))
     );
 
-    Assert.assertTrue("Should return empty list when fingerprints don't exist", records.isEmpty());
+    Assertions.assertTrue(records.isEmpty(), "Should return empty list when fingerprints don't exist");
   }
 
   @Test
@@ -774,12 +774,12 @@ public class SqlSegmentsMetadataQueryTest
         sql -> sql.retrieveIndexingStatesForFingerprints(Set.of("fp1", "fp999", "fp2", "fp888"))
     );
 
-    Assert.assertEquals("Should return only existing fingerprints", 2, records.size());
+    Assertions.assertEquals(2, records.size(), "Should return only existing fingerprints");
 
     Set<String> retrievedFingerprints = records.stream()
                                                 .map(IndexingStateRecord::getFingerprint)
                                                 .collect(Collectors.toSet());
-    Assert.assertEquals("Should contain only existing fingerprints", Set.of("fp1", "fp2"), retrievedFingerprints);
+    Assertions.assertEquals(Set.of("fp1", "fp2"), retrievedFingerprints, "Should contain only existing fingerprints");
   }
 
   @Test
@@ -799,8 +799,8 @@ public class SqlSegmentsMetadataQueryTest
         sql -> sql.retrieveIndexingStatesForFingerprints(Set.of("fp1", "fp2"))
     );
 
-    Assert.assertEquals("Should only return used indexing states", 1, records.size());
-    Assert.assertEquals("Should return fp1", "fp1", records.get(0).getFingerprint());
+    Assertions.assertEquals(1, records.size(), "Should only return used indexing states");
+    Assertions.assertEquals("fp1", records.get(0).getFingerprint(), "Should return fp1");
   }
 
   // ==================== Helper Methods for Indexing State Tests ====================
@@ -900,8 +900,8 @@ public class SqlSegmentsMetadataQueryTest
     updateUsedStatusLastUpdated(segment.getId(), markedAsUnusedAtTime);
 
     final int numUpdatedRows = updateWithConfig(sql -> markAsUsedFunction.apply(sql, segment), managerConfig);
-    Assert.assertEquals(1, numUpdatedRows);
-    Assert.assertTrue(retrieveAllUsedSegments().contains(segment));
+    Assertions.assertEquals(1, numUpdatedRows);
+    Assertions.assertTrue(retrieveAllUsedSegments().contains(segment));
   }
 
   /**
@@ -923,7 +923,7 @@ public class SqlSegmentsMetadataQueryTest
 
     // Verify that the mark as used operation fails with a CONFLICT DruidException
     DruidExceptionMatcher.assertThat(
-        Assert.assertThrows(
+        Assertions.assertThrows(
             DruidException.class,
             () -> updateWithConfig(sql -> markAsUsedFunction.apply(sql, segment), managerConfig)
         ),

--- a/server/src/test/java/org/apache/druid/metadata/TestDerbyConnector.java
+++ b/server/src/test/java/org/apache/druid/metadata/TestDerbyConnector.java
@@ -29,11 +29,12 @@ import org.apache.druid.segment.metadata.CentralizedDatasourceSchemaConfig;
 import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.rules.ExternalResource;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.PreparedBatch;
 import org.skife.jdbi.v2.exceptions.UnableToObtainConnectionException;
@@ -117,10 +118,10 @@ public class TestDerbyConnector extends DerbyConnector
     catch (UnableToObtainConnectionException e) {
       SQLException cause = (SQLException) e.getCause();
       // error code "08006" indicates proper shutdown
-      Assert.assertEquals(
-          StringUtils.format("Derby not shutdown: [%s]", cause.toString()),
+      Assertions.assertEquals(
           "08006",
-          cause.getSQLState()
+          cause.getSQLState(),
+          StringUtils.format("Derby not shutdown: [%s]", cause.toString())
       );
     }
   }
@@ -140,7 +141,7 @@ public class TestDerbyConnector extends DerbyConnector
     this.getDBI().open().close();
   }
 
-  public static class DerbyConnectorRule extends ExternalResource
+  public static class DerbyConnectorRule implements BeforeEachCallback, AfterEachCallback
   {
     private TestDerbyConnector connector;
     private final MetadataStorageTablesConfig tablesConfig;
@@ -187,7 +188,6 @@ public class TestDerbyConnector extends DerbyConnector
       this.centralizedDatasourceSchemaConfig = centralizedDatasourceSchemaConfig;
     }
 
-    @Override
     public void before()
     {
       connector = new TestDerbyConnector(
@@ -198,7 +198,6 @@ public class TestDerbyConnector extends DerbyConnector
       connector.createDatabase(); // create db
     }
 
-    @Override
     public void after()
     {
       connector.tearDown();
@@ -227,6 +226,18 @@ public class TestDerbyConnector extends DerbyConnector
     public PendingSegmentsTable pendingSegments()
     {
       return new PendingSegmentsTable(this);
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context)
+    {
+      before();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context)
+    {
+      after();
     }
   }
 
@@ -342,6 +353,18 @@ public class TestDerbyConnector extends DerbyConnector
 
   public static class DerbyConnectorRule5 extends DerbyConnectorRule implements BeforeAllCallback, AfterAllCallback
   {
+
+    @Override
+    public void beforeEach(ExtensionContext context)
+    {
+      // Managed once per class by beforeAll.
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context)
+    {
+      // Managed once per class by afterAll.
+    }
 
     @Override
     public void beforeAll(ExtensionContext context)

--- a/server/src/test/java/org/apache/druid/metadata/TestDerbyConnector.java
+++ b/server/src/test/java/org/apache/druid/metadata/TestDerbyConnector.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.rules.ExternalResource;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.PreparedBatch;
 import org.skife.jdbi.v2.exceptions.UnableToObtainConnectionException;
@@ -141,7 +142,7 @@ public class TestDerbyConnector extends DerbyConnector
     this.getDBI().open().close();
   }
 
-  public static class DerbyConnectorRule implements BeforeEachCallback, AfterEachCallback
+  public static class DerbyConnectorRule extends ExternalResource implements BeforeEachCallback, AfterEachCallback
   {
     private TestDerbyConnector connector;
     private final MetadataStorageTablesConfig tablesConfig;
@@ -188,6 +189,7 @@ public class TestDerbyConnector extends DerbyConnector
       this.centralizedDatasourceSchemaConfig = centralizedDatasourceSchemaConfig;
     }
 
+    @Override
     public void before()
     {
       connector = new TestDerbyConnector(
@@ -198,6 +200,7 @@ public class TestDerbyConnector extends DerbyConnector
       connector.createDatabase(); // create db
     }
 
+    @Override
     public void after()
     {
       connector.tearDown();

--- a/server/src/test/java/org/apache/druid/metadata/input/InputSourceModuleTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/input/InputSourceModuleTest.java
@@ -38,9 +38,9 @@ import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.guice.LifecycleModule;
 import org.apache.druid.guice.ServerModule;
 import org.apache.druid.jackson.JacksonModule;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Properties;
@@ -51,7 +51,7 @@ public class InputSourceModuleTest
   private final ObjectMapper mapper = new ObjectMapper();
   private final String SQL_NAMED_TYPE = "sql";
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     for (Module jacksonModule : new InputSourceModule().getJacksonModules()) {
@@ -69,8 +69,8 @@ public class InputSourceModuleTest
                                   .stream()
                                   .map(NamedType::getName)
                                   .collect(Collectors.toList());
-    Assert.assertNotNull(subtypes);
-    Assert.assertEquals(SQL_NAMED_TYPE, Iterables.getOnlyElement(subtypes));
+    Assertions.assertNotNull(subtypes);
+    Assertions.assertEquals(SQL_NAMED_TYPE, Iterables.getOnlyElement(subtypes));
   }
 
   @Test
@@ -79,8 +79,8 @@ public class InputSourceModuleTest
     Properties props = new Properties();
     Injector injector = makeInjectorWithProperties(props);
     HttpInputSourceConfig instance = injector.getInstance(HttpInputSourceConfig.class);
-    Assert.assertEquals(new HttpInputSourceConfig(null, null), instance);
-    Assert.assertEquals(HttpInputSourceConfig.DEFAULT_ALLOWED_PROTOCOLS, instance.getAllowedProtocols());
+    Assertions.assertEquals(new HttpInputSourceConfig(null, null), instance);
+    Assertions.assertEquals(HttpInputSourceConfig.DEFAULT_ALLOWED_PROTOCOLS, instance.getAllowedProtocols());
   }
 
   private Injector makeInjectorWithProperties(final Properties props)

--- a/server/src/test/java/org/apache/druid/metadata/input/SqlEntityTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/input/SqlEntityTest.java
@@ -27,10 +27,10 @@ import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.metadata.TestDerbyConnector;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -41,7 +41,7 @@ import java.util.Collections;
 
 public class SqlEntityTest
 {
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
 
   private final ObjectMapper mapper = TestHelper.makeSmileMapper();
@@ -51,7 +51,7 @@ public class SqlEntityTest
   String VALID_SQL = "SELECT timestamp,a,b FROM FOOS_TABLE";
   String INVALID_SQL = "DONT SELECT timestamp,a,b FROM FOOS_TABLE";
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     for (Module jacksonModule : new InputSourceModule().getJacksonModules()) {
@@ -80,7 +80,7 @@ public class SqlEntityTest
     String expectedJson = mapper.writeValueAsString(
         Collections.singletonList(((MapBasedInputRow) expectedRow).getEvent())
     );
-    Assert.assertEquals(actualJson, expectedJson);
+    Assertions.assertEquals(actualJson, expectedJson);
     testUtils.dropTable(TABLE_NAME_1);
   }
 
@@ -91,9 +91,9 @@ public class SqlEntityTest
     SqlTestUtils testUtils = new SqlTestUtils(derbyConnector);
     testUtils.createTableWithRows(TABLE_NAME_1, 1);
     File tmpFile = File.createTempFile("testQueryResults", "");
-    Assert.assertTrue(tmpFile.exists());
+    Assertions.assertTrue(tmpFile.exists());
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IOException.class,
         () -> SqlEntity.openCleanableFile(
             INVALID_SQL,
@@ -105,6 +105,6 @@ public class SqlEntityTest
     );
 
     // Verify that the temporary file is cleaned up
-    Assert.assertFalse(tmpFile.exists());
+    Assertions.assertFalse(tmpFile.exists());
   }
 }

--- a/server/src/test/java/org/apache/druid/metadata/input/SqlInputSourceTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/input/SqlInputSourceTest.java
@@ -46,11 +46,11 @@ import org.apache.druid.metadata.TestDerbyConnector;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
 import org.easymock.EasyMock;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.skife.jdbi.v2.DBI;
 
 import java.io.File;
@@ -78,12 +78,12 @@ public class SqlInputSourceTest
       ColumnsFilter.all()
   );
 
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
   private final ObjectMapper mapper = TestHelper.makeSmileMapper();
   private TestDerbyConnector derbyConnector;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     for (Module jacksonModule : new InputSourceModule().getJacksonModules()) {
@@ -91,7 +91,7 @@ public class SqlInputSourceTest
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() throws IOException
   {
     for (File dir : INPUT_SOURCE_TMP_DIRS) {
@@ -121,7 +121,7 @@ public class SqlInputSourceTest
         new SqlInputSource(SqlTestUtils.selectFrom(TABLE_1), true, serdeInputSourceConnector, mapper);
     final String valueString = mapper.writeValueAsString(sqlInputSource);
     final SqlInputSource inputSourceFromJson = mapper.readValue(valueString, SqlInputSource.class);
-    Assert.assertEquals(sqlInputSource, inputSourceFromJson);
+    Assertions.assertEquals(sqlInputSource, inputSourceFromJson);
   }
 
   @Test
@@ -132,7 +132,7 @@ public class SqlInputSourceTest
         new MetadataStorageConnectorConfig());
     final SqlInputSource sqlInputSource =
         new SqlInputSource(SqlTestUtils.selectFrom(TABLE_1), true, serdeInputSourceConnector, mapper);
-    Assert.assertEquals(Collections.singleton(SqlInputSource.TYPE_KEY), sqlInputSource.getTypes());
+    Assertions.assertEquals(Collections.singleton(SqlInputSource.TYPE_KEY), sqlInputSource.getTypes());
   }
 
   @Test
@@ -156,8 +156,8 @@ public class SqlInputSourceTest
 
     // Records for each split are written to a temp file as a json array
     // file size = 1B (array open char) + 10 records * 60B (including trailing comma)
-    Assert.assertEquals(601, inputStats.getProcessedBytes());
-    Assert.assertEquals(expectedRows, rows);
+    Assertions.assertEquals(601, inputStats.getProcessedBytes());
+    Assertions.assertEquals(expectedRows, rows);
 
     testUtils.dropTable(TABLE_1);
   }
@@ -183,9 +183,9 @@ public class SqlInputSourceTest
     CloseableIterator<InputRow> resultIterator = sqlReader.read(inputStats);
     final List<InputRow> rows = Lists.newArrayList(resultIterator);
 
-    Assert.assertEquals(expectedRowsTable1, rows.subList(0, 10));
-    Assert.assertEquals(expectedRowsTable2, rows.subList(10, 20));
-    Assert.assertEquals(1202, inputStats.getProcessedBytes());
+    Assertions.assertEquals(expectedRowsTable1, rows.subList(0, 10));
+    Assertions.assertEquals(expectedRowsTable2, rows.subList(10, 20));
+    Assertions.assertEquals(1202, inputStats.getProcessedBytes());
 
     testUtils.dropTable(TABLE_1);
     testUtils.dropTable(TABLE_2);
@@ -201,8 +201,8 @@ public class SqlInputSourceTest
         new SqlInputSource(sqls, true, testUtils.getDerbyInputSourceConnector(), mapper);
     InputFormat inputFormat = EasyMock.createMock(InputFormat.class);
     Stream<InputSplit<String>> sqlSplits = sqlInputSource.createSplits(inputFormat, null);
-    Assert.assertEquals(sqls, sqlSplits.map(InputSplit::get).collect(Collectors.toList()));
-    Assert.assertEquals(2, sqlInputSource.estimateNumSplits(inputFormat, null));
+    Assertions.assertEquals(sqls, sqlSplits.map(InputSplit::get).collect(Collectors.toList()));
+    Assertions.assertEquals(2, sqlInputSource.estimateNumSplits(inputFormat, null));
   }
 
   @Test
@@ -220,10 +220,10 @@ public class SqlInputSourceTest
       final List<InputRow> rows = new ArrayList<>();
       while (resultIterator.hasNext()) {
         InputRowListPlusRawValues row = resultIterator.next();
-        Assert.assertNull(row.getParseException());
+        Assertions.assertNull(row.getParseException());
         rows.addAll(row.getInputRows());
       }
-      Assert.assertEquals(expectedRows, rows);
+      Assertions.assertEquals(expectedRows, rows);
     }
     finally {
       testUtils.dropTable(TABLE_1);
@@ -234,7 +234,7 @@ public class SqlInputSourceTest
   public void testConnectorValidationInvalidUri()
   {
     derbyConnector = derbyConnectorRule.getConnector();
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new SqlTestUtils(
             derbyConnector,
@@ -248,14 +248,14 @@ public class SqlInputSourceTest
             }
         )
     );
-    Assert.assertEquals("connectURI cannot be null or empty", t.getMessage());
+    Assertions.assertEquals("connectURI cannot be null or empty", t.getMessage());
   }
 
   @Test
   public void testConnectorValidationAllowedProperties()
   {
     derbyConnector = derbyConnectorRule.getConnector();
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new SqlTestUtils(
             derbyConnector,
@@ -263,7 +263,7 @@ public class SqlInputSourceTest
             new JdbcAccessSecurityConfig()
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "The property [user] is not in the allowed list [useSSL, requireSSL, ssl, sslmode]",
         t.getMessage()
     );
@@ -285,7 +285,7 @@ public class SqlInputSourceTest
           }
         }
     );
-    Assert.assertNotNull(testUtils);
+    Assertions.assertNotNull(testUtils);
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/metadata/input/SqlTestUtils.java
+++ b/server/src/test/java/org/apache/druid/metadata/input/SqlTestUtils.java
@@ -31,7 +31,6 @@ import org.apache.druid.metadata.MetadataStorageConnectorConfig;
 import org.apache.druid.metadata.SQLInputSourceDatabaseConnector;
 import org.apache.druid.metadata.TestDerbyConnector;
 import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
-import org.junit.Rule;
 import org.skife.jdbi.v2.Batch;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.tweak.HandleCallback;
@@ -47,8 +46,6 @@ import java.util.stream.IntStream;
 
 public class SqlTestUtils
 {
-  @Rule
-  public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
   private final TestDerbyInputSourceConnector derbyInputSourceConnector;
   private final TestDerbyConnector derbyConnector;
 

--- a/server/src/test/java/org/apache/druid/metadata/segment/SqlSegmentsMetadataManagerV2Test.java
+++ b/server/src/test/java/org/apache/druid/metadata/segment/SqlSegmentsMetadataManagerV2Test.java
@@ -43,18 +43,18 @@ import org.apache.druid.timeline.DataSegment;
 import org.assertj.core.util.Sets;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.List;
 import java.util.Set;
 
 public class SqlSegmentsMetadataManagerV2Test extends SqlSegmentsMetadataManagerTestBase
 {
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule =
       new TestDerbyConnector.DerbyConnectorRule(CentralizedDatasourceSchemaConfig.enabled(true));
 
@@ -70,7 +70,7 @@ public class SqlSegmentsMetadataManagerV2Test extends SqlSegmentsMetadataManager
                           .startingAt(JAN_1)
                           .eachOfSize(500);
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception
   {
     setUp(derbyConnectorRule);
@@ -120,7 +120,7 @@ public class SqlSegmentsMetadataManagerV2Test extends SqlSegmentsMetadataManager
     segmentMetadataCacheExec.finishNextPendingTasks(2);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     if (manager == null) {
@@ -139,14 +139,14 @@ public class SqlSegmentsMetadataManagerV2Test extends SqlSegmentsMetadataManager
     initManager(SegmentMetadataCache.UsageMode.ALWAYS, false);
 
     manager.startPollingDatabasePeriodically();
-    Assert.assertTrue(manager.isPollingDatabasePeriodically());
+    Assertions.assertTrue(manager.isPollingDatabasePeriodically());
 
     syncSegmentMetadataCache();
     verifyDatasourceSnapshot();
 
     // isPolling returns true even after stop since cache is still polling the metadata store
     manager.stopPollingDatabasePeriodically();
-    Assert.assertTrue(manager.isPollingDatabasePeriodically());
+    Assertions.assertTrue(manager.isPollingDatabasePeriodically());
 
     emitter.verifyNotEmitted("segment/poll/time");
     emitter.verifyNotEmitted("segment/pollWithSchema/time");
@@ -162,12 +162,12 @@ public class SqlSegmentsMetadataManagerV2Test extends SqlSegmentsMetadataManager
     initManager(SegmentMetadataCache.UsageMode.NEVER, false);
 
     manager.startPollingDatabasePeriodically();
-    Assert.assertTrue(manager.isPollingDatabasePeriodically());
+    Assertions.assertTrue(manager.isPollingDatabasePeriodically());
 
     verifyDatasourceSnapshot();
 
     manager.stopPollingDatabasePeriodically();
-    Assert.assertFalse(manager.isPollingDatabasePeriodically());
+    Assertions.assertFalse(manager.isPollingDatabasePeriodically());
 
     emitter.verifyEmitted("segment/poll/time", 1);
     emitter.verifyNotEmitted(Metric.SYNC_DURATION_MILLIS);
@@ -179,14 +179,14 @@ public class SqlSegmentsMetadataManagerV2Test extends SqlSegmentsMetadataManager
     initManager(SegmentMetadataCache.UsageMode.ALWAYS, true);
 
     manager.startPollingDatabasePeriodically();
-    Assert.assertTrue(manager.isPollingDatabasePeriodically());
+    Assertions.assertTrue(manager.isPollingDatabasePeriodically());
 
     syncSegmentMetadataCache();
     verifyDatasourceSnapshot();
 
     // isPolling returns true even after stop since cache is still polling the metadata store
     manager.stopPollingDatabasePeriodically();
-    Assert.assertTrue(manager.isPollingDatabasePeriodically());
+    Assertions.assertTrue(manager.isPollingDatabasePeriodically());
 
     emitter.verifyNotEmitted("segment/poll/time");
     emitter.verifyNotEmitted("segment/pollWithSchema/time");
@@ -198,11 +198,11 @@ public class SqlSegmentsMetadataManagerV2Test extends SqlSegmentsMetadataManager
   private void verifyDatasourceSnapshot()
   {
     final DataSourcesSnapshot snapshot = manager.getRecentDataSourcesSnapshot();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.copyOf(WIKI_SEGMENTS_1X5D),
         Sets.newHashSet(snapshot.iterateAllUsedSegmentsInSnapshot())
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.copyOf(WIKI_SEGMENTS_1X5D),
         Set.copyOf(snapshot.getDataSource(TestDataSource.WIKI).getSegments())
     );

--- a/server/src/test/java/org/apache/druid/metadata/segment/cache/HeapMemoryDatasourceSegmentCacheTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/segment/cache/HeapMemoryDatasourceSegmentCacheTest.java
@@ -32,9 +32,9 @@ import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -54,7 +54,7 @@ public class HeapMemoryDatasourceSegmentCacheTest
 
   private HeapMemoryDatasourceSegmentCache cache;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     cache = new HeapMemoryDatasourceSegmentCache(WIKI);
@@ -63,9 +63,9 @@ public class HeapMemoryDatasourceSegmentCacheTest
   @Test
   public void testEmptyCache()
   {
-    Assert.assertNull(cache.findUsedSegment(SegmentId.dummy(WIKI)));
-    Assert.assertTrue(cache.findUsedSegmentsPlusOverlappingAnyOf(List.of()).isEmpty());
-    Assert.assertTrue(cache.findPendingSegmentsOverlapping(Intervals.ETERNITY).isEmpty());
+    Assertions.assertNull(cache.findUsedSegment(SegmentId.dummy(WIKI)));
+    Assertions.assertTrue(cache.findUsedSegmentsPlusOverlappingAnyOf(List.of()).isEmpty());
+    Assertions.assertTrue(cache.findPendingSegmentsOverlapping(Intervals.ETERNITY).isEmpty());
   }
 
   @Test
@@ -129,19 +129,19 @@ public class HeapMemoryDatasourceSegmentCacheTest
     final SegmentId segmentId = segment.getId();
     final Interval interval = segmentId.getInterval();
 
-    Assert.assertEquals(segment, cache.findUsedSegment(segmentId));
-    Assert.assertEquals(List.of(segmentPlus), cache.findUsedSegments(Set.of(segmentId)));
+    Assertions.assertEquals(segment, cache.findUsedSegment(segmentId));
+    Assertions.assertEquals(List.of(segmentPlus), cache.findUsedSegments(Set.of(segmentId)));
 
-    Assert.assertEquals(Set.of(segmentId), cache.findUsedSegmentIdsOverlapping(interval));
-    Assert.assertEquals(Set.of(segmentId), cache.findUsedSegmentIdsOverlapping(Intervals.ETERNITY));
+    Assertions.assertEquals(Set.of(segmentId), cache.findUsedSegmentIdsOverlapping(interval));
+    Assertions.assertEquals(Set.of(segmentId), cache.findUsedSegmentIdsOverlapping(Intervals.ETERNITY));
 
-    Assert.assertEquals(Set.of(segment), cache.findUsedSegmentsOverlappingAnyOf(List.of()));
-    Assert.assertEquals(Set.of(segment), cache.findUsedSegmentsOverlappingAnyOf(List.of(interval)));
-    Assert.assertEquals(Set.of(segment), cache.findUsedSegmentsOverlappingAnyOf(List.of(Intervals.ETERNITY)));
+    Assertions.assertEquals(Set.of(segment), cache.findUsedSegmentsOverlappingAnyOf(List.of()));
+    Assertions.assertEquals(Set.of(segment), cache.findUsedSegmentsOverlappingAnyOf(List.of(interval)));
+    Assertions.assertEquals(Set.of(segment), cache.findUsedSegmentsOverlappingAnyOf(List.of(Intervals.ETERNITY)));
 
-    Assert.assertEquals(Set.of(segmentPlus), cache.findUsedSegmentsPlusOverlappingAnyOf(List.of()));
-    Assert.assertEquals(Set.of(segmentPlus), cache.findUsedSegmentsPlusOverlappingAnyOf(List.of(interval)));
-    Assert.assertEquals(Set.of(segmentPlus), cache.findUsedSegmentsPlusOverlappingAnyOf(List.of(Intervals.ETERNITY)));
+    Assertions.assertEquals(Set.of(segmentPlus), cache.findUsedSegmentsPlusOverlappingAnyOf(List.of()));
+    Assertions.assertEquals(Set.of(segmentPlus), cache.findUsedSegmentsPlusOverlappingAnyOf(List.of(interval)));
+    Assertions.assertEquals(Set.of(segmentPlus), cache.findUsedSegmentsPlusOverlappingAnyOf(List.of(Intervals.ETERNITY)));
   }
 
   @Test
@@ -150,18 +150,18 @@ public class HeapMemoryDatasourceSegmentCacheTest
     final DateTime now = DateTimes.nowUtc();
     final DataSegmentPlus segmentPlus = createUsedSegment().lastUpdatedOn(now).asPlus();
 
-    Assert.assertEquals(1, cache.insertSegments(Set.of(segmentPlus)));
-    Assert.assertEquals(Set.of(segmentPlus), cache.findUsedSegmentsPlusOverlappingAnyOf(List.of()));
+    Assertions.assertEquals(1, cache.insertSegments(Set.of(segmentPlus)));
+    Assertions.assertEquals(Set.of(segmentPlus), cache.findUsedSegmentsPlusOverlappingAnyOf(List.of()));
 
     // Verify that a segment with older updated time does not update cache
     final DataSegmentPlus oldSegmentPlus = updateSegment(segmentPlus, now.minus(1));
-    Assert.assertEquals(0, cache.insertSegments(Set.of(oldSegmentPlus)));
-    Assert.assertEquals(Set.of(segmentPlus), cache.findUsedSegmentsPlusOverlappingAnyOf(List.of()));
+    Assertions.assertEquals(0, cache.insertSegments(Set.of(oldSegmentPlus)));
+    Assertions.assertEquals(Set.of(segmentPlus), cache.findUsedSegmentsPlusOverlappingAnyOf(List.of()));
 
     // Verify that a segment with newer updated time updates the cache
     final DataSegmentPlus newSegmentPlus = updateSegment(segmentPlus, now.plus(1));
-    Assert.assertEquals(1, cache.insertSegments(Set.of(newSegmentPlus)));
-    Assert.assertEquals(Set.of(newSegmentPlus), cache.findUsedSegmentsPlusOverlappingAnyOf(List.of()));
+    Assertions.assertEquals(1, cache.insertSegments(Set.of(newSegmentPlus)));
+    Assertions.assertEquals(Set.of(newSegmentPlus), cache.findUsedSegmentsPlusOverlappingAnyOf(List.of()));
   }
 
   @Test
@@ -174,31 +174,31 @@ public class HeapMemoryDatasourceSegmentCacheTest
     cache.insertSegments(Set.of(segmentPlus));
 
     // Verify that the segment is not returned in any of the used segment methods
-    Assert.assertNull(cache.findUsedSegment(segmentId));
-    Assert.assertTrue(cache.findUsedSegments(Set.of(segmentId)).isEmpty());
-    Assert.assertTrue(cache.findUsedSegmentIdsOverlapping(segment.getInterval()).isEmpty());
-    Assert.assertTrue(cache.findUsedSegmentsOverlappingAnyOf(List.of()).isEmpty());
-    Assert.assertTrue(cache.findUsedSegmentsPlusOverlappingAnyOf(List.of()).isEmpty());
+    Assertions.assertNull(cache.findUsedSegment(segmentId));
+    Assertions.assertTrue(cache.findUsedSegments(Set.of(segmentId)).isEmpty());
+    Assertions.assertTrue(cache.findUsedSegmentIdsOverlapping(segment.getInterval()).isEmpty());
+    Assertions.assertTrue(cache.findUsedSegmentsOverlappingAnyOf(List.of()).isEmpty());
+    Assertions.assertTrue(cache.findUsedSegmentsPlusOverlappingAnyOf(List.of()).isEmpty());
 
     final CacheStats cacheStats = cache.markCacheSynced();
-    Assert.assertEquals(0, cacheStats.getNumUsedSegments());
-    Assert.assertEquals(1, cacheStats.getNumUnusedSegments());
+    Assertions.assertEquals(0, cacheStats.getNumUsedSegments());
+    Assertions.assertEquals(1, cacheStats.getNumUnusedSegments());
   }
 
   @Test
   public void testInsertSegments_addsToCache_ifUpdatedTimeIsNull()
   {
     final DataSegmentPlus usedSegmentPlus = createUsedSegment().lastUpdatedOn(null).asPlus();
-    Assert.assertEquals(1, cache.insertSegments(Set.of(usedSegmentPlus)));
-    Assert.assertEquals(Set.of(usedSegmentPlus), cache.findUsedSegmentsPlusOverlappingAnyOf(List.of()));
+    Assertions.assertEquals(1, cache.insertSegments(Set.of(usedSegmentPlus)));
+    Assertions.assertEquals(Set.of(usedSegmentPlus), cache.findUsedSegmentsPlusOverlappingAnyOf(List.of()));
   }
 
   @Test
   public void testInsertSegments_doesNotUpdateCache_ifNewUpdatedTimeIsNull()
   {
     final DataSegmentPlus usedSegment = createUsedSegment().lastUpdatedOn(null).asPlus();
-    Assert.assertEquals(1, cache.insertSegments(Set.of(usedSegment)));
-    Assert.assertEquals(0, cache.insertSegments(Set.of(updateSegment(usedSegment, null))));
+    Assertions.assertEquals(1, cache.insertSegments(Set.of(usedSegment)));
+    Assertions.assertEquals(0, cache.insertSegments(Set.of(updateSegment(usedSegment, null))));
   }
 
   @Test
@@ -211,7 +211,7 @@ public class HeapMemoryDatasourceSegmentCacheTest
     cache.insertSegments(Set.of(unusedSegmentPlus));
 
     // TODO: Assert.assertEquals(segmentId, cache.findHighestUnusedSegmentId(segment.getInterval(), segment.getVersion()));
-    Assert.assertNull(cache.findUsedSegment(segmentId));
+    Assertions.assertNull(cache.findUsedSegment(segmentId));
 
     final DataSegmentPlus usedSegmentPlus = new DataSegmentPlus(
         segment,
@@ -226,7 +226,7 @@ public class HeapMemoryDatasourceSegmentCacheTest
 
     cache.insertSegments(Set.of(usedSegmentPlus));
 
-    Assert.assertEquals(segment, cache.findUsedSegment(segmentId));
+    Assertions.assertEquals(segment, cache.findUsedSegment(segmentId));
   }
 
   @Test
@@ -237,7 +237,7 @@ public class HeapMemoryDatasourceSegmentCacheTest
 
     final DateTime now = DateTimes.nowUtc();
     SegmentSyncResult result = cache.syncSegmentIds(List.of(usedRecord), now);
-    Assert.assertEquals(Set.of(usedRecord.getSegmentId()), result.getExpiredIds());
+    Assertions.assertEquals(Set.of(usedRecord.getSegmentId()), result.getExpiredIds());
   }
 
   @Test
@@ -248,9 +248,9 @@ public class HeapMemoryDatasourceSegmentCacheTest
 
     final DateTime now = DateTimes.nowUtc();
     SegmentSyncResult result = cache.syncSegmentIds(List.of(unusedRecord), now);
-    Assert.assertEquals(0, result.getUpdated());
-    Assert.assertEquals(0, result.getDeleted());
-    Assert.assertTrue(result.getExpiredIds().isEmpty());
+    Assertions.assertEquals(0, result.getUpdated());
+    Assertions.assertEquals(0, result.getDeleted());
+    Assertions.assertTrue(result.getExpiredIds().isEmpty());
   }
 
   @Test
@@ -263,22 +263,22 @@ public class HeapMemoryDatasourceSegmentCacheTest
         null,
         "allocatorId"
     );
-    Assert.assertTrue(cache.insertPendingSegment(pendingSegment, false));
+    Assertions.assertTrue(cache.insertPendingSegment(pendingSegment, false));
 
-    Assert.assertEquals(List.of(pendingSegment), cache.findPendingSegments("allocatorId"));
-    Assert.assertEquals(
+    Assertions.assertEquals(List.of(pendingSegment), cache.findPendingSegments("allocatorId"));
+    Assertions.assertEquals(
         List.of(pendingSegment.getId()),
         cache.findPendingSegmentIds("sequenceName", "")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(pendingSegment),
         cache.findPendingSegmentsOverlapping(FIRST_WEEK_OF_JAN.withDurationAfterStart(Duration.standardHours(1)))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(pendingSegment),
         cache.findPendingSegmentsWithExactInterval(FIRST_WEEK_OF_JAN)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(pendingSegment.getId()),
         cache.findPendingSegmentIdsWithExactInterval("sequenceName", FIRST_WEEK_OF_JAN)
     );
@@ -296,8 +296,8 @@ public class HeapMemoryDatasourceSegmentCacheTest
         "allocatorId",
         now
     );
-    Assert.assertTrue(cache.insertPendingSegment(pendingSegment, false));
-    Assert.assertEquals(
+    Assertions.assertTrue(cache.insertPendingSegment(pendingSegment, false));
+    Assertions.assertEquals(
         List.of(pendingSegment),
         cache.findPendingSegments(pendingSegment.getTaskAllocatorId())
     );
@@ -311,8 +311,8 @@ public class HeapMemoryDatasourceSegmentCacheTest
         pendingSegment.getTaskAllocatorId(),
         now.plusDays(1)
     );
-    Assert.assertFalse(cache.insertPendingSegment(updatedPendingSegment, false));
-    Assert.assertEquals(
+    Assertions.assertFalse(cache.insertPendingSegment(updatedPendingSegment, false));
+    Assertions.assertEquals(
         List.of(pendingSegment),
         cache.findPendingSegments(pendingSegment.getTaskAllocatorId())
     );
@@ -343,7 +343,7 @@ public class HeapMemoryDatasourceSegmentCacheTest
         "group2"
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         3,
         cache.insertPendingSegments(List.of(segment1, segment2, segment3), false)
     );
@@ -359,9 +359,9 @@ public class HeapMemoryDatasourceSegmentCacheTest
         null,
         null
     );
-    Assert.assertTrue(cache.insertPendingSegment(pendingSegment, true));
-    Assert.assertFalse(cache.insertPendingSegment(pendingSegment, true));
-    Assert.assertEquals(List.of(pendingSegment), cache.findPendingSegmentsOverlapping(Intervals.ETERNITY));
+    Assertions.assertTrue(cache.insertPendingSegment(pendingSegment, true));
+    Assertions.assertFalse(cache.insertPendingSegment(pendingSegment, true));
+    Assertions.assertEquals(List.of(pendingSegment), cache.findPendingSegmentsOverlapping(Intervals.ETERNITY));
   }
 
   @Test
@@ -382,7 +382,7 @@ public class HeapMemoryDatasourceSegmentCacheTest
         unpersistedSegmentUpdatedAfterSync
     );
     cache.insertSegments(allSegments);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         allSegments,
         cache.findUsedSegmentsPlusOverlappingAnyOf(List.of())
     );
@@ -393,7 +393,7 @@ public class HeapMemoryDatasourceSegmentCacheTest
         List.of(asRecord(persistedSegment)),
         syncTime
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(persistedSegment, unpersistedSegmentUpdatedAfterSync),
         cache.findUsedSegmentsPlusOverlappingAnyOf(List.of())
     );
@@ -420,8 +420,8 @@ public class HeapMemoryDatasourceSegmentCacheTest
     );
 
     CacheStats cacheStats = cache.markCacheSynced();
-    Assert.assertEquals(1, cacheStats.getNumUsedSegments());
-    Assert.assertEquals(2, cacheStats.getNumUnusedSegments());
+    Assertions.assertEquals(1, cacheStats.getNumUsedSegments());
+    Assertions.assertEquals(2, cacheStats.getNumUnusedSegments());
 
     // Remove unpersisted segments and verify that only unpersisted segments
     // last updated before the sync time are removed
@@ -431,8 +431,8 @@ public class HeapMemoryDatasourceSegmentCacheTest
     );
 
     cacheStats = cache.markCacheSynced();
-    Assert.assertEquals(1, cacheStats.getNumUsedSegments());
-    Assert.assertEquals(1, cacheStats.getNumUnusedSegments());
+    Assertions.assertEquals(1, cacheStats.getNumUsedSegments());
+    Assertions.assertEquals(1, cacheStats.getNumUnusedSegments());
   }
 
   @Test
@@ -472,7 +472,7 @@ public class HeapMemoryDatasourceSegmentCacheTest
         unpersistedSegmentCreatedAfterSync
     );
     cache.insertPendingSegments(allSegments, false);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.copyOf(allSegments),
         Set.copyOf(cache.findPendingSegments(taskAllocator))
     );
@@ -483,7 +483,7 @@ public class HeapMemoryDatasourceSegmentCacheTest
         List.of(persistedSegment),
         syncTime
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(persistedSegment, unpersistedSegmentCreatedAfterSync),
         Set.copyOf(cache.findPendingSegments(taskAllocator))
     );
@@ -499,32 +499,32 @@ public class HeapMemoryDatasourceSegmentCacheTest
     final SegmentId unusedSegmentId = unusedSegmentPlus.getDataSegment().getId();
 
     cache.insertSegments(Set.of(usedSegmentPlus, unusedSegmentPlus));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(usedSegmentPlus),
         cache.findUsedSegments(Set.of(usedSegmentId))
     );
 
     CacheStats cacheStats = cache.markCacheSynced();
-    Assert.assertEquals(1, cacheStats.getNumUsedSegments());
-    Assert.assertEquals(1, cacheStats.getNumUnusedSegments());
-    Assert.assertFalse(cache.isEmpty());
+    Assertions.assertEquals(1, cacheStats.getNumUsedSegments());
+    Assertions.assertEquals(1, cacheStats.getNumUnusedSegments());
+    Assertions.assertFalse(cache.isEmpty());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2,
         cache.deleteSegments(Set.of(usedSegmentId, unusedSegmentId))
     );
 
     cacheStats = cache.markCacheSynced();
-    Assert.assertEquals(0, cacheStats.getNumUsedSegments());
-    Assert.assertEquals(0, cacheStats.getNumUnusedSegments());
-    Assert.assertTrue(cache.isEmpty());
+    Assertions.assertEquals(0, cacheStats.getNumUsedSegments());
+    Assertions.assertEquals(0, cacheStats.getNumUnusedSegments());
+    Assertions.assertTrue(cache.isEmpty());
   }
 
   @Test
   public void testDeleteSegments_forEmptyOrAbsentIdsReturnsZero()
   {
-    Assert.assertEquals(0, cache.deleteSegments(Set.of()));
-    Assert.assertEquals(0, cache.deleteSegments(Set.of(SegmentId.dummy(WIKI))));
+    Assertions.assertEquals(0, cache.deleteSegments(Set.of()));
+    Assertions.assertEquals(0, cache.deleteSegments(Set.of(SegmentId.dummy(WIKI))));
   }
 
   @Test
@@ -558,9 +558,9 @@ public class HeapMemoryDatasourceSegmentCacheTest
     );
 
     // Delete the segments for group1 and verify contents
-    Assert.assertEquals(2, cache.deletePendingSegments("group1"));
-    Assert.assertTrue(cache.findPendingSegments("group1").isEmpty());
-    Assert.assertEquals(List.of(group2PendingSegment1), cache.findPendingSegments("group2"));
+    Assertions.assertEquals(2, cache.deletePendingSegments("group1"));
+    Assertions.assertTrue(cache.findPendingSegments("group1").isEmpty());
+    Assertions.assertEquals(List.of(group2PendingSegment1), cache.findPendingSegments("group2"));
   }
 
   @Test
@@ -590,13 +590,13 @@ public class HeapMemoryDatasourceSegmentCacheTest
 
     cache.insertPendingSegments(List.of(segment1, segment2, segment3), false);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2,
         cache.deletePendingSegments(
             Set.of(segment1.getId().toString(), segment2.getId().toString())
         )
     );
-    Assert.assertEquals(List.of(segment3), cache.findPendingSegments("group1"));
+    Assertions.assertEquals(List.of(segment3), cache.findPendingSegments("group1"));
   }
 
   @Test
@@ -619,8 +619,8 @@ public class HeapMemoryDatasourceSegmentCacheTest
 
     cache.insertPendingSegments(List.of(segment1, segment2), true);
 
-    Assert.assertEquals(2, cache.deleteAllPendingSegments());
-    Assert.assertTrue(cache.findPendingSegmentsOverlapping(FIRST_WEEK_OF_JAN).isEmpty());
+    Assertions.assertEquals(2, cache.deleteAllPendingSegments());
+    Assertions.assertTrue(cache.findPendingSegmentsOverlapping(FIRST_WEEK_OF_JAN).isEmpty());
   }
 
   @Test
@@ -656,8 +656,8 @@ public class HeapMemoryDatasourceSegmentCacheTest
     cache.insertPendingSegments(List.of(segment1, segment2, segment3), false);
 
 
-    Assert.assertEquals(2, cache.deletePendingSegmentsCreatedIn(firstWeekOfJan));
-    Assert.assertEquals(
+    Assertions.assertEquals(2, cache.deletePendingSegmentsCreatedIn(firstWeekOfJan));
+    Assertions.assertEquals(
         List.of(segment2),
         cache.findPendingSegmentsOverlapping(firstWeekOfJan)
     );
@@ -667,13 +667,13 @@ public class HeapMemoryDatasourceSegmentCacheTest
   public void testMarkSegmentsWithinIntervalAsUnused()
   {
     cache.insertSegments(Set.of(JAN_1_SEGMENT, JAN_2_SEGMENT, JAN_3_SEGMENT));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(JAN_1_SEGMENT, JAN_2_SEGMENT, JAN_3_SEGMENT),
         cache.findUsedSegmentsPlusOverlappingAnyOf(List.of(FIRST_WEEK_OF_JAN))
     );
 
     // Mark segments as unused by interval
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         cache.markSegmentsWithinIntervalAsUnused(
             FIRST_DAY_OF_JAN.withDurationAfterStart(Duration.standardDays(1)),
@@ -683,7 +683,7 @@ public class HeapMemoryDatasourceSegmentCacheTest
     );
 
     // Mark segment as unused by version
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         cache.markSegmentsWithinIntervalAsUnused(
             Intervals.ETERNITY,
@@ -694,15 +694,15 @@ public class HeapMemoryDatasourceSegmentCacheTest
 
     // Verify that all the segment IDs are still present in cache but 2 have
     // been marked as unused
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(JAN_3_SEGMENT),
         cache.findUsedSegmentsPlusOverlappingAnyOf(List.of(FIRST_WEEK_OF_JAN))
     );
 
     final CacheStats cacheStats = cache.markCacheSynced();
-    Assert.assertEquals(1, cacheStats.getNumUsedSegments());
-    Assert.assertEquals(2, cacheStats.getNumUnusedSegments());
-    Assert.assertEquals(3, cacheStats.getNumIntervals());
+    Assertions.assertEquals(1, cacheStats.getNumUsedSegments());
+    Assertions.assertEquals(2, cacheStats.getNumUnusedSegments());
+    Assertions.assertEquals(3, cacheStats.getNumIntervals());
   }
 
   @Test
@@ -711,7 +711,7 @@ public class HeapMemoryDatasourceSegmentCacheTest
     cache.insertSegments(Set.of(JAN_1_SEGMENT, JAN_2_SEGMENT, JAN_3_SEGMENT));
 
     cache.markSegmentAsUnused(JAN_1_SEGMENT.getDataSegment().getId(), DateTimes.nowUtc());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(JAN_2_SEGMENT, JAN_3_SEGMENT),
         cache.findUsedSegmentsPlusOverlappingAnyOf(List.of(FIRST_WEEK_OF_JAN))
     );
@@ -726,7 +726,7 @@ public class HeapMemoryDatasourceSegmentCacheTest
         Set.of(JAN_1_SEGMENT.getDataSegment().getId(), JAN_2_SEGMENT.getDataSegment().getId()),
         DateTimes.nowUtc()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(JAN_3_SEGMENT),
         cache.findUsedSegmentsPlusOverlappingAnyOf(List.of(FIRST_WEEK_OF_JAN))
     );
@@ -737,7 +737,7 @@ public class HeapMemoryDatasourceSegmentCacheTest
   {
     cache.insertSegments(Set.of(JAN_1_SEGMENT, JAN_2_SEGMENT, JAN_3_SEGMENT));
     cache.markAllSegmentsAsUnused(DateTimes.nowUtc());
-    Assert.assertTrue(
+    Assertions.assertTrue(
         cache.findUsedSegmentsPlusOverlappingAnyOf(List.of(FIRST_WEEK_OF_JAN))
              .isEmpty()
     );

--- a/server/src/test/java/org/apache/druid/metadata/segment/cache/HeapMemorySegmentMetadataCacheTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/segment/cache/HeapMemorySegmentMetadataCacheTest.java
@@ -52,21 +52,23 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.DateTime;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class HeapMemorySegmentMetadataCacheTest
 {
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule
       = new TestDerbyConnector.DerbyConnectorRule(CentralizedDatasourceSchemaConfig.enabled(true));
 
@@ -80,7 +82,7 @@ public class HeapMemorySegmentMetadataCacheTest
   private IndexingStateCache indexingStateCache;
   private SegmentSchemaTestUtils schemaTestUtils;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     pollExecutor = new BlockingExecutorService("test-poll-exec");
@@ -97,7 +99,7 @@ public class HeapMemorySegmentMetadataCacheTest
     EmittingLogger.registerEmitter(serviceEmitter);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     if (cache != null) {
@@ -173,40 +175,40 @@ public class HeapMemorySegmentMetadataCacheTest
   public void testStart_schedulesDbPoll_ifCacheIsEnabled()
   {
     setupTargetWithCaching(SegmentMetadataCache.UsageMode.ALWAYS);
-    Assert.assertTrue(cache.isEnabled());
+    Assertions.assertTrue(cache.isEnabled());
 
     cache.start();
-    Assert.assertTrue(pollExecutor.hasPendingTasks());
+    Assertions.assertTrue(pollExecutor.hasPendingTasks());
 
     syncCache();
     serviceEmitter.verifyEmitted(Metric.SYNC_DURATION_MILLIS, 1);
 
-    Assert.assertTrue(pollExecutor.hasPendingTasks());
+    Assertions.assertTrue(pollExecutor.hasPendingTasks());
   }
 
   @Test
   public void testStart_doesNotScheduleDbPoll_ifCacheIsDisabled()
   {
     setupTargetWithCaching(SegmentMetadataCache.UsageMode.NEVER);
-    Assert.assertFalse(cache.isEnabled());
+    Assertions.assertFalse(cache.isEnabled());
 
     cache.start();
-    Assert.assertFalse(cache.isEnabled());
-    Assert.assertFalse(pollExecutor.hasPendingTasks());
+    Assertions.assertFalse(cache.isEnabled());
+    Assertions.assertFalse(pollExecutor.hasPendingTasks());
   }
 
   @Test
   public void testStop_stopsDbPoll_ifCacheIsEnabled()
   {
     setupTargetWithCaching(SegmentMetadataCache.UsageMode.ALWAYS);
-    Assert.assertTrue(cache.isEnabled());
+    Assertions.assertTrue(cache.isEnabled());
 
     cache.start();
-    Assert.assertTrue(pollExecutor.hasPendingTasks());
+    Assertions.assertTrue(pollExecutor.hasPendingTasks());
 
     cache.stop();
-    Assert.assertTrue(pollExecutor.isShutdown());
-    Assert.assertFalse(pollExecutor.hasPendingTasks());
+    Assertions.assertTrue(pollExecutor.isShutdown());
+    Assertions.assertFalse(pollExecutor.hasPendingTasks());
   }
 
   @Test
@@ -215,10 +217,10 @@ public class HeapMemorySegmentMetadataCacheTest
     setupTargetWithCaching(SegmentMetadataCache.UsageMode.NEVER);
 
     cache.start();
-    Assert.assertFalse(pollExecutor.hasPendingTasks());
+    Assertions.assertFalse(pollExecutor.hasPendingTasks());
 
     cache.becomeLeader();
-    Assert.assertFalse(pollExecutor.hasPendingTasks());
+    Assertions.assertFalse(pollExecutor.hasPendingTasks());
   }
 
   @Test
@@ -247,7 +249,7 @@ public class HeapMemorySegmentMetadataCacheTest
   public void testReadCacheForDataSource_throwsException_ifCacheIsStoppedOrNotLeader()
   {
     setupTargetWithCaching(SegmentMetadataCache.UsageMode.ALWAYS);
-    Assert.assertTrue(cache.isEnabled());
+    Assertions.assertTrue(cache.isEnabled());
 
     DruidExceptionMatcher.internalServerError().expectMessageIs(
         "Segment metadata cache has not been started yet."
@@ -263,7 +265,8 @@ public class HeapMemorySegmentMetadataCacheTest
     );
   }
 
-  @Test(timeout = 60_000)
+  @Test
+  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS)
   public void testReadCacheForDataSource_waitsForOneSync_afterBecomingLeader() throws InterruptedException
   {
     setupTargetWithCaching(SegmentMetadataCache.UsageMode.ALWAYS);
@@ -290,7 +293,7 @@ public class HeapMemorySegmentMetadataCacheTest
     // Verify that the getDatasource call finishes only after the first sync
     getDatasourceThread.join();
     syncCompleteThread.join();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of("before first sync", "getDatasource completed"),
         observedEventOrder
     );
@@ -303,7 +306,7 @@ public class HeapMemorySegmentMetadataCacheTest
     getDatasourceThread2.start();
     getDatasourceThread2.join();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of("before first sync", "getDatasource completed", "getDatasource 2 completed"),
         observedEventOrder
     );
@@ -318,7 +321,7 @@ public class HeapMemorySegmentMetadataCacheTest
                                                       .markUsed().asPlus();
     final SegmentId segmentId = segment.getDataSegment().getId();
 
-    Assert.assertNull(
+    Assertions.assertNull(
         cache.readCacheForDataSource(
             TestDataSource.WIKI,
             wikiCache -> wikiCache.findUsedSegment(segmentId)
@@ -329,8 +332,8 @@ public class HeapMemorySegmentMetadataCacheTest
         TestDataSource.WIKI,
         wikiCache -> wikiCache.insertSegments(Set.of(segment))
     );
-    Assert.assertEquals(1, numInsertedSegments);
-    Assert.assertEquals(
+    Assertions.assertEquals(1, numInsertedSegments);
+    Assertions.assertEquals(
         segment.getDataSegment(),
         cache.readCacheForDataSource(
             TestDataSource.WIKI,
@@ -348,7 +351,7 @@ public class HeapMemorySegmentMetadataCacheTest
         = CreateDataSegments.ofDatasource(TestDataSource.WIKI).updatedNow().markUsed().asPlus();
     insertSegmentsInMetadataStore(Set.of(usedSegmentPlus));
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         cache.readCacheForDataSource(
             TestDataSource.WIKI,
             wikiCache -> wikiCache.findUsedSegmentsPlusOverlappingAnyOf(List.of())
@@ -360,7 +363,7 @@ public class HeapMemorySegmentMetadataCacheTest
     serviceEmitter.verifyValue(Metric.UPDATED_USED_SEGMENTS, 1L);
     serviceEmitter.verifyValue(Metric.PERSISTED_USED_SEGMENTS, 1L);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         usedSegmentPlus.getDataSegment(),
         cache.readCacheForDataSource(
             TestDataSource.WIKI,
@@ -381,8 +384,8 @@ public class HeapMemorySegmentMetadataCacheTest
     syncCache();
 
     final List<AlertEvent> alerts = serviceEmitter.getAlerts();
-    Assert.assertEquals(1, alerts.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, alerts.size());
+    Assertions.assertEquals(
         "Could not sync segment metadata cache with metadata store",
         alerts.get(0).getDescription()
     );
@@ -414,13 +417,13 @@ public class HeapMemorySegmentMetadataCacheTest
     serviceEmitter.verifyValue(Metric.CACHED_USED_SEGMENTS, 1L);
     serviceEmitter.verifyValue(Metric.SKIPPED_SEGMENTS, 1L);
 
-    Assert.assertNull(
+    Assertions.assertNull(
         cache.readCacheForDataSource(
             TestDataSource.WIKI,
             wikiCache -> wikiCache.findUsedSegment(invalidSegment.getDataSegment().getId())
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         validSegment.getDataSegment(),
         cache.readCacheForDataSource(
             TestDataSource.WIKI,
@@ -470,14 +473,14 @@ public class HeapMemorySegmentMetadataCacheTest
     serviceEmitter.verifyValue(Metric.PERSISTED_USED_SEGMENTS, 1L);
     serviceEmitter.verifyValue(Metric.PERSISTED_PENDING_SEGMENTS, 0L);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         segment.getDataSegment(),
         cache.readCacheForDataSource(
             TestDataSource.WIKI,
             wikiCache -> wikiCache.findUsedSegment(segment.getDataSegment().getId())
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         cache.readCacheForDataSource(
             TestDataSource.WIKI,
             wikiCache -> wikiCache.findPendingSegmentsOverlapping(Intervals.ETERNITY)
@@ -501,7 +504,7 @@ public class HeapMemorySegmentMetadataCacheTest
         wikiCache -> wikiCache.insertSegments(Set.of(usedSegmentPlus))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(usedSegmentPlus),
         cache.readCacheForDataSource(
             TestDataSource.WIKI,
@@ -527,7 +530,7 @@ public class HeapMemorySegmentMetadataCacheTest
     serviceEmitter.verifyValue(Metric.STALE_USED_SEGMENTS, 1L);
     serviceEmitter.verifyValue(Metric.UPDATED_USED_SEGMENTS, 1L);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(updatedSegment),
         cache.readCacheForDataSource(
             TestDataSource.WIKI,
@@ -549,7 +552,7 @@ public class HeapMemorySegmentMetadataCacheTest
     );
 
     final DataSegment unpersistedSegment = unpersistedSegmentPlus.getDataSegment();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         unpersistedSegment,
         cache.readCacheForDataSource(
             TestDataSource.WIKI,
@@ -561,7 +564,7 @@ public class HeapMemorySegmentMetadataCacheTest
     serviceEmitter.verifyValue(Metric.DELETED_SEGMENTS, 1L);
     serviceEmitter.verifyNotEmitted(Metric.PERSISTED_USED_SEGMENTS);
 
-    Assert.assertNull(
+    Assertions.assertNull(
         cache.readCacheForDataSource(
             TestDataSource.WIKI,
             wikiCache -> wikiCache.findUsedSegment(unpersistedSegment.getId())
@@ -639,7 +642,7 @@ public class HeapMemorySegmentMetadataCacheTest
     );
 
     final SegmentIdWithShardSpec segmentId = pendingSegment.getId();
-    Assert.assertTrue(
+    Assertions.assertTrue(
         cache.readCacheForDataSource(
             TestDataSource.WIKI,
             wikiCache -> wikiCache.findPendingSegmentIdsWithExactInterval(
@@ -653,7 +656,7 @@ public class HeapMemorySegmentMetadataCacheTest
     serviceEmitter.verifyValue(Metric.PERSISTED_PENDING_SEGMENTS, 1L);
     serviceEmitter.verifyValue(Metric.UPDATED_PENDING_SEGMENTS, 1L);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(segmentId),
         cache.readCacheForDataSource(
             TestDataSource.WIKI,
@@ -678,7 +681,7 @@ public class HeapMemorySegmentMetadataCacheTest
     );
 
     final SegmentIdWithShardSpec segmentId = pendingSegment.getId();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(segmentId),
         cache.readCacheForDataSource(
             TestDataSource.WIKI,
@@ -694,7 +697,7 @@ public class HeapMemorySegmentMetadataCacheTest
     serviceEmitter.verifyNotEmitted(Metric.PERSISTED_PENDING_SEGMENTS);
     serviceEmitter.verifyValue(Metric.DELETED_PENDING_SEGMENTS, 1L);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         cache.readCacheForDataSource(
             TestDataSource.WIKI,
             wikiCache -> wikiCache.findPendingSegmentIdsWithExactInterval(
@@ -718,7 +721,7 @@ public class HeapMemorySegmentMetadataCacheTest
         TestDataSource.WIKI,
         wikiCache -> wikiCache.insertSegments(Set.of(segment))
     );
-    Assert.assertEquals(1, numInsertedSegments);
+    Assertions.assertEquals(1, numInsertedSegments);
 
     // Verify that sync removes the extra entry from the cache and also cleans it up
     syncCache();
@@ -731,7 +734,7 @@ public class HeapMemorySegmentMetadataCacheTest
   {
     setupAndSyncCacheWithSchema();
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         schemaCache.getPublishedSchemaPayloadMap().isEmpty()
     );
 
@@ -748,7 +751,7 @@ public class HeapMemorySegmentMetadataCacheTest
     syncCache();
     serviceEmitter.verifyValue("segment/schemaCache/usedFingerprint/count", 1L);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Map.of(fingerprint, payload),
         schemaCache.getPublishedSchemaPayloadMap()
     );
@@ -768,7 +771,7 @@ public class HeapMemorySegmentMetadataCacheTest
         Map.of(),
         Map.of(fingerprint, payload)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Map.of(fingerprint, payload),
         schemaCache.getPublishedSchemaPayloadMap()
     );
@@ -776,7 +779,7 @@ public class HeapMemorySegmentMetadataCacheTest
     syncCache();
     serviceEmitter.verifyValue("segment/schemaCache/usedFingerprint/count", 0L);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         schemaCache.getPublishedSchemaPayloadMap().isEmpty()
     );
   }
@@ -786,7 +789,7 @@ public class HeapMemorySegmentMetadataCacheTest
   {
     setupAndSyncCacheWithSchema();
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         schemaCache.getPublishedSegmentMetadataMap().isEmpty()
     );
 
@@ -807,7 +810,7 @@ public class HeapMemorySegmentMetadataCacheTest
     serviceEmitter.verifyValue(Metric.UPDATED_USED_SEGMENTS, 1L);
     serviceEmitter.verifyValue("segment/schemaCache/used/count", 1L);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Map.of(usedSegmentPlus.getDataSegment().getId(), new SegmentMetadata(10L, fingerprint)),
         schemaCache.getPublishedSegmentMetadataMap()
     );
@@ -829,7 +832,7 @@ public class HeapMemorySegmentMetadataCacheTest
         Map.of(segmentId, metadata),
         Map.of()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Map.of(segmentId, metadata),
         schemaCache.getPublishedSegmentMetadataMap()
     );
@@ -837,7 +840,7 @@ public class HeapMemorySegmentMetadataCacheTest
     syncCache();
     serviceEmitter.verifyValue("segment/schemaCache/used/count", 0L);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         schemaCache.getPublishedSegmentMetadataMap().isEmpty()
     );
   }
@@ -872,8 +875,8 @@ public class HeapMemorySegmentMetadataCacheTest
 
     // The published snapshot must still include the write-through segment, even
     // though the incremental rebuild saw no metadata-store change for WIKI.
-    Assert.assertNotNull(cache.getDataSourcesSnapshot().getDataSource(TestDataSource.WIKI));
-    Assert.assertTrue(
+    Assertions.assertNotNull(cache.getDataSourcesSnapshot().getDataSource(TestDataSource.WIKI));
+    Assertions.assertTrue(
         cache.getDataSourcesSnapshot()
              .getDataSource(TestDataSource.WIKI)
              .getSegments()
@@ -901,7 +904,7 @@ public class HeapMemorySegmentMetadataCacheTest
         segment.getUsedStatusLastUpdatedDate().toString(),
         segment.getDataSegment().getId().toString()
     );
-    Assert.assertEquals(1, updatedRows);
+    Assertions.assertEquals(1, updatedRows);
   }
 
   private static PendingSegmentRecord createPendingSegment(DateTime createdTime)

--- a/server/src/test/java/org/apache/druid/metadata/segment/cache/HeapMemorySegmentMetadataCacheTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/segment/cache/HeapMemorySegmentMetadataCacheTest.java
@@ -57,6 +57,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.nio.charset.StandardCharsets;
@@ -266,7 +267,7 @@ public class HeapMemorySegmentMetadataCacheTest
   }
 
   @Test
-  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testReadCacheForDataSource_waitsForOneSync_afterBecomingLeader() throws InterruptedException
   {
     setupTargetWithCaching(SegmentMetadataCache.UsageMode.ALWAYS);

--- a/server/src/test/java/org/apache/druid/segment/LookupSegmentWranglerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/LookupSegmentWranglerTest.java
@@ -29,12 +29,8 @@ import org.apache.druid.query.lookup.LookupExtractorFactoryContainer;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.lookup.LookupSegment;
 import org.apache.druid.query.lookup.LookupSegmentTest;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
@@ -42,9 +38,6 @@ import java.util.Set;
 
 public class LookupSegmentWranglerTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   private final LookupSegmentWrangler factory = new LookupSegmentWrangler(
       new LookupExtractorFactoryContainerProvider()
       {
@@ -80,13 +73,15 @@ public class LookupSegmentWranglerTest
   @Test
   public void test_getSegmentsForIntervals_nonLookup()
   {
-    expectedException.expect(ClassCastException.class);
-    expectedException.expectMessage("TableDataSource cannot be cast");
-
-    final Iterable<Segment> ignored = factory.getSegmentsForIntervals(
-        new TableDataSource("foo"),
-        Intervals.ONLY_ETERNITY
+    final ClassCastException exception = Assertions.assertThrows(
+        ClassCastException.class,
+        () -> factory.getSegmentsForIntervals(
+            new TableDataSource("foo"),
+            Intervals.ONLY_ETERNITY
+        )
     );
+    Assertions.assertNotNull(exception.getMessage());
+    Assertions.assertTrue(exception.getMessage().contains("TableDataSource cannot be cast"));
   }
 
   @Test
@@ -99,8 +94,8 @@ public class LookupSegmentWranglerTest
         )
     );
 
-    Assert.assertEquals(1, segments.size());
-    MatcherAssert.assertThat(Iterables.getOnlyElement(segments), CoreMatchers.instanceOf(LookupSegment.class));
+    Assertions.assertEquals(1, segments.size());
+    Assertions.assertInstanceOf(LookupSegment.class, Iterables.getOnlyElement(segments));
   }
 
   @Test
@@ -113,6 +108,6 @@ public class LookupSegmentWranglerTest
         )
     );
 
-    Assert.assertEquals(0, segments.size());
+    Assertions.assertEquals(0, segments.size());
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
@@ -55,8 +55,7 @@ import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -978,8 +977,8 @@ class DataSchemaTest extends InitializedNullHandlingTest
                        .withSegmentGranularity(new SegmentGranularitySpec(Granularities.DAY, null))
                        .build()
     );
-    MatcherAssert.assertThat(t.getMessage(), Matchers.containsString("segmentGranularitySpec"));
-    MatcherAssert.assertThat(t.getMessage(), Matchers.containsString("baseTable"));
+    AssertionsForClassTypes.assertThat(t.getMessage()).contains("segmentGranularitySpec");
+    AssertionsForClassTypes.assertThat(t.getMessage()).contains("baseTable");
   }
 
   @Test
@@ -1004,8 +1003,8 @@ class DataSchemaTest extends InitializedNullHandlingTest
                        .withBaseTable(spec)
                        .build()
     );
-    MatcherAssert.assertThat(t.getMessage(), Matchers.containsString("granularitySpec"));
-    MatcherAssert.assertThat(t.getMessage(), Matchers.containsString("baseTable"));
+    AssertionsForClassTypes.assertThat(t.getMessage()).contains("granularitySpec");
+    AssertionsForClassTypes.assertThat(t.getMessage()).contains("baseTable");
   }
 
   @Test
@@ -1101,6 +1100,6 @@ class DataSchemaTest extends InitializedNullHandlingTest
         DruidException.class,
         () -> schema.withDimensionsSpec(DimensionsSpec.builder().build())
     );
-    MatcherAssert.assertThat(t.getMessage(), Matchers.containsString("dimensionsSpec"));
+    AssertionsForClassTypes.assertThat(t.getMessage()).contains("dimensionsSpec");
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/indexing/ReaderUtilsTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/ReaderUtilsTest.java
@@ -39,8 +39,8 @@ import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.segment.transform.ExpressionTransform;
 import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -64,7 +64,7 @@ public class ReaderUtilsTest extends InitializedNullHandlingTest
     );
 
     Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, TransformSpec.NONE, new AggregatorFactory[]{}, null);
-    Assert.assertEquals(ImmutableSet.of("A", "B", "C", "D"), actual);
+    Assertions.assertEquals(ImmutableSet.of("A", "B", "C", "D"), actual);
   }
 
   @Test
@@ -85,7 +85,7 @@ public class ReaderUtilsTest extends InitializedNullHandlingTest
     };
 
     Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, TransformSpec.NONE, aggregators, null);
-    Assert.assertEquals(ImmutableSet.of("A", "B", "C", "D", "E", "F"), actual);
+    Assertions.assertEquals(ImmutableSet.of("A", "B", "C", "D", "E", "F"), actual);
   }
 
   @Test
@@ -117,7 +117,7 @@ public class ReaderUtilsTest extends InitializedNullHandlingTest
     );
 
     Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, transformSpec, new AggregatorFactory[]{}, null);
-    Assert.assertEquals(ImmutableSet.of("A", "B", "C", "D", "E", "F", "G"), actual);
+    Assertions.assertEquals(ImmutableSet.of("A", "B", "C", "D", "E", "F", "G"), actual);
   }
 
   @Test
@@ -156,7 +156,7 @@ public class ReaderUtilsTest extends InitializedNullHandlingTest
     );
 
     Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, transformSpec, new AggregatorFactory[]{}, flattenSpec);
-    Assert.assertEquals(ImmutableSet.of("A", "B", "C", "D"), actual);
+    Assertions.assertEquals(ImmutableSet.of("A", "B", "C", "D"), actual);
   }
 
   @Test
@@ -190,7 +190,7 @@ public class ReaderUtilsTest extends InitializedNullHandlingTest
     );
 
     Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, transformSpec, new AggregatorFactory[]{}, flattenSpec);
-    Assert.assertEquals(ImmutableSet.of("A", "B", "C", "D", "E", "F", "G", "H"), actual);
+    Assertions.assertEquals(ImmutableSet.of("A", "B", "C", "D", "E", "F", "G", "H"), actual);
   }
 
   @Test
@@ -220,7 +220,7 @@ public class ReaderUtilsTest extends InitializedNullHandlingTest
     JSONPathSpec flattenSpec = new JSONPathSpec(false, flattenExpr);
 
     Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, TransformSpec.NONE, new AggregatorFactory[]{}, flattenSpec);
-    Assert.assertEquals(fullInputSchema, actual);
+    Assertions.assertEquals(fullInputSchema, actual);
   }
 
   @Test
@@ -250,7 +250,7 @@ public class ReaderUtilsTest extends InitializedNullHandlingTest
     JSONPathSpec flattenSpec = new JSONPathSpec(false, flattenExpr);
 
     Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, TransformSpec.NONE, new AggregatorFactory[]{}, flattenSpec);
-    Assert.assertEquals(fullInputSchema, actual);
+    Assertions.assertEquals(fullInputSchema, actual);
   }
 
   @Test
@@ -280,7 +280,7 @@ public class ReaderUtilsTest extends InitializedNullHandlingTest
     JSONPathSpec flattenSpec = new JSONPathSpec(false, flattenExpr);
 
     Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, TransformSpec.NONE, new AggregatorFactory[]{}, flattenSpec);
-    Assert.assertEquals(fullInputSchema, actual);
+    Assertions.assertEquals(fullInputSchema, actual);
   }
 
   @Test
@@ -310,7 +310,7 @@ public class ReaderUtilsTest extends InitializedNullHandlingTest
     JSONPathSpec flattenSpec = new JSONPathSpec(false, flattenExpr);
 
     Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, TransformSpec.NONE, new AggregatorFactory[]{}, flattenSpec);
-    Assert.assertEquals(fullInputSchema, actual);
+    Assertions.assertEquals(fullInputSchema, actual);
   }
 
   @Test
@@ -328,7 +328,7 @@ public class ReaderUtilsTest extends InitializedNullHandlingTest
     JSONPathSpec flattenSpec = new JSONPathSpec(true, flattenExpr);
 
     Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, TransformSpec.NONE, new AggregatorFactory[]{}, flattenSpec);
-    Assert.assertEquals(ImmutableSet.of("B", "C"), actual);
+    Assertions.assertEquals(ImmutableSet.of("B", "C"), actual);
   }
 
   @Test
@@ -338,7 +338,7 @@ public class ReaderUtilsTest extends InitializedNullHandlingTest
     DimensionsSpec dimensionsSpec = DimensionsSpec.EMPTY;
 
     Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, TransformSpec.NONE, new AggregatorFactory[]{}, null);
-    Assert.assertEquals(fullInputSchema, actual);
+    Assertions.assertEquals(fullInputSchema, actual);
   }
 
   @Test
@@ -351,7 +351,7 @@ public class ReaderUtilsTest extends InitializedNullHandlingTest
     );
     JSONPathSpec flattenSpec = new JSONPathSpec(true, flattenExpr);
     Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, TransformSpec.NONE, new AggregatorFactory[]{}, flattenSpec);
-    Assert.assertEquals(fullInputSchema, actual);
+    Assertions.assertEquals(fullInputSchema, actual);
   }
 
   @Test
@@ -364,7 +364,7 @@ public class ReaderUtilsTest extends InitializedNullHandlingTest
     );
     JSONPathSpec flattenSpec = new JSONPathSpec(false, flattenExpr);
     Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, TransformSpec.NONE, new AggregatorFactory[]{}, flattenSpec);
-    Assert.assertEquals(ImmutableSet.of("A", "C"), actual);
+    Assertions.assertEquals(ImmutableSet.of("A", "C"), actual);
   }
 
   @Test
@@ -392,6 +392,6 @@ public class ReaderUtilsTest extends InitializedNullHandlingTest
     );
 
     Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, transformSpec, new AggregatorFactory[]{}, null);
-    Assert.assertEquals(ImmutableSet.of("A", "B", "C", "D", "E", "F", "G", "H"), actual);
+    Assertions.assertEquals(ImmutableSet.of("A", "B", "C", "D", "E", "F", "G", "H"), actual);
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/join/LookupJoinableFactoryTest.java
+++ b/server/src/test/java/org/apache/druid/segment/join/LookupJoinableFactoryTest.java
@@ -29,12 +29,8 @@ import org.apache.druid.query.lookup.LookupExtractorFactoryContainer;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.lookup.MapLookupExtractorFactory;
 import org.apache.druid.segment.join.lookup.LookupJoinable;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -43,9 +39,6 @@ import java.util.Set;
 public class LookupJoinableFactoryTest
 {
   private static final String PREFIX = "j.";
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   private final LookupJoinableFactory factory;
   private final LookupDataSource lookupDataSource = new LookupDataSource("country_code_to_name");
@@ -97,16 +90,18 @@ public class LookupJoinableFactoryTest
   @Test
   public void testBuildNonLookup()
   {
-    expectedException.expect(ClassCastException.class);
-    expectedException.expectMessage("TableDataSource cannot be cast");
-
-    final Optional<Joinable> ignored = factory.build(new TableDataSource("foo"), makeCondition("x == \"j.k\""));
+    final ClassCastException exception = Assertions.assertThrows(
+        ClassCastException.class,
+        () -> factory.build(new TableDataSource("foo"), makeCondition("x == \"j.k\""))
+    );
+    Assertions.assertNotNull(exception.getMessage());
+    Assertions.assertTrue(exception.getMessage().contains("TableDataSource cannot be cast"));
   }
 
   @Test
   public void testBuildNonHashJoin()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Optional.empty(),
         factory.build(lookupDataSource, makeCondition("x > \"j.k\""))
     );
@@ -115,7 +110,7 @@ public class LookupJoinableFactoryTest
   @Test
   public void testBuildDifferentLookup()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Optional.empty(),
         factory.build(new LookupDataSource("beep"), makeCondition("x == \"j.k\""))
     );
@@ -126,17 +121,17 @@ public class LookupJoinableFactoryTest
   {
     final Joinable joinable = factory.build(lookupDataSource, makeCondition("x == \"j.k\"")).get();
 
-    MatcherAssert.assertThat(joinable, CoreMatchers.instanceOf(LookupJoinable.class));
-    Assert.assertEquals(ImmutableList.of("k", "v"), joinable.getAvailableColumns());
-    Assert.assertEquals(Joinable.CARDINALITY_UNKNOWN, joinable.getCardinality("k"));
-    Assert.assertEquals(Joinable.CARDINALITY_UNKNOWN, joinable.getCardinality("v"));
+    Assertions.assertInstanceOf(LookupJoinable.class, joinable);
+    Assertions.assertEquals(ImmutableList.of("k", "v"), joinable.getAvailableColumns());
+    Assertions.assertEquals(Joinable.CARDINALITY_UNKNOWN, joinable.getCardinality("k"));
+    Assertions.assertEquals(Joinable.CARDINALITY_UNKNOWN, joinable.getCardinality("v"));
   }
 
   @Test
   public void testIsDirectlyJoinable()
   {
-    Assert.assertTrue(factory.isDirectlyJoinable(lookupDataSource));
-    Assert.assertFalse(factory.isDirectlyJoinable(new TableDataSource("foo")));
+    Assertions.assertTrue(factory.isDirectlyJoinable(lookupDataSource));
+    Assertions.assertFalse(factory.isDirectlyJoinable(new TableDataSource("foo")));
   }
 
   private static JoinConditionAnalysis makeCondition(final String condition)

--- a/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentDataCacheConcurrencyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentDataCacheConcurrencyTest.java
@@ -65,15 +65,18 @@ import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.easymock.EasyMock;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
+
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -92,7 +95,7 @@ import java.util.stream.Collectors;
 
 public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataCacheTestBase
 {
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule =
       new TestDerbyConnector.DerbyConnectorRule(CentralizedDatasourceSchemaConfig.enabled(true));
 
@@ -110,12 +113,12 @@ public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataC
   private Supplier<SegmentsMetadataManagerConfig> segmentsMetadataManagerConfigSupplier;
   private final ObjectMapper mapper = TestHelper.makeJsonMapper();
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     setUpData();
     setUpCommon();
-    tmpDir = temporaryFolder.newFolder();
+    tmpDir = newFolder(temporaryFolder, "junit");
     inventoryView = new TestServerInventoryView();
     serverView = newCoordinatorServerView(inventoryView);
     walker = new TestSegmentMetadataQueryWalker(
@@ -205,7 +208,7 @@ public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataC
     exec = Execs.multiThreaded(4, "DruidSchemaConcurrencyTest-%d");
   }
 
-  @After
+  @AfterEach
   @Override
   public void tearDown() throws Exception
   {
@@ -225,7 +228,8 @@ public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataC
    * {@link BrokerServerView#getTimeline} is continuously called to mimic user query
    * processing. All these calls must return without heavy contention.
    */
-  @Test(timeout = 30000L)
+  @Test
+  @Timeout(value = 30000L, unit = TimeUnit.MILLISECONDS)
   public void testSegmentMetadataRefreshAndInventoryViewAddSegmentAndBrokerServerViewGetTimeline()
       throws InterruptedException, ExecutionException, TimeoutException
   {
@@ -317,12 +321,12 @@ public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataC
     // for the first 30 segments, we will still have replicas.
     // for the other 20 segments, they will be completely removed from the cluster.
     removeSegmentsFromCluster(numServers, 50);
-    Assert.assertFalse(refreshFuture.isDone());
+    Assertions.assertFalse(refreshFuture.isDone());
 
     for (int i = 0; i < 1000; i++) {
       boolean hasTimeline = exec.submit(() -> (serverView.getTimeline(new TableDataSource(DATASOURCE)) != null))
                                 .get(100, TimeUnit.MILLISECONDS);
-      Assert.assertTrue(hasTimeline);
+      Assertions.assertTrue(hasTimeline);
       // We want to call getTimeline while BrokerServerView is being updated. Sleep might help with timing.
       Thread.sleep(2);
     }
@@ -341,7 +345,8 @@ public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataC
    * called to mimic reading the segments table of SystemSchema. All these calls
    * must return without heavy contention.
    */
-  @Test(timeout = 30000L)
+  @Test
+  @Timeout(value = 30000L, unit = TimeUnit.MILLISECONDS)
   public void testSegmentMetadataRefreshAndDruidSchemaGetSegmentMetadata()
       throws InterruptedException, ExecutionException, TimeoutException
   {
@@ -415,7 +420,7 @@ public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataC
     );
     addSegmentsToCluster(0, numServers, numExistingSegments);
     // Wait for all segments to be loaded in BrokerServerView
-    Assert.assertTrue(segmentLoadLatch.await(5, TimeUnit.SECONDS));
+    Assertions.assertTrue(segmentLoadLatch.await(5, TimeUnit.SECONDS));
 
     // Trigger refresh of SegmentMetadataCache. This will internally run the heavy work mimicked
     // by the overridden buildDruidTable
@@ -426,13 +431,13 @@ public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataC
       );
       return null;
     });
-    Assert.assertFalse(refreshFuture.isDone());
+    Assertions.assertFalse(refreshFuture.isDone());
 
     for (int i = 0; i < 1000; i++) {
       Map<SegmentId, AvailableSegmentMetadata> segmentsMetadata = exec.submit(
           () -> schema.getSegmentMetadataSnapshot()
       ).get(100, TimeUnit.MILLISECONDS);
-      Assert.assertFalse(segmentsMetadata.isEmpty());
+      Assertions.assertFalse(segmentsMetadata.isEmpty());
       // We want to call getTimeline while refreshing. Sleep might help with timing.
       Thread.sleep(2);
     }
@@ -594,6 +599,19 @@ public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataC
       Set<DataSegment> segments = segmentsMap.get(serverKey);
       return segments != null && segments.contains(segment);
     }
+
+    private static File newFolder(File root, String... subDirs) throws IOException
+    {
+      if (subDirs.length == 0) {
+        return java.nio.file.Files.createTempDirectory(root.toPath(), "junit").toFile();
+      }
+      String subFolder = String.join("/", subDirs);
+      File result = new File(root, subFolder);
+      if (!result.mkdirs()) {
+        throw new IOException("Couldn't create folders " + root);
+      }
+      return result;
+    }
   }
 
   private static class TestCoordinatorServerView extends CoordinatorServerView
@@ -613,5 +631,31 @@ public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataC
     {
       return EasyMock.mock(QueryRunner.class);
     }
+
+    private static File newFolder(File root, String... subDirs) throws IOException
+    {
+      if (subDirs.length == 0) {
+        return java.nio.file.Files.createTempDirectory(root.toPath(), "junit").toFile();
+      }
+      String subFolder = String.join("/", subDirs);
+      File result = new File(root, subFolder);
+      if (!result.mkdirs()) {
+        throw new IOException("Couldn't create folders " + root);
+      }
+      return result;
+    }
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
+    if (subDirs.length == 0 || (subDirs.length == 1 && "junit".equals(subDirs[0]))) {
+      return java.nio.file.Files.createTempDirectory(root.toPath(), "junit").toFile();
+    }
+    String subFolder = String.join("/", subDirs);
+    File result = new File(root, subFolder);
+    if (!result.mkdirs()) {
+      throw new IOException("Couldn't create folders " + root);
+    }
+    return result;
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentDataCacheConcurrencyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentDataCacheConcurrencyTest.java
@@ -70,6 +70,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
@@ -228,7 +229,7 @@ public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataC
    * processing. All these calls must return without heavy contention.
    */
   @Test
-  @Timeout(value = 30000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 30000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testSegmentMetadataRefreshAndInventoryViewAddSegmentAndBrokerServerViewGetTimeline()
       throws InterruptedException, ExecutionException, TimeoutException
   {
@@ -345,7 +346,7 @@ public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataC
    * must return without heavy contention.
    */
   @Test
-  @Timeout(value = 30000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 30000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testSegmentMetadataRefreshAndDruidSchemaGetSegmentMetadata()
       throws InterruptedException, ExecutionException, TimeoutException
   {

--- a/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentDataCacheConcurrencyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentDataCacheConcurrencyTest.java
@@ -76,7 +76,6 @@ import org.mockito.Mockito;
 import javax.annotation.Nullable;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -118,7 +117,7 @@ public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataC
   {
     setUpData();
     setUpCommon();
-    tmpDir = newFolder(temporaryFolder, "junit");
+    tmpDir = temporaryFolder.newFolder();
     inventoryView = new TestServerInventoryView();
     serverView = newCoordinatorServerView(inventoryView);
     walker = new TestSegmentMetadataQueryWalker(
@@ -599,19 +598,6 @@ public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataC
       Set<DataSegment> segments = segmentsMap.get(serverKey);
       return segments != null && segments.contains(segment);
     }
-
-    private static File newFolder(File root, String... subDirs) throws IOException
-    {
-      if (subDirs.length == 0) {
-        return java.nio.file.Files.createTempDirectory(root.toPath(), "junit").toFile();
-      }
-      String subFolder = String.join("/", subDirs);
-      File result = new File(root, subFolder);
-      if (!result.mkdirs()) {
-        throw new IOException("Couldn't create folders " + root);
-      }
-      return result;
-    }
   }
 
   private static class TestCoordinatorServerView extends CoordinatorServerView
@@ -631,31 +617,5 @@ public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataC
     {
       return EasyMock.mock(QueryRunner.class);
     }
-
-    private static File newFolder(File root, String... subDirs) throws IOException
-    {
-      if (subDirs.length == 0) {
-        return java.nio.file.Files.createTempDirectory(root.toPath(), "junit").toFile();
-      }
-      String subFolder = String.join("/", subDirs);
-      File result = new File(root, subFolder);
-      if (!result.mkdirs()) {
-        throw new IOException("Couldn't create folders " + root);
-      }
-      return result;
-    }
-  }
-
-  private static File newFolder(File root, String... subDirs) throws IOException
-  {
-    if (subDirs.length == 0 || (subDirs.length == 1 && "junit".equals(subDirs[0]))) {
-      return java.nio.file.Files.createTempDirectory(root.toPath(), "junit").toFile();
-    }
-    String subFolder = String.join("/", subDirs);
-    File result = new File(root, subFolder);
-    if (!result.mkdirs()) {
-      throw new IOException("Couldn't create folders " + root);
-    }
-    return result;
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCacheConfigTest.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCacheConfigTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.JsonConfigurator;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -49,9 +49,9 @@ public class CoordinatorSegmentMetadataCacheConfigTest
     final Properties properties = new Properties();
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
     final SegmentMetadataCacheConfig config = provider.get();
-    Assert.assertFalse(config.isAwaitInitializationOnStart());
-    Assert.assertEquals(Period.minutes(1), config.getMetadataRefreshPeriod());
-    Assert.assertEquals(new AbstractSegmentMetadataCache.LeastRestrictiveTypeMergePolicy(), config.getMetadataColumnTypeMergePolicy());
+    Assertions.assertFalse(config.isAwaitInitializationOnStart());
+    Assertions.assertEquals(Period.minutes(1), config.getMetadataRefreshPeriod());
+    Assertions.assertEquals(new AbstractSegmentMetadataCache.LeastRestrictiveTypeMergePolicy(), config.getMetadataColumnTypeMergePolicy());
   }
 
   @Test
@@ -71,9 +71,9 @@ public class CoordinatorSegmentMetadataCacheConfigTest
     properties.setProperty(CONFIG_BASE + ".awaitInitializationOnStart", "false");
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
     final SegmentMetadataCacheConfig config = provider.get();
-    Assert.assertFalse(config.isAwaitInitializationOnStart());
-    Assert.assertEquals(Period.minutes(2), config.getMetadataRefreshPeriod());
-    Assert.assertEquals(
+    Assertions.assertFalse(config.isAwaitInitializationOnStart());
+    Assertions.assertEquals(Period.minutes(2), config.getMetadataRefreshPeriod());
+    Assertions.assertEquals(
         new AbstractSegmentMetadataCache.FirstTypeMergePolicy(),
         config.getMetadataColumnTypeMergePolicy()
     );
@@ -83,9 +83,8 @@ public class CoordinatorSegmentMetadataCacheConfigTest
   {
     return GuiceInjectors.makeStartupInjectorWithModules(
         ImmutableList.of(
-            binder -> {
-              JsonConfigProvider.bind(binder, CONFIG_BASE, SegmentMetadataCacheConfig.class);
-            }
+            binder ->
+              JsonConfigProvider.bind(binder, CONFIG_BASE, SegmentMetadataCacheConfig.class)
         )
     );
   }

--- a/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCacheTest.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCacheTest.java
@@ -91,10 +91,10 @@ import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
 import org.easymock.EasyMock;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.skife.jdbi.v2.StatementContext;
@@ -128,7 +128,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
   private SegmentsMetadataManager segmentsMetadataManager;
   private Supplier<SegmentsMetadataManagerConfig> segmentsMetadataManagerConfigSupplier;
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception
   {
@@ -141,7 +141,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     segmentsMetadataManagerConfigSupplier = Suppliers.ofInstance(metadataManagerConfig);
   }
 
-  @After
+  @AfterEach
   @Override
   public void tearDown() throws Exception
   {
@@ -198,10 +198,10 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
   public void testGetTableMap() throws InterruptedException
   {
     CoordinatorSegmentMetadataCache schema = buildSchemaMarkAndTableLatch();
-    Assert.assertEquals(ImmutableSet.of(DATASOURCE1, DATASOURCE2, SOME_DATASOURCE), schema.getDatasourceNames());
+    Assertions.assertEquals(ImmutableSet.of(DATASOURCE1, DATASOURCE2, SOME_DATASOURCE), schema.getDatasourceNames());
 
     final Set<String> tableNames = schema.getDatasourceNames();
-    Assert.assertEquals(ImmutableSet.of(DATASOURCE1, DATASOURCE2, SOME_DATASOURCE), tableNames);
+    Assertions.assertEquals(ImmutableSet.of(DATASOURCE1, DATASOURCE2, SOME_DATASOURCE), tableNames);
   }
 
   @Test
@@ -235,34 +235,34 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     final DataSourceInformation fooDs = schema.getDatasource(SOME_DATASOURCE);
     final RowSignature fooRowSignature = fooDs.getRowSignature();
     List<String> columnNames = fooRowSignature.getColumnNames();
-    Assert.assertEquals(9, columnNames.size());
+    Assertions.assertEquals(9, columnNames.size());
 
-    Assert.assertEquals("__time", columnNames.get(0));
-    Assert.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(0)).get());
+    Assertions.assertEquals("__time", columnNames.get(0));
+    Assertions.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(0)).get());
 
-    Assert.assertEquals("numbery", columnNames.get(1));
-    Assert.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(1)).get());
+    Assertions.assertEquals("numbery", columnNames.get(1));
+    Assertions.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(1)).get());
 
-    Assert.assertEquals("numberyArrays", columnNames.get(2));
-    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, fooRowSignature.getColumnType(columnNames.get(2)).get());
+    Assertions.assertEquals("numberyArrays", columnNames.get(2));
+    Assertions.assertEquals(ColumnType.DOUBLE_ARRAY, fooRowSignature.getColumnType(columnNames.get(2)).get());
 
-    Assert.assertEquals("stringy", columnNames.get(3));
-    Assert.assertEquals(ColumnType.STRING, fooRowSignature.getColumnType(columnNames.get(3)).get());
+    Assertions.assertEquals("stringy", columnNames.get(3));
+    Assertions.assertEquals(ColumnType.STRING, fooRowSignature.getColumnType(columnNames.get(3)).get());
 
-    Assert.assertEquals("array", columnNames.get(4));
-    Assert.assertEquals(ColumnType.LONG_ARRAY, fooRowSignature.getColumnType(columnNames.get(4)).get());
+    Assertions.assertEquals("array", columnNames.get(4));
+    Assertions.assertEquals(ColumnType.LONG_ARRAY, fooRowSignature.getColumnType(columnNames.get(4)).get());
 
-    Assert.assertEquals("nested", columnNames.get(5));
-    Assert.assertEquals(ColumnType.ofComplex("json"), fooRowSignature.getColumnType(columnNames.get(5)).get());
+    Assertions.assertEquals("nested", columnNames.get(5));
+    Assertions.assertEquals(ColumnType.ofComplex("json"), fooRowSignature.getColumnType(columnNames.get(5)).get());
 
-    Assert.assertEquals("cnt", columnNames.get(6));
-    Assert.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(6)).get());
+    Assertions.assertEquals("cnt", columnNames.get(6));
+    Assertions.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(6)).get());
 
-    Assert.assertEquals("m1", columnNames.get(7));
-    Assert.assertEquals(ColumnType.DOUBLE, fooRowSignature.getColumnType(columnNames.get(7)).get());
+    Assertions.assertEquals("m1", columnNames.get(7));
+    Assertions.assertEquals(ColumnType.DOUBLE, fooRowSignature.getColumnType(columnNames.get(7)).get());
 
-    Assert.assertEquals("unique_dim1", columnNames.get(8));
-    Assert.assertEquals(ColumnType.ofComplex("hyperUnique"), fooRowSignature.getColumnType(columnNames.get(8)).get());
+    Assertions.assertEquals("unique_dim1", columnNames.get(8));
+    Assertions.assertEquals(ColumnType.ofComplex("hyperUnique"), fooRowSignature.getColumnType(columnNames.get(8)).get());
   }
 
   @Test
@@ -275,34 +275,34 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
 
     final RowSignature fooRowSignature = fooDs.getRowSignature();
     List<String> columnNames = fooRowSignature.getColumnNames();
-    Assert.assertEquals(9, columnNames.size());
+    Assertions.assertEquals(9, columnNames.size());
 
-    Assert.assertEquals("__time", columnNames.get(0));
-    Assert.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(0)).get());
+    Assertions.assertEquals("__time", columnNames.get(0));
+    Assertions.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(0)).get());
 
-    Assert.assertEquals("numbery", columnNames.get(1));
-    Assert.assertEquals(ColumnType.DOUBLE, fooRowSignature.getColumnType(columnNames.get(1)).get());
+    Assertions.assertEquals("numbery", columnNames.get(1));
+    Assertions.assertEquals(ColumnType.DOUBLE, fooRowSignature.getColumnType(columnNames.get(1)).get());
 
-    Assert.assertEquals("numberyArrays", columnNames.get(2));
-    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, fooRowSignature.getColumnType(columnNames.get(2)).get());
+    Assertions.assertEquals("numberyArrays", columnNames.get(2));
+    Assertions.assertEquals(ColumnType.DOUBLE_ARRAY, fooRowSignature.getColumnType(columnNames.get(2)).get());
 
-    Assert.assertEquals("stringy", columnNames.get(3));
-    Assert.assertEquals(ColumnType.STRING_ARRAY, fooRowSignature.getColumnType(columnNames.get(3)).get());
+    Assertions.assertEquals("stringy", columnNames.get(3));
+    Assertions.assertEquals(ColumnType.STRING_ARRAY, fooRowSignature.getColumnType(columnNames.get(3)).get());
 
-    Assert.assertEquals("array", columnNames.get(4));
-    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, fooRowSignature.getColumnType(columnNames.get(4)).get());
+    Assertions.assertEquals("array", columnNames.get(4));
+    Assertions.assertEquals(ColumnType.DOUBLE_ARRAY, fooRowSignature.getColumnType(columnNames.get(4)).get());
 
-    Assert.assertEquals("nested", columnNames.get(5));
-    Assert.assertEquals(ColumnType.ofComplex("json"), fooRowSignature.getColumnType(columnNames.get(5)).get());
+    Assertions.assertEquals("nested", columnNames.get(5));
+    Assertions.assertEquals(ColumnType.ofComplex("json"), fooRowSignature.getColumnType(columnNames.get(5)).get());
 
-    Assert.assertEquals("cnt", columnNames.get(6));
-    Assert.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(6)).get());
+    Assertions.assertEquals("cnt", columnNames.get(6));
+    Assertions.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(6)).get());
 
-    Assert.assertEquals("m1", columnNames.get(7));
-    Assert.assertEquals(ColumnType.DOUBLE, fooRowSignature.getColumnType(columnNames.get(7)).get());
+    Assertions.assertEquals("m1", columnNames.get(7));
+    Assertions.assertEquals(ColumnType.DOUBLE, fooRowSignature.getColumnType(columnNames.get(7)).get());
 
-    Assert.assertEquals("unique_dim1", columnNames.get(8));
-    Assert.assertEquals(ColumnType.ofComplex("hyperUnique"), fooRowSignature.getColumnType(columnNames.get(8)).get());
+    Assertions.assertEquals("unique_dim1", columnNames.get(8));
+    Assertions.assertEquals(ColumnType.ofComplex("hyperUnique"), fooRowSignature.getColumnType(columnNames.get(8)).get());
   }
 
   @Test
@@ -314,20 +314,20 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
                                                        .stream()
                                                        .map(AvailableSegmentMetadata::getSegment)
                                                        .collect(Collectors.toList());
-    Assert.assertEquals(6, segments.size());
+    Assertions.assertEquals(6, segments.size());
     // segments contains two segments with datasource "foo" and one with datasource "foo2"
     // let's remove the only segment with datasource "foo2"
     final DataSegment segmentToRemove = segments.stream()
                                                 .filter(segment -> segment.getDataSource().equals("foo2"))
                                                 .findFirst()
                                                 .orElse(null);
-    Assert.assertNotNull(segmentToRemove);
+    Assertions.assertNotNull(segmentToRemove);
     schema.removeSegment(segmentToRemove);
 
     // The following line can cause NPE without segmentMetadata null check in
     // SegmentMetadataCache#refreshSegmentsForDataSource
     schema.refreshSegments(segments.stream().map(DataSegment::getId).collect(Collectors.toSet()));
-    Assert.assertEquals(5, schema.getSegmentMetadataSnapshot().size());
+    Assertions.assertEquals(5, schema.getSegmentMetadataSnapshot().size());
   }
 
   @Test
@@ -385,11 +385,11 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
                                                        .stream()
                                                        .map(AvailableSegmentMetadata::getSegment)
                                                        .collect(Collectors.toList());
-    Assert.assertEquals(6, segments.size());
+    Assertions.assertEquals(6, segments.size());
 
     // verify that dim3 column isn't present in schema for datasource foo
     DataSourceInformation fooDs = schema.getDatasource("foo");
-    Assert.assertTrue(fooDs.getRowSignature().getColumnNames().stream().noneMatch("dim3"::equals));
+    Assertions.assertTrue(fooDs.getRowSignature().getColumnNames().stream().noneMatch("dim3"::equals));
 
     // segments contains two segments with datasource "foo" and one with datasource "foo2"
     // let's remove the only segment with datasource "foo2"
@@ -397,7 +397,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
                                                 .filter(segment -> segment.getDataSource().equals("foo2"))
                                                 .findFirst()
                                                 .orElse(null);
-    Assert.assertNotNull(segmentToRemove);
+    Assertions.assertNotNull(segmentToRemove);
     schema.removeSegment(segmentToRemove);
 
     // we will add a segment to another datasource and
@@ -411,7 +411,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
                    .size(0)
                    .build();
 
-    final File tmpDir = temporaryFolder.newFolder();
+    final File tmpDir = newFolder(temporaryFolder, "junit");
 
     List<InputRow> rows = ImmutableList.of(
         createRow(ImmutableMap.of("t", "2002-01-01", "m1", "1.0", "dim1", "", "dim3", "c1")),
@@ -438,7 +438,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     walker.add(newSegment, index);
     serverView.addSegment(newSegment, ServerType.HISTORICAL);
 
-    Assert.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
+    Assertions.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
 
     Set<String> dataSources = segments.stream().map(DataSegment::getDataSource).collect(Collectors.toSet());
     dataSources.remove("foo2");
@@ -454,13 +454,13 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
                     .collect(Collectors.toList());
 
     schema.refresh(segments.stream().map(DataSegment::getId).collect(Collectors.toSet()), dataSourcesToRefresh);
-    Assert.assertEquals(6, schema.getSegmentMetadataSnapshot().size());
+    Assertions.assertEquals(6, schema.getSegmentMetadataSnapshot().size());
 
     fooDs = schema.getDatasource("foo");
 
     // check if the new column present in the added segment is present in the datasource schema
     // ensuring that the schema is rebuilt
-    Assert.assertTrue(fooDs.getRowSignature().getColumnNames().stream().anyMatch("dim3"::equals));
+    Assertions.assertTrue(fooDs.getRowSignature().getColumnNames().stream().anyMatch("dim3"::equals));
   }
 
   @Test
@@ -472,19 +472,19 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
                                                        .stream()
                                                        .map(AvailableSegmentMetadata::getSegment)
                                                        .collect(Collectors.toList());
-    Assert.assertEquals(6, segments.size());
+    Assertions.assertEquals(6, segments.size());
     // remove one of the segments with datasource "foo"
     final DataSegment segmentToRemove = segments.stream()
                                                 .filter(segment -> segment.getDataSource().equals("foo"))
                                                 .findFirst()
                                                 .orElse(null);
-    Assert.assertNotNull(segmentToRemove);
+    Assertions.assertNotNull(segmentToRemove);
     schema.removeSegment(segmentToRemove);
 
     // The following line can cause NPE without segmentMetadata null check in
     // SegmentMetadataCache#refreshSegmentsForDataSource
     schema.refreshSegments(segments.stream().map(DataSegment::getId).collect(Collectors.toSet()));
-    Assert.assertEquals(5, schema.getSegmentMetadataSnapshot().size());
+    Assertions.assertEquals(5, schema.getSegmentMetadataSnapshot().size());
   }
 
   @Test
@@ -501,16 +501,16 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
                                                 .filter(segment -> segment.getDataSource().equals("foo3"))
                                                 .findFirst()
                                                 .orElse(null);
-    Assert.assertNotNull(existingSegment);
+    Assertions.assertNotNull(existingSegment);
     final AvailableSegmentMetadata metadata = segmentsMetadata.get(existingSegment.getId());
-    Assert.assertEquals(1L, metadata.isRealtime());
+    Assertions.assertEquals(1L, metadata.isRealtime());
     // get the historical server
     final DruidServer historicalServer = druidServers.stream()
                                                               .filter(s -> s.getType().equals(ServerType.HISTORICAL))
                                                               .findAny()
                                                               .orElse(null);
 
-    Assert.assertNotNull(historicalServer);
+    Assertions.assertNotNull(historicalServer);
     final DruidServerMetadata historicalServerMetadata = historicalServer.getMetadata();
 
     // add existingSegment to historical
@@ -521,15 +521,15 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
                                          .filter(segment -> segment.getDataSource().equals("foo3"))
                                          .findFirst()
                                          .orElse(null);
-    Assert.assertNotNull(currentSegment);
+    Assertions.assertNotNull(currentSegment);
     AvailableSegmentMetadata currentMetadata = segmentsMetadata.get(currentSegment.getId());
-    Assert.assertEquals(0L, currentMetadata.isRealtime());
+    Assertions.assertEquals(0L, currentMetadata.isRealtime());
 
     DruidServer realtimeServer = druidServers.stream()
                                                       .filter(s -> s.getType().equals(ServerType.INDEXER_EXECUTOR))
                                                       .findAny()
                                                       .orElse(null);
-    Assert.assertNotNull(realtimeServer);
+    Assertions.assertNotNull(realtimeServer);
     // drop existingSegment from realtime task
     schema.removeServerSegment(realtimeServer.getMetadata(), existingSegment);
     segmentsMetadata = schema.getSegmentMetadataSnapshot();
@@ -537,9 +537,9 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
                              .filter(segment -> segment.getDataSource().equals("foo3"))
                              .findFirst()
                              .orElse(null);
-    Assert.assertNotNull(currentSegment);
+    Assertions.assertNotNull(currentSegment);
     currentMetadata = segmentsMetadata.get(currentSegment.getId());
-    Assert.assertEquals(0L, currentMetadata.isRealtime());
+    Assertions.assertEquals(0L, currentMetadata.isRealtime());
   }
 
   @Test
@@ -571,20 +571,20 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     };
 
     serverView.addSegment(newSegment(datasource, 1), ServerType.HISTORICAL);
-    Assert.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
+    Assertions.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
 
-    Assert.assertEquals(7, schema.getTotalSegments());
+    Assertions.assertEquals(7, schema.getTotalSegments());
     List<AvailableSegmentMetadata> metadatas = schema
         .getSegmentMetadataSnapshot()
         .values()
         .stream()
         .filter(metadata -> datasource.equals(metadata.getSegment().getDataSource()))
         .collect(Collectors.toList());
-    Assert.assertEquals(1, metadatas.size());
+    Assertions.assertEquals(1, metadatas.size());
     AvailableSegmentMetadata metadata = metadatas.get(0);
-    Assert.assertEquals(0, metadata.isRealtime());
-    Assert.assertEquals(0, metadata.getNumRows());
-    Assert.assertTrue(schema.getSegmentsNeedingRefresh().contains(metadata.getSegment().getId()));
+    Assertions.assertEquals(0, metadata.isRealtime());
+    Assertions.assertEquals(0, metadata.getNumRows());
+    Assertions.assertTrue(schema.getSegmentsNeedingRefresh().contains(metadata.getSegment().getId()));
   }
 
   @Test
@@ -624,22 +624,22 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     DataSegment segment = newSegment(datasource, 1);
     serverView.addSegment(segment, ServerType.INDEXER_EXECUTOR);
     serverView.addSegment(segment, ServerType.HISTORICAL);
-    Assert.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
+    Assertions.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
 
-    Assert.assertEquals(7, schema.getTotalSegments());
+    Assertions.assertEquals(7, schema.getTotalSegments());
     List<AvailableSegmentMetadata> metadatas = schema
         .getSegmentMetadataSnapshot()
         .values()
         .stream()
         .filter(metadata -> datasource.equals(metadata.getSegment().getDataSource()))
         .collect(Collectors.toList());
-    Assert.assertEquals(1, metadatas.size());
+    Assertions.assertEquals(1, metadatas.size());
     AvailableSegmentMetadata metadata = metadatas.get(0);
-    Assert.assertEquals(0, metadata.isRealtime()); // realtime flag is unset when there is any historical
-    Assert.assertEquals(0, metadata.getNumRows());
-    Assert.assertEquals(2, metadata.getNumReplicas());
-    Assert.assertTrue(schema.getSegmentsNeedingRefresh().contains(metadata.getSegment().getId()));
-    Assert.assertFalse(schema.getMutableSegments().contains(metadata.getSegment().getId()));
+    Assertions.assertEquals(0, metadata.isRealtime()); // realtime flag is unset when there is any historical
+    Assertions.assertEquals(0, metadata.getNumRows());
+    Assertions.assertEquals(2, metadata.getNumReplicas());
+    Assertions.assertTrue(schema.getSegmentsNeedingRefresh().contains(metadata.getSegment().getId()));
+    Assertions.assertFalse(schema.getMutableSegments().contains(metadata.getSegment().getId()));
   }
 
   @Test
@@ -677,21 +677,21 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     };
 
     serverView.addSegment(newSegment(datasource, 1), ServerType.INDEXER_EXECUTOR);
-    Assert.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
+    Assertions.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
 
-    Assert.assertEquals(7, schema.getTotalSegments());
+    Assertions.assertEquals(7, schema.getTotalSegments());
     List<AvailableSegmentMetadata> metadatas = schema
         .getSegmentMetadataSnapshot()
         .values()
         .stream()
         .filter(metadata -> datasource.equals(metadata.getSegment().getDataSource()))
         .collect(Collectors.toList());
-    Assert.assertEquals(1, metadatas.size());
+    Assertions.assertEquals(1, metadatas.size());
     AvailableSegmentMetadata metadata = metadatas.get(0);
-    Assert.assertEquals(1, metadata.isRealtime());
-    Assert.assertEquals(0, metadata.getNumRows());
-    Assert.assertTrue(schema.getSegmentsNeedingRefresh().contains(metadata.getSegment().getId()));
-    Assert.assertTrue(schema.getMutableSegments().contains(metadata.getSegment().getId()));
+    Assertions.assertEquals(1, metadata.isRealtime());
+    Assertions.assertEquals(0, metadata.getNumRows());
+    Assertions.assertTrue(schema.getSegmentsNeedingRefresh().contains(metadata.getSegment().getId()));
+    Assertions.assertTrue(schema.getMutableSegments().contains(metadata.getSegment().getId()));
   }
 
   @Test
@@ -729,17 +729,17 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     };
 
     serverView.addSegment(newSegment(datasource, 1), ServerType.BROKER);
-    Assert.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
+    Assertions.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
 
-    Assert.assertEquals(6, schema.getTotalSegments());
+    Assertions.assertEquals(6, schema.getTotalSegments());
     List<AvailableSegmentMetadata> metadatas = schema
         .getSegmentMetadataSnapshot()
         .values()
         .stream()
         .filter(metadata -> datasource.equals(metadata.getSegment().getDataSource()))
         .collect(Collectors.toList());
-    Assert.assertEquals(0, metadatas.size());
-    Assert.assertTrue(schema.getDataSourcesNeedingRebuild().contains(datasource));
+    Assertions.assertEquals(0, metadatas.size());
+    Assertions.assertTrue(schema.getDataSourcesNeedingRebuild().contains(datasource));
   }
 
   @Test
@@ -782,24 +782,24 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
 
     DataSegment segment = newSegment(datasource, 1);
     serverView.addSegment(segment, ServerType.INDEXER_EXECUTOR);
-    Assert.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
+    Assertions.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
     schema.refresh(Sets.newHashSet(segment.getId()), Sets.newHashSet(datasource));
 
     serverView.removeSegment(segment, ServerType.INDEXER_EXECUTOR);
-    Assert.assertTrue(removeSegmentLatch.await(1, TimeUnit.SECONDS));
+    Assertions.assertTrue(removeSegmentLatch.await(1, TimeUnit.SECONDS));
 
-    Assert.assertEquals(6, schema.getTotalSegments());
+    Assertions.assertEquals(6, schema.getTotalSegments());
     List<AvailableSegmentMetadata> metadatas = schema
         .getSegmentMetadataSnapshot()
         .values()
         .stream()
         .filter(metadata -> datasource.equals(metadata.getSegment().getDataSource()))
         .collect(Collectors.toList());
-    Assert.assertEquals(0, metadatas.size());
-    Assert.assertFalse(schema.getSegmentsNeedingRefresh().contains(segment.getId()));
-    Assert.assertFalse(schema.getMutableSegments().contains(segment.getId()));
-    Assert.assertFalse(schema.getDataSourcesNeedingRebuild().contains(datasource));
-    Assert.assertFalse(schema.getDatasourceNames().contains(datasource));
+    Assertions.assertEquals(0, metadatas.size());
+    Assertions.assertFalse(schema.getSegmentsNeedingRefresh().contains(segment.getId()));
+    Assertions.assertFalse(schema.getMutableSegments().contains(segment.getId()));
+    Assertions.assertFalse(schema.getDataSourcesNeedingRebuild().contains(datasource));
+    Assertions.assertFalse(schema.getDatasourceNames().contains(datasource));
   }
 
   @Test
@@ -846,24 +846,24 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     );
     serverView.addSegment(segments.get(0), ServerType.INDEXER_EXECUTOR);
     serverView.addSegment(segments.get(1), ServerType.HISTORICAL);
-    Assert.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
+    Assertions.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
     schema.refresh(segments.stream().map(DataSegment::getId).collect(Collectors.toSet()), Sets.newHashSet(datasource));
 
     serverView.removeSegment(segments.get(0), ServerType.INDEXER_EXECUTOR);
-    Assert.assertTrue(removeSegmentLatch.await(1, TimeUnit.SECONDS));
+    Assertions.assertTrue(removeSegmentLatch.await(1, TimeUnit.SECONDS));
 
-    Assert.assertEquals(7, schema.getTotalSegments());
+    Assertions.assertEquals(7, schema.getTotalSegments());
     List<AvailableSegmentMetadata> metadatas = schema
         .getSegmentMetadataSnapshot()
         .values()
         .stream()
         .filter(metadata -> datasource.equals(metadata.getSegment().getDataSource()))
         .collect(Collectors.toList());
-    Assert.assertEquals(1, metadatas.size());
-    Assert.assertFalse(schema.getSegmentsNeedingRefresh().contains(segments.get(0).getId()));
-    Assert.assertFalse(schema.getMutableSegments().contains(segments.get(0).getId()));
-    Assert.assertTrue(schema.getDataSourcesNeedingRebuild().contains(datasource));
-    Assert.assertTrue(schema.getDatasourceNames().contains(datasource));
+    Assertions.assertEquals(1, metadatas.size());
+    Assertions.assertFalse(schema.getSegmentsNeedingRefresh().contains(segments.get(0).getId()));
+    Assertions.assertFalse(schema.getMutableSegments().contains(segments.get(0).getId()));
+    Assertions.assertTrue(schema.getDataSourcesNeedingRebuild().contains(datasource));
+    Assertions.assertTrue(schema.getDatasourceNames().contains(datasource));
   }
 
   @Test
@@ -897,9 +897,9 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     serverView.addSegment(newSegment(datasource, 1), ServerType.BROKER);
 
     serverView.removeSegment(newSegment(datasource, 1), ServerType.HISTORICAL);
-    Assert.assertTrue(removeServerSegmentLatch.await(1, TimeUnit.SECONDS));
+    Assertions.assertTrue(removeServerSegmentLatch.await(1, TimeUnit.SECONDS));
 
-    Assert.assertEquals(6, schema.getTotalSegments());
+    Assertions.assertEquals(6, schema.getTotalSegments());
   }
 
   @Test
@@ -943,13 +943,13 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     DataSegment segment = newSegment(datasource, 1);
     serverView.addSegment(segment, ServerType.HISTORICAL);
     serverView.addSegment(segment, ServerType.BROKER);
-    Assert.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
+    Assertions.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
 
     serverView.removeSegment(segment, ServerType.BROKER);
-    Assert.assertTrue(removeServerSegmentLatch.await(1, TimeUnit.SECONDS));
+    Assertions.assertTrue(removeServerSegmentLatch.await(1, TimeUnit.SECONDS));
 
-    Assert.assertEquals(7, schema.getTotalSegments());
-    Assert.assertTrue(schema.getDataSourcesNeedingRebuild().contains(datasource));
+    Assertions.assertEquals(7, schema.getTotalSegments());
+    Assertions.assertTrue(schema.getDataSourcesNeedingRebuild().contains(datasource));
   }
 
   @Test
@@ -993,23 +993,23 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     DataSegment segment = newSegment(datasource, 1);
     serverView.addSegment(segment, ServerType.HISTORICAL);
     serverView.addSegment(segment, ServerType.BROKER);
-    Assert.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
+    Assertions.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
 
     serverView.removeSegment(segment, ServerType.HISTORICAL);
-    Assert.assertTrue(removeServerSegmentLatch.await(1, TimeUnit.SECONDS));
+    Assertions.assertTrue(removeServerSegmentLatch.await(1, TimeUnit.SECONDS));
 
-    Assert.assertEquals(7, schema.getTotalSegments());
+    Assertions.assertEquals(7, schema.getTotalSegments());
     List<AvailableSegmentMetadata> metadatas = schema
         .getSegmentMetadataSnapshot()
         .values()
         .stream()
         .filter(metadata -> datasource.equals(metadata.getSegment().getDataSource()))
         .collect(Collectors.toList());
-    Assert.assertEquals(1, metadatas.size());
+    Assertions.assertEquals(1, metadatas.size());
     AvailableSegmentMetadata metadata = metadatas.get(0);
-    Assert.assertEquals(0, metadata.isRealtime());
-    Assert.assertEquals(0, metadata.getNumRows());
-    Assert.assertEquals(0, metadata.getNumReplicas()); // brokers are not counted as replicas yet
+    Assertions.assertEquals(0, metadata.isRealtime());
+    Assertions.assertEquals(0, metadata.getNumRows());
+    Assertions.assertEquals(0, metadata.getNumReplicas()); // brokers are not counted as replicas yet
   }
 
   /**
@@ -1122,7 +1122,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .add("a", ColumnType.STRING)
                     .add("count", ColumnType.LONG)
@@ -1188,7 +1188,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
             null
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder().add("a", ColumnType.STRING).add("count", ColumnType.LONG).add("distinct", ColumnType.ofComplex("hyperUnique")).build(),
         signature
     );
@@ -1225,7 +1225,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .add("a", ColumnType.STRING)
                     .add("error_col", ColumnType.STRING)
@@ -1245,9 +1245,9 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     Set<SegmentId> segments = new HashSet<>();
     Set<String> datasources = new HashSet<>();
     datasources.add("wat");
-    Assert.assertNull(schema.getDatasource("wat"));
+    Assertions.assertNull(schema.getDatasource("wat"));
     schema.refresh(segments, datasources);
-    Assert.assertNull(schema.getDatasource("wat"));
+    Assertions.assertNull(schema.getDatasource("wat"));
   }
 
   @Test
@@ -1291,7 +1291,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     );
     serverView.addSegment(segments.get(0), ServerType.HISTORICAL);
     serverView.addSegment(segments.get(1), ServerType.INDEXER_EXECUTOR);
-    Assert.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
+    Assertions.assertTrue(addSegmentLatch.await(1, TimeUnit.SECONDS));
     schema.refresh(segments.stream().map(DataSegment::getId).collect(Collectors.toSet()), Sets.newHashSet(dataSource));
 
     emitter.verifyEmitted(Metric.REFRESH_DURATION_MILLIS, Map.of(DruidMetrics.DATASOURCE, dataSource), 1);
@@ -1305,7 +1305,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
 
     EmittingLogger.registerEmitter(new StubServiceEmitter("coordinator", "dummy"));
 
-    Assert.assertFalse(schema.mergeOrCreateRowSignature(
+    Assertions.assertFalse(schema.mergeOrCreateRowSignature(
         segment1.getId(),
         null,
         new SegmentSchemas.SegmentSchema(
@@ -1341,7 +1341,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
         )
     );
 
-    Assert.assertTrue(mergedSignature.isPresent());
+    Assertions.assertTrue(mergedSignature.isPresent());
     RowSignature.Builder rowSignatureBuilder = RowSignature.builder();
     rowSignatureBuilder.add("__time", ColumnType.LONG);
     rowSignatureBuilder.add("dim1", ColumnType.STRING);
@@ -1349,7 +1349,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     rowSignatureBuilder.add("m1", ColumnType.STRING);
     rowSignatureBuilder.add("unique_dim1", ColumnType.ofComplex("hyperUnique"));
     rowSignatureBuilder.add("dim2", ColumnType.STRING);
-    Assert.assertEquals(rowSignatureBuilder.build(), mergedSignature.get());
+    Assertions.assertEquals(rowSignatureBuilder.build(), mergedSignature.get());
   }
 
   @Test
@@ -1375,7 +1375,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
         )
     );
 
-    Assert.assertTrue(mergedSignature.isPresent());
+    Assertions.assertTrue(mergedSignature.isPresent());
     RowSignature.Builder rowSignatureBuilder = RowSignature.builder();
     rowSignatureBuilder.add("__time", ColumnType.LONG);
     rowSignatureBuilder.add("dim1", ColumnType.STRING);
@@ -1385,7 +1385,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     rowSignatureBuilder.add("unique_dim1", ColumnType.ofComplex("hyperUnique"));
     // m2 is added
     rowSignatureBuilder.add("m2", ColumnType.STRING);
-    Assert.assertEquals(rowSignatureBuilder.build(), mergedSignature.get());
+    Assertions.assertEquals(rowSignatureBuilder.build(), mergedSignature.get());
   }
 
   @Test
@@ -1409,12 +1409,12 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
         )
     );
 
-    Assert.assertTrue(mergedSignature.isPresent());
+    Assertions.assertTrue(mergedSignature.isPresent());
     RowSignature.Builder rowSignatureBuilder = RowSignature.builder();
     rowSignatureBuilder.add("__time", ColumnType.LONG);
     rowSignatureBuilder.add("cnt", ColumnType.LONG);
     rowSignatureBuilder.add("dim2", ColumnType.STRING);
-    Assert.assertEquals(rowSignatureBuilder.build(), mergedSignature.get());
+    Assertions.assertEquals(rowSignatureBuilder.build(), mergedSignature.get());
   }
 
   @Test
@@ -1447,15 +1447,15 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     schema.awaitInitialization();
 
     AvailableSegmentMetadata availableSegmentMetadata = schema.getAvailableSegmentMetadata(DATASOURCE3, realtimeSegment1.getId());
-    Assert.assertNull(availableSegmentMetadata.getRowSignature());
+    Assertions.assertNull(availableSegmentMetadata.getRowSignature());
 
     // refresh all segments, verify that realtime segments isn't refreshed
     schema.refresh(walker.getSegments().stream().map(DataSegment::getId).collect(Collectors.toSet()), new HashSet<>());
 
-    Assert.assertNull(schema.getDatasource(DATASOURCE3));
-    Assert.assertNotNull(schema.getDatasource(DATASOURCE1));
-    Assert.assertNotNull(schema.getDatasource(DATASOURCE2));
-    Assert.assertNotNull(schema.getDatasource(SOME_DATASOURCE));
+    Assertions.assertNull(schema.getDatasource(DATASOURCE3));
+    Assertions.assertNotNull(schema.getDatasource(DATASOURCE1));
+    Assertions.assertNotNull(schema.getDatasource(DATASOURCE2));
+    Assertions.assertNotNull(schema.getDatasource(SOME_DATASOURCE));
 
     serverView.addSegmentSchemas(
         new SegmentSchemas(Collections.singletonList(
@@ -1483,7 +1483,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
             )
         )));
 
-    Assert.assertTrue(schemaAddedLatch.await(1, TimeUnit.SECONDS));
+    Assertions.assertTrue(schemaAddedLatch.await(1, TimeUnit.SECONDS));
 
     availableSegmentMetadata = schema.getAvailableSegmentMetadata(DATASOURCE3, realtimeSegment1.getId());
 
@@ -1494,7 +1494,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     rowSignatureBuilder.add("m1", ColumnType.STRING);
     rowSignatureBuilder.add("unique_dim1", ColumnType.ofComplex("hyperUnique"));
     rowSignatureBuilder.add("dim2", ColumnType.STRING);
-    Assert.assertEquals(rowSignatureBuilder.build(), availableSegmentMetadata.getRowSignature());
+    Assertions.assertEquals(rowSignatureBuilder.build(), availableSegmentMetadata.getRowSignature());
   }
 
   @Test
@@ -1531,15 +1531,15 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
 
     schema.onLeaderStart();
     schema.awaitInitialization();
-    Assert.assertTrue(refresh1Latch.await(10, TimeUnit.SECONDS));
+    Assertions.assertTrue(refresh1Latch.await(10, TimeUnit.SECONDS));
 
     AvailableSegmentMetadata availableSegmentMetadata = schema.getAvailableSegmentMetadata(DATASOURCE3, realtimeSegment1.getId());
-    Assert.assertNull(availableSegmentMetadata.getRowSignature());
+    Assertions.assertNull(availableSegmentMetadata.getRowSignature());
 
-    Assert.assertNull(schema.getDatasource(DATASOURCE3));
-    Assert.assertNotNull(schema.getDatasource(DATASOURCE1));
-    Assert.assertNotNull(schema.getDatasource(DATASOURCE2));
-    Assert.assertNotNull(schema.getDatasource(SOME_DATASOURCE));
+    Assertions.assertNull(schema.getDatasource(DATASOURCE3));
+    Assertions.assertNotNull(schema.getDatasource(DATASOURCE1));
+    Assertions.assertNotNull(schema.getDatasource(DATASOURCE2));
+    Assertions.assertNotNull(schema.getDatasource(SOME_DATASOURCE));
 
     serverView.addSegmentSchemas(
         new SegmentSchemas(Collections.singletonList(
@@ -1567,12 +1567,12 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
             )
         )));
 
-    Assert.assertTrue(refresh2Latch.await(10, TimeUnit.SECONDS));
+    Assertions.assertTrue(refresh2Latch.await(10, TimeUnit.SECONDS));
 
-    Assert.assertNotNull(schema.getDatasource(DATASOURCE3));
-    Assert.assertNotNull(schema.getDatasource(DATASOURCE1));
-    Assert.assertNotNull(schema.getDatasource(DATASOURCE2));
-    Assert.assertNotNull(schema.getDatasource(SOME_DATASOURCE));
+    Assertions.assertNotNull(schema.getDatasource(DATASOURCE3));
+    Assertions.assertNotNull(schema.getDatasource(DATASOURCE1));
+    Assertions.assertNotNull(schema.getDatasource(DATASOURCE2));
+    Assertions.assertNotNull(schema.getDatasource(SOME_DATASOURCE));
 
     RowSignature.Builder rowSignatureBuilder = RowSignature.builder();
     rowSignatureBuilder.add("__time", ColumnType.LONG);
@@ -1581,7 +1581,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     rowSignatureBuilder.add("m1", ColumnType.STRING);
     rowSignatureBuilder.add("unique_dim1", ColumnType.ofComplex("hyperUnique"));
     rowSignatureBuilder.add("dim2", ColumnType.STRING);
-    Assert.assertEquals(rowSignatureBuilder.build(), schema.getDatasource(DATASOURCE3).getRowSignature());
+    Assertions.assertEquals(rowSignatureBuilder.build(), schema.getDatasource(DATASOURCE3).getRowSignature());
   }
 
   @Test
@@ -1735,8 +1735,8 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
                 SchemaPayload schemaPayload = mapper.readValue(r.getBytes(1), SchemaPayload.class);
                 long numRows = r.getLong(2);
                 QueryableIndexCursorFactory cursorFa = new QueryableIndexCursorFactory(index2);
-                Assert.assertEquals(cursorFa.getRowSignature(), schemaPayload.getRowSignature());
-                Assert.assertEquals(index2.getNumRows(), numRows);
+                Assertions.assertEquals(cursorFa.getRowSignature(), schemaPayload.getRowSignature());
+                Assertions.assertEquals(index2.getNumRows(), numRows);
               }
               catch (IOException e) {
                 throw new RuntimeException(e);
@@ -1776,13 +1776,13 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
                                                        .stream()
                                                        .map(AvailableSegmentMetadata::getSegment)
                                                        .collect(Collectors.toList());
-    Assert.assertEquals(6, segments.size());
+    Assertions.assertEquals(6, segments.size());
     // find the only segment with datasource "foo2"
     final DataSegment existingSegment = segments.stream()
                                                 .filter(segment -> segment.getDataSource().equals("foo2"))
                                                 .findFirst()
                                                 .orElse(null);
-    Assert.assertNotNull(existingSegment);
+    Assertions.assertNotNull(existingSegment);
 
     AvailableSegmentMetadata existingMetadata = segmentsMetadata.get(existingSegment.getId());
 
@@ -1804,9 +1804,9 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
         .findAny()
         .orElse(null);
 
-    Assert.assertNotNull(pair);
+    Assertions.assertNotNull(pair);
     final DruidServer server = pair.lhs;
-    Assert.assertNotNull(server);
+    Assertions.assertNotNull(server);
     final DruidServerMetadata druidServerMetadata = server.getMetadata();
     // invoke SegmentMetadataCache#addSegment on existingSegment
     schema.addSegment(druidServerMetadata, existingSegment);
@@ -1817,7 +1817,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
                                                        .stream()
                                                        .map(AvailableSegmentMetadata::getSegment)
                                                        .collect(Collectors.toList());
-    Assert.assertEquals(6, segments.size());
+    Assertions.assertEquals(6, segments.size());
 
     schema.refresh(segments.stream().map(DataSegment::getId).collect(Collectors.toSet()), new HashSet<>());
 
@@ -1832,10 +1832,10 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
                                                .findFirst()
                                                .orElse(null);
     final AvailableSegmentMetadata currentMetadata = segmentsMetadata.get(currentSegment.getId());
-    Assert.assertEquals(currentSegment.getId(), currentMetadata.getSegment().getId());
-    Assert.assertEquals(5L, currentMetadata.getNumRows());
+    Assertions.assertEquals(currentSegment.getId(), currentMetadata.getSegment().getId());
+    Assertions.assertEquals(5L, currentMetadata.getNumRows());
     // numreplicas do not change here since we addSegment with the same server which was serving existingSegment before
-    Assert.assertEquals(existingMetadata.getNumReplicas(), currentMetadata.getNumReplicas());
+    Assertions.assertEquals(existingMetadata.getNumReplicas(), currentMetadata.getNumReplicas());
   }
 
   private CoordinatorSegmentMetadataCache setupForColdDatasourceSchemaTest(ServiceEmitter emitter)
@@ -1938,31 +1938,31 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     emitter.verifyEmitted(Metric.COLD_SEGMENT_SCHEMAS, Map.of(DruidMetrics.DATASOURCE, "cold"), 1);
     emitter.verifyEmitted(Metric.COLD_SCHEMA_REFRESH_DURATION_MILLIS, 1);
 
-    Assert.assertEquals(Set.of("foo", "cold"), schema.getDataSourceInformationMap().keySet());
+    Assertions.assertEquals(Set.of("foo", "cold"), schema.getDataSourceInformationMap().keySet());
 
     // verify that cold schema for both foo and cold is present
     RowSignature fooSignature = schema.getDatasource("foo").getRowSignature();
     List<String> columnNames = fooSignature.getColumnNames();
 
     // verify that foo schema doesn't contain columns from hot segments
-    Assert.assertEquals(3, columnNames.size());
+    Assertions.assertEquals(3, columnNames.size());
 
-    Assert.assertEquals("dim1", columnNames.get(0));
-    Assert.assertEquals(ColumnType.STRING, fooSignature.getColumnType(columnNames.get(0)).get());
+    Assertions.assertEquals("dim1", columnNames.get(0));
+    Assertions.assertEquals(ColumnType.STRING, fooSignature.getColumnType(columnNames.get(0)).get());
 
-    Assert.assertEquals("c1", columnNames.get(1));
-    Assert.assertEquals(ColumnType.STRING, fooSignature.getColumnType(columnNames.get(1)).get());
+    Assertions.assertEquals("c1", columnNames.get(1));
+    Assertions.assertEquals(ColumnType.STRING, fooSignature.getColumnType(columnNames.get(1)).get());
 
-    Assert.assertEquals("c2", columnNames.get(2));
-    Assert.assertEquals(ColumnType.LONG, fooSignature.getColumnType(columnNames.get(2)).get());
+    Assertions.assertEquals("c2", columnNames.get(2));
+    Assertions.assertEquals(ColumnType.LONG, fooSignature.getColumnType(columnNames.get(2)).get());
 
     RowSignature coldSignature = schema.getDatasource("cold").getRowSignature();
     columnNames = coldSignature.getColumnNames();
-    Assert.assertEquals("f1", columnNames.get(0));
-    Assert.assertEquals(ColumnType.STRING, coldSignature.getColumnType(columnNames.get(0)).get());
+    Assertions.assertEquals("f1", columnNames.get(0));
+    Assertions.assertEquals(ColumnType.STRING, coldSignature.getColumnType(columnNames.get(0)).get());
 
-    Assert.assertEquals("f2", columnNames.get(1));
-    Assert.assertEquals(ColumnType.DOUBLE, coldSignature.getColumnType(columnNames.get(1)).get());
+    Assertions.assertEquals("f2", columnNames.get(1));
+    Assertions.assertEquals(ColumnType.DOUBLE, coldSignature.getColumnType(columnNames.get(1)).get());
 
     Set<SegmentId> segmentIds = new HashSet<>();
     segmentIds.add(segment1.getId());
@@ -1970,15 +1970,15 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
 
     schema.refresh(segmentIds, new HashSet<>());
 
-    Assert.assertEquals(new HashSet<>(Arrays.asList("foo", "cold")), schema.getDataSourceInformationMap().keySet());
+    Assertions.assertEquals(new HashSet<>(Arrays.asList("foo", "cold")), schema.getDataSourceInformationMap().keySet());
 
     coldSignature = schema.getDatasource("cold").getRowSignature();
     columnNames = coldSignature.getColumnNames();
-    Assert.assertEquals("f1", columnNames.get(0));
-    Assert.assertEquals(ColumnType.STRING, coldSignature.getColumnType(columnNames.get(0)).get());
+    Assertions.assertEquals("f1", columnNames.get(0));
+    Assertions.assertEquals(ColumnType.STRING, coldSignature.getColumnType(columnNames.get(0)).get());
 
-    Assert.assertEquals("f2", columnNames.get(1));
-    Assert.assertEquals(ColumnType.DOUBLE, coldSignature.getColumnType(columnNames.get(1)).get());
+    Assertions.assertEquals("f2", columnNames.get(1));
+    Assertions.assertEquals(ColumnType.DOUBLE, coldSignature.getColumnType(columnNames.get(1)).get());
 
     // foo now contains schema from both hot and cold segments
     verifyFooDSSchema(schema, 8);
@@ -1986,11 +1986,11 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
 
     // cold columns should be present at the end
     columnNames = rowSignature.getColumnNames();
-    Assert.assertEquals("c1", columnNames.get(6));
-    Assert.assertEquals(ColumnType.STRING, rowSignature.getColumnType(columnNames.get(6)).get());
+    Assertions.assertEquals("c1", columnNames.get(6));
+    Assertions.assertEquals(ColumnType.STRING, rowSignature.getColumnType(columnNames.get(6)).get());
 
-    Assert.assertEquals("c2", columnNames.get(7));
-    Assert.assertEquals(ColumnType.LONG, rowSignature.getColumnType(columnNames.get(7)).get());
+    Assertions.assertEquals("c2", columnNames.get(7));
+    Assertions.assertEquals(ColumnType.LONG, rowSignature.getColumnType(columnNames.get(7)).get());
   }
 
   @Test
@@ -2005,11 +2005,11 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
 
     schema.refresh(segmentIds, new HashSet<>());
     // cold datasource shouldn't be present
-    Assert.assertEquals(Collections.singleton("foo"), schema.getDataSourceInformationMap().keySet());
+    Assertions.assertEquals(Collections.singleton("foo"), schema.getDataSourceInformationMap().keySet());
 
     // cold columns shouldn't be present
     verifyFooDSSchema(schema, 6);
-    Assert.assertNull(schema.getDatasource("cold"));
+    Assertions.assertNull(schema.getDatasource("cold"));
 
     schema.refreshColdSegmentSchemas();
 
@@ -2020,26 +2020,26 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     emitter.verifyEmitted(Metric.COLD_SCHEMA_REFRESH_DURATION_MILLIS, 1);
 
     // cold datasource should be present now
-    Assert.assertEquals(Set.of("foo", "cold"), schema.getDataSourceInformationMap().keySet());
+    Assertions.assertEquals(Set.of("foo", "cold"), schema.getDataSourceInformationMap().keySet());
 
     RowSignature coldSignature = schema.getDatasource("cold").getRowSignature();
     List<String> columnNames = coldSignature.getColumnNames();
-    Assert.assertEquals("f1", columnNames.get(0));
-    Assert.assertEquals(ColumnType.STRING, coldSignature.getColumnType(columnNames.get(0)).get());
+    Assertions.assertEquals("f1", columnNames.get(0));
+    Assertions.assertEquals(ColumnType.STRING, coldSignature.getColumnType(columnNames.get(0)).get());
 
-    Assert.assertEquals("f2", columnNames.get(1));
-    Assert.assertEquals(ColumnType.DOUBLE, coldSignature.getColumnType(columnNames.get(1)).get());
+    Assertions.assertEquals("f2", columnNames.get(1));
+    Assertions.assertEquals(ColumnType.DOUBLE, coldSignature.getColumnType(columnNames.get(1)).get());
 
     // columns from cold datasource should be present
     verifyFooDSSchema(schema, 8);
     RowSignature rowSignature = schema.getDatasource("foo").getRowSignature();
 
     columnNames = rowSignature.getColumnNames();
-    Assert.assertEquals("c1", columnNames.get(6));
-    Assert.assertEquals(ColumnType.STRING, rowSignature.getColumnType(columnNames.get(6)).get());
+    Assertions.assertEquals("c1", columnNames.get(6));
+    Assertions.assertEquals(ColumnType.STRING, rowSignature.getColumnType(columnNames.get(6)).get());
 
-    Assert.assertEquals("c2", columnNames.get(7));
-    Assert.assertEquals(ColumnType.LONG, rowSignature.getColumnType(columnNames.get(7)).get());
+    Assertions.assertEquals("c2", columnNames.get(7));
+    Assertions.assertEquals(ColumnType.LONG, rowSignature.getColumnType(columnNames.get(7)).get());
   }
 
   @Test
@@ -2141,32 +2141,32 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
 
     schema.refreshColdSegmentSchemas();
     // alpha has only 1 cold segment
-    Assert.assertNotNull(schema.getDatasource("alpha"));
+    Assertions.assertNotNull(schema.getDatasource("alpha"));
     // gamma has both hot and cold segment
-    Assert.assertNotNull(schema.getDatasource("gamma"));
+    Assertions.assertNotNull(schema.getDatasource("gamma"));
     // assert that cold schema for gamma doesn't contain any columns from hot segment
     RowSignature rowSignature = schema.getDatasource("gamma").getRowSignature();
-    Assert.assertTrue(rowSignature.contains("dim1"));
-    Assert.assertTrue(rowSignature.contains("c1"));
-    Assert.assertTrue(rowSignature.contains("c2"));
-    Assert.assertFalse(rowSignature.contains("c3"));
-    Assert.assertFalse(rowSignature.contains("c4"));
+    Assertions.assertTrue(rowSignature.contains("dim1"));
+    Assertions.assertTrue(rowSignature.contains("c1"));
+    Assertions.assertTrue(rowSignature.contains("c2"));
+    Assertions.assertFalse(rowSignature.contains("c3"));
+    Assertions.assertFalse(rowSignature.contains("c4"));
 
-    Assert.assertEquals(new HashSet<>(Arrays.asList("alpha", "gamma")), schema.getDataSourceInformationMap().keySet());
+    Assertions.assertEquals(new HashSet<>(Arrays.asList("alpha", "gamma")), schema.getDataSourceInformationMap().keySet());
 
     Mockito.when(segmentsMetadataManager.getRecentDataSourcesSnapshot())
            .thenReturn(DataSourcesSnapshot.fromUsedSegments(List.of(coldSegmentBeta, hotSegmentGamma)));
 
     schema.refreshColdSegmentSchemas();
-    Assert.assertNotNull(schema.getDatasource("beta"));
+    Assertions.assertNotNull(schema.getDatasource("beta"));
     // alpha doesn't have any segments
-    Assert.assertNull(schema.getDatasource("alpha"));
+    Assertions.assertNull(schema.getDatasource("alpha"));
     // gamma just has 1 hot segment
-    Assert.assertNull(schema.getDatasource("gamma"));
+    Assertions.assertNull(schema.getDatasource("gamma"));
 
-    Assert.assertNull(schema.getDatasource("doesnotexist"));
+    Assertions.assertNull(schema.getDatasource("doesnotexist"));
 
-    Assert.assertEquals(Collections.singleton("beta"), schema.getDataSourceInformationMap().keySet());
+    Assertions.assertEquals(Collections.singleton("beta"), schema.getDataSourceInformationMap().keySet());
   }
 
   @Test
@@ -2199,7 +2199,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     schema.awaitInitialization();
 
     latch.await(1, TimeUnit.SECONDS);
-    Assert.assertEquals(0, latch.getCount());
+    Assertions.assertEquals(0, latch.getCount());
   }
 
   @Test
@@ -2254,12 +2254,12 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
                                                      .findAny()
                                                      .orElse(null);
 
-    Assert.assertNotNull(historicalServer);
+    Assertions.assertNotNull(historicalServer);
     final DruidServerMetadata historicalServerMetadata = historicalServer.getMetadata();
 
     schema.addSegment(historicalServerMetadata, segment);
     schema.addSegment(historicalServerMetadata, tombstone);
-    Assert.assertFalse(schema.getSegmentsNeedingRefresh().contains(tombstone.getId()));
+    Assertions.assertFalse(schema.getSegmentsNeedingRefresh().contains(tombstone.getId()));
 
     List<SegmentId> segmentIterable = ImmutableList.of(segment.getId(), tombstone.getId());
 
@@ -2299,20 +2299,20 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     EasyMock.verify(factoryMock, lifecycleMock);
 
     // Verify that datasource schema building logic doesn't mark the tombstone segment for refresh
-    Assert.assertFalse(schema.getSegmentsNeedingRefresh().contains(tombstone.getId()));
+    Assertions.assertFalse(schema.getSegmentsNeedingRefresh().contains(tombstone.getId()));
 
     AvailableSegmentMetadata availableSegmentMetadata = schema.getAvailableSegmentMetadata("test", tombstone.getId());
-    Assert.assertNotNull(availableSegmentMetadata);
+    Assertions.assertNotNull(availableSegmentMetadata);
     // fetching metadata for tombstone segment shouldn't mark it for refresh
-    Assert.assertFalse(schema.getSegmentsNeedingRefresh().contains(tombstone.getId()));
+    Assertions.assertFalse(schema.getSegmentsNeedingRefresh().contains(tombstone.getId()));
 
     Set<AvailableSegmentMetadata> metadatas = new HashSet<>();
     schema.iterateSegmentMetadata().forEachRemaining(metadatas::add);
 
-    Assert.assertEquals(1, metadatas.stream().filter(metadata -> metadata.getSegment().isTombstone()).count());
+    Assertions.assertEquals(1, metadatas.stream().filter(metadata -> metadata.getSegment().isTombstone()).count());
 
     // iterating over entire metadata doesn't cause tombstone to be marked for refresh
-    Assert.assertFalse(schema.getSegmentsNeedingRefresh().contains(tombstone.getId()));
+    Assertions.assertFalse(schema.getSegmentsNeedingRefresh().contains(tombstone.getId()));
   }
 
   @Test
@@ -2352,7 +2352,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
                                                      .findAny()
                                                      .orElse(null);
 
-    Assert.assertNotNull(historicalServer);
+    Assertions.assertNotNull(historicalServer);
     final DruidServerMetadata historicalServerMetadata = historicalServer.getMetadata();
 
     ImmutableMap.Builder<SegmentId, SegmentMetadata> segmentStatsMap = new ImmutableMap.Builder<>();
@@ -2375,7 +2375,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     schema.onLeaderStart();
     schema.awaitInitialization();
 
-    Assert.assertTrue(latch.await(2, TimeUnit.SECONDS));
+    Assertions.assertTrue(latch.await(2, TimeUnit.SECONDS));
 
     // make segment3 unused
     segmentStatsMap = new ImmutableMap.Builder<>();
@@ -2392,20 +2392,20 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
 
     schema.refresh(segmentsToRefresh, Sets.newHashSet(dataSource));
 
-    Assert.assertTrue(schema.getSegmentsNeedingRefresh().contains(segments.get(1).getId()));
-    Assert.assertFalse(schema.getSegmentsNeedingRefresh().contains(segments.get(2).getId()));
+    Assertions.assertTrue(schema.getSegmentsNeedingRefresh().contains(segments.get(1).getId()));
+    Assertions.assertFalse(schema.getSegmentsNeedingRefresh().contains(segments.get(2).getId()));
 
     AvailableSegmentMetadata availableSegmentMetadata =
         schema.getAvailableSegmentMetadata(dataSource, segments.get(0).getId());
 
-    Assert.assertNotNull(availableSegmentMetadata);
+    Assertions.assertNotNull(availableSegmentMetadata);
     // fetching metadata for unused segment shouldn't mark it for refresh
-    Assert.assertFalse(schema.getSegmentsNeedingRefresh().contains(segments.get(0).getId()));
+    Assertions.assertFalse(schema.getSegmentsNeedingRefresh().contains(segments.get(0).getId()));
 
     Set<AvailableSegmentMetadata> metadatas = new HashSet<>();
     schema.iterateSegmentMetadata().forEachRemaining(metadatas::add);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         metadatas.stream()
                  .filter(
@@ -2414,7 +2414,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     );
 
     // iterating over entire metadata doesn't cause unsed segment to be marked for refresh
-    Assert.assertFalse(schema.getSegmentsNeedingRefresh().contains(segments.get(0).getId()));
+    Assertions.assertFalse(schema.getSegmentsNeedingRefresh().contains(segments.get(0).getId()));
   }
 
   private void verifyFooDSSchema(CoordinatorSegmentMetadataCache schema, int columns)
@@ -2422,25 +2422,25 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     final DataSourceInformation fooDs = schema.getDatasource("foo");
     final RowSignature fooRowSignature = fooDs.getRowSignature();
     List<String> columnNames = fooRowSignature.getColumnNames();
-    Assert.assertEquals(columns, columnNames.size());
+    Assertions.assertEquals(columns, columnNames.size());
 
-    Assert.assertEquals("__time", columnNames.get(0));
-    Assert.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(0)).get());
+    Assertions.assertEquals("__time", columnNames.get(0));
+    Assertions.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(0)).get());
 
-    Assert.assertEquals("dim2", columnNames.get(1));
-    Assert.assertEquals(ColumnType.STRING, fooRowSignature.getColumnType(columnNames.get(1)).get());
+    Assertions.assertEquals("dim2", columnNames.get(1));
+    Assertions.assertEquals(ColumnType.STRING, fooRowSignature.getColumnType(columnNames.get(1)).get());
 
-    Assert.assertEquals("m1", columnNames.get(2));
-    Assert.assertEquals(ColumnType.DOUBLE, fooRowSignature.getColumnType(columnNames.get(2)).get());
+    Assertions.assertEquals("m1", columnNames.get(2));
+    Assertions.assertEquals(ColumnType.DOUBLE, fooRowSignature.getColumnType(columnNames.get(2)).get());
 
-    Assert.assertEquals("dim1", columnNames.get(3));
-    Assert.assertEquals(ColumnType.STRING, fooRowSignature.getColumnType(columnNames.get(3)).get());
+    Assertions.assertEquals("dim1", columnNames.get(3));
+    Assertions.assertEquals(ColumnType.STRING, fooRowSignature.getColumnType(columnNames.get(3)).get());
 
-    Assert.assertEquals("cnt", columnNames.get(4));
-    Assert.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(4)).get());
+    Assertions.assertEquals("cnt", columnNames.get(4));
+    Assertions.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(4)).get());
 
-    Assert.assertEquals("unique_dim1", columnNames.get(5));
-    Assert.assertEquals(ColumnType.ofComplex("hyperUnique"), fooRowSignature.getColumnType(columnNames.get(5)).get());
+    Assertions.assertEquals("unique_dim1", columnNames.get(5));
+    Assertions.assertEquals(ColumnType.ofComplex("hyperUnique"), fooRowSignature.getColumnType(columnNames.get(5)).get());
   }
 
   private void verifyFoo2DSSchema(CoordinatorSegmentMetadataCache schema)
@@ -2448,16 +2448,16 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     final DataSourceInformation fooDs = schema.getDatasource("foo2");
     final RowSignature fooRowSignature = fooDs.getRowSignature();
     List<String> columnNames = fooRowSignature.getColumnNames();
-    Assert.assertEquals(3, columnNames.size());
+    Assertions.assertEquals(3, columnNames.size());
 
-    Assert.assertEquals("__time", columnNames.get(0));
-    Assert.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(0)).get());
+    Assertions.assertEquals("__time", columnNames.get(0));
+    Assertions.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(0)).get());
 
-    Assert.assertEquals("dim2", columnNames.get(1));
-    Assert.assertEquals(ColumnType.STRING, fooRowSignature.getColumnType(columnNames.get(1)).get());
+    Assertions.assertEquals("dim2", columnNames.get(1));
+    Assertions.assertEquals(ColumnType.STRING, fooRowSignature.getColumnType(columnNames.get(1)).get());
 
-    Assert.assertEquals("m1", columnNames.get(2));
-    Assert.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(2)).get());
+    Assertions.assertEquals("m1", columnNames.get(2));
+    Assertions.assertEquals(ColumnType.LONG, fooRowSignature.getColumnType(columnNames.get(2)).get());
   }
 
   /**
@@ -2504,18 +2504,18 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     final Set<SegmentId> refreshed = schema.refreshSegments(allSegmentIds);
 
     // The healthy dataSources were still refreshed despite DATASOURCE1 failing.
-    Assert.assertTrue(
-        "expected a refreshed segment from " + DATASOURCE2,
-        refreshed.stream().anyMatch(id -> DATASOURCE2.equals(id.getDataSource()))
+    Assertions.assertTrue(
+        refreshed.stream().anyMatch(id -> DATASOURCE2.equals(id.getDataSource())),
+        "expected a refreshed segment from " + DATASOURCE2
     );
-    Assert.assertTrue(
-        "expected a refreshed segment from " + SOME_DATASOURCE,
-        refreshed.stream().anyMatch(id -> SOME_DATASOURCE.equals(id.getDataSource()))
+    Assertions.assertTrue(
+        refreshed.stream().anyMatch(id -> SOME_DATASOURCE.equals(id.getDataSource())),
+        "expected a refreshed segment from " + SOME_DATASOURCE
     );
     // The failing dataSource produced no refreshed segments.
-    Assert.assertTrue(
-        "expected no refreshed segments from the failing " + DATASOURCE1,
-        refreshed.stream().noneMatch(id -> DATASOURCE1.equals(id.getDataSource()))
+    Assertions.assertTrue(
+        refreshed.stream().noneMatch(id -> DATASOURCE1.equals(id.getDataSource())),
+        "expected no refreshed segments from the failing " + DATASOURCE1
     );
 
     // A failure metric was emitted, dimensioned by the failing dataSource.
@@ -2523,8 +2523,8 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
         Metric.REFRESH_FAILED,
         ImmutableMap.of(DruidMetrics.DATASOURCE, DATASOURCE1)
     );
-    Assert.assertFalse("expected a refresh/failed metric for " + DATASOURCE1, failures.isEmpty());
-    Assert.assertEquals(1, failures.get(0).intValue());
+    Assertions.assertFalse(failures.isEmpty(), "expected a refresh/failed metric for " + DATASOURCE1);
+    Assertions.assertEquals(1, failures.get(0).intValue());
   }
 
   @Test
@@ -2558,22 +2558,35 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
 
     // Genuine local interruption: propagate, restore the interrupt flag, record no failure.
     causeRef.set(new InterruptedException("test interrupt"));
-    Assert.assertThrows(QueryInterruptedException.class, () -> schema.refreshSegments(segments));
-    Assert.assertTrue("interrupt flag should be restored", Thread.interrupted()); // also clears it for the next case
-    Assert.assertTrue(
-        "local interruption must not emit a refresh/failed metric",
-        emitter.getMetricEvents(Metric.REFRESH_FAILED).isEmpty()
+    Assertions.assertThrows(QueryInterruptedException.class, () -> schema.refreshSegments(segments));
+    Assertions.assertTrue(Thread.interrupted(), "interrupt flag should be restored"); // also clears it for the next case
+    Assertions.assertTrue(
+        emitter.getMetricEvents(Metric.REFRESH_FAILED).isEmpty(),
+        "local interruption must not emit a refresh/failed metric"
     );
 
     // Wrapped ordinary failure (no InterruptedException cause): isolate it - no propagation, failure recorded.
     causeRef.set(new RuntimeException("wrapped query failure"));
     schema.refreshSegments(segments); // must not throw
-    Assert.assertFalse("interrupt flag must not be set for a wrapped failure", Thread.currentThread().isInterrupted());
+    Assertions.assertFalse(Thread.currentThread().isInterrupted(), "interrupt flag must not be set for a wrapped failure");
     final List<Number> failures = emitter.getMetricValues(
         Metric.REFRESH_FAILED,
         ImmutableMap.of(DruidMetrics.DATASOURCE, DATASOURCE1)
     );
-    Assert.assertFalse("a wrapped query failure should emit refresh/failed", failures.isEmpty());
-    Assert.assertEquals(1, failures.get(0).intValue());
+    Assertions.assertFalse(failures.isEmpty(), "a wrapped query failure should emit refresh/failed");
+    Assertions.assertEquals(1, failures.get(0).intValue());
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
+    if (subDirs.length == 0 || (subDirs.length == 1 && "junit".equals(subDirs[0]))) {
+      return java.nio.file.Files.createTempDirectory(root.toPath(), "junit").toFile();
+    }
+    String subFolder = String.join("/", subDirs);
+    File result = new File(root, subFolder);
+    if (!result.mkdirs()) {
+      throw new IOException("Couldn't create folders " + root);
+    }
+    return result;
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCacheTest.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCacheTest.java
@@ -411,7 +411,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
                    .size(0)
                    .build();
 
-    final File tmpDir = newFolder(temporaryFolder, "junit");
+    final File tmpDir = temporaryFolder.newFolder();
 
     List<InputRow> rows = ImmutableList.of(
         createRow(ImmutableMap.of("t", "2002-01-01", "m1", "1.0", "dim1", "", "dim3", "c1")),
@@ -2575,18 +2575,5 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     );
     Assertions.assertFalse(failures.isEmpty(), "a wrapped query failure should emit refresh/failed");
     Assertions.assertEquals(1, failures.get(0).intValue());
-  }
-
-  private static File newFolder(File root, String... subDirs) throws IOException
-  {
-    if (subDirs.length == 0 || (subDirs.length == 1 && "junit".equals(subDirs[0]))) {
-      return java.nio.file.Files.createTempDirectory(root.toPath(), "junit").toFile();
-    }
-    String subFolder = String.join("/", subDirs);
-    File result = new File(root, subFolder);
-    if (!result.mkdirs()) {
-      throw new IOException("Couldn't create folders " + root);
-    }
-    return result;
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCacheTestBase.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCacheTestBase.java
@@ -32,7 +32,7 @@ import org.apache.druid.segment.TestHelper;
 import org.apache.druid.server.initialization.ServerConfig;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Rule;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,7 +41,7 @@ import java.util.Map;
 
 public class CoordinatorSegmentMetadataCacheTestBase extends SegmentMetadataCacheTestBase
 {
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule(CentralizedDatasourceSchemaConfig.enabled(true));
 
   public final ObjectMapper mapper = TestHelper.makeJsonMapper();

--- a/server/src/test/java/org/apache/druid/segment/metadata/FingerprintGeneratorTest.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/FingerprintGeneratorTest.java
@@ -27,8 +27,8 @@ import org.apache.druid.segment.SchemaPayload;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -57,7 +57,7 @@ public class FingerprintGeneratorTest
     SchemaPayload schemaPayload = new SchemaPayload(rowSignature, aggregatorFactoryMap);
 
     String expected = "82E774457D26D0B8D481B6C39872070B25EA3C72C6EFC107B346FA42641740E1";
-    Assert.assertEquals(expected, fingerprintGenerator.generateFingerprint(schemaPayload, "ds", 0));
+    Assertions.assertEquals(expected, fingerprintGenerator.generateFingerprint(schemaPayload, "ds", 0));
   }
 
   @Test
@@ -96,7 +96,7 @@ public class FingerprintGeneratorTest
     );
 
     SchemaPayload schemaPayloadNew = new SchemaPayload(rowSignaturePermutation, aggregatorFactoryMapForPermutation);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         fingerprintGenerator.generateFingerprint(schemaPayload, "ds", 0),
         fingerprintGenerator.generateFingerprint(schemaPayloadNew, "ds", 0)
     );
@@ -117,7 +117,7 @@ public class FingerprintGeneratorTest
 
     SchemaPayload schemaPayload = new SchemaPayload(rowSignature, aggregatorFactoryMap);
 
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         fingerprintGenerator.generateFingerprint(schemaPayload, "ds1", 0),
         fingerprintGenerator.generateFingerprint(schemaPayload, "ds2", 0)
     );
@@ -138,7 +138,7 @@ public class FingerprintGeneratorTest
 
     SchemaPayload schemaPayload = new SchemaPayload(rowSignature, aggregatorFactoryMap);
 
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         fingerprintGenerator.generateFingerprint(schemaPayload, "ds", 0),
         fingerprintGenerator.generateFingerprint(schemaPayload, "ds", 1)
     );
@@ -158,14 +158,14 @@ public class FingerprintGeneratorTest
 
     RowSignature sortedSignature = fingerprintGenerator.getLexicographicallySortedSignature(rowSignature);
 
-    Assert.assertNotEquals(rowSignature, sortedSignature);
+    Assertions.assertNotEquals(rowSignature, sortedSignature);
 
     List<String> columnNames = sortedSignature.getColumnNames();
     List<String> sortedOrder = Arrays.asList("a1", "b2", "c1", "c5", "d3");
-    Assert.assertEquals(sortedOrder, columnNames);
+    Assertions.assertEquals(sortedOrder, columnNames);
 
     for (String column : sortedOrder) {
-      Assert.assertEquals(sortedSignature.getColumnType(column), rowSignature.getColumnType(column));
+      Assertions.assertEquals(sortedSignature.getColumnType(column), rowSignature.getColumnType(column));
     }
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/metadata/SegmentMetadataCacheTestBase.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/SegmentMetadataCacheTestBase.java
@@ -52,10 +52,10 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -89,8 +89,8 @@ public abstract class SegmentMetadataCacheTestBase extends InitializedNullHandli
   public QueryRunnerFactoryConglomerate conglomerate;
   public Closer resourceCloser;
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
 
   public QueryableIndex index1;
   public QueryableIndex index2;
@@ -113,7 +113,7 @@ public abstract class SegmentMetadataCacheTestBase extends InitializedNullHandli
 
   public void setUpData() throws Exception
   {
-    final File tmpDir = temporaryFolder.newFolder();
+    final File tmpDir = newFolder(temporaryFolder, "junit");
     index1 = IndexBuilder.create()
                          .tmpDir(new File(tmpDir, "1"))
                          .segmentWriteOutMediumFactory(OffHeapMemorySegmentWriteOutMediumFactory.instance())
@@ -306,5 +306,18 @@ public abstract class SegmentMetadataCacheTestBase extends InitializedNullHandli
                       .binaryVersion(1)
                       .size(100L)
                       .build();
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
+    if (subDirs.length == 0 || (subDirs.length == 1 && "junit".equals(subDirs[0]))) {
+      return java.nio.file.Files.createTempDirectory(root.toPath(), "junit").toFile();
+    }
+    String subFolder = String.join("/", subDirs);
+    File result = new File(root, subFolder);
+    if (!result.mkdirs()) {
+      throw new IOException("Couldn't create folders " + root);
+    }
+    return result;
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/metadata/SegmentMetadataCacheTestBase.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/SegmentMetadataCacheTestBase.java
@@ -48,14 +48,14 @@ import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.server.security.AuthConfig;
 import org.apache.druid.server.security.AuthTestUtils;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -89,8 +89,8 @@ public abstract class SegmentMetadataCacheTestBase extends InitializedNullHandli
   public QueryRunnerFactoryConglomerate conglomerate;
   public Closer resourceCloser;
 
-  @TempDir
-  public File temporaryFolder;
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   public QueryableIndex index1;
   public QueryableIndex index2;
@@ -113,7 +113,7 @@ public abstract class SegmentMetadataCacheTestBase extends InitializedNullHandli
 
   public void setUpData() throws Exception
   {
-    final File tmpDir = newFolder(temporaryFolder, "junit");
+    final File tmpDir = temporaryFolder.newFolder();
     index1 = IndexBuilder.create()
                          .tmpDir(new File(tmpDir, "1"))
                          .segmentWriteOutMediumFactory(OffHeapMemorySegmentWriteOutMediumFactory.instance())
@@ -306,18 +306,5 @@ public abstract class SegmentMetadataCacheTestBase extends InitializedNullHandli
                       .binaryVersion(1)
                       .size(100L)
                       .build();
-  }
-
-  private static File newFolder(File root, String... subDirs) throws IOException
-  {
-    if (subDirs.length == 0 || (subDirs.length == 1 && "junit".equals(subDirs[0]))) {
-      return java.nio.file.Files.createTempDirectory(root.toPath(), "junit").toFile();
-    }
-    String subFolder = String.join("/", subDirs);
-    File result = new File(root, subFolder);
-    if (!result.mkdirs()) {
-      throw new IOException("Couldn't create folders " + root);
-    }
-    return result;
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/metadata/SegmentSchemaBackFillQueueTest.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/SegmentSchemaBackFillQueueTest.java
@@ -37,8 +37,8 @@ import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.LinearShardSpec;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,7 +49,7 @@ import java.util.concurrent.CountDownLatch;
 
 public class SegmentSchemaBackFillQueueTest
 {
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule =
       new TestDerbyConnector.DerbyConnectorRule(CentralizedDatasourceSchemaConfig.enabled(true));
 

--- a/server/src/test/java/org/apache/druid/segment/metadata/SegmentSchemaCacheTest.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/SegmentSchemaCacheTest.java
@@ -26,8 +26,8 @@ import org.apache.druid.segment.SegmentMetadata;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.timeline.SegmentId;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -44,14 +44,14 @@ public class SegmentSchemaCacheTest
     SegmentId id = SegmentId.dummy("ds");
     cache.addRealtimeSegmentSchema(id, expected);
 
-    Assert.assertTrue(cache.isSchemaCached(id));
+    Assertions.assertTrue(cache.isSchemaCached(id));
     Optional<SchemaPayloadPlus> schema = cache.getSchemaForSegment(id);
-    Assert.assertTrue(schema.isPresent());
+    Assertions.assertTrue(schema.isPresent());
 
-    Assert.assertEquals(expected, schema.get());
+    Assertions.assertEquals(expected, schema.get());
 
     cache.segmentRemoved(id);
-    Assert.assertFalse(cache.isSchemaCached(id));
+    Assertions.assertFalse(cache.isSchemaCached(id));
   }
 
   @Test
@@ -70,21 +70,21 @@ public class SegmentSchemaCacheTest
     cache.addSchemaPendingBackfill(id, expected);
     cache.addSchemaPendingBackfill(id2, expected);
 
-    Assert.assertTrue(cache.isSchemaCached(id));
-    Assert.assertTrue(cache.isSchemaCached(id2));
+    Assertions.assertTrue(cache.isSchemaCached(id));
+    Assertions.assertTrue(cache.isSchemaCached(id2));
     Optional<SchemaPayloadPlus> schema = cache.getSchemaForSegment(id);
-    Assert.assertTrue(schema.isPresent());
-    Assert.assertEquals(expected, schema.get());
+    Assertions.assertTrue(schema.isPresent());
+    Assertions.assertEquals(expected, schema.get());
     Optional<SchemaPayloadPlus> schema2 = cache.getSchemaForSegment(id);
-    Assert.assertTrue(schema2.isPresent());
-    Assert.assertEquals(expected, schema2.get());
+    Assertions.assertTrue(schema2.isPresent());
+    Assertions.assertEquals(expected, schema2.get());
 
     cache.markSchemaPersisted(id);
     cache.markSchemaPersisted(id2);
 
     schema = cache.getSchemaForSegment(id);
-    Assert.assertTrue(schema.isPresent());
-    Assert.assertEquals(expected, schema.get());
+    Assertions.assertTrue(schema.isPresent());
+    Assertions.assertEquals(expected, schema.get());
 
     // simulate call after segment polling
 
@@ -96,15 +96,15 @@ public class SegmentSchemaCacheTest
 
     cache.resetSchemaForPublishedSegments(segmentMetadataBuilder.build(), schemaPayloadBuilder.build());
 
-    Assert.assertNull(cache.getTemporaryPublishedMetadataQueryResults(id));
-    Assert.assertNotNull(cache.getTemporaryPublishedMetadataQueryResults(id2));
-    Assert.assertTrue(cache.isSchemaCached(id));
-    Assert.assertTrue(cache.isSchemaCached(id2));
+    Assertions.assertNull(cache.getTemporaryPublishedMetadataQueryResults(id));
+    Assertions.assertNotNull(cache.getTemporaryPublishedMetadataQueryResults(id2));
+    Assertions.assertTrue(cache.isSchemaCached(id));
+    Assertions.assertTrue(cache.isSchemaCached(id2));
     schema = cache.getSchemaForSegment(id);
-    Assert.assertTrue(schema.isPresent());
+    Assertions.assertTrue(schema.isPresent());
 
     schema2 = cache.getSchemaForSegment(id2);
-    Assert.assertTrue(schema2.isPresent());
+    Assertions.assertTrue(schema2.isPresent());
   }
 
   @Test
@@ -112,7 +112,7 @@ public class SegmentSchemaCacheTest
   {
     SegmentSchemaCache cache = new SegmentSchemaCache();
 
-    Assert.assertFalse(cache.isInitialized());
+    Assertions.assertFalse(cache.isInitialized());
 
     RowSignature rowSignature = RowSignature.builder().add("cx", ColumnType.FLOAT).build();
     SchemaPayloadPlus expected = new SchemaPayloadPlus(new SchemaPayload(rowSignature), 20L);
@@ -126,11 +126,11 @@ public class SegmentSchemaCacheTest
 
     cache.resetSchemaForPublishedSegments(segmentMetadataBuilder.build(), schemaPayloadBuilder.build());
 
-    Assert.assertTrue(cache.isInitialized());
-    Assert.assertTrue(cache.isSchemaCached(id));
+    Assertions.assertTrue(cache.isInitialized());
+    Assertions.assertTrue(cache.isSchemaCached(id));
     Optional<SchemaPayloadPlus> schema = cache.getSchemaForSegment(id);
-    Assert.assertTrue(schema.isPresent());
+    Assertions.assertTrue(schema.isPresent());
 
-    Assert.assertEquals(expected, schema.get());
+    Assertions.assertEquals(expected, schema.get());
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/metadata/SegmentSchemaManagerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/SegmentSchemaManagerTest.java
@@ -35,9 +35,9 @@ import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.LinearShardSpec;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -50,7 +50,7 @@ import java.util.Set;
 
 public class SegmentSchemaManagerTest
 {
-  @Rule
+  @RegisterExtension
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule(CentralizedDatasourceSchemaConfig.enabled(true));
 
   private final ObjectMapper mapper = TestHelper.makeJsonMapper();
@@ -62,7 +62,7 @@ public class SegmentSchemaManagerTest
   FingerprintGenerator fingerprintGenerator;
   SegmentSchemaTestUtils segmentSchemaTestUtils;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     derbyConnector = derbyConnectorRule.getConnector();

--- a/server/src/test/java/org/apache/druid/segment/metadata/SegmentSchemaTestUtils.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/SegmentSchemaTestUtils.java
@@ -32,7 +32,7 @@ import org.apache.druid.segment.SchemaPayloadPlus;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NoneShardSpec;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.skife.jdbi.v2.PreparedBatch;
 
 import java.util.Arrays;
@@ -214,14 +214,14 @@ public class SegmentSchemaTestUtils
       SchemaPayload schemaPayload = entry.getValue().getSchemaPayload();
       Long numRows = entry.getValue().getNumRows();
 
-      Assert.assertTrue(segmentStats.containsKey(id));
-      Assert.assertEquals(numRows, segmentStats.get(id).rhs);
-      Assert.assertTrue(schemaRepresentationMap.containsKey(segmentStats.get(id).lhs));
+      Assertions.assertTrue(segmentStats.containsKey(id));
+      Assertions.assertEquals(numRows, segmentStats.get(id).rhs);
+      Assertions.assertTrue(schemaRepresentationMap.containsKey(segmentStats.get(id).lhs));
 
       SegmentSchemaRecord schemaRepresentation = schemaRepresentationMap.get(segmentStats.get(id).lhs);
-      Assert.assertEquals(schemaPayload, schemaRepresentation.schemaPayload);
-      Assert.assertTrue(schemaRepresentation.isUsed);
-      Assert.assertEquals(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION, schemaRepresentation.version);
+      Assertions.assertEquals(schemaPayload, schemaRepresentation.schemaPayload);
+      Assertions.assertTrue(schemaRepresentation.isUsed);
+      Assertions.assertEquals(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION, schemaRepresentation.version);
     }
   }
 

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupCoordinatorManagerConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupCoordinatorManagerConfigTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.server.lookup.cache;
 
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LookupCoordinatorManagerConfigTest
 {
@@ -35,19 +35,19 @@ public class LookupCoordinatorManagerConfigTest
     config.setPeriod(funnyDuration.getMillis());
     config.setThreadPoolSize(1200);
 
-    Assert.assertEquals(funnyDuration, config.getHostTimeout());
-    Assert.assertEquals(funnyDuration, config.getAllHostTimeout());
-    Assert.assertEquals(funnyDuration.getMillis(), config.getPeriod());
-    Assert.assertEquals(1200, config.getThreadPoolSize());
+    Assertions.assertEquals(funnyDuration, config.getHostTimeout());
+    Assertions.assertEquals(funnyDuration, config.getAllHostTimeout());
+    Assertions.assertEquals(funnyDuration.getMillis(), config.getPeriod());
+    Assertions.assertEquals(1200, config.getThreadPoolSize());
   }
 
   @Test
   public void testSimpleConfigDefaults()
   {
     final LookupCoordinatorManagerConfig config = new LookupCoordinatorManagerConfig();
-    Assert.assertEquals(LookupCoordinatorManagerConfig.DEFAULT_HOST_TIMEOUT, config.getHostTimeout());
-    Assert.assertEquals(LookupCoordinatorManagerConfig.DEFAULT_ALL_HOST_TIMEOUT, config.getAllHostTimeout());
-    Assert.assertEquals(10, config.getThreadPoolSize());
-    Assert.assertEquals(120_000, config.getPeriod());
+    Assertions.assertEquals(LookupCoordinatorManagerConfig.DEFAULT_HOST_TIMEOUT, config.getHostTimeout());
+    Assertions.assertEquals(LookupCoordinatorManagerConfig.DEFAULT_ALL_HOST_TIMEOUT, config.getAllHostTimeout());
+    Assertions.assertEquals(10, config.getThreadPoolSize());
+    Assertions.assertEquals(120_000, config.getPeriod());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupCoordinatorManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupCoordinatorManagerTest.java
@@ -42,13 +42,15 @@ import org.apache.druid.java.util.metrics.StubServiceEmitter;
 import org.apache.druid.query.lookup.LookupsState;
 import org.apache.druid.server.http.HostAndPortWithScheme;
 import org.easymock.EasyMock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.ws.rs.core.Response;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -56,6 +58,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -107,14 +110,14 @@ public class LookupCoordinatorManagerTest
   private final AuditInfo auditInfo = new AuditInfo("author", "identify", "comment", "127.0.0.1");
   private static StubServiceEmitter SERVICE_EMITTER;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpStatic()
   {
     SERVICE_EMITTER = new StubServiceEmitter("", "");
     EmittingLogger.registerEmitter(SERVICE_EMITTER);
   }
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     SERVICE_EMITTER.flush();
@@ -139,10 +142,10 @@ public class LookupCoordinatorManagerTest
     EasyMock.replay(configManager);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
-    Assert.assertEquals(0, SERVICE_EMITTER.getNumEmittedEvents());
+    Assertions.assertEquals(0, SERVICE_EMITTER.getNumEmittedEvents());
     SERVICE_EMITTER.flush();
   }
 
@@ -190,7 +193,7 @@ public class LookupCoordinatorManagerTest
     );
 
     EasyMock.verify(client, responseHandler);
-    Assert.assertEquals(resp, LOOKUPS_STATE);
+    Assertions.assertEquals(resp, LOOKUPS_STATE);
   }
 
   @Test
@@ -228,7 +231,7 @@ public class LookupCoordinatorManagerTest
           HostAndPortWithScheme.fromString("localhost"),
           LOOKUPS_STATE
       );
-      Assert.fail();
+      Assertions.fail();
     }
     catch (IOException ex) {
     }
@@ -271,7 +274,7 @@ public class LookupCoordinatorManagerTest
           HostAndPortWithScheme.fromString("localhost"),
           LOOKUPS_STATE
       );
-      Assert.fail();
+      Assertions.fail();
     }
     catch (IOException ex) {
     }
@@ -314,7 +317,7 @@ public class LookupCoordinatorManagerTest
           HostAndPortWithScheme.fromString("localhost"),
           LOOKUPS_STATE
       );
-      Assert.fail();
+      Assertions.fail();
     }
     catch (InterruptedException ex) {
     }
@@ -370,7 +373,7 @@ public class LookupCoordinatorManagerTest
     );
 
     EasyMock.verify(client, responseHandler);
-    Assert.assertEquals(resp, LOOKUPS_STATE);
+    Assertions.assertEquals(resp, LOOKUPS_STATE);
   }
 
 
@@ -408,7 +411,7 @@ public class LookupCoordinatorManagerTest
       lookupsCommunicator.getLookupStateForNode(
           HostAndPortWithScheme.fromString("localhost")
       );
-      Assert.fail();
+      Assertions.fail();
     }
     catch (IOException ex) {
     }
@@ -450,7 +453,7 @@ public class LookupCoordinatorManagerTest
       lookupsCommunicator.getLookupStateForNode(
           HostAndPortWithScheme.fromString("localhost")
       );
-      Assert.fail();
+      Assertions.fail();
     }
     catch (IOException ex) {
     }
@@ -493,7 +496,7 @@ public class LookupCoordinatorManagerTest
       lookupsCommunicator.getLookupStateForNode(
           HostAndPortWithScheme.fromString("localhost")
       );
-      Assert.fail();
+      Assertions.fail();
     }
     catch (InterruptedException ex) {
     }
@@ -524,7 +527,7 @@ public class LookupCoordinatorManagerTest
     };
     manager.start();
     try {
-      Assert.assertThrows(ISE.class, () -> manager.updateLookups(TIERED_LOOKUP_MAP_V0, auditInfo));
+      Assertions.assertThrows(ISE.class, () -> manager.updateLookups(TIERED_LOOKUP_MAP_V0, auditInfo));
     }
     finally {
       manager.stop();
@@ -655,7 +658,7 @@ public class LookupCoordinatorManagerTest
           )
       ).andReturn(SetResult.ok()).once();
       EasyMock.replay(configManager);
-      Assert.assertTrue(
+      Assertions.assertTrue(
           manager.updateLookups(
               ImmutableMap.of(
                   LOOKUP_TIER + "1", ImmutableMap.of(
@@ -720,7 +723,7 @@ public class LookupCoordinatorManagerTest
           )
       ).andReturn(SetResult.ok()).once();
       EasyMock.replay(configManager);
-      Assert.assertTrue(
+      Assertions.assertTrue(
           manager.updateLookups(
               ImmutableMap.of(
                   LOOKUP_TIER + "1", ImmutableMap.of(
@@ -790,7 +793,7 @@ public class LookupCoordinatorManagerTest
     };
     manager.start();
     try {
-      Assert.assertThrows(IAE.class, () -> manager.updateLookups(TIERED_LOOKUP_MAP_V0, auditInfo));
+      Assertions.assertThrows(IAE.class, () -> manager.updateLookups(TIERED_LOOKUP_MAP_V0, auditInfo));
     }
     finally {
       manager.stop();
@@ -841,7 +844,7 @@ public class LookupCoordinatorManagerTest
           )
       ).andReturn(SetResult.ok()).once();
       EasyMock.replay(configManager);
-      Assert.assertTrue(manager.updateLookups(ImmutableMap.of(
+      Assertions.assertTrue(manager.updateLookups(ImmutableMap.of(
                                                   LOOKUP_TIER + "1", ImmutableMap.of(
                                                       "foo",
                                                       newSpec
@@ -897,7 +900,7 @@ public class LookupCoordinatorManagerTest
           )
       ).andReturn(SetResult.ok()).once();
       EasyMock.replay(configManager);
-      Assert.assertTrue(manager.deleteTier(LOOKUP_TIER, auditInfo));
+      Assertions.assertTrue(manager.deleteTier(LOOKUP_TIER, auditInfo));
       EasyMock.verify(configManager);
     }
     finally {
@@ -952,7 +955,7 @@ public class LookupCoordinatorManagerTest
           )
       ).andReturn(SetResult.ok()).once();
       EasyMock.replay(configManager);
-      Assert.assertTrue(manager.deleteLookup(LOOKUP_TIER, "foo", auditInfo));
+      Assertions.assertTrue(manager.deleteLookup(LOOKUP_TIER, "foo", auditInfo));
       EasyMock.verify(configManager);
     }
     finally {
@@ -998,7 +1001,7 @@ public class LookupCoordinatorManagerTest
           )
       ).andReturn(SetResult.ok()).once();
       EasyMock.replay(configManager);
-      Assert.assertTrue(manager.deleteLookup(LOOKUP_TIER, "foo", auditInfo));
+      Assertions.assertTrue(manager.deleteLookup(LOOKUP_TIER, "foo", auditInfo));
       EasyMock.verify(configManager);
     }
     finally {
@@ -1033,7 +1036,7 @@ public class LookupCoordinatorManagerTest
     };
     manager.start();
     try {
-      Assert.assertFalse(manager.deleteLookup(LOOKUP_TIER, "foo", auditInfo));
+      Assertions.assertFalse(manager.deleteLookup(LOOKUP_TIER, "foo", auditInfo));
     }
     finally {
       manager.stop();
@@ -1060,7 +1063,7 @@ public class LookupCoordinatorManagerTest
     };
     manager.start();
     try {
-      Assert.assertFalse(manager.deleteLookup(LOOKUP_TIER, "foo", auditInfo));
+      Assertions.assertFalse(manager.deleteLookup(LOOKUP_TIER, "foo", auditInfo));
     }
     finally {
       manager.stop();
@@ -1092,9 +1095,9 @@ public class LookupCoordinatorManagerTest
         ));
       }
     };
-    Assert.assertEquals(lookup, manager.getLookup(LOOKUP_TIER, "foo"));
-    Assert.assertNull(manager.getLookup(LOOKUP_TIER, "does not exit"));
-    Assert.assertNull(manager.getLookup("not a tier", "foo"));
+    Assertions.assertEquals(lookup, manager.getLookup(LOOKUP_TIER, "foo"));
+    Assertions.assertNull(manager.getLookup(LOOKUP_TIER, "does not exit"));
+    Assertions.assertNull(manager.getLookup("not a tier", "foo"));
   }
 
   @Test
@@ -1121,9 +1124,9 @@ public class LookupCoordinatorManagerTest
         ));
       }
     };
-    Assert.assertEquals(lookup, manager.getLookup(LOOKUP_TIER, "foo"));
-    Assert.assertNull(manager.getLookup(LOOKUP_TIER, "does not exit"));
-    Assert.assertNull(manager.getLookup("not a tier", "foo"));
+    Assertions.assertEquals(lookup, manager.getLookup(LOOKUP_TIER, "foo"));
+    Assertions.assertNull(manager.getLookup(LOOKUP_TIER, "does not exit"));
+    Assertions.assertNull(manager.getLookup("not a tier", "foo"));
   }
 
   @Test
@@ -1143,11 +1146,12 @@ public class LookupCoordinatorManagerTest
         return null;
       }
     };
-    Assert.assertNull(manager.getLookup(LOOKUP_TIER, "foo"));
+    Assertions.assertNull(manager.getLookup(LOOKUP_TIER, "foo"));
   }
 
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testLookupManagementLoop() throws Exception
   {
     Map<String, LookupExtractorFactoryMapContainer> lookup1 = ImmutableMap.of(
@@ -1249,7 +1253,7 @@ public class LookupCoordinatorManagerTest
         lookupNodeDiscovery
     );
 
-    Assert.assertTrue(manager.knownOldState.get().isEmpty());
+    Assertions.assertTrue(manager.knownOldState.get().isEmpty());
 
     manager.start();
     try {
@@ -1299,7 +1303,7 @@ public class LookupCoordinatorManagerTest
         "lookup2", new LookupExtractorFactoryMapContainer("v1", ImmutableMap.of("k2", "v2"))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             "lookup1", new LookupExtractorFactoryMapContainer("v2", ImmutableMap.of("k1", "v1")),
             "lookup2", new LookupExtractorFactoryMapContainer("v1", ImmutableMap.of("k2", "v2"))
@@ -1333,7 +1337,7 @@ public class LookupCoordinatorManagerTest
         "lookup0", new LookupExtractorFactoryMapContainer("v1", ImmutableMap.of("k0", "v0"))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of("lookup1", "lookup3"),
         manager.getToBeDroppedFromNode(currNodeState, stateToBe)
     );
@@ -1366,17 +1370,17 @@ public class LookupCoordinatorManagerTest
         lookupCoordinatorManagerConfig
     );
 
-    Assert.assertFalse(manager.isStarted());
+    Assertions.assertFalse(manager.isStarted());
 
     manager.start();
-    Assert.assertTrue(manager.awaitStarted(1));
-    Assert.assertTrue(manager.backgroundManagerIsRunning());
-    Assert.assertFalse(manager.waitForBackgroundTermination(10));
+    Assertions.assertTrue(manager.awaitStarted(1));
+    Assertions.assertTrue(manager.backgroundManagerIsRunning());
+    Assertions.assertFalse(manager.waitForBackgroundTermination(10));
 
     manager.stop();
-    Assert.assertFalse(manager.awaitStarted(1));
-    Assert.assertTrue(manager.waitForBackgroundTermination(10));
-    Assert.assertFalse(manager.backgroundManagerIsRunning());
+    Assertions.assertFalse(manager.awaitStarted(1));
+    Assertions.assertTrue(manager.waitForBackgroundTermination(10));
+    Assertions.assertFalse(manager.backgroundManagerIsRunning());
 
     EasyMock.verify(configManager);
   }
@@ -1404,37 +1408,37 @@ public class LookupCoordinatorManagerTest
         lookupCoordinatorManagerConfig
     );
 
-    Assert.assertFalse(manager.awaitStarted(1));
+    Assertions.assertFalse(manager.awaitStarted(1));
 
     manager.start();
-    Assert.assertTrue(manager.awaitStarted(1));
-    Assert.assertTrue(manager.backgroundManagerIsRunning());
-    Assert.assertFalse(manager.waitForBackgroundTermination(10));
+    Assertions.assertTrue(manager.awaitStarted(1));
+    Assertions.assertTrue(manager.backgroundManagerIsRunning());
+    Assertions.assertFalse(manager.waitForBackgroundTermination(10));
 
     manager.stop();
-    Assert.assertFalse(manager.awaitStarted(1));
-    Assert.assertTrue(manager.waitForBackgroundTermination(10));
-    Assert.assertFalse(manager.backgroundManagerIsRunning());
+    Assertions.assertFalse(manager.awaitStarted(1));
+    Assertions.assertTrue(manager.waitForBackgroundTermination(10));
+    Assertions.assertFalse(manager.backgroundManagerIsRunning());
 
     manager.start();
-    Assert.assertTrue(manager.awaitStarted(1));
-    Assert.assertTrue(manager.backgroundManagerIsRunning());
-    Assert.assertFalse(manager.waitForBackgroundTermination(10));
+    Assertions.assertTrue(manager.awaitStarted(1));
+    Assertions.assertTrue(manager.backgroundManagerIsRunning());
+    Assertions.assertFalse(manager.waitForBackgroundTermination(10));
 
     manager.stop();
-    Assert.assertFalse(manager.awaitStarted(1));
-    Assert.assertTrue(manager.waitForBackgroundTermination(10));
-    Assert.assertFalse(manager.backgroundManagerIsRunning());
+    Assertions.assertFalse(manager.awaitStarted(1));
+    Assertions.assertTrue(manager.waitForBackgroundTermination(10));
+    Assertions.assertFalse(manager.backgroundManagerIsRunning());
 
     manager.start();
-    Assert.assertTrue(manager.awaitStarted(1));
-    Assert.assertTrue(manager.backgroundManagerIsRunning());
-    Assert.assertFalse(manager.waitForBackgroundTermination(10));
+    Assertions.assertTrue(manager.awaitStarted(1));
+    Assertions.assertTrue(manager.backgroundManagerIsRunning());
+    Assertions.assertFalse(manager.waitForBackgroundTermination(10));
 
     manager.stop();
-    Assert.assertFalse(manager.awaitStarted(1));
-    Assert.assertTrue(manager.waitForBackgroundTermination(10));
-    Assert.assertFalse(manager.backgroundManagerIsRunning());
+    Assertions.assertFalse(manager.awaitStarted(1));
+    Assertions.assertTrue(manager.waitForBackgroundTermination(10));
+    Assertions.assertFalse(manager.backgroundManagerIsRunning());
 
     EasyMock.verify(configManager);
   }
@@ -1459,7 +1463,7 @@ public class LookupCoordinatorManagerTest
 
     manager.start();
     try {
-      Assert.assertEquals(fakeChildren, manager.discoverTiers());
+      Assertions.assertEquals(fakeChildren, manager.discoverTiers());
       EasyMock.verify(lookupNodeDiscovery);
     }
     finally {
@@ -1492,7 +1496,7 @@ public class LookupCoordinatorManagerTest
 
     manager.start();
     try {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableSet.of(
               HostAndPort.fromParts("h1", 8080),
               HostAndPort.fromParts("h2", 8080)

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupCoordinatorManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupCoordinatorManagerTest.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 
 import javax.ws.rs.core.Response;
 
@@ -1151,7 +1152,7 @@ public class LookupCoordinatorManagerTest
 
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testLookupManagementLoop() throws Exception
   {
     Map<String, LookupExtractorFactoryMapContainer> lookup1 = ImmutableMap.of(

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupExtractorFactoryMapContainerTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupExtractorFactoryMapContainerTest.java
@@ -24,8 +24,8 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainer;
 import org.apache.druid.query.lookup.MapLookupExtractorFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  */
@@ -68,8 +68,8 @@ public class LookupExtractorFactoryMapContainerTest
         ),
         LookupExtractorFactoryMapContainer.class
     );
-    Assert.assertEquals("v1", actual.getVersion());
-    Assert.assertEquals(testContainer, actual);
+    Assertions.assertEquals("v1", actual.getVersion());
+    Assertions.assertEquals(testContainer, actual);
   }
 
   @Test
@@ -80,11 +80,11 @@ public class LookupExtractorFactoryMapContainerTest
     LookupExtractorFactoryMapContainer l2 = new LookupExtractorFactoryMapContainer("V2", ImmutableMap.of());
     LookupExtractorFactoryMapContainer l3 = new LookupExtractorFactoryMapContainer("V3", ImmutableMap.of());
 
-    Assert.assertFalse(l0.replaces(l1));
-    Assert.assertFalse(l1.replaces(l2));
-    Assert.assertTrue(l2.replaces(l1));
-    Assert.assertFalse(l2.replaces(l3));
-    Assert.assertTrue(l3.replaces(l2));
+    Assertions.assertFalse(l0.replaces(l1));
+    Assertions.assertFalse(l1.replaces(l2));
+    Assertions.assertTrue(l2.replaces(l1));
+    Assertions.assertFalse(l2.replaces(l3));
+    Assertions.assertTrue(l3.replaces(l2));
   }
 
   //test interchangeability with LookupExtractorFactoryContainer
@@ -100,8 +100,8 @@ public class LookupExtractorFactoryMapContainerTest
         LookupExtractorFactoryMapContainer.class
     );
 
-    Assert.assertEquals("v1", actual.getVersion());
-    Assert.assertEquals(testContainer, actual);
+    Assertions.assertEquals("v1", actual.getVersion());
+    Assertions.assertEquals(testContainer, actual);
   }
 
   //test interchangeability with LookupExtractorFactoryContainer
@@ -117,8 +117,8 @@ public class LookupExtractorFactoryMapContainerTest
         LookupExtractorFactoryContainer.class
     );
 
-    Assert.assertEquals("v1", actual.getVersion());
-    Assert.assertEquals(
+    Assertions.assertEquals("v1", actual.getVersion());
+    Assertions.assertEquals(
         actual,
         new LookupExtractorFactoryContainer(
             "v1",

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
@@ -21,34 +21,32 @@ package org.apache.druid.server.lookup.cache;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.Set;
 
-@RunWith(JUnitParamsRunner.class)
 public class LookupLoadingSpecTest
 {
   @Test
   public void testLoadingAllLookups()
   {
     LookupLoadingSpec spec = LookupLoadingSpec.ALL;
-    Assert.assertEquals(LookupLoadingSpec.Mode.ALL, spec.getMode());
-    Assert.assertNull(spec.getLookupsToLoad());
+    Assertions.assertEquals(LookupLoadingSpec.Mode.ALL, spec.getMode());
+    Assertions.assertNull(spec.getLookupsToLoad());
   }
 
   @Test
   public void testLoadingNoLookups()
   {
     LookupLoadingSpec spec = LookupLoadingSpec.NONE;
-    Assert.assertEquals(LookupLoadingSpec.Mode.NONE, spec.getMode());
-    Assert.assertNull(spec.getLookupsToLoad());
+    Assertions.assertEquals(LookupLoadingSpec.Mode.NONE, spec.getMode());
+    Assertions.assertNull(spec.getLookupsToLoad());
   }
 
   @Test
@@ -56,22 +54,22 @@ public class LookupLoadingSpecTest
   {
     Set<String> lookupsToLoad = ImmutableSet.of("lookupName1", "lookupName2");
     LookupLoadingSpec spec = LookupLoadingSpec.loadOnly(lookupsToLoad);
-    Assert.assertEquals(LookupLoadingSpec.Mode.ONLY_REQUIRED, spec.getMode());
-    Assert.assertEquals(lookupsToLoad, spec.getLookupsToLoad());
+    Assertions.assertEquals(LookupLoadingSpec.Mode.ONLY_REQUIRED, spec.getMode());
+    Assertions.assertEquals(lookupsToLoad, spec.getLookupsToLoad());
   }
 
   @Test
   public void testLoadingOnlyRequiredLookupsWithNullList()
   {
-    DruidException exception = Assert.assertThrows(DruidException.class, () -> LookupLoadingSpec.loadOnly(null));
-    Assert.assertEquals("Expected non-null set of lookups to load.", exception.getMessage());
+    DruidException exception = Assertions.assertThrows(DruidException.class, () -> LookupLoadingSpec.loadOnly(null));
+    Assertions.assertEquals("Expected non-null set of lookups to load.", exception.getMessage());
   }
 
   @Test
   public void testCreateLookupLoadingSpecFromEmptyContext()
   {
     // Default spec is returned in the case of context not having the lookup keys.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         LookupLoadingSpec.ALL,
         LookupLoadingSpec.createFromContext(
             ImmutableMap.of(),
@@ -79,7 +77,7 @@ public class LookupLoadingSpecTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         LookupLoadingSpec.NONE,
         LookupLoadingSpec.createFromContext(
             ImmutableMap.of(),
@@ -92,7 +90,7 @@ public class LookupLoadingSpecTest
   public void testCreateLookupLoadingSpecFromNullContext()
   {
     // Default spec is returned in the case of context=null.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         LookupLoadingSpec.NONE,
         LookupLoadingSpec.createFromContext(
             null,
@@ -100,7 +98,7 @@ public class LookupLoadingSpecTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         LookupLoadingSpec.ALL,
         LookupLoadingSpec.createFromContext(
             null,
@@ -113,7 +111,7 @@ public class LookupLoadingSpecTest
   public void testCreateLookupLoadingSpecFromContext()
   {
     // Only required lookups are returned in the case of context having the lookup keys.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         LookupLoadingSpec.loadOnly(ImmutableSet.of("lookup1", "lookup2")),
         LookupLoadingSpec.createFromContext(
             ImmutableMap.of(
@@ -125,7 +123,7 @@ public class LookupLoadingSpecTest
     );
 
     // No lookups are returned in the case of context having mode=NONE, irrespective of the default spec.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         LookupLoadingSpec.NONE,
         LookupLoadingSpec.createFromContext(
             ImmutableMap.of(
@@ -135,7 +133,7 @@ public class LookupLoadingSpecTest
     );
 
     // All lookups are returned in the case of context having mode=ALL, irrespective of the default spec.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         LookupLoadingSpec.ALL,
         LookupLoadingSpec.createFromContext(
             ImmutableMap.of(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ALL),
@@ -144,8 +142,8 @@ public class LookupLoadingSpecTest
     );
   }
 
-  @Test
-  @Parameters({
+  @ParameterizedTest
+  @ValueSource(strings = {
       "NONE1",
       "A",
       "Random mode",
@@ -155,27 +153,27 @@ public class LookupLoadingSpecTest
   })
   public void testCreateLookupLoadingSpecFromInvalidModeInContext(String mode)
   {
-    final DruidException exception = Assert.assertThrows(DruidException.class, () -> LookupLoadingSpec.createFromContext(
+    final DruidException exception = Assertions.assertThrows(DruidException.class, () -> LookupLoadingSpec.createFromContext(
         ImmutableMap.of(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, mode), LookupLoadingSpec.ALL));
-    Assert.assertEquals(StringUtils.format("Invalid value of %s[%s]. Allowed values are [ALL, NONE, ONLY_REQUIRED]",
+    Assertions.assertEquals(StringUtils.format("Invalid value of %s[%s]. Allowed values are [ALL, NONE, ONLY_REQUIRED]",
                                            LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, mode), exception.getMessage());
   }
 
-  @Test
-  @Parameters({
+  @ParameterizedTest
+  @ValueSource(strings = {
       "foo bar",
       "foo]"
   })
   public void testCreateLookupLoadingSpecFromInvalidLookupsInContext(Object lookupsToLoad)
   {
-    final DruidException exception = Assert.assertThrows(DruidException.class, () ->
+    final DruidException exception = Assertions.assertThrows(DruidException.class, () ->
         LookupLoadingSpec.createFromContext(
             ImmutableMap.of(
                 LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, lookupsToLoad,
                 LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ONLY_REQUIRED),
             LookupLoadingSpec.ALL)
     );
-    Assert.assertEquals(StringUtils.format("Invalid value of %s[%s]. Please provide a comma-separated list of "
+    Assertions.assertEquals(StringUtils.format("Invalid value of %s[%s]. Please provide a comma-separated list of "
                                            + "lookup names. For example: [\"lookupName1\", \"lookupName2\"]",
                                            LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, lookupsToLoad), exception.getMessage());
   }


### PR DESCRIPTION
## Summary

- Migrate 73 owned `server/src/test` Java sources in catalog, Guice, indexing, metadata, segment-metadata, and lookup areas to JUnit 5.
- Preserve class-wide cache-mode parameterization with Jupiter `@ParameterizedClass` and adapt owned Derby/Mockito test lifecycles to Jupiter extensions.
- Keep `server/pom.xml`, shared POMs, and the other workers' coordinator/discovery/PR1-owned tests unchanged.

## Validation

- `mvn -ntp -pl server -am -DskipTests -Pskip-static-checks -Dweb.console.skip=true -T1C test-compile` — PASS.
- Focused catalog suite — PASS, 129 tests.
- Focused Guice suite — PASS, 43 tests.
- Focused indexing suite — PASS, 69 tests.
- Focused lookup suite — PASS, 53 tests.
- Focused metadata/coordinator suite — PASS, 73 tests across all three cache modes.
- Focused segment-metadata/cache suite — PASS, 115 tests.
- `mvn -ntp -pl server -DskipTests -Dweb.console.skip=true checkstyle:check` — PASS, 0 violations.
- `mvn -ntp -pl server -DskipTests -Dweb.console.skip=true spotbugs:check` — PASS, 0 bugs and 0 errors.
- `git diff --check offical/master` — PASS; no static imports in changed files.

Part of #13948
