### PR TITLE
test(server): migrate coordination and service tests to JUnit 5

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -359,6 +359,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>

--- a/server/src/test/java/org/apache/druid/server/AsyncManagementForwardingServletTest.java
+++ b/server/src/test/java/org/apache/druid/server/AsyncManagementForwardingServletTest.java
@@ -49,10 +49,10 @@ import org.eclipse.jetty.ee8.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee8.servlet.ServletHolder;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServlet;
@@ -99,7 +99,7 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
   }
 
   @Override
-  @Before
+  @BeforeEach
   public void setup() throws Exception
   {
     super.setup();
@@ -115,15 +115,20 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
     isValidLeader = true;
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception
   {
-    coordinator.stop();
-    overlord.stop();
+    try {
+      coordinator.stop();
+      overlord.stop();
 
-    COORDINATOR_EXPECTED_REQUEST.reset();
-    OVERLORD_EXPECTED_REQUEST.reset();
-    isValidLeader = true;
+      COORDINATOR_EXPECTED_REQUEST.reset();
+      OVERLORD_EXPECTED_REQUEST.reset();
+      isValidLeader = true;
+    }
+    finally {
+      super.teardown();
+    }
   }
 
   @Override
@@ -154,9 +159,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
 
     COORDINATOR_EXPECTED_REQUEST.headers.forEach(connection::setRequestProperty);
 
-    Assert.assertEquals(200, connection.getResponseCode());
-    Assert.assertTrue("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(200, connection.getResponseCode());
+    Assertions.assertTrue(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertFalse(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
   }
 
   @Test
@@ -175,9 +180,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
 
     COORDINATOR_EXPECTED_REQUEST.headers.forEach(connection::setRequestProperty);
 
-    Assert.assertEquals(200, connection.getResponseCode());
-    Assert.assertTrue("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(200, connection.getResponseCode());
+    Assertions.assertTrue(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertFalse(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
   }
 
   @Test
@@ -191,9 +196,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
             .openConnection());
     connection.setRequestMethod(COORDINATOR_EXPECTED_REQUEST.method);
 
-    Assert.assertEquals(200, connection.getResponseCode());
-    Assert.assertTrue("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(200, connection.getResponseCode());
+    Assertions.assertTrue(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertFalse(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
   }
 
   @Test
@@ -207,9 +212,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
             .openConnection());
     connection.setRequestMethod(COORDINATOR_EXPECTED_REQUEST.method);
 
-    Assert.assertEquals(200, connection.getResponseCode());
-    Assert.assertTrue("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(200, connection.getResponseCode());
+    Assertions.assertTrue(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertFalse(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
   }
 
   @Test
@@ -226,9 +231,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
 
     COORDINATOR_EXPECTED_REQUEST.headers.forEach(connection::setRequestProperty);
 
-    Assert.assertEquals(200, connection.getResponseCode());
-    Assert.assertTrue("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(200, connection.getResponseCode());
+    Assertions.assertTrue(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertFalse(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
   }
 
   @Test
@@ -251,9 +256,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
     os.write(COORDINATOR_EXPECTED_REQUEST.body.getBytes(StandardCharsets.UTF_8));
     os.close();
 
-    Assert.assertEquals(200, connection.getResponseCode());
-    Assert.assertTrue("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(200, connection.getResponseCode());
+    Assertions.assertTrue(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertFalse(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
   }
 
   @Test
@@ -279,9 +284,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
     os.write(OVERLORD_EXPECTED_REQUEST.body.getBytes(StandardCharsets.UTF_8));
     os.close();
 
-    Assert.assertEquals(200, connection.getResponseCode());
-    Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertTrue("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(200, connection.getResponseCode());
+    Assertions.assertFalse(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertTrue(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
   }
 
   @Test
@@ -298,9 +303,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
 
     OVERLORD_EXPECTED_REQUEST.headers.forEach(connection::setRequestProperty);
 
-    Assert.assertEquals(200, connection.getResponseCode());
-    Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertTrue("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(200, connection.getResponseCode());
+    Assertions.assertFalse(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertTrue(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
   }
 
   @Test
@@ -317,9 +322,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
 
     OVERLORD_EXPECTED_REQUEST.headers.forEach(connection::setRequestProperty);
 
-    Assert.assertEquals(200, connection.getResponseCode());
-    Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertTrue("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(200, connection.getResponseCode());
+    Assertions.assertFalse(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertTrue(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
   }
 
   @Test
@@ -329,12 +334,12 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
         new URL(StringUtils.format("http://localhost:%d/proxy/enabled", port)).openConnection());
     connection.setRequestMethod("GET");
 
-    Assert.assertEquals(200, connection.getResponseCode());
+    Assertions.assertEquals(200, connection.getResponseCode());
     byte[] bytes = new byte[connection.getContentLength()];
-    Assert.assertEquals(connection.getInputStream().read(bytes), connection.getContentLength());
-    Assert.assertEquals(ImmutableMap.of("enabled", true), new ObjectMapper().readValue(bytes, Map.class));
-    Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(connection.getInputStream().read(bytes), connection.getContentLength());
+    Assertions.assertEquals(ImmutableMap.of("enabled", true), new ObjectMapper().readValue(bytes, Map.class));
+    Assertions.assertFalse(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertFalse(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
   }
 
   @Test
@@ -344,9 +349,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
         new URL(StringUtils.format("http://localhost:%d/proxy/other/status", port)).openConnection());
     connection.setRequestMethod("GET");
 
-    Assert.assertEquals(400, connection.getResponseCode());
-    Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(400, connection.getResponseCode());
+    Assertions.assertFalse(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertFalse(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
   }
 
   @Test
@@ -356,9 +361,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
         new URL(StringUtils.format("http://localhost:%d/proxy/coordinator", port)).openConnection());
     connection.setRequestMethod("GET");
 
-    Assert.assertEquals(403, connection.getResponseCode()); // proxy with no path is not allowed
-    Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(403, connection.getResponseCode()); // proxy with no path is not allowed
+    Assertions.assertFalse(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertFalse(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
   }
 
   @Test
@@ -368,9 +373,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
         new URL(StringUtils.format("http://localhost:%d/proxy/overlord", port)).openConnection());
     connection.setRequestMethod("GET");
 
-    Assert.assertEquals(403, connection.getResponseCode()); // proxy with no path is not allowed
-    Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(403, connection.getResponseCode()); // proxy with no path is not allowed
+    Assertions.assertFalse(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertFalse(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
   }
 
   @Test
@@ -381,9 +386,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
         new URL(StringUtils.format("http://localhost:%d/druid/coordinator/status", port)).openConnection());
     connection.setRequestMethod("GET");
 
-    Assert.assertEquals(503, connection.getResponseCode());
-    Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(503, connection.getResponseCode());
+    Assertions.assertFalse(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertFalse(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
   }
 
   @Test
@@ -394,9 +399,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
         new URL(StringUtils.format("http://localhost:%d/druid/indexer/status", port)).openConnection());
     connection.setRequestMethod("GET");
 
-    Assert.assertEquals(503, connection.getResponseCode());
-    Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(503, connection.getResponseCode());
+    Assertions.assertFalse(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertFalse(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
     isValidLeader = true;
   }
 
@@ -407,9 +412,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
         new URL(StringUtils.format("http://localhost:%d/proxy/other/status2", port)).openConnection());
     connection.setRequestMethod("GET");
 
-    Assert.assertEquals(400, connection.getResponseCode());
-    Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(400, connection.getResponseCode());
+    Assertions.assertFalse(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertFalse(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
   }
 
   @Test
@@ -419,9 +424,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
         new URL(StringUtils.format("http://localhost:%d/status", port)).openConnection());
     connection.setRequestMethod("GET");
 
-    Assert.assertEquals(404, connection.getResponseCode());
-    Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
-    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    Assertions.assertEquals(404, connection.getResponseCode());
+    Assertions.assertFalse(COORDINATOR_EXPECTED_REQUEST.called, "coordinator called");
+    Assertions.assertFalse(OVERLORD_EXPECTED_REQUEST.called, "overlord called");
   }
 
   private static Server makeTestServer(int port, ExpectedRequest expectedRequest)

--- a/server/src/test/java/org/apache/druid/server/BrokerDynamicConfigResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/BrokerDynamicConfigResourceTest.java
@@ -23,9 +23,9 @@ import org.apache.druid.client.BrokerViewOfBrokerConfig;
 import org.apache.druid.client.BrokerViewOfCoordinatorConfig;
 import org.apache.druid.server.broker.BrokerDynamicConfig;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.ws.rs.core.Response;
@@ -36,7 +36,7 @@ public class BrokerDynamicConfigResourceTest
   private BrokerViewOfBrokerConfig brokerViewOfBrokerConfig;
   private BrokerDynamicConfigResource resource;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     brokerViewOfCoordinatorConfig = Mockito.mock(BrokerViewOfCoordinatorConfig.class);
@@ -55,8 +55,8 @@ public class BrokerDynamicConfigResourceTest
 
     Response response = resource.getBrokerDynamicConfig();
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(config, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(config, response.getEntity());
     Mockito.verify(brokerViewOfBrokerConfig, Mockito.times(1)).getDynamicConfig();
   }
 
@@ -67,7 +67,7 @@ public class BrokerDynamicConfigResourceTest
 
     Response response = resource.setBrokerDynamicConfig(config);
 
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     Mockito.verify(brokerViewOfBrokerConfig, Mockito.times(1)).setDynamicConfig(config);
   }
 
@@ -79,8 +79,8 @@ public class BrokerDynamicConfigResourceTest
 
     Response response = resource.getDynamicConfig();
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(config, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(config, response.getEntity());
     Mockito.verify(brokerViewOfCoordinatorConfig, Mockito.times(1)).getDynamicConfig();
   }
 
@@ -91,7 +91,7 @@ public class BrokerDynamicConfigResourceTest
 
     Response response = resource.setDynamicConfig(config);
 
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     Mockito.verify(brokerViewOfCoordinatorConfig, Mockito.times(1)).setDynamicConfig(config);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/BuildInfoTest.java
+++ b/server/src/test/java/org/apache/druid/server/BuildInfoTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.server;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -33,7 +33,7 @@ public class BuildInfoTest
   public void testGetBuildRevisionReturnsEmptyStringOutsideJar()
   {
     // During mvn test the class loads from the filesystem, not a JAR, so this must return "".
-    Assert.assertEquals("", BuildInfo.getBuildRevision());
+    Assertions.assertEquals("", BuildInfo.getBuildRevision());
   }
 
   @Test
@@ -41,7 +41,7 @@ public class BuildInfoTest
   {
     String manifest = "Manifest-Version: 1.0\nBuild-Revision: abc123\n\n";
     InputStream is = new ByteArrayInputStream(manifest.getBytes(StandardCharsets.UTF_8));
-    Assert.assertEquals("abc123", BuildInfo.readRevisionFromManifest(is));
+    Assertions.assertEquals("abc123", BuildInfo.readRevisionFromManifest(is));
   }
 
   @Test
@@ -49,6 +49,6 @@ public class BuildInfoTest
   {
     String manifest = "Manifest-Version: 1.0\n\n";
     InputStream is = new ByteArrayInputStream(manifest.getBytes(StandardCharsets.UTF_8));
-    Assert.assertEquals("", BuildInfo.readRevisionFromManifest(is));
+    Assertions.assertEquals("", BuildInfo.readRevisionFromManifest(is));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/ClientInfoResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/ClientInfoResourceTest.java
@@ -43,9 +43,9 @@ import org.apache.druid.timeline.partition.SingleElementPartitionChunk;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
@@ -64,7 +64,7 @@ public class ClientInfoResourceTest
   private TimelineServerView timelineServerView;
   private ClientInfoResource resource;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     VersionedIntervalTimeline<String, ServerSelector> timeline = new VersionedIntervalTimeline<>(Ordering.natural());
@@ -147,7 +147,7 @@ public class ClientInfoResourceTest
         KEY_METRICS, ImmutableSet.of("m1", "m2")
     );
     EasyMock.verify(serverInventoryView);
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -164,7 +164,7 @@ public class ClientInfoResourceTest
     );
 
     EasyMock.verify(serverInventoryView, timelineServerView);
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -185,7 +185,7 @@ public class ClientInfoResourceTest
     );
 
     EasyMock.verify(serverInventoryView, timelineServerView);
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -194,7 +194,7 @@ public class ClientInfoResourceTest
     Map<String, Object> actual = resource.getDatasource(dataSource, null, null);
     Map<String, Object> expected = ImmutableMap.of(KEY_DIMENSIONS, ImmutableSet.of(), KEY_METRICS, ImmutableSet.of());
 
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -213,7 +213,7 @@ public class ClientInfoResourceTest
 
     Map<String, Object> actual = defaultResource.getDatasource(dataSource, null, null);
 
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -240,7 +240,7 @@ public class ClientInfoResourceTest
     );
 
     EasyMock.verify(serverInventoryView, timelineServerView);
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
 
   }
 
@@ -265,7 +265,7 @@ public class ClientInfoResourceTest
     );
 
     EasyMock.verify(serverInventoryView, timelineServerView);
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   /**
@@ -287,7 +287,7 @@ public class ClientInfoResourceTest
     );
 
     EasyMock.verify(serverInventoryView, timelineServerView);
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   /**
@@ -300,7 +300,7 @@ public class ClientInfoResourceTest
     Map<String, Object> expected = ImmutableMap.of();
 
     EasyMock.verify(serverInventoryView, timelineServerView);
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -348,7 +348,7 @@ public class ClientInfoResourceTest
     ).build();
 
     EasyMock.verify(serverInventoryView, timelineServerView);
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   private void addSegment(

--- a/server/src/test/java/org/apache/druid/server/ConsistentHasherTest.java
+++ b/server/src/test/java/org/apache/druid/server/ConsistentHasherTest.java
@@ -24,8 +24,8 @@ import com.google.common.hash.Hashing;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.router.ConsistentHasher;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -64,7 +64,7 @@ public class ConsistentHasherTest
     for (int i = 0; i < 2; i++) {
       for (Map.Entry<String, String> entry : uuidServerMap.entrySet()) {
         String targetServer = hasher.findKey(StringUtils.toUtf8(entry.getKey()));
-        Assert.assertEquals(entry.getValue(), targetServer);
+        Assertions.assertEquals(entry.getValue(), targetServer);
       }
     }
   }
@@ -106,7 +106,7 @@ public class ConsistentHasherTest
 
     // ~1/6 of the entries should change, check that less than 1/5 of the entries hash differently
     double diffRatio = ((double) diff) / NUM_ITERATIONS;
-    Assert.assertTrue(diffRatio < 0.20);
+    Assertions.assertTrue(diffRatio < 0.20);
   }
 
   @Test
@@ -146,7 +146,7 @@ public class ConsistentHasherTest
 
     // ~1/5 of the entries should change, check that less than 1/4 of the entries hash differently
     double diffRatio = ((double) diff) / NUM_ITERATIONS;
-    Assert.assertTrue(diffRatio < 0.25);
+    Assertions.assertTrue(diffRatio < 0.25);
   }
 
   @Test
@@ -258,6 +258,6 @@ public class ConsistentHasherTest
     log.info(StringUtils.format("%s Total: %s, Same: %s, Diff: %s", testName, NUM_ITERATIONS, same, diff));
     log.info("Expected diff ratio: %s, Actual diff ratio: %s", expectedDiffRatio, actualDiffRatio);
 
-    Assert.assertTrue(actualDiffRatio <= expectedDiffRatio);
+    Assertions.assertTrue(actualDiffRatio <= expectedDiffRatio);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/DruidNodeTest.java
+++ b/server/src/test/java/org/apache/druid/server/DruidNodeTest.java
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -51,213 +51,257 @@ public class DruidNodeTest
     DruidNode node;
 
     node = new DruidNode(service, null, false, null, null, true, false);
-    Assert.assertEquals(DruidNode.getDefaultHost(), node.getHost());
-    Assert.assertEquals(-1, node.getPlaintextPort());
+    Assertions.assertEquals(DruidNode.getDefaultHost(), node.getHost());
+    Assertions.assertEquals(-1, node.getPlaintextPort());
     // Hosts which report only ipv6 will have getDefaultHost() report something like fe80::6e40:8ff:fe93:9230
     // but getHostAndPort() reports [fe80::6e40:8ff:fe93:9230]
-    Assert.assertEquals(HostAndPort.fromString(DruidNode.getDefaultHost()).toString(), node.getHostAndPort());
-    Assert.assertEquals(DruidNode.UNKNOWN_VERSION, node.getVersion()); // unknown because not compiled with version
+    Assertions.assertEquals(HostAndPort.fromString(DruidNode.getDefaultHost()).toString(), node.getHostAndPort());
+    Assertions.assertEquals(DruidNode.UNKNOWN_VERSION, node.getVersion()); // unknown because not compiled with version
 
     node = new DruidNode(service, "2001:db8:85a3::8a2e:370:7334", false, -1, null, true, false);
-    Assert.assertEquals("2001:db8:85a3::8a2e:370:7334", node.getHost());
-    Assert.assertEquals(-1, node.getPlaintextPort());
-    Assert.assertEquals("[2001:db8:85a3::8a2e:370:7334]", node.getHostAndPort());
+    Assertions.assertEquals("2001:db8:85a3::8a2e:370:7334", node.getHost());
+    Assertions.assertEquals(-1, node.getPlaintextPort());
+    Assertions.assertEquals("[2001:db8:85a3::8a2e:370:7334]", node.getHostAndPort());
 
     node = new DruidNode(service, "abc:123", false, null, null, true, false);
-    Assert.assertEquals("abc", node.getHost());
-    Assert.assertEquals(123, node.getPlaintextPort());
-    Assert.assertEquals("abc:123", node.getHostAndPort());
+    Assertions.assertEquals("abc", node.getHost());
+    Assertions.assertEquals(123, node.getPlaintextPort());
+    Assertions.assertEquals("abc:123", node.getHostAndPort());
 
     node = new DruidNode(service, "2001:db8:85a3::8a2e:370:7334", false, null, null, true, false);
-    Assert.assertEquals("2001:db8:85a3::8a2e:370:7334", node.getHost());
-    Assert.assertTrue(8080 <= node.getPlaintextPort());
+    Assertions.assertEquals("2001:db8:85a3::8a2e:370:7334", node.getHost());
+    Assertions.assertTrue(8080 <= node.getPlaintextPort());
 
     node = new DruidNode(service, "[2001:db8:85a3::8a2e:370:7334]", false, null, null, true, false);
-    Assert.assertEquals("2001:db8:85a3::8a2e:370:7334", node.getHost());
-    Assert.assertTrue(8080 <= node.getPlaintextPort());
+    Assertions.assertEquals("2001:db8:85a3::8a2e:370:7334", node.getHost());
+    Assertions.assertTrue(8080 <= node.getPlaintextPort());
 
     node = new DruidNode(service, "abc", false, null, null, true, false);
-    Assert.assertEquals("abc", node.getHost());
-    Assert.assertTrue(8080 <= node.getPlaintextPort());
+    Assertions.assertEquals("abc", node.getHost());
+    Assertions.assertTrue(8080 <= node.getPlaintextPort());
 
     node = new DruidNode(service, "abc", false, 123, null, true, false);
-    Assert.assertEquals("abc", node.getHost());
-    Assert.assertEquals(123, node.getPlaintextPort());
-    Assert.assertEquals("abc:123", node.getHostAndPort());
+    Assertions.assertEquals("abc", node.getHost());
+    Assertions.assertEquals(123, node.getPlaintextPort());
+    Assertions.assertEquals("abc:123", node.getHostAndPort());
 
     node = new DruidNode(service, "abc:123", false, 123, null, true, false);
-    Assert.assertEquals("abc", node.getHost());
-    Assert.assertEquals(123, node.getPlaintextPort());
-    Assert.assertEquals("abc:123", node.getHostAndPort());
+    Assertions.assertEquals("abc", node.getHost());
+    Assertions.assertEquals(123, node.getPlaintextPort());
+    Assertions.assertEquals("abc:123", node.getHostAndPort());
 
     node = new DruidNode(service, "[2001:db8:85a3::8a2e:370:7334]:123", false, null, null, true, false);
-    Assert.assertEquals("2001:db8:85a3::8a2e:370:7334", node.getHost());
-    Assert.assertEquals(123, node.getPlaintextPort());
-    Assert.assertEquals("[2001:db8:85a3::8a2e:370:7334]:123", node.getHostAndPort());
+    Assertions.assertEquals("2001:db8:85a3::8a2e:370:7334", node.getHost());
+    Assertions.assertEquals(123, node.getPlaintextPort());
+    Assertions.assertEquals("[2001:db8:85a3::8a2e:370:7334]:123", node.getHostAndPort());
 
     node = new DruidNode(service, "2001:db8:85a3::8a2e:370:7334", false, 123, null, true, false);
-    Assert.assertEquals("2001:db8:85a3::8a2e:370:7334", node.getHost());
-    Assert.assertEquals(123, node.getPlaintextPort());
-    Assert.assertEquals("[2001:db8:85a3::8a2e:370:7334]:123", node.getHostAndPort());
+    Assertions.assertEquals("2001:db8:85a3::8a2e:370:7334", node.getHost());
+    Assertions.assertEquals(123, node.getPlaintextPort());
+    Assertions.assertEquals("[2001:db8:85a3::8a2e:370:7334]:123", node.getHostAndPort());
 
     node = new DruidNode(service, "[2001:db8:85a3::8a2e:370:7334]", false, 123, null, true, false);
-    Assert.assertEquals("2001:db8:85a3::8a2e:370:7334", node.getHost());
-    Assert.assertEquals(123, node.getPlaintextPort());
-    Assert.assertEquals("[2001:db8:85a3::8a2e:370:7334]:123", node.getHostAndPort());
+    Assertions.assertEquals("2001:db8:85a3::8a2e:370:7334", node.getHost());
+    Assertions.assertEquals(123, node.getPlaintextPort());
+    Assertions.assertEquals("[2001:db8:85a3::8a2e:370:7334]:123", node.getHostAndPort());
 
     node = new DruidNode(service, null, false, 123, null, true, false);
-    Assert.assertEquals(DruidNode.getDefaultHost(), node.getHost());
-    Assert.assertEquals(123, node.getPlaintextPort());
+    Assertions.assertEquals(DruidNode.getDefaultHost(), node.getHost());
+    Assertions.assertEquals(123, node.getPlaintextPort());
 
     node = new DruidNode(service, null, false, 123, 123, true, false);
-    Assert.assertEquals(DruidNode.getDefaultHost(), node.getHost());
-    Assert.assertEquals(123, node.getPlaintextPort());
-    Assert.assertEquals(-1, node.getTlsPort());
+    Assertions.assertEquals(DruidNode.getDefaultHost(), node.getHost());
+    Assertions.assertEquals(123, node.getPlaintextPort());
+    Assertions.assertEquals(-1, node.getTlsPort());
 
     node = new DruidNode(service, "host", false, 123, 123, true, false);
-    Assert.assertEquals("host", node.getHost());
-    Assert.assertEquals(123, node.getPlaintextPort());
-    Assert.assertEquals(-1, node.getTlsPort());
+    Assertions.assertEquals("host", node.getHost());
+    Assertions.assertEquals(123, node.getPlaintextPort());
+    Assertions.assertEquals(-1, node.getTlsPort());
 
     node = new DruidNode(service, "host:123", false, null, 123, true, false);
-    Assert.assertEquals("host", node.getHost());
-    Assert.assertEquals(123, node.getPlaintextPort());
-    Assert.assertEquals(-1, node.getTlsPort());
+    Assertions.assertEquals("host", node.getHost());
+    Assertions.assertEquals(123, node.getPlaintextPort());
+    Assertions.assertEquals(-1, node.getTlsPort());
 
     node = new DruidNode("test", "host:123", false, null, 214, true, true);
-    Assert.assertEquals("host", node.getHost());
-    Assert.assertEquals(123, node.getPlaintextPort());
-    Assert.assertEquals(214, node.getTlsPort());
+    Assertions.assertEquals("host", node.getHost());
+    Assertions.assertEquals(123, node.getPlaintextPort());
+    Assertions.assertEquals(214, node.getTlsPort());
 
     node = new DruidNode("test", "host", false, 123, 214, true, true);
-    Assert.assertEquals("host", node.getHost());
-    Assert.assertEquals(123, node.getPlaintextPort());
-    Assert.assertEquals(214, node.getTlsPort());
+    Assertions.assertEquals("host", node.getHost());
+    Assertions.assertEquals(123, node.getPlaintextPort());
+    Assertions.assertEquals(214, node.getTlsPort());
 
     node = new DruidNode("test", "host:123", false, 123, 214, true, true);
-    Assert.assertEquals("host", node.getHost());
-    Assert.assertEquals(123, node.getPlaintextPort());
-    Assert.assertEquals(214, node.getTlsPort());
+    Assertions.assertEquals("host", node.getHost());
+    Assertions.assertEquals(123, node.getPlaintextPort());
+    Assertions.assertEquals(214, node.getTlsPort());
 
     node = new DruidNode("test", null, false, 123, 214, true, true);
-    Assert.assertEquals(DruidNode.getDefaultHost(), node.getHost());
-    Assert.assertEquals(123, node.getPlaintextPort());
-    Assert.assertEquals(214, node.getTlsPort());
+    Assertions.assertEquals(DruidNode.getDefaultHost(), node.getHost());
+    Assertions.assertEquals(123, node.getPlaintextPort());
+    Assertions.assertEquals(214, node.getTlsPort());
 
     node = new DruidNode("test", "host:123", false, null, 214, false, true);
-    Assert.assertEquals("host", node.getHost());
-    Assert.assertEquals(-1, node.getPlaintextPort());
-    Assert.assertEquals(214, node.getTlsPort());
+    Assertions.assertEquals("host", node.getHost());
+    Assertions.assertEquals(-1, node.getPlaintextPort());
+    Assertions.assertEquals(214, node.getTlsPort());
 
     node = new DruidNode("test", "host:123", false, null, 123, false, true);
-    Assert.assertEquals("host", node.getHost());
-    Assert.assertEquals(-1, node.getPlaintextPort());
-    Assert.assertEquals(123, node.getTlsPort());
+    Assertions.assertEquals("host", node.getHost());
+    Assertions.assertEquals(-1, node.getPlaintextPort());
+    Assertions.assertEquals(123, node.getTlsPort());
 
     node = new DruidNode("test", null, false, null, 123, false, true);
-    Assert.assertEquals(DruidNode.getDefaultHost(), node.getHost());
-    Assert.assertEquals(-1, node.getPlaintextPort());
-    Assert.assertEquals(123, node.getTlsPort());
+    Assertions.assertEquals(DruidNode.getDefaultHost(), node.getHost());
+    Assertions.assertEquals(-1, node.getPlaintextPort());
+    Assertions.assertEquals(123, node.getTlsPort());
 
     node = new DruidNode("test", null, false, -1, 123, false, true);
-    Assert.assertEquals(DruidNode.getDefaultHost(), node.getHost());
-    Assert.assertEquals(-1, node.getPlaintextPort());
-    Assert.assertEquals(123, node.getTlsPort());
+    Assertions.assertEquals(DruidNode.getDefaultHost(), node.getHost());
+    Assertions.assertEquals(-1, node.getPlaintextPort());
+    Assertions.assertEquals(123, node.getTlsPort());
 
     node = new DruidNode("test", "host", false, -1, null, 123, false, true, ImmutableMap.of("labelKey1", "labelValue1"));
-    Assert.assertEquals("host", node.getHost());
-    Assert.assertEquals(-1, node.getPlaintextPort());
-    Assert.assertEquals(123, node.getTlsPort());
-    Assert.assertEquals(ImmutableMap.of("labelKey1", "labelValue1"), node.getLabels());
+    Assertions.assertEquals("host", node.getHost());
+    Assertions.assertEquals(-1, node.getPlaintextPort());
+    Assertions.assertEquals(123, node.getTlsPort());
+    Assertions.assertEquals(ImmutableMap.of("labelKey1", "labelValue1"), node.getLabels());
 
     node = new DruidNode("test", "host", false, -1, null, 123, true, false, ImmutableMap.of("labelKey1", "labelValue1", "labelKey2", "labelValue2"));
-    Assert.assertEquals("host", node.getHost());
-    Assert.assertEquals(-1, node.getPlaintextPort());
-    Assert.assertEquals(-1, node.getTlsPort());
-    Assert.assertEquals(ImmutableMap.of("labelKey1", "labelValue1", "labelKey2", "labelValue2"), node.getLabels());
+    Assertions.assertEquals("host", node.getHost());
+    Assertions.assertEquals(-1, node.getPlaintextPort());
+    Assertions.assertEquals(-1, node.getTlsPort());
+    Assertions.assertEquals(ImmutableMap.of("labelKey1", "labelValue1", "labelKey2", "labelValue2"), node.getLabels());
 
     node = new DruidNode("test", "host:123", false, 123, null, true, false);
-    Assert.assertEquals("host", node.getHost());
-    Assert.assertEquals(123, node.getPlaintextPort());
-    Assert.assertEquals(-1, node.getTlsPort());
-    Assert.assertNull(node.getLabels());
+    Assertions.assertEquals("host", node.getHost());
+    Assertions.assertEquals(123, node.getPlaintextPort());
+    Assertions.assertEquals(-1, node.getTlsPort());
+    Assertions.assertNull(node.getLabels());
 
     node = new DruidNode("test", "host:123", false, null, 123, true, false);
-    Assert.assertEquals("host", node.getHost());
-    Assert.assertEquals(123, node.getPlaintextPort());
-    Assert.assertEquals(-1, node.getTlsPort());
+    Assertions.assertEquals("host", node.getHost());
+    Assertions.assertEquals(123, node.getPlaintextPort());
+    Assertions.assertEquals(-1, node.getTlsPort());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testConflictingPorts()
   {
-    new DruidNode("test/service", "abc:123", false, 456, null, true, false);
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new DruidNode("test/service", "abc:123", false, 456, null, true, false)
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testAtLeastTlsOrPlainTextIsSet()
   {
-    new DruidNode("test", "host:123", false, null, 123, false, false);
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new DruidNode("test", "host:123", false, null, 123, false, false)
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSamePlainTextAndTlsPort()
   {
-    new DruidNode("test", "host:123", false, null, 123, true, true);
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new DruidNode("test", "host:123", false, null, 123, true, true)
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSamePlainTextAndTlsPort1()
   {
-    new DruidNode("test", "host", false, 123, 123, true, true);
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new DruidNode("test", "host", false, 123, 123, true, true)
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullTlsPort()
   {
-    new DruidNode("test", "host:123", false, null, null, true, true);
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new DruidNode("test", "host:123", false, null, null, true, true)
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullPlainTextAndTlsPort1()
   {
-    new DruidNode("test", "host", false, null, null, true, true);
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new DruidNode("test", "host", false, null, null, true, true)
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullTlsPort1()
   {
-    new DruidNode("test", "host:123", false, 123, null, true, true);
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new DruidNode("test", "host:123", false, 123, null, true, true)
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullPlainTextAndTlsPort()
   {
-    new DruidNode("test", null, false, null, null, true, true);
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new DruidNode("test", null, false, null, null, true, true)
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testConflictingPlainTextPort()
   {
-    new DruidNode("test", "host:123", false, 321, null, true, true);
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new DruidNode("test", "host:123", false, 321, null, true, true)
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidIPv6WithPort()
   {
-    new DruidNode("test/service", "[abc:fff]:123", false, 456, null, true, false);
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new DruidNode("test/service", "[abc:fff]:123", false, 456, null, true, false)
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidIPv6()
   {
-    new DruidNode("test/service", "abc:fff", false, 456, null, true, false);
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new DruidNode("test/service", "abc:fff", false, 456, null, true, false)
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testConflictingPortsNonsense()
   {
-    new DruidNode("test/service", "[2001:db8:85a3::8a2e:370:7334]:123", false, 456, null, true, false);
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new DruidNode(
+            "test/service",
+            "[2001:db8:85a3::8a2e:370:7334]:123",
+            false,
+            456,
+            null,
+            true,
+            false
+        )
+    );
   }
 
   @Test
@@ -267,11 +311,11 @@ public class DruidNodeTest
     final String host = "some.host";
     final int port = 9898;
     final Map<String, String> labels = ImmutableMap.of("key1", "value1");
-    Assert.assertEquals(new DruidNode(serviceName, host, false, port, null, null, true, false, labels), new DruidNode(serviceName, host, false, port, null, null, true, false, labels));
-    Assert.assertEquals(new DruidNode(serviceName, host, false, port, null, null, true, false, labels), new DruidNode(serviceName, host, false, port, null, null, true, false, ImmutableMap.of("key1", "value1")));
-    Assert.assertNotEquals(new DruidNode(serviceName, host, false, port, null, true, false), new DruidNode(serviceName, host, false, -1, null, true, false));
-    Assert.assertNotEquals(new DruidNode(serviceName, host, false, port, null, true, false), new DruidNode(serviceName, "other.host", false, port, null, true, false));
-    Assert.assertNotEquals(new DruidNode(serviceName, host, false, port, null, true, false), new DruidNode("otherServiceName", host, false, port, null, true, false));
+    Assertions.assertEquals(new DruidNode(serviceName, host, false, port, null, null, true, false, labels), new DruidNode(serviceName, host, false, port, null, null, true, false, labels));
+    Assertions.assertEquals(new DruidNode(serviceName, host, false, port, null, null, true, false, labels), new DruidNode(serviceName, host, false, port, null, null, true, false, ImmutableMap.of("key1", "value1")));
+    Assertions.assertNotEquals(new DruidNode(serviceName, host, false, port, null, true, false), new DruidNode(serviceName, host, false, -1, null, true, false));
+    Assertions.assertNotEquals(new DruidNode(serviceName, host, false, port, null, true, false), new DruidNode(serviceName, "other.host", false, port, null, true, false));
+    Assertions.assertNotEquals(new DruidNode(serviceName, host, false, port, null, true, false), new DruidNode("otherServiceName", host, false, port, null, true, false));
   }
 
   @Test
@@ -282,14 +326,14 @@ public class DruidNodeTest
     final String host = "some.host";
     final int port = 9898;
     final Map<String, String> labels = ImmutableMap.of("key1", "value1");
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new DruidNode(serviceName, host, false, port, null, null, true, false, labels).hashCode(),
         new DruidNode(serviceName, host, false, port, null, null, true, false, labels).hashCode()
     );
     // Potential hash collision if hashCode method ever changes
-    Assert.assertNotEquals(new DruidNode(serviceName, host, false, port, null, true, false).hashCode(), new DruidNode(serviceName, host, false, -1, null, true, false).hashCode());
-    Assert.assertNotEquals(new DruidNode(serviceName, host, false, port, null, true, false).hashCode(), new DruidNode(serviceName, "other.host", false, port, null, true, false).hashCode());
-    Assert.assertNotEquals(new DruidNode(serviceName, host, false, port, null, true, false).hashCode(), new DruidNode("otherServiceName", host, false, port, null, true, false).hashCode());
+    Assertions.assertNotEquals(new DruidNode(serviceName, host, false, port, null, true, false).hashCode(), new DruidNode(serviceName, host, false, -1, null, true, false).hashCode());
+    Assertions.assertNotEquals(new DruidNode(serviceName, host, false, port, null, true, false).hashCode(), new DruidNode(serviceName, "other.host", false, port, null, true, false).hashCode());
+    Assertions.assertNotEquals(new DruidNode(serviceName, host, false, port, null, true, false).hashCode(), new DruidNode("otherServiceName", host, false, port, null, true, false).hashCode());
   }
 
 
@@ -300,14 +344,14 @@ public class DruidNodeTest
         mapper.writeValueAsString(new DruidNode("service", "host", true, 1234, null, 5678, true, true, ImmutableMap.of("key1", "value1"))),
         DruidNode.class
     );
-    Assert.assertEquals("service", actual.getServiceName());
-    Assert.assertEquals("host", actual.getHost());
-    Assert.assertTrue(actual.isBindOnHost());
-    Assert.assertTrue(actual.isEnablePlaintextPort());
-    Assert.assertTrue(actual.isEnableTlsPort());
-    Assert.assertEquals(1234, actual.getPlaintextPort());
-    Assert.assertEquals(5678, actual.getTlsPort());
-    Assert.assertEquals(ImmutableMap.of("key1", "value1"), actual.getLabels());
+    Assertions.assertEquals("service", actual.getServiceName());
+    Assertions.assertEquals("host", actual.getHost());
+    Assertions.assertTrue(actual.isBindOnHost());
+    Assertions.assertTrue(actual.isEnablePlaintextPort());
+    Assertions.assertTrue(actual.isEnableTlsPort());
+    Assertions.assertEquals(1234, actual.getPlaintextPort());
+    Assertions.assertEquals(5678, actual.getTlsPort());
+    Assertions.assertEquals(ImmutableMap.of("key1", "value1"), actual.getLabels());
   }
 
   @Test
@@ -317,14 +361,14 @@ public class DruidNodeTest
         mapper.writeValueAsString(new DruidNode("service", "host", false, 1234, null, 5678, null, false, null)),
         DruidNode.class
     );
-    Assert.assertEquals("service", actual.getServiceName());
-    Assert.assertEquals("host", actual.getHost());
-    Assert.assertFalse(actual.isBindOnHost());
-    Assert.assertTrue(actual.isEnablePlaintextPort());
-    Assert.assertFalse(actual.isEnableTlsPort());
-    Assert.assertEquals(1234, actual.getPlaintextPort());
-    Assert.assertEquals(-1, actual.getTlsPort());
-    Assert.assertNull(actual.getLabels());
+    Assertions.assertEquals("service", actual.getServiceName());
+    Assertions.assertEquals("host", actual.getHost());
+    Assertions.assertFalse(actual.isBindOnHost());
+    Assertions.assertTrue(actual.isEnablePlaintextPort());
+    Assertions.assertFalse(actual.isEnableTlsPort());
+    Assertions.assertEquals(1234, actual.getPlaintextPort());
+    Assertions.assertEquals(-1, actual.getTlsPort());
+    Assertions.assertNull(actual.getLabels());
   }
 
   @Test
@@ -334,14 +378,14 @@ public class DruidNodeTest
         mapper.writeValueAsString(new DruidNode("service", "host", true, 1234, null, 5678, false, true, ImmutableMap.of("key1", "value1", "key2", "value2"))),
         DruidNode.class
     );
-    Assert.assertEquals("service", actual.getServiceName());
-    Assert.assertEquals("host", actual.getHost());
-    Assert.assertTrue(actual.isBindOnHost());
-    Assert.assertFalse(actual.isEnablePlaintextPort());
-    Assert.assertTrue(actual.isEnableTlsPort());
-    Assert.assertEquals(-1, actual.getPlaintextPort());
-    Assert.assertEquals(5678, actual.getTlsPort());
-    Assert.assertEquals(ImmutableMap.of("key1", "value1", "key2", "value2"), actual.getLabels());
+    Assertions.assertEquals("service", actual.getServiceName());
+    Assertions.assertEquals("host", actual.getHost());
+    Assertions.assertTrue(actual.isBindOnHost());
+    Assertions.assertFalse(actual.isEnablePlaintextPort());
+    Assertions.assertTrue(actual.isEnableTlsPort());
+    Assertions.assertEquals(-1, actual.getPlaintextPort());
+    Assertions.assertEquals(5678, actual.getTlsPort());
+    Assertions.assertEquals(ImmutableMap.of("key1", "value1", "key2", "value2"), actual.getLabels());
   }
 
   @Test
@@ -360,12 +404,12 @@ public class DruidNodeTest
 
 
     DruidNode actual = mapper.readValue(json, DruidNode.class);
-    Assert.assertEquals(new DruidNode("service", "host", true, 1234, null, 5678, true, true, ImmutableMap.of("key1", "value1")), actual);
+    Assertions.assertEquals(new DruidNode("service", "host", true, 1234, null, 5678, true, true, ImmutableMap.of("key1", "value1")), actual);
 
-    Assert.assertEquals("https", actual.getServiceScheme());
-    Assert.assertEquals("host:1234", actual.getHostAndPort());
-    Assert.assertEquals("host:5678", actual.getHostAndTlsPort());
-    Assert.assertEquals("host:5678", actual.getHostAndPortToUse());
+    Assertions.assertEquals("https", actual.getServiceScheme());
+    Assertions.assertEquals("host:1234", actual.getHostAndPort());
+    Assertions.assertEquals("host:5678", actual.getHostAndTlsPort());
+    Assertions.assertEquals("host:5678", actual.getHostAndPortToUse());
   }
 
   @Test
@@ -381,12 +425,12 @@ public class DruidNodeTest
 
 
     DruidNode actual = mapper.readValue(json, DruidNode.class);
-    Assert.assertEquals(new DruidNode("service", "host", false, 1234, null, 5678, true, false, null), actual);
+    Assertions.assertEquals(new DruidNode("service", "host", false, 1234, null, 5678, true, false, null), actual);
 
-    Assert.assertEquals("http", actual.getServiceScheme());
-    Assert.assertEquals("host:1234", actual.getHostAndPort());
-    Assert.assertNull(actual.getHostAndTlsPort());
-    Assert.assertEquals("host:1234", actual.getHostAndPortToUse());
+    Assertions.assertEquals("http", actual.getServiceScheme());
+    Assertions.assertEquals("host:1234", actual.getHostAndPort());
+    Assertions.assertNull(actual.getHostAndTlsPort());
+    Assertions.assertEquals("host:1234", actual.getHostAndPortToUse());
   }
 
   @Test
@@ -401,12 +445,12 @@ public class DruidNodeTest
 
 
     DruidNode actual = mapper.readValue(json, DruidNode.class);
-    Assert.assertEquals(new DruidNode("service", "host", false, 1234, null, 5678, null, false, null), actual);
+    Assertions.assertEquals(new DruidNode("service", "host", false, 1234, null, 5678, null, false, null), actual);
 
-    Assert.assertEquals("http", actual.getServiceScheme());
-    Assert.assertEquals("host:1234", actual.getHostAndPort());
-    Assert.assertNull(actual.getHostAndTlsPort());
-    Assert.assertEquals("host:1234", actual.getHostAndPortToUse());
+    Assertions.assertEquals("http", actual.getServiceScheme());
+    Assertions.assertEquals("host:1234", actual.getHostAndPort());
+    Assertions.assertNull(actual.getHostAndTlsPort());
+    Assertions.assertEquals("host:1234", actual.getHostAndPortToUse());
   }
 
   @Test
@@ -421,12 +465,12 @@ public class DruidNodeTest
 
 
     DruidNode actual = mapper.readValue(json, DruidNode.class);
-    Assert.assertEquals(new DruidNode("service", "host", false, null, 1234, 5678, null, false, null), actual);
+    Assertions.assertEquals(new DruidNode("service", "host", false, null, 1234, 5678, null, false, null), actual);
 
-    Assert.assertEquals("http", actual.getServiceScheme());
-    Assert.assertEquals("host:1234", actual.getHostAndPort());
-    Assert.assertNull(actual.getHostAndTlsPort());
-    Assert.assertEquals("host:1234", actual.getHostAndPortToUse());
+    Assertions.assertEquals("http", actual.getServiceScheme());
+    Assertions.assertEquals("host:1234", actual.getHostAndPort());
+    Assertions.assertNull(actual.getHostAndTlsPort());
+    Assertions.assertEquals("host:1234", actual.getHostAndPortToUse());
   }
 
 }

--- a/server/src/test/java/org/apache/druid/server/PerSegmentTimeoutInjectionTest.java
+++ b/server/src/test/java/org/apache/druid/server/PerSegmentTimeoutInjectionTest.java
@@ -37,10 +37,10 @@ import org.apache.druid.server.log.RequestLogger;
 import org.apache.druid.server.security.AuthConfig;
 import org.apache.druid.server.security.AuthorizerMapper;
 import org.easymock.EasyMock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -71,7 +71,7 @@ public class PerSegmentTimeoutInjectionTest
       .aggregators(new CountAggregatorFactory("count"))
       .build();
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     conglomerate = EasyMock.createMock(QueryRunnerFactoryConglomerate.class);
@@ -83,7 +83,7 @@ public class PerSegmentTimeoutInjectionTest
     toolChest = EasyMock.createNiceMock(QueryToolChest.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     EasyMock.verify(conglomerate);
@@ -95,7 +95,7 @@ public class PerSegmentTimeoutInjectionTest
     QueryLifecycle lifecycle = createLifecycle(perSegmentTimeout(5000));
     lifecycle.initialize(baseQuery);
 
-    Assert.assertEquals(5000L, lifecycle.getQuery().context().getPerSegmentTimeout());
+    Assertions.assertEquals(5000L, lifecycle.getQuery().context().getPerSegmentTimeout());
   }
 
   @Test
@@ -107,7 +107,7 @@ public class PerSegmentTimeoutInjectionTest
     QueryLifecycle lifecycle = createLifecycle(perSegmentTimeout(5000));
     lifecycle.initialize(query, Collections.emptySet());
 
-    Assert.assertEquals(5000L, lifecycle.getQuery().context().getPerSegmentTimeout());
+    Assertions.assertEquals(5000L, lifecycle.getQuery().context().getPerSegmentTimeout());
   }
 
   @Test
@@ -118,7 +118,7 @@ public class PerSegmentTimeoutInjectionTest
     QueryLifecycle lifecycle = createLifecycle(perSegmentTimeout(5000));
     lifecycle.initialize(query, Set.of(KEY));
 
-    Assert.assertEquals(2000L, lifecycle.getQuery().context().getPerSegmentTimeout());
+    Assertions.assertEquals(2000L, lifecycle.getQuery().context().getPerSegmentTimeout());
   }
 
   @Test
@@ -128,7 +128,7 @@ public class PerSegmentTimeoutInjectionTest
     QueryLifecycle lifecycle = createLifecycle(Map.of(KEY, 100L), perSegmentTimeout(5000));
     lifecycle.initialize(baseQuery);
 
-    Assert.assertEquals(5000L, lifecycle.getQuery().context().getPerSegmentTimeout());
+    Assertions.assertEquals(5000L, lifecycle.getQuery().context().getPerSegmentTimeout());
   }
 
   @Test
@@ -137,7 +137,7 @@ public class PerSegmentTimeoutInjectionTest
     QueryLifecycle lifecycle = createLifecycle(Map.of(KEY, 100L), BrokerDynamicConfig.builder().build());
     lifecycle.initialize(baseQuery);
 
-    Assert.assertEquals(100L, lifecycle.getQuery().context().getPerSegmentTimeout());
+    Assertions.assertEquals(100L, lifecycle.getQuery().context().getPerSegmentTimeout());
   }
 
   @Test
@@ -151,7 +151,7 @@ public class PerSegmentTimeoutInjectionTest
     QueryLifecycle lifecycle = createLifecycle(dynamicConfig);
     lifecycle.initialize(baseQuery);
 
-    Assert.assertFalse(lifecycle.getQuery().context().usePerSegmentTimeout());
+    Assertions.assertFalse(lifecycle.getQuery().context().usePerSegmentTimeout());
   }
 
   @Test
@@ -160,7 +160,7 @@ public class PerSegmentTimeoutInjectionTest
     QueryLifecycle lifecycle = createLifecycle(null);
     lifecycle.initialize(baseQuery);
 
-    Assert.assertFalse(lifecycle.getQuery().context().usePerSegmentTimeout());
+    Assertions.assertFalse(lifecycle.getQuery().context().usePerSegmentTimeout());
   }
 
   private static BrokerDynamicConfig perSegmentTimeout(long timeoutMs)

--- a/server/src/test/java/org/apache/druid/server/RendezvousHasherTest.java
+++ b/server/src/test/java/org/apache/druid/server/RendezvousHasherTest.java
@@ -24,8 +24,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.router.RendezvousHasher;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -65,7 +65,7 @@ public class RendezvousHasherTest
     for (int i = 0; i < 2; i++) {
       for (Map.Entry<String, String> entry : uuidServerMap.entrySet()) {
         String targetServer = hasher.chooseNode(nodes, StringUtils.toUtf8(entry.getKey()));
-        Assert.assertEquals(entry.getValue(), targetServer);
+        Assertions.assertEquals(entry.getValue(), targetServer);
       }
     }
   }
@@ -104,7 +104,7 @@ public class RendezvousHasherTest
     log.info(StringUtils.format("testAddNode Total: %s, Same: %s, Diff: %s", NUM_ITERATIONS, same, diff));
 
     double diffRatio = ((double) diff) / NUM_ITERATIONS;
-    Assert.assertTrue(diffRatio < 0.33);
+    Assertions.assertTrue(diffRatio < 0.33);
   }
 
   @Test
@@ -141,7 +141,7 @@ public class RendezvousHasherTest
     log.info(StringUtils.format("testRemoveNode Total: %s, Same: %s, Diff: %s", NUM_ITERATIONS, same, diff));
 
     double diffRatio = ((double) diff) / NUM_ITERATIONS;
-    Assert.assertTrue(diffRatio < 0.33);
+    Assertions.assertTrue(diffRatio < 0.33);
   }
 
   @Test
@@ -249,7 +249,7 @@ public class RendezvousHasherTest
     log.info(StringUtils.format("%s Total: %s, Same: %s, Diff: %s", testName, NUM_ITERATIONS, same, diff));
     log.info("Expected diff ratio: %s, Actual diff ratio: %s", expectedDiffRatio, actualDiffRatio);
 
-    Assert.assertTrue(actualDiffRatio <= expectedDiffRatio);
+    Assertions.assertTrue(actualDiffRatio <= expectedDiffRatio);
   }
 
   @Test
@@ -280,6 +280,6 @@ public class RendezvousHasherTest
                                                             .put("localhost:3", 25)
                                                             .put("localhost:4", 15)
                                                             .build();
-    Assert.assertEquals(expectedDistribution, brokerToConnectionCount);
+    Assertions.assertEquals(expectedDistribution, brokerToConnectionCount);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/RequestLogLineTest.java
+++ b/server/src/test/java/org/apache/druid/server/RequestLogLineTest.java
@@ -26,15 +26,15 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.TableDataSource;
 import org.apache.druid.query.timeboundary.TimeBoundaryQuery;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RequestLogLineTest
 {
   private Query query;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     query = new TimeBoundaryQuery(
@@ -46,25 +46,31 @@ public class RequestLogLineTest
     );
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void nullTimestamp()
   {
-    RequestLogLine requestLogLine = RequestLogLine.forNative(
-        query,
-        null,
-        "",
-        new QueryStats(ImmutableMap.of())
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> RequestLogLine.forNative(
+            query,
+            null,
+            "",
+            new QueryStats(ImmutableMap.of())
+        )
     );
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void nullQueryStats()
   {
-    RequestLogLine requestLogLine = RequestLogLine.forNative(
-        query,
-        DateTimes.nowUtc(),
-        "",
-        null
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> RequestLogLine.forNative(
+            query,
+            DateTimes.nowUtc(),
+            "",
+            null
+        )
     );
   }
 
@@ -77,14 +83,14 @@ public class RequestLogLineTest
         null,
         new QueryStats(ImmutableMap.of())
     );
-    Assert.assertEquals("", requestLogLine.getRemoteAddr());
+    Assertions.assertEquals("", requestLogLine.getRemoteAddr());
     requestLogLine.getNativeQueryLine(new DefaultObjectMapper()); // call should not throw exception
 
     requestLogLine = RequestLogLine.forSql(
         "", null, DateTimes.nowUtc(), null, new QueryStats(ImmutableMap.of())
     );
-    Assert.assertEquals("", requestLogLine.getRemoteAddr());
-    Assert.assertEquals(ImmutableMap.<String, Object>of(), requestLogLine.getSqlQueryContext());
+    Assertions.assertEquals("", requestLogLine.getRemoteAddr());
+    Assertions.assertEquals(ImmutableMap.<String, Object>of(), requestLogLine.getSqlQueryContext());
     requestLogLine.getSqlQueryLine(new DefaultObjectMapper()); // call should not throw exception
   }
 

--- a/server/src/test/java/org/apache/druid/server/SegmentManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/SegmentManagerTest.java
@@ -56,16 +56,16 @@ import org.apache.druid.segment.loading.StorageLocationConfig;
 import org.apache.druid.server.SegmentManager.DataSourceState;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.NumberedOverwriteShardSpec;
 import org.apache.druid.timeline.partition.PartitionIds;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.io.IOException;
@@ -96,10 +96,10 @@ public class SegmentManagerTest extends InitializedNullHandlingTest
   private SegmentLocalCacheManager virtualCacheManager;
   private SegmentManager virtualSegmentManager;
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     EmittingLogger.registerEmitter(new NoopServiceEmitter());
@@ -158,7 +158,7 @@ public class SegmentManagerTest extends InitializedNullHandlingTest
     executor = Execs.multiThreaded(SEGMENTS.size(), "SegmentManagerTest-%d");
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     executor.shutdownNow();
@@ -219,7 +219,7 @@ public class SegmentManagerTest extends InitializedNullHandlingTest
       segmentManager.loadSegment(eachSegment);
       ReferenceCountedSegmentProvider refProvider = cacheManager.getSegmentReferenceProvider(eachSegment);
       referenceProviders.add(refProvider);
-      Assert.assertFalse(refProvider.isClosed());
+      Assertions.assertFalse(refProvider.isClosed());
     }
 
     final List<Future<Void>> futures = ImmutableList.of(SEGMENTS.get(0), SEGMENTS.get(2)).stream()
@@ -241,11 +241,11 @@ public class SegmentManagerTest extends InitializedNullHandlingTest
         ImmutableList.of(SEGMENTS.get(1), SEGMENTS.get(3), SEGMENTS.get(4))
     );
     for (int i = 0; i < SEGMENTS.size(); i++) {
-      Assert.assertEquals(0, referenceProviders.get(i).getNumReferences());
+      Assertions.assertEquals(0, referenceProviders.get(i).getNumReferences());
       if (i == 0 || i == 2) {
-        Assert.assertTrue(referenceProviders.get(i).isClosed());
+        Assertions.assertTrue(referenceProviders.get(i).isClosed());
       } else {
-        Assert.assertFalse(referenceProviders.get(i).isClosed());
+        Assertions.assertFalse(referenceProviders.get(i).isClosed());
       }
     }
   }
@@ -368,15 +368,15 @@ public class SegmentManagerTest extends InitializedNullHandlingTest
   {
     segmentManager.loadSegment(SEGMENTS.get(0));
     assertResult(ImmutableList.of(SEGMENTS.get(0)));
-    Assert.assertEquals(1, segmentManager.getDataSources().size());
+    Assertions.assertEquals(1, segmentManager.getDataSources().size());
     segmentManager.dropSegment(SEGMENTS.get(0));
-    Assert.assertEquals(0, segmentManager.getDataSources().size());
+    Assertions.assertEquals(0, segmentManager.getDataSources().size());
   }
 
   @Test
   public void testGetNonExistingTimeline()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Optional.empty(),
         segmentManager.getTimeline((new TableDataSource("nonExisting")))
     );
@@ -427,22 +427,22 @@ public class SegmentManagerTest extends InitializedNullHandlingTest
     );
 
     // expect 2 cached segments
-    Assert.assertEquals(2, bundle.getCachedSegments().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(2, bundle.getCachedSegments().size());
+    Assertions.assertEquals(
         d1.getDescriptor(),
         bundle.getCachedSegments().get(0).getSegmentDescriptor()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         d2.getDescriptor(),
         bundle.getCachedSegments().get(1).getSegmentDescriptor()
     );
     // no loadable segments since vsf is not enabled
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(),
         bundle.getLoadableSegments()
     );
     // 2 missing segments since cannot load d3 on demand and it was not loaded into the cache
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(d3.getDescriptor(), d4.getDescriptor()),
         bundle.getMissingSegments()
     );
@@ -462,9 +462,9 @@ public class SegmentManagerTest extends InitializedNullHandlingTest
 
     final AcquireSegmentAction action = virtualSegmentManager.acquireSegment(toLoad, AcquireMode.FULL);
     AcquireSegmentResult result = action.getSegmentFuture().get();
-    Assert.assertNotNull(result);
-    Assert.assertEquals(1L, result.getLoadSizeBytes());
-    Assert.assertTrue(result.getLoadTimeNanos() > 0);
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(1L, result.getLoadSizeBytes());
+    Assertions.assertTrue(result.getLoadTimeNanos() > 0);
 
     DataSegmentAndDescriptor d1 = new DataSegmentAndDescriptor(SEGMENTS.get(0), SEGMENTS.get(0).toDescriptor());
     DataSegmentAndDescriptor d2 = new DataSegmentAndDescriptor(toLoad, toLoad.toDescriptor());
@@ -477,18 +477,18 @@ public class SegmentManagerTest extends InitializedNullHandlingTest
     );
 
     // expect 1 cached segment since we called acquireSegment
-    Assert.assertEquals(1, bundle.getCachedSegments().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, bundle.getCachedSegments().size());
+    Assertions.assertEquals(
         d2.getDescriptor(),
         bundle.getCachedSegments().get(0).getSegmentDescriptor()
     );
     // 2 loadable segments (in theory, would explode if we tried since they dont have real files)
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(d1, d3),
         bundle.getLoadableSegments()
     );
     // 1 missing segment
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(d4.getDescriptor()),
         bundle.getMissingSegments()
     );
@@ -519,21 +519,21 @@ public class SegmentManagerTest extends InitializedNullHandlingTest
       );
     }
 
-    Assert.assertEquals(expectedDataSourceNames, segmentManager.getDataSourceNames());
-    Assert.assertEquals(expectedDataSourceCounts, segmentManager.getDataSourceCounts());
-    Assert.assertEquals(expectedDataSourceSizes, segmentManager.getDataSourceSizes());
+    Assertions.assertEquals(expectedDataSourceNames, segmentManager.getDataSourceNames());
+    Assertions.assertEquals(expectedDataSourceCounts, segmentManager.getDataSourceCounts());
+    Assertions.assertEquals(expectedDataSourceSizes, segmentManager.getDataSourceSizes());
 
     final Map<String, DataSourceState> dataSources = segmentManager.getDataSources();
-    Assert.assertEquals(expectedTimelines.size(), dataSources.size());
+    Assertions.assertEquals(expectedTimelines.size(), dataSources.size());
 
     dataSources.forEach(
         (sourceName, dataSourceState) -> {
-          Assert.assertEquals(expectedDataSourceCounts.get(sourceName).longValue(), dataSourceState.getNumSegments());
-          Assert.assertEquals(
+          Assertions.assertEquals(expectedDataSourceCounts.get(sourceName).longValue(), dataSourceState.getNumSegments());
+          Assertions.assertEquals(
               expectedDataSourceSizes.get(sourceName).longValue(),
               dataSourceState.getTotalSegmentSize()
           );
-          Assert.assertEquals(
+          Assertions.assertEquals(
               expectedTimelines.get(sourceName).getAllTimelineEntries(),
               dataSourceState.getTimeline().getAllTimelineEntries()
           );

--- a/server/src/test/java/org/apache/druid/server/ServiceAnnouncementStateTest.java
+++ b/server/src/test/java/org/apache/druid/server/ServiceAnnouncementStateTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.server;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ServiceAnnouncementStateTest
 {
@@ -28,7 +28,7 @@ public class ServiceAnnouncementStateTest
   public void testInitialStateIsNotReady()
   {
     final ServiceAnnouncementState state = new ServiceAnnouncementState();
-    Assert.assertFalse(state.isReady());
+    Assertions.assertFalse(state.isReady());
   }
 
   @Test
@@ -36,7 +36,7 @@ public class ServiceAnnouncementStateTest
   {
     final ServiceAnnouncementState state = new ServiceAnnouncementState();
     state.markReady();
-    Assert.assertTrue(state.isReady());
+    Assertions.assertTrue(state.isReady());
   }
 
   @Test
@@ -44,9 +44,9 @@ public class ServiceAnnouncementStateTest
   {
     final ServiceAnnouncementState state = new ServiceAnnouncementState();
     state.markReady();
-    Assert.assertTrue(state.isReady());
+    Assertions.assertTrue(state.isReady());
     state.markNotReady();
-    Assert.assertFalse(state.isReady());
+    Assertions.assertFalse(state.isReady());
   }
 
   @Test
@@ -55,10 +55,10 @@ public class ServiceAnnouncementStateTest
     final ServiceAnnouncementState state = new ServiceAnnouncementState();
     state.markReady();
     state.markReady();
-    Assert.assertTrue(state.isReady());
+    Assertions.assertTrue(state.isReady());
     state.markNotReady();
-    Assert.assertFalse(state.isReady());
+    Assertions.assertFalse(state.isReady());
     state.markNotReady();
-    Assert.assertFalse(state.isReady());
+    Assertions.assertFalse(state.isReady());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/StatusResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/StatusResourceTest.java
@@ -30,8 +30,8 @@ import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.loading.SegmentLoaderConfig;
 import org.apache.druid.utils.JvmUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 import java.util.Collection;
@@ -52,7 +52,7 @@ public class StatusResourceTest
     List<StatusResource.ModuleVersion> statusResourceModuleList =
         new StatusResource.Status(modules, JvmUtils.getRuntimeInfo()).getModules();
 
-    Assert.assertEquals("Status should have all modules loaded!", modules.size(), statusResourceModuleList.size());
+    Assertions.assertEquals(modules.size(), statusResourceModuleList.size(), "Status should have all modules loaded!");
 
     for (DruidModule module : modules) {
       String moduleName = module.getClass().getName();
@@ -64,7 +64,7 @@ public class StatusResourceTest
           break;
         }
       }
-      Assert.assertTrue("Status resource should contain module " + moduleName, contains);
+      Assertions.assertTrue(contains, "Status resource should contain module " + moduleName);
     }
   }
 
@@ -87,8 +87,8 @@ public class StatusResourceTest
     state.markReady();
     final StatusResource resource = new StatusResource(new Properties(), null, null, null, state);
     final Response response = resource.getReady();
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(true, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(true, response.getEntity());
   }
 
   @Test
@@ -97,8 +97,8 @@ public class StatusResourceTest
     final ServiceAnnouncementState state = new ServiceAnnouncementState();
     final StatusResource resource = new StatusResource(new Properties(), null, null, null, state);
     final Response response = resource.getReady();
-    Assert.assertEquals(503, response.getStatus());
-    Assert.assertEquals(false, response.getEntity());
+    Assertions.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(false, response.getEntity());
   }
 
   private void testHiddenPropertiesWithPropertyFileName(String fileName) throws Exception
@@ -115,9 +115,9 @@ public class StatusResourceTest
                                                            .map(StringUtils::toLowerCase)
                                                            .collect(Collectors.toSet());
 
-    Assert.assertTrue(
-        "The list of unfiltered Properties is not > the list of filtered Properties?!?",
-        injector.getInstance(Properties.class).stringPropertyNames().size() > returnedProperties.size()
+    Assertions.assertTrue(
+        injector.getInstance(Properties.class).stringPropertyNames().size() > returnedProperties.size(),
+        "The list of unfiltered Properties is not > the list of filtered Properties?!?"
     );
 
     Set<String> hiddenProperties = new ObjectMapper().readValue(
@@ -128,7 +128,7 @@ public class StatusResourceTest
     hiddenProperties.forEach(
         (property) -> {
           lowerCasePropertyNames.forEach(
-              lowerCasePropertyName -> Assert.assertFalse(lowerCasePropertyName.contains(StringUtils.toLowerCase(
+              lowerCasePropertyName -> Assertions.assertFalse(lowerCasePropertyName.contains(StringUtils.toLowerCase(
                   property)))
           );
         }

--- a/server/src/test/java/org/apache/druid/server/SubqueryGuardrailHelperTest.java
+++ b/server/src/test/java/org/apache/druid/server/SubqueryGuardrailHelperTest.java
@@ -26,8 +26,8 @@ import org.apache.druid.query.lookup.LookupExtractorFactory;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainer;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
@@ -43,37 +43,37 @@ public class SubqueryGuardrailHelperTest
   @Test
   public void testConvertSubqueryLimitStringToLongWithoutLookups()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         10737418L,
         fetchSubqueryLimitUtilsForNoLookups(humanReadableSizeToBytes("512MiB"), 25)
             .convertSubqueryLimitStringToLong("auto")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         13421772L,
         fetchSubqueryLimitUtilsForNoLookups(humanReadableSizeToBytes("640MiB"), 25)
             .convertSubqueryLimitStringToLong("auto")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         16106127L,
         fetchSubqueryLimitUtilsForNoLookups(humanReadableSizeToBytes("768MiB"), 25)
             .convertSubqueryLimitStringToLong("auto")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         21474836L,
         fetchSubqueryLimitUtilsForNoLookups(humanReadableSizeToBytes("1GiB"), 25)
             .convertSubqueryLimitStringToLong("auto")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         171798691L,
         fetchSubqueryLimitUtilsForNoLookups(humanReadableSizeToBytes("8GiB"), 25)
             .convertSubqueryLimitStringToLong("auto")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         429496729L,
         fetchSubqueryLimitUtilsForNoLookups(humanReadableSizeToBytes("20GiB"), 25)
             .convertSubqueryLimitStringToLong("auto")
@@ -83,37 +83,37 @@ public class SubqueryGuardrailHelperTest
   @Test
   public void testConvertSubqueryLimitStringToLongWithLookups()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         10527703L,
         fetchSubqueryLimitUtilsForLookups(humanReadableSizeToBytes("512MiB"), 25)
             .convertSubqueryLimitStringToLong("auto")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         13212057L,
         fetchSubqueryLimitUtilsForLookups(humanReadableSizeToBytes("640MiB"), 25)
             .convertSubqueryLimitStringToLong("auto")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         15896412,
         fetchSubqueryLimitUtilsForLookups(humanReadableSizeToBytes("768MiB"), 25)
             .convertSubqueryLimitStringToLong("auto")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         21265121L,
         fetchSubqueryLimitUtilsForLookups(humanReadableSizeToBytes("1GiB"), 25)
             .convertSubqueryLimitStringToLong("auto")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         171588976L,
         fetchSubqueryLimitUtilsForLookups(humanReadableSizeToBytes("8GiB"), 25)
             .convertSubqueryLimitStringToLong("auto")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         429287014L,
         fetchSubqueryLimitUtilsForLookups(humanReadableSizeToBytes("20GiB"), 25)
             .convertSubqueryLimitStringToLong("auto")

--- a/server/src/test/java/org/apache/druid/server/audit/AuditManagerConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/audit/AuditManagerConfigTest.java
@@ -24,8 +24,8 @@ import com.google.inject.Injector;
 import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.JsonConfigurator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -44,14 +44,14 @@ public class AuditManagerConfigTest
 
     provider.inject(new Properties(), injector.getInstance(JsonConfigurator.class));
     final AuditManagerConfig config = provider.get();
-    Assert.assertTrue(config instanceof SQLAuditManagerConfig);
+    Assertions.assertTrue(config instanceof SQLAuditManagerConfig);
 
     final SQLAuditManagerConfig sqlAuditConfig = (SQLAuditManagerConfig) config;
-    Assert.assertTrue(sqlAuditConfig.isAuditSystemRequests());
-    Assert.assertFalse(sqlAuditConfig.isSkipNullField());
-    Assert.assertFalse(sqlAuditConfig.isIncludePayloadAsDimensionInMetric());
-    Assert.assertEquals(-1, sqlAuditConfig.getMaxPayloadSizeBytes());
-    Assert.assertEquals(7 * 86400 * 1000, sqlAuditConfig.getAuditHistoryMillis());
+    Assertions.assertTrue(sqlAuditConfig.isAuditSystemRequests());
+    Assertions.assertFalse(sqlAuditConfig.isSkipNullField());
+    Assertions.assertFalse(sqlAuditConfig.isIncludePayloadAsDimensionInMetric());
+    Assertions.assertEquals(-1, sqlAuditConfig.getMaxPayloadSizeBytes());
+    Assertions.assertEquals(7 * 86400 * 1000, sqlAuditConfig.getAuditHistoryMillis());
   }
 
   @Test
@@ -68,13 +68,13 @@ public class AuditManagerConfigTest
 
     provider.inject(props, injector.getInstance(JsonConfigurator.class));
     final AuditManagerConfig config = provider.get();
-    Assert.assertTrue(config instanceof LoggingAuditManagerConfig);
+    Assertions.assertTrue(config instanceof LoggingAuditManagerConfig);
 
     final LoggingAuditManagerConfig logAuditConfig = (LoggingAuditManagerConfig) config;
-    Assert.assertTrue(logAuditConfig.isAuditSystemRequests());
-    Assert.assertFalse(logAuditConfig.isSkipNullField());
-    Assert.assertEquals(-1, logAuditConfig.getMaxPayloadSizeBytes());
-    Assert.assertEquals(AuditLogger.Level.INFO, logAuditConfig.getLogLevel());
+    Assertions.assertTrue(logAuditConfig.isAuditSystemRequests());
+    Assertions.assertFalse(logAuditConfig.isSkipNullField());
+    Assertions.assertEquals(-1, logAuditConfig.getMaxPayloadSizeBytes());
+    Assertions.assertEquals(AuditLogger.Level.INFO, logAuditConfig.getLogLevel());
   }
 
   @Test
@@ -94,13 +94,13 @@ public class AuditManagerConfigTest
     provider.inject(props, injector.getInstance(JsonConfigurator.class));
 
     final AuditManagerConfig config = provider.get();
-    Assert.assertTrue(config instanceof LoggingAuditManagerConfig);
+    Assertions.assertTrue(config instanceof LoggingAuditManagerConfig);
 
     final LoggingAuditManagerConfig logAuditConfig = (LoggingAuditManagerConfig) config;
-    Assert.assertTrue(logAuditConfig.isAuditSystemRequests());
-    Assert.assertFalse(logAuditConfig.isSkipNullField());
-    Assert.assertEquals(-1, logAuditConfig.getMaxPayloadSizeBytes());
-    Assert.assertEquals(AuditLogger.Level.WARN, logAuditConfig.getLogLevel());
+    Assertions.assertTrue(logAuditConfig.isAuditSystemRequests());
+    Assertions.assertFalse(logAuditConfig.isSkipNullField());
+    Assertions.assertEquals(-1, logAuditConfig.getMaxPayloadSizeBytes());
+    Assertions.assertEquals(AuditLogger.Level.WARN, logAuditConfig.getLogLevel());
   }
 
   @Test
@@ -122,13 +122,13 @@ public class AuditManagerConfigTest
     provider.inject(props, injector.getInstance(JsonConfigurator.class));
 
     final AuditManagerConfig config = provider.get();
-    Assert.assertTrue(config instanceof SQLAuditManagerConfig);
+    Assertions.assertTrue(config instanceof SQLAuditManagerConfig);
 
     final SQLAuditManagerConfig sqlAuditConfig = (SQLAuditManagerConfig) config;
-    Assert.assertTrue(sqlAuditConfig.isSkipNullField());
-    Assert.assertTrue(sqlAuditConfig.isIncludePayloadAsDimensionInMetric());
-    Assert.assertEquals(100, sqlAuditConfig.getMaxPayloadSizeBytes());
-    Assert.assertEquals(1000L, sqlAuditConfig.getAuditHistoryMillis());
+    Assertions.assertTrue(sqlAuditConfig.isSkipNullField());
+    Assertions.assertTrue(sqlAuditConfig.isIncludePayloadAsDimensionInMetric());
+    Assertions.assertEquals(100, sqlAuditConfig.getMaxPayloadSizeBytes());
+    Assertions.assertEquals(1000L, sqlAuditConfig.getAuditHistoryMillis());
   }
 
   private Injector createInjector()

--- a/server/src/test/java/org/apache/druid/server/audit/SQLAuditManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/audit/SQLAuditManagerTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
@@ -106,7 +107,7 @@ public class SQLAuditManagerTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testCreateAuditEntry() throws IOException
   {
     final AuditEntry entry = createAuditEntry("key1", "type1", DateTimes.nowUtc());
@@ -131,7 +132,7 @@ public class SQLAuditManagerTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testFetchAuditHistory()
   {
     final AuditEntry event = createAuditEntry("testKey", "testType", DateTimes.nowUtc());
@@ -150,7 +151,7 @@ public class SQLAuditManagerTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testFetchAuditHistoryByKeyAndTypeWithLimit()
   {
     final AuditEntry entry1 = createAuditEntry("key1", "type1", DateTimes.nowUtc());
@@ -165,7 +166,7 @@ public class SQLAuditManagerTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testRemoveAuditLogsOlderThanWithEntryOlderThanTime() throws IOException
   {
     final AuditEntry entry = createAuditEntry("key1", "type1", DateTimes.nowUtc());
@@ -180,7 +181,7 @@ public class SQLAuditManagerTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testRemoveAuditLogsOlderThanWithEntryNotOlderThanTime() throws IOException
   {
     AuditEntry entry = createAuditEntry("key", "type", DateTimes.nowUtc());
@@ -197,7 +198,7 @@ public class SQLAuditManagerTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testFetchAuditHistoryByTypeWithLimit()
   {
     final AuditEntry entry1 = createAuditEntry("testKey", "testType", DateTimes.of("2022-01"));
@@ -215,7 +216,7 @@ public class SQLAuditManagerTest
   }
 
   @Test
-  @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testFetchAuditHistoryLimitBelowZero()
   {
     Assertions.assertThrows(IllegalArgumentException.class, () ->
@@ -223,7 +224,7 @@ public class SQLAuditManagerTest
   }
 
   @Test
-  @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testFetchAuditHistoryLimitZero()
   {
     Assertions.assertThrows(IllegalArgumentException.class, () ->
@@ -231,7 +232,7 @@ public class SQLAuditManagerTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testCreateAuditEntryWithPayloadOverSkipPayloadLimit() throws IOException
   {
     final SQLAuditManager auditManager = createAuditManager(
@@ -254,7 +255,7 @@ public class SQLAuditManagerTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testCreateAuditEntryWithPayloadUnderSkipPayloadLimit() throws IOException
   {
     SQLAuditManager auditManager = createAuditManager(
@@ -270,7 +271,7 @@ public class SQLAuditManagerTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testCreateAuditEntryWithSkipNullsInPayload() throws IOException
   {
     final SQLAuditManager auditManagerSkipNull = createAuditManager(

--- a/server/src/test/java/org/apache/druid/server/audit/SQLAuditManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/audit/SQLAuditManagerTest.java
@@ -32,25 +32,24 @@ import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
 import org.apache.druid.metadata.TestDerbyConnector;
 import org.joda.time.DateTime;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SQLAuditManagerTest
 {
-  @Rule
-  public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule
-      = new TestDerbyConnector.DerbyConnectorRule();
+  @RegisterExtension
+  public static final TestDerbyConnector.DerbyConnectorRule5 DERBY_CONNECTOR_RULE
+      = new TestDerbyConnector.DerbyConnectorRule5();
 
   private TestDerbyConnector connector;
   private SQLAuditManager auditManager;
@@ -60,11 +59,11 @@ public class SQLAuditManagerTest
   private final ObjectMapper mapperSkipNull
       = new DefaultObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     serviceEmitter = new StubServiceEmitter("audit-test", "localhost");
-    connector = derbyConnectorRule.getConnector();
+    connector = DERBY_CONNECTOR_RULE.getConnector();
     connector.createAuditTable();
     auditManager = createAuditManager(new SQLAuditManagerConfig(null, null, null, null, null));
   }
@@ -75,7 +74,7 @@ public class SQLAuditManagerTest
         config,
         new AuditSerdeHelper(config, null, mapper, mapperSkipNull),
         connector,
-        derbyConnectorRule.metadataTablesConfigSupplier(),
+        DERBY_CONNECTOR_RULE.metadataTablesConfigSupplier(),
         serviceEmitter,
         mapper
     );
@@ -92,45 +91,47 @@ public class SQLAuditManagerTest
     auditManager.doAudit(entry);
 
     List<ServiceMetricEvent> auditMetricEvents = serviceEmitter.getMetricEvents("config/audit");
-    Assert.assertEquals(1, auditMetricEvents.size());
+    Assertions.assertEquals(1, auditMetricEvents.size());
 
     ServiceMetricEvent metric = auditMetricEvents.get(0);
 
     final AuditEntry dbEntry = lookupAuditEntryForKey("testKey");
-    Assert.assertNotNull(dbEntry);
-    Assert.assertEquals(dbEntry.getKey(), metric.getUserDims().get("key"));
-    Assert.assertEquals(dbEntry.getType(), metric.getUserDims().get("type"));
-    Assert.assertEquals(dbEntry.getPayload().serialized(), metric.getUserDims().get("payload"));
-    Assert.assertEquals(dbEntry.getAuditInfo().getAuthor(), metric.getUserDims().get("author"));
-    Assert.assertEquals(dbEntry.getAuditInfo().getComment(), metric.getUserDims().get("comment"));
-    Assert.assertEquals(dbEntry.getAuditInfo().getIp(), metric.getUserDims().get("remote_address"));
+    Assertions.assertNotNull(dbEntry);
+    Assertions.assertEquals(dbEntry.getKey(), metric.getUserDims().get("key"));
+    Assertions.assertEquals(dbEntry.getType(), metric.getUserDims().get("type"));
+    Assertions.assertEquals(dbEntry.getPayload().serialized(), metric.getUserDims().get("payload"));
+    Assertions.assertEquals(dbEntry.getAuditInfo().getAuthor(), metric.getUserDims().get("author"));
+    Assertions.assertEquals(dbEntry.getAuditInfo().getComment(), metric.getUserDims().get("comment"));
+    Assertions.assertEquals(dbEntry.getAuditInfo().getIp(), metric.getUserDims().get("remote_address"));
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCreateAuditEntry() throws IOException
   {
     final AuditEntry entry = createAuditEntry("key1", "type1", DateTimes.nowUtc());
     auditManager.doAudit(entry);
 
     AuditEntry dbEntry = lookupAuditEntryForKey(entry.getKey());
-    Assert.assertEquals(entry, dbEntry);
+    Assertions.assertEquals(entry, dbEntry);
 
     // Verify emitted metrics
     List<ServiceMetricEvent> auditMetricEvents
         = serviceEmitter.getMetricEvents("config/audit");
-    Assert.assertNotNull(auditMetricEvents);
-    Assert.assertEquals(1, auditMetricEvents.size());
+    Assertions.assertNotNull(auditMetricEvents);
+    Assertions.assertEquals(1, auditMetricEvents.size());
 
     ServiceMetricEvent metric = auditMetricEvents.get(0);
-    Assert.assertEquals(dbEntry.getKey(), metric.getUserDims().get("key"));
-    Assert.assertEquals(dbEntry.getType(), metric.getUserDims().get("type"));
-    Assert.assertNull(metric.getUserDims().get("payload"));
-    Assert.assertEquals(dbEntry.getAuditInfo().getAuthor(), metric.getUserDims().get("author"));
-    Assert.assertEquals(dbEntry.getAuditInfo().getComment(), metric.getUserDims().get("comment"));
-    Assert.assertEquals(dbEntry.getAuditInfo().getIp(), metric.getUserDims().get("remote_address"));
+    Assertions.assertEquals(dbEntry.getKey(), metric.getUserDims().get("key"));
+    Assertions.assertEquals(dbEntry.getType(), metric.getUserDims().get("type"));
+    Assertions.assertNull(metric.getUserDims().get("payload"));
+    Assertions.assertEquals(dbEntry.getAuditInfo().getAuthor(), metric.getUserDims().get("author"));
+    Assertions.assertEquals(dbEntry.getAuditInfo().getComment(), metric.getUserDims().get("comment"));
+    Assertions.assertEquals(dbEntry.getAuditInfo().getIp(), metric.getUserDims().get("remote_address"));
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testFetchAuditHistory()
   {
     final AuditEntry event = createAuditEntry("testKey", "testType", DateTimes.nowUtc());
@@ -143,12 +144,13 @@ public class SQLAuditManagerTest
         Intervals.of("2000-01-01T00:00:00Z/2100-01-03T00:00:00Z")
     );
 
-    Assert.assertEquals(2, auditEntries.size());
-    Assert.assertEquals(event, auditEntries.get(0));
-    Assert.assertEquals(event, auditEntries.get(1));
+    Assertions.assertEquals(2, auditEntries.size());
+    Assertions.assertEquals(event, auditEntries.get(0));
+    Assertions.assertEquals(event, auditEntries.get(1));
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testFetchAuditHistoryByKeyAndTypeWithLimit()
   {
     final AuditEntry entry1 = createAuditEntry("key1", "type1", DateTimes.nowUtc());
@@ -158,41 +160,44 @@ public class SQLAuditManagerTest
     auditManager.doAudit(entry2);
 
     List<AuditEntry> auditEntries = auditManager.fetchAuditHistory(entry1.getKey(), entry1.getType(), 1);
-    Assert.assertEquals(1, auditEntries.size());
-    Assert.assertEquals(entry1, auditEntries.get(0));
+    Assertions.assertEquals(1, auditEntries.size());
+    Assertions.assertEquals(entry1, auditEntries.get(0));
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRemoveAuditLogsOlderThanWithEntryOlderThanTime() throws IOException
   {
     final AuditEntry entry = createAuditEntry("key1", "type1", DateTimes.nowUtc());
     auditManager.doAudit(entry);
 
     AuditEntry dbEntry = lookupAuditEntryForKey(entry.getKey());
-    Assert.assertEquals(entry, dbEntry);
+    Assertions.assertEquals(entry, dbEntry);
 
     // Verify that the audit entry gets deleted
     auditManager.removeAuditLogsOlderThan(System.currentTimeMillis());
-    Assert.assertNull(lookupAuditEntryForKey(entry.getKey()));
+    Assertions.assertNull(lookupAuditEntryForKey(entry.getKey()));
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRemoveAuditLogsOlderThanWithEntryNotOlderThanTime() throws IOException
   {
     AuditEntry entry = createAuditEntry("key", "type", DateTimes.nowUtc());
     auditManager.doAudit(entry);
 
     AuditEntry dbEntry = lookupAuditEntryForKey(entry.getKey());
-    Assert.assertEquals(entry, dbEntry);
+    Assertions.assertEquals(entry, dbEntry);
 
     // Delete old audit logs
     auditManager.removeAuditLogsOlderThan(DateTimes.of("2012-01-01T00:00:00Z").getMillis());
 
     dbEntry = lookupAuditEntryForKey(entry.getKey());
-    Assert.assertEquals(entry, dbEntry);
+    Assertions.assertEquals(entry, dbEntry);
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testFetchAuditHistoryByTypeWithLimit()
   {
     final AuditEntry entry1 = createAuditEntry("testKey", "testType", DateTimes.of("2022-01"));
@@ -204,24 +209,29 @@ public class SQLAuditManagerTest
     auditManager.doAudit(entry3);
 
     List<AuditEntry> auditEntries = auditManager.fetchAuditHistory("testType", 2);
-    Assert.assertEquals(2, auditEntries.size());
-    Assert.assertEquals(entry2, auditEntries.get(0));
-    Assert.assertEquals(entry3, auditEntries.get(1));
+    Assertions.assertEquals(2, auditEntries.size());
+    Assertions.assertEquals(entry2, auditEntries.get(0));
+    Assertions.assertEquals(entry3, auditEntries.get(1));
   }
 
-  @Test(expected = IllegalArgumentException.class, timeout = 10_000L)
+  @Test
+  @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
   public void testFetchAuditHistoryLimitBelowZero()
   {
-    auditManager.fetchAuditHistory("testType", -1);
+    Assertions.assertThrows(IllegalArgumentException.class, () ->
+      auditManager.fetchAuditHistory("testType", -1));
   }
 
-  @Test(expected = IllegalArgumentException.class, timeout = 10_000L)
+  @Test
+  @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
   public void testFetchAuditHistoryLimitZero()
   {
-    auditManager.fetchAuditHistory("testType", 0);
+    Assertions.assertThrows(IllegalArgumentException.class, () ->
+      auditManager.fetchAuditHistory("testType", 0));
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCreateAuditEntryWithPayloadOverSkipPayloadLimit() throws IOException
   {
     final SQLAuditManager auditManager = createAuditManager(
@@ -233,17 +243,18 @@ public class SQLAuditManagerTest
 
     // Verify that all the fields are the same except for the payload
     AuditEntry dbEntry = lookupAuditEntryForKey(entry.getKey());
-    Assert.assertEquals(entry.getKey(), dbEntry.getKey());
+    Assertions.assertEquals(entry.getKey(), dbEntry.getKey());
     // Assert.assertNotEquals(entry.getPayload(), dbEntry.getPayload());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Payload truncated as it exceeds 'druid.audit.manager.maxPayloadSizeBytes'[10].",
         dbEntry.getPayload().serialized()
     );
-    Assert.assertEquals(entry.getType(), dbEntry.getType());
-    Assert.assertEquals(entry.getAuditInfo(), dbEntry.getAuditInfo());
+    Assertions.assertEquals(entry.getType(), dbEntry.getType());
+    Assertions.assertEquals(entry.getAuditInfo(), dbEntry.getAuditInfo());
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCreateAuditEntryWithPayloadUnderSkipPayloadLimit() throws IOException
   {
     SQLAuditManager auditManager = createAuditManager(
@@ -255,10 +266,11 @@ public class SQLAuditManagerTest
 
     // Verify that the actual payload has been persisted
     AuditEntry dbEntry = lookupAuditEntryForKey(entry.getKey());
-    Assert.assertEquals(entry, dbEntry);
+    Assertions.assertEquals(entry, dbEntry);
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCreateAuditEntryWithSkipNullsInPayload() throws IOException
   {
     final SQLAuditManager auditManagerSkipNull = createAuditManager(
@@ -275,19 +287,19 @@ public class SQLAuditManagerTest
         AuditEntry.builder().key("key1").type("type1").auditInfo(auditInfo).payload(payloadMap).build()
     );
     AuditEntry entryWithNulls = lookupAuditEntryForKey("key1");
-    Assert.assertEquals("{\"something\":null,\"version\":\"x\"}", entryWithNulls.getPayload().serialized());
+    Assertions.assertEquals("{\"something\":null,\"version\":\"x\"}", entryWithNulls.getPayload().serialized());
 
     auditManagerSkipNull.doAudit(
         AuditEntry.builder().key("key2").type("type2").auditInfo(auditInfo).payload(payloadMap).build()
     );
     AuditEntry entryWithoutNulls = lookupAuditEntryForKey("key2");
-    Assert.assertEquals("{\"version\":\"x\"}", entryWithoutNulls.getPayload().serialized());
+    Assertions.assertEquals("{\"version\":\"x\"}", entryWithoutNulls.getPayload().serialized());
   }
 
-  @After
+  @AfterEach
   public void cleanup()
   {
-    dropTable(derbyConnectorRule.metadataTablesConfigSupplier().get().getAuditTable());
+    dropTable(DERBY_CONNECTOR_RULE.metadataTablesConfigSupplier().get().getAuditTable());
   }
 
   private void dropTable(final String tableName)
@@ -296,13 +308,13 @@ public class SQLAuditManagerTest
         handle -> handle.createStatement(StringUtils.format("DROP TABLE %s", tableName))
                         .execute()
     );
-    Assert.assertEquals(0, rowsAffected);
+    Assertions.assertEquals(0, rowsAffected);
   }
 
   private AuditEntry lookupAuditEntryForKey(String key) throws IOException
   {
     byte[] payload = connector.lookup(
-        derbyConnectorRule.metadataTablesConfigSupplier().get().getAuditTable(),
+        DERBY_CONNECTOR_RULE.metadataTablesConfigSupplier().get().getAuditTable(),
         "audit_key",
         "payload",
         key

--- a/server/src/test/java/org/apache/druid/server/broker/BrokerDynamicConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/broker/BrokerDynamicConfigTest.java
@@ -32,8 +32,8 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.server.DefaultQueryBlocklistRule;
 import org.apache.druid.server.QueryBlocklistRule;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
@@ -68,7 +68,7 @@ public class BrokerDynamicConfigTest
         new DefaultQueryBlocklistRule("block-wikipedia", ImmutableSet.of("wikipedia"), null, null)
     );
 
-    Assert.assertEquals(expectedBlocklist, actual.getQueryBlocklist());
+    Assertions.assertEquals(expectedBlocklist, actual.getQueryBlocklist());
   }
 
   @Test
@@ -86,9 +86,9 @@ public class BrokerDynamicConfigTest
 
     BrokerDynamicConfig actual = mapper.readValue(jsonStr, BrokerDynamicConfig.class);
 
-    Assert.assertEquals(1, actual.getQueryBlocklist().size());
-    Assert.assertTrue(actual.getQueryBlocklist().get(0) instanceof DefaultQueryBlocklistRule);
-    Assert.assertEquals(
+    Assertions.assertEquals(1, actual.getQueryBlocklist().size());
+    Assertions.assertTrue(actual.getQueryBlocklist().get(0) instanceof DefaultQueryBlocklistRule);
+    Assertions.assertEquals(
         new DefaultQueryBlocklistRule("block-wikipedia", ImmutableSet.of("wikipedia"), null, null),
         actual.getQueryBlocklist().get(0)
     );
@@ -101,8 +101,8 @@ public class BrokerDynamicConfigTest
 
     BrokerDynamicConfig actual = mapper.readValue(jsonStr, BrokerDynamicConfig.class);
     // When no blocklist is provided, it defaults to an empty list
-    Assert.assertNotNull(actual.getQueryBlocklist());
-    Assert.assertTrue(actual.getQueryBlocklist().isEmpty());
+    Assertions.assertNotNull(actual.getQueryBlocklist());
+    Assertions.assertTrue(actual.getQueryBlocklist().isEmpty());
   }
 
   @Test
@@ -111,8 +111,8 @@ public class BrokerDynamicConfigTest
     String jsonStr = "{\"queryBlocklist\": []}";
 
     BrokerDynamicConfig actual = mapper.readValue(jsonStr, BrokerDynamicConfig.class);
-    Assert.assertNotNull(actual.getQueryBlocklist());
-    Assert.assertTrue(actual.getQueryBlocklist().isEmpty());
+    Assertions.assertNotNull(actual.getQueryBlocklist());
+    Assertions.assertTrue(actual.getQueryBlocklist().isEmpty());
   }
 
   @Test
@@ -133,16 +133,16 @@ public class BrokerDynamicConfigTest
 
     BrokerDynamicConfig actual = mapper.readValue(jsonStr, BrokerDynamicConfig.class);
 
-    Assert.assertNotNull(actual.getQueryBlocklist());
-    Assert.assertEquals(2, actual.getQueryBlocklist().size());
+    Assertions.assertNotNull(actual.getQueryBlocklist());
+    Assertions.assertEquals(2, actual.getQueryBlocklist().size());
 
     DefaultQueryBlocklistRule rule1 = (DefaultQueryBlocklistRule) actual.getQueryBlocklist().get(0);
-    Assert.assertEquals("block-scan-queries", rule1.getRuleName());
-    Assert.assertEquals(ImmutableSet.of("scan"), rule1.getQueryTypes());
+    Assertions.assertEquals("block-scan-queries", rule1.getRuleName());
+    Assertions.assertEquals(ImmutableSet.of("scan"), rule1.getQueryTypes());
 
     DefaultQueryBlocklistRule rule2 = (DefaultQueryBlocklistRule) actual.getQueryBlocklist().get(1);
-    Assert.assertEquals("block-context", rule2.getRuleName());
-    Assert.assertEquals(ImmutableMap.of("priority", "0"), rule2.getContextMatches());
+    Assertions.assertEquals("block-context", rule2.getRuleName());
+    Assertions.assertEquals(ImmutableMap.of("priority", "0"), rule2.getContextMatches());
   }
 
   @Test
@@ -160,15 +160,15 @@ public class BrokerDynamicConfigTest
         BrokerDynamicConfig.class
     );
 
-    Assert.assertEquals(QueryContext.of(ImmutableMap.of("priority", 10, "useCache", false)), actual.getQueryContext());
+    Assertions.assertEquals(QueryContext.of(ImmutableMap.of("priority", 10, "useCache", false)), actual.getQueryContext());
   }
 
   @Test
   public void testNullQueryContextDefaultsToEmptyMap() throws Exception
   {
     BrokerDynamicConfig actual = mapper.readValue("{}", BrokerDynamicConfig.class);
-    Assert.assertNotNull(actual.getQueryContext());
-    Assert.assertTrue(actual.getQueryContext().isEmpty());
+    Assertions.assertNotNull(actual.getQueryContext());
+    Assertions.assertTrue(actual.getQueryContext().isEmpty());
   }
 
   @Test
@@ -190,15 +190,15 @@ public class BrokerDynamicConfigTest
         "my_large_ds", new PerSegmentTimeoutConfig(5000, true),
         "my_other_ds", new PerSegmentTimeoutConfig(3000, null)
     );
-    Assert.assertEquals(expected, actual.getPerSegmentTimeoutConfig());
+    Assertions.assertEquals(expected, actual.getPerSegmentTimeoutConfig());
   }
 
   @Test
   public void testNullPerSegmentTimeoutConfigDefaultsToEmptyMap() throws Exception
   {
     BrokerDynamicConfig actual = mapper.readValue("{}", BrokerDynamicConfig.class);
-    Assert.assertNotNull(actual.getPerSegmentTimeoutConfig());
-    Assert.assertTrue(actual.getPerSegmentTimeoutConfig().isEmpty());
+    Assertions.assertNotNull(actual.getPerSegmentTimeoutConfig());
+    Assertions.assertTrue(actual.getPerSegmentTimeoutConfig().isEmpty());
   }
 
   @Test
@@ -213,27 +213,27 @@ public class BrokerDynamicConfigTest
   public void testContextOverridesInjectsPerSegmentTimeoutForMatchingDatasource()
   {
     BrokerDynamicConfig config = perSegmentTimeout("ds", new PerSegmentTimeoutConfig(5000, false));
-    Assert.assertEquals(5000L, config.getContextOverridesForQuery(query("ds")).getPerSegmentTimeout());
+    Assertions.assertEquals(5000L, config.getContextOverridesForQuery(query("ds")).getPerSegmentTimeout());
   }
 
   @Test
   public void testContextOverridesEmptyForMonitorOnly()
   {
     BrokerDynamicConfig config = perSegmentTimeout("ds", new PerSegmentTimeoutConfig(5000, true));
-    Assert.assertTrue(config.getContextOverridesForQuery(query("ds")).isEmpty());
+    Assertions.assertTrue(config.getContextOverridesForQuery(query("ds")).isEmpty());
   }
 
   @Test
   public void testContextOverridesEmptyForNonMatchingDatasource()
   {
     BrokerDynamicConfig config = perSegmentTimeout("other", new PerSegmentTimeoutConfig(5000, false));
-    Assert.assertTrue(config.getContextOverridesForQuery(query("ds")).isEmpty());
+    Assertions.assertTrue(config.getContextOverridesForQuery(query("ds")).isEmpty());
   }
 
   @Test
   public void testContextOverridesEmptyWhenNoPerSegmentTimeoutConfigured()
   {
-    Assert.assertTrue(BrokerDynamicConfig.builder().build().getContextOverridesForQuery(query("ds")).isEmpty());
+    Assertions.assertTrue(BrokerDynamicConfig.builder().build().getContextOverridesForQuery(query("ds")).isEmpty());
   }
 
   private static BrokerDynamicConfig perSegmentTimeout(String datasource, PerSegmentTimeoutConfig timeoutConfig)

--- a/server/src/test/java/org/apache/druid/server/broker/PerSegmentTimeoutConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/broker/PerSegmentTimeoutConfigTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.server.broker;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PerSegmentTimeoutConfigTest
 {
@@ -34,15 +34,15 @@ public class PerSegmentTimeoutConfigTest
   {
     String json = "{\"perSegmentTimeoutMs\": 5000, \"monitorOnly\": true}";
     PerSegmentTimeoutConfig config = mapper.readValue(json, PerSegmentTimeoutConfig.class);
-    Assert.assertEquals(5000L, config.getPerSegmentTimeoutMs());
-    Assert.assertTrue(config.isMonitorOnly());
+    Assertions.assertEquals(5000L, config.getPerSegmentTimeoutMs());
+    Assertions.assertTrue(config.isMonitorOnly());
 
     // Round-trip
     PerSegmentTimeoutConfig roundTripped = mapper.readValue(
         mapper.writeValueAsString(config),
         PerSegmentTimeoutConfig.class
     );
-    Assert.assertEquals(config, roundTripped);
+    Assertions.assertEquals(config, roundTripped);
   }
 
   @Test
@@ -50,14 +50,14 @@ public class PerSegmentTimeoutConfigTest
   {
     String json = "{\"perSegmentTimeoutMs\": 3000}";
     PerSegmentTimeoutConfig config = mapper.readValue(json, PerSegmentTimeoutConfig.class);
-    Assert.assertEquals(3000L, config.getPerSegmentTimeoutMs());
-    Assert.assertFalse(config.isMonitorOnly());
+    Assertions.assertEquals(3000L, config.getPerSegmentTimeoutMs());
+    Assertions.assertFalse(config.isMonitorOnly());
   }
 
   @Test
   public void testRejectsZeroTimeout()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new PerSegmentTimeoutConfig(0, null)
     );
@@ -66,7 +66,7 @@ public class PerSegmentTimeoutConfigTest
   @Test
   public void testRejectsNegativeTimeout()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new PerSegmentTimeoutConfig(-1, null)
     );

--- a/server/src/test/java/org/apache/druid/server/coordination/BroadcastDatasourceLoadingSpecTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/BroadcastDatasourceLoadingSpecTest.java
@@ -21,42 +21,40 @@ package org.apache.druid.server.coordination;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.Set;
 
-@RunWith(JUnitParamsRunner.class)
 public class BroadcastDatasourceLoadingSpecTest
 {
   @Test
   public void testLoadingAllBroadcastDatasources()
   {
     final BroadcastDatasourceLoadingSpec spec = BroadcastDatasourceLoadingSpec.ALL;
-    Assert.assertEquals(BroadcastDatasourceLoadingSpec.Mode.ALL, spec.getMode());
-    Assert.assertNull(spec.getBroadcastDatasourcesToLoad());
+    Assertions.assertEquals(BroadcastDatasourceLoadingSpec.Mode.ALL, spec.getMode());
+    Assertions.assertNull(spec.getBroadcastDatasourcesToLoad());
   }
 
   @Test
   public void testModeNeedsBroadcastSegments()
   {
-    Assert.assertTrue(BroadcastDatasourceLoadingSpec.Mode.ALL.needsBroadcastSegments());
-    Assert.assertFalse(BroadcastDatasourceLoadingSpec.Mode.NONE.needsBroadcastSegments());
-    Assert.assertTrue(BroadcastDatasourceLoadingSpec.Mode.ONLY_REQUIRED.needsBroadcastSegments());
+    Assertions.assertTrue(BroadcastDatasourceLoadingSpec.Mode.ALL.needsBroadcastSegments());
+    Assertions.assertFalse(BroadcastDatasourceLoadingSpec.Mode.NONE.needsBroadcastSegments());
+    Assertions.assertTrue(BroadcastDatasourceLoadingSpec.Mode.ONLY_REQUIRED.needsBroadcastSegments());
   }
 
   @Test
   public void testLoadingNoLookups()
   {
     final BroadcastDatasourceLoadingSpec spec = BroadcastDatasourceLoadingSpec.NONE;
-    Assert.assertEquals(BroadcastDatasourceLoadingSpec.Mode.NONE, spec.getMode());
-    Assert.assertNull(spec.getBroadcastDatasourcesToLoad());
+    Assertions.assertEquals(BroadcastDatasourceLoadingSpec.Mode.NONE, spec.getMode());
+    Assertions.assertNull(spec.getBroadcastDatasourcesToLoad());
   }
 
   @Test
@@ -64,25 +62,25 @@ public class BroadcastDatasourceLoadingSpecTest
   {
     final Set<String> broadcastDatasourcesToLoad = ImmutableSet.of("ds1", "ds2");
     final BroadcastDatasourceLoadingSpec spec = BroadcastDatasourceLoadingSpec.loadOnly(ImmutableSet.of("ds1", "ds2"));
-    Assert.assertEquals(BroadcastDatasourceLoadingSpec.Mode.ONLY_REQUIRED, spec.getMode());
-    Assert.assertEquals(broadcastDatasourcesToLoad, spec.getBroadcastDatasourcesToLoad());
+    Assertions.assertEquals(BroadcastDatasourceLoadingSpec.Mode.ONLY_REQUIRED, spec.getMode());
+    Assertions.assertEquals(broadcastDatasourcesToLoad, spec.getBroadcastDatasourcesToLoad());
   }
 
   @Test
   public void testLoadingOnlyRequiredLookupsWithNullList()
   {
-    DruidException exception = Assert.assertThrows(
+    DruidException exception = Assertions.assertThrows(
         DruidException.class,
         () -> BroadcastDatasourceLoadingSpec.loadOnly(null)
     );
-    Assert.assertEquals("Expected non-null set of broadcast datasources to load.", exception.getMessage());
+    Assertions.assertEquals("Expected non-null set of broadcast datasources to load.", exception.getMessage());
   }
 
   @Test
   public void testCreateBroadcastLoadingSpecFromNullContext()
   {
     // Default spec is returned in the case of context=null.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         BroadcastDatasourceLoadingSpec.NONE,
         BroadcastDatasourceLoadingSpec.createFromContext(
             null,
@@ -90,7 +88,7 @@ public class BroadcastDatasourceLoadingSpecTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         BroadcastDatasourceLoadingSpec.ALL,
         BroadcastDatasourceLoadingSpec.createFromContext(
             null,
@@ -103,7 +101,7 @@ public class BroadcastDatasourceLoadingSpecTest
   public void testCreateBroadcastLoadingSpecFromContext()
   {
     // Only required lookups are returned in the case of context having the lookup keys.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         BroadcastDatasourceLoadingSpec.loadOnly(ImmutableSet.of("ds1", "ds2")),
         BroadcastDatasourceLoadingSpec.createFromContext(
             ImmutableMap.of(
@@ -117,7 +115,7 @@ public class BroadcastDatasourceLoadingSpecTest
     );
 
     // No lookups are returned in the case of context having mode=NONE, irrespective of the default spec.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         BroadcastDatasourceLoadingSpec.NONE,
         BroadcastDatasourceLoadingSpec.createFromContext(
             ImmutableMap.of(
@@ -129,7 +127,7 @@ public class BroadcastDatasourceLoadingSpecTest
     );
 
     // All lookups are returned in the case of context having mode=ALL, irrespective of the default spec.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         BroadcastDatasourceLoadingSpec.ALL,
         BroadcastDatasourceLoadingSpec.createFromContext(
             ImmutableMap.of(
@@ -141,8 +139,8 @@ public class BroadcastDatasourceLoadingSpecTest
     );
   }
 
-  @Test
-  @Parameters({
+  @ParameterizedTest
+  @ValueSource(strings = {
       "NONE1",
       "A",
       "Random mode",
@@ -152,14 +150,14 @@ public class BroadcastDatasourceLoadingSpecTest
   })
   public void testSpecFromInvalidModeInContext(final String mode)
   {
-    final DruidException exception = Assert.assertThrows(
+    final DruidException exception = Assertions.assertThrows(
         DruidException.class,
         () -> BroadcastDatasourceLoadingSpec.createFromContext(
             ImmutableMap.of(BroadcastDatasourceLoadingSpec.CTX_BROADCAST_DATASOURCE_LOADING_MODE, mode),
             BroadcastDatasourceLoadingSpec.ALL
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         StringUtils.format(
             "Invalid value of %s[%s]. Allowed values are [ALL, NONE, ONLY_REQUIRED]",
             BroadcastDatasourceLoadingSpec.CTX_BROADCAST_DATASOURCE_LOADING_MODE, mode
@@ -169,14 +167,14 @@ public class BroadcastDatasourceLoadingSpecTest
   }
 
 
-  @Test
-  @Parameters({
+  @ParameterizedTest
+  @ValueSource(strings = {
       "foo bar",
       "foo]"
   })
   public void testSpecFromInvalidBroadcastDatasourcesInContext(final Object lookupsToLoad)
   {
-    final DruidException exception = Assert.assertThrows(
+    final DruidException exception = Assertions.assertThrows(
         DruidException.class,
         () ->
             BroadcastDatasourceLoadingSpec.createFromContext(
@@ -189,7 +187,7 @@ public class BroadcastDatasourceLoadingSpecTest
                 BroadcastDatasourceLoadingSpec.ALL
             )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         StringUtils.format(
             "Invalid value of %s[%s]. Please provide a comma-separated list of "
             + "broadcast datasource names. For example: [\"datasourceName1\", \"datasourceName2\"]",

--- a/server/src/test/java/org/apache/druid/server/coordination/ChangeRequestHistoryTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/ChangeRequestHistoryTest.java
@@ -24,8 +24,8 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -41,26 +41,26 @@ public class ChangeRequestHistoryTest
   public void testSimple() throws Exception
   {
     ChangeRequestHistory<DataSegmentChangeRequest> history = new ChangeRequestHistory();
-    Assert.assertEquals(0, history.getLastCounter().getCounter());
+    Assertions.assertEquals(0, history.getLastCounter().getCounter());
 
     history.addChangeRequest(new SegmentChangeRequestNoop());
-    Assert.assertEquals(1, history.getLastCounter().getCounter());
+    Assertions.assertEquals(1, history.getLastCounter().getCounter());
 
     ChangeRequestsSnapshot<DataSegmentChangeRequest> snapshot = history.getRequestsSince(ChangeRequestHistory.Counter.ZERO)
                                                                        .get();
-    Assert.assertEquals(1, snapshot.getRequests().size());
-    Assert.assertEquals(1, snapshot.getCounter().getCounter());
+    Assertions.assertEquals(1, snapshot.getRequests().size());
+    Assertions.assertEquals(1, snapshot.getCounter().getCounter());
 
     history.addChangeRequest(new SegmentChangeRequestNoop());
-    Assert.assertEquals(2, history.getLastCounter().getCounter());
+    Assertions.assertEquals(2, history.getLastCounter().getCounter());
 
     snapshot = history.getRequestsSince(snapshot.getCounter()).get();
-    Assert.assertEquals(1, snapshot.getRequests().size());
-    Assert.assertEquals(2, snapshot.getCounter().getCounter());
+    Assertions.assertEquals(1, snapshot.getRequests().size());
+    Assertions.assertEquals(2, snapshot.getCounter().getCounter());
 
     snapshot = history.getRequestsSince(ChangeRequestHistory.Counter.ZERO).get();
-    Assert.assertEquals(2, snapshot.getRequests().size());
-    Assert.assertEquals(2, snapshot.getCounter().getCounter());
+    Assertions.assertEquals(2, snapshot.getRequests().size());
+    Assertions.assertEquals(2, snapshot.getCounter().getCounter());
   }
 
   @Test
@@ -80,13 +80,13 @@ public class ChangeRequestHistoryTest
     history.addChangeRequest(new SegmentChangeRequestNoop());
     ChangeRequestHistory.Counter four = history.getLastCounter();
 
-    Assert.assertTrue(history.getRequestsSince(ChangeRequestHistory.Counter.ZERO).get().isResetCounter());
-    Assert.assertTrue(history.getRequestsSince(one).get().isResetCounter());
-    Assert.assertTrue(history.getRequestsSince(two).get().isResetCounter());
+    Assertions.assertTrue(history.getRequestsSince(ChangeRequestHistory.Counter.ZERO).get().isResetCounter());
+    Assertions.assertTrue(history.getRequestsSince(one).get().isResetCounter());
+    Assertions.assertTrue(history.getRequestsSince(two).get().isResetCounter());
 
     ChangeRequestsSnapshot<DataSegmentChangeRequest> snapshot = history.getRequestsSince(three).get();
-    Assert.assertEquals(1, snapshot.getRequests().size());
-    Assert.assertEquals(4, snapshot.getCounter().getCounter());
+    Assertions.assertEquals(1, snapshot.getRequests().size());
+    Assertions.assertEquals(4, snapshot.getCounter().getCounter());
   }
 
   @Test
@@ -94,7 +94,7 @@ public class ChangeRequestHistoryTest
   {
     ChangeRequestHistory<DataSegmentChangeRequest> history = new ChangeRequestHistory(3);
 
-    Assert.assertTrue(history.getRequestsSince(new ChangeRequestHistory.Counter(0, 1234)).get().isResetCounter());
+    Assertions.assertTrue(history.getRequestsSince(new ChangeRequestHistory.Counter(0, 1234)).get().isResetCounter());
 
     history.addChangeRequest(new SegmentChangeRequestNoop());
     ChangeRequestHistory.Counter one = history.getLastCounter();
@@ -102,13 +102,13 @@ public class ChangeRequestHistoryTest
     history.addChangeRequest(new SegmentChangeRequestNoop());
     ChangeRequestHistory.Counter two = history.getLastCounter();
 
-    Assert.assertTrue(history.getRequestsSince(new ChangeRequestHistory.Counter(0, 1234)).get().isResetCounter());
+    Assertions.assertTrue(history.getRequestsSince(new ChangeRequestHistory.Counter(0, 1234)).get().isResetCounter());
 
     ChangeRequestsSnapshot<DataSegmentChangeRequest> snapshot = history.getRequestsSince(one).get();
-    Assert.assertEquals(1, snapshot.getRequests().size());
-    Assert.assertEquals(2, snapshot.getCounter().getCounter());
+    Assertions.assertEquals(1, snapshot.getRequests().size());
+    Assertions.assertEquals(2, snapshot.getCounter().getCounter());
 
-    Assert.assertTrue(history.getRequestsSince(new ChangeRequestHistory.Counter(1, 1234)).get().isResetCounter());
+    Assertions.assertTrue(history.getRequestsSince(new ChangeRequestHistory.Counter(1, 1234)).get().isResetCounter());
 
     history.addChangeRequest(new SegmentChangeRequestNoop());
     ChangeRequestHistory.Counter three = history.getLastCounter();
@@ -117,10 +117,10 @@ public class ChangeRequestHistoryTest
     ChangeRequestHistory.Counter four = history.getLastCounter();
 
     snapshot = history.getRequestsSince(two).get();
-    Assert.assertEquals(2, snapshot.getRequests().size());
-    Assert.assertEquals(4, snapshot.getCounter().getCounter());
+    Assertions.assertEquals(2, snapshot.getRequests().size());
+    Assertions.assertEquals(4, snapshot.getCounter().getCounter());
 
-    Assert.assertTrue(history.getRequestsSince(new ChangeRequestHistory.Counter(2, 1234)).get().isResetCounter());
+    Assertions.assertTrue(history.getRequestsSince(new ChangeRequestHistory.Counter(2, 1234)).get().isResetCounter());
   }
 
   @Test
@@ -131,7 +131,7 @@ public class ChangeRequestHistoryTest
     ListenableFuture<ChangeRequestsSnapshot<DataSegmentChangeRequest>> future = history.getRequestsSince(
         ChangeRequestHistory.Counter.ZERO
     );
-    Assert.assertEquals(1, history.waitingFutures.size());
+    Assertions.assertEquals(1, history.waitingFutures.size());
 
     final AtomicBoolean callbackExcecuted = new AtomicBoolean(false);
     Futures.addCallback(
@@ -154,8 +154,8 @@ public class ChangeRequestHistoryTest
     );
 
     future.cancel(true);
-    Assert.assertEquals(0, history.waitingFutures.size());
-    Assert.assertFalse(callbackExcecuted.get());
+    Assertions.assertEquals(0, history.waitingFutures.size());
+    Assertions.assertFalse(callbackExcecuted.get());
   }
 
   @Test
@@ -167,18 +167,18 @@ public class ChangeRequestHistoryTest
         ChangeRequestHistory.Counter.ZERO
     );
 
-    Assert.assertFalse(future.isDone());
+    Assertions.assertFalse(future.isDone());
 
     // An empty list of changes should not trigger the future to return!
     history.addChangeRequests(ImmutableList.of());
 
-    Assert.assertFalse(future.isDone());
+    Assertions.assertFalse(future.isDone());
 
     history.addChangeRequest(new SegmentChangeRequestNoop());
 
     ChangeRequestsSnapshot snapshot = future.get(1, TimeUnit.MINUTES);
-    Assert.assertEquals(1, snapshot.getCounter().getCounter());
-    Assert.assertEquals(1, snapshot.getRequests().size());
+    Assertions.assertEquals(1, snapshot.getCounter().getCounter());
+    Assertions.assertEquals(1, snapshot.getRequests().size());
   }
 
   @Test
@@ -189,7 +189,7 @@ public class ChangeRequestHistoryTest
     ListenableFuture<ChangeRequestsSnapshot<DataSegmentChangeRequest>> future = history.getRequestsSince(
         ChangeRequestHistory.Counter.ZERO
     );
-    Assert.assertEquals(1, history.waitingFutures.size());
+    Assertions.assertEquals(1, history.waitingFutures.size());
 
     final AtomicBoolean callbackExcecuted = new AtomicBoolean(false);
     Futures.addCallback(
@@ -214,11 +214,11 @@ public class ChangeRequestHistoryTest
     history.stop();
     // any new change requests should be ignored, there should be no waiting futures, and open futures should be resolved
     history.addChangeRequest(new SegmentChangeRequestNoop());
-    Assert.assertEquals(0, history.waitingFutures.size());
-    Assert.assertTrue(callbackExcecuted.get());
-    Assert.assertTrue(future.isDone());
+    Assertions.assertEquals(0, history.waitingFutures.size());
+    Assertions.assertTrue(callbackExcecuted.get());
+    Assertions.assertTrue(future.isDone());
 
-    Throwable thrown = Assert.assertThrows(ExecutionException.class, future::get);
-    Assert.assertEquals("java.lang.IllegalStateException: Server is shutting down.", thrown.getMessage());
+    Throwable thrown = Assertions.assertThrows(ExecutionException.class, future::get);
+    Assertions.assertEquals("java.lang.IllegalStateException: Server is shutting down.", thrown.getMessage());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordination/ChangeRequestHttpSyncerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/ChangeRequestHttpSyncerTest.java
@@ -37,20 +37,23 @@ import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.joda.time.Duration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.ByteArrayInputStream;
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  */
 public class ChangeRequestHttpSyncerTest
 {
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testSimple() throws Exception
   {
     ObjectMapper jsonMapper = TestHelper.makeJsonMapper();

--- a/server/src/test/java/org/apache/druid/server/coordination/ChangeRequestHttpSyncerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/ChangeRequestHttpSyncerTest.java
@@ -39,6 +39,7 @@ import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 
 import java.io.ByteArrayInputStream;
 import java.net.URL;
@@ -53,7 +54,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ChangeRequestHttpSyncerTest
 {
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testSimple() throws Exception
   {
     ObjectMapper jsonMapper = TestHelper.makeJsonMapper();

--- a/server/src/test/java/org/apache/druid/server/coordination/LoadableDataSegmentTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/LoadableDataSegmentTest.java
@@ -41,8 +41,8 @@ import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -107,6 +107,6 @@ public class LoadableDataSegmentTest
         MAPPER.writeValueAsString(segment),
         LoadableDataSegment.class
     );
-    Assert.assertEquals(segment.toString(), loadableDataSegment.toString());
+    Assertions.assertEquals(segment.toString(), loadableDataSegment.toString());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentCacheBootstrapperCacheTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentCacheBootstrapperCacheTest.java
@@ -36,12 +36,12 @@ import org.apache.druid.segment.loading.StorageLocation;
 import org.apache.druid.segment.loading.StorageLocationConfig;
 import org.apache.druid.server.SegmentManager;
 import org.apache.druid.server.metrics.DefaultLoadSpecHolder;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,8 +56,8 @@ public class SegmentCacheBootstrapperCacheTest
 {
   private static final long MAX_SIZE = 1000L;
   private static final long SEGMENT_SIZE = 100L;
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   private File infoDir;
   private File cacheDir;
@@ -69,7 +69,7 @@ public class SegmentCacheBootstrapperCacheTest
   private ServiceEmitter emitter;
   private ObjectMapper objectMapper;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     infoDir = temporaryFolder.newFolder();
@@ -194,18 +194,19 @@ public class SegmentCacheBootstrapperCacheTest
     bootstrapper.start();
 
     // Verify the expected announcements
-    Assert.assertTrue(segmentAnnouncer.getObservedSegments().containsAll(expectedSegments));
+    Assertions.assertTrue(segmentAnnouncer.getObservedSegments().containsAll(expectedSegments));
 
     // Make sure adding segments beyond allowed size fails
     DataSegment newSegment = TestSegmentUtils.makeSegment("test", "new-segment", SEGMENT_SIZE);
     loadDropHandler.addSegment(newSegment, null, null);
-    Assert.assertFalse(segmentAnnouncer.getObservedSegments().contains(newSegment));
+    Assertions.assertFalse(segmentAnnouncer.getObservedSegments().contains(newSegment));
 
     // Clearing some segment should allow for new segments
     loadDropHandler.removeSegment(expectedSegments.get(0), null, false);
     loadDropHandler.addSegment(newSegment, null, null);
-    Assert.assertTrue(segmentAnnouncer.getObservedSegments().contains(newSegment));
+    Assertions.assertTrue(segmentAnnouncer.getObservedSegments().contains(newSegment));
 
     bootstrapper.stop();
   }
+
 }

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentCacheBootstrapperTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentCacheBootstrapperTest.java
@@ -31,12 +31,12 @@ import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.apache.druid.server.metrics.DefaultLoadSpecHolder;
 import org.apache.druid.server.metrics.TestLoadSpecHolder;
 import org.apache.druid.test.utils.TestSegmentCacheManager;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.io.IOException;
@@ -55,10 +55,10 @@ public class SegmentCacheBootstrapperTest
   private TestCoordinatorClient coordinatorClient;
   private StubServiceEmitter serviceEmitter;
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
     final File segmentCacheDir = temporaryFolder.newFolder();
@@ -106,14 +106,14 @@ public class SegmentCacheBootstrapperTest
         new DefaultLoadSpecHolder()
     );
 
-    Assert.assertTrue(segmentManager.getDataSourceCounts().isEmpty());
+    Assertions.assertTrue(segmentManager.getDataSourceCounts().isEmpty());
     bootstrapper.start();
 
-    Assert.assertFalse(segmentManager.getDataSourceCounts().isEmpty());
+    Assertions.assertFalse(segmentManager.getDataSourceCounts().isEmpty());
 
     for (int i = 0; i < COUNT; ++i) {
-      Assert.assertEquals(3L, segmentManager.getDataSourceCounts().get("test" + i).longValue());
-      Assert.assertEquals(2L, segmentManager.getDataSourceCounts().get("test_two" + i).longValue());
+      Assertions.assertEquals(3L, segmentManager.getDataSourceCounts().get("test" + i).longValue());
+      Assertions.assertEquals(2L, segmentManager.getDataSourceCounts().get("test_two" + i).longValue());
     }
 
     final ImmutableList<DataSegment> expectedBootstrapSegments = ImmutableList.copyOf(segments);
@@ -121,11 +121,11 @@ public class SegmentCacheBootstrapperTest
     assertUnsortedListsAreEqual(expectedBootstrapSegments, segmentAnnouncer.getObservedSegments());
     assertUnsortedListsAreEqual(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegments());
 
-    Assert.assertEquals(ImmutableList.of(), cacheManager.getObservedSegments());
+    Assertions.assertEquals(ImmutableList.of(), cacheManager.getObservedSegments());
 
     bootstrapper.stop();
 
-    Assert.assertEquals(1, cacheManager.getObservedShutdownBootstrapCount().get());
+    Assertions.assertEquals(1, cacheManager.getObservedShutdownBootstrapCount().get());
   }
 
   @Test
@@ -161,15 +161,15 @@ public class SegmentCacheBootstrapperTest
         new DefaultLoadSpecHolder()
     );
 
-    Assert.assertTrue(segmentManager.getDataSourceCounts().isEmpty());
+    Assertions.assertTrue(segmentManager.getDataSourceCounts().isEmpty());
 
     bootstrapper.start();
 
-    Assert.assertFalse(segmentManager.getDataSourceCounts().isEmpty());
+    Assertions.assertFalse(segmentManager.getDataSourceCounts().isEmpty());
 
     for (int i = 0; i < COUNT; ++i) {
-      Assert.assertEquals(11L, segmentManager.getDataSourceCounts().get("test" + i).longValue());
-      Assert.assertEquals(2L, segmentManager.getDataSourceCounts().get("test_two" + i).longValue());
+      Assertions.assertEquals(11L, segmentManager.getDataSourceCounts().get("test" + i).longValue());
+      Assertions.assertEquals(2L, segmentManager.getDataSourceCounts().get("test_two" + i).longValue());
     }
 
     final ImmutableList<DataSegment> expectedBootstrapSegments = ImmutableList.copyOf(segments);
@@ -177,11 +177,11 @@ public class SegmentCacheBootstrapperTest
     assertUnsortedListsAreEqual(expectedBootstrapSegments, segmentAnnouncer.getObservedSegments());
     assertUnsortedListsAreEqual(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegments());
 
-    Assert.assertEquals(ImmutableList.of(), cacheManager.getObservedSegments());
+    Assertions.assertEquals(ImmutableList.of(), cacheManager.getObservedSegments());
 
     bootstrapper.stop();
 
-    Assert.assertEquals(1, cacheManager.getObservedShutdownBootstrapCount().get());
+    Assertions.assertEquals(1, cacheManager.getObservedShutdownBootstrapCount().get());
   }
 
   @Test
@@ -213,15 +213,15 @@ public class SegmentCacheBootstrapperTest
         new DefaultLoadSpecHolder()
     );
 
-    Assert.assertTrue(segmentManager.getDataSourceCounts().isEmpty());
+    Assertions.assertTrue(segmentManager.getDataSourceCounts().isEmpty());
 
     bootstrapper.start();
 
-    Assert.assertFalse(segmentManager.getDataSourceCounts().isEmpty());
+    Assertions.assertFalse(segmentManager.getDataSourceCounts().isEmpty());
 
     for (int i = 0; i < COUNT; ++i) {
-      Assert.assertEquals(2L, segmentManager.getDataSourceCounts().get("test" + i).longValue());
-      Assert.assertEquals(2L, segmentManager.getDataSourceCounts().get("test_two" + i).longValue());
+      Assertions.assertEquals(2L, segmentManager.getDataSourceCounts().get("test" + i).longValue());
+      Assertions.assertEquals(2L, segmentManager.getDataSourceCounts().get("test_two" + i).longValue());
     }
 
     final ImmutableList<DataSegment> expectedBootstrapSegments = ImmutableList.copyOf(segments);
@@ -264,17 +264,17 @@ public class SegmentCacheBootstrapperTest
         new TestLoadSpecHolder(LookupLoadingSpec.ALL, BroadcastDatasourceLoadingSpec.NONE)
     );
 
-    Assert.assertTrue(segmentManager.getDataSourceCounts().isEmpty());
+    Assertions.assertTrue(segmentManager.getDataSourceCounts().isEmpty());
 
     bootstrapper.start();
 
-    Assert.assertTrue(segmentManager.getDataSourceCounts().isEmpty());
+    Assertions.assertTrue(segmentManager.getDataSourceCounts().isEmpty());
 
     final ImmutableList<DataSegment> expectedBootstrapSegments = ImmutableList.of();
 
-    Assert.assertEquals(expectedBootstrapSegments, segmentAnnouncer.getObservedSegments());
+    Assertions.assertEquals(expectedBootstrapSegments, segmentAnnouncer.getObservedSegments());
 
-    Assert.assertEquals(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegments());
+    Assertions.assertEquals(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegments());
 
     bootstrapper.stop();
   }
@@ -310,12 +310,12 @@ public class SegmentCacheBootstrapperTest
         new TestLoadSpecHolder(LookupLoadingSpec.NONE, BroadcastDatasourceLoadingSpec.loadOnly(Set.of("test1")))
     );
 
-    Assert.assertTrue(segmentManager.getDataSourceCounts().isEmpty());
+    Assertions.assertTrue(segmentManager.getDataSourceCounts().isEmpty());
 
     bootstrapper.start();
 
-    Assert.assertFalse(segmentManager.getDataSourceCounts().isEmpty());
-    Assert.assertEquals(ImmutableSet.of("test1"), segmentManager.getDataSourceNames());
+    Assertions.assertFalse(segmentManager.getDataSourceCounts().isEmpty());
+    Assertions.assertEquals(ImmutableSet.of("test1"), segmentManager.getDataSourceNames());
 
     final ImmutableList<DataSegment> expectedBootstrapSegments = ImmutableList.of(ds1Segment2, ds1Segment1);
 
@@ -348,14 +348,14 @@ public class SegmentCacheBootstrapperTest
         new DefaultLoadSpecHolder()
     );
 
-    Assert.assertTrue(segmentManager.getDataSourceCounts().isEmpty());
+    Assertions.assertTrue(segmentManager.getDataSourceCounts().isEmpty());
 
     bootstrapper.start();
 
-    Assert.assertTrue(segmentManager.getDataSourceCounts().isEmpty());
+    Assertions.assertTrue(segmentManager.getDataSourceCounts().isEmpty());
 
-    Assert.assertEquals(ImmutableList.of(), segmentAnnouncer.getObservedSegments());
-    Assert.assertEquals(ImmutableList.of(), cacheManager.getObservedBootstrapSegments());
+    Assertions.assertEquals(ImmutableList.of(), segmentAnnouncer.getObservedSegments());
+    Assertions.assertEquals(ImmutableList.of(), cacheManager.getObservedBootstrapSegments());
     serviceEmitter.verifyValue("segment/bootstrap/count", 0);
     serviceEmitter.verifyEmitted("segment/bootstrap/time", 1);
 
@@ -370,7 +370,8 @@ public class SegmentCacheBootstrapperTest
    */
   private static <T> void assertUnsortedListsAreEqual(List<T> expected, List<T> actual)
   {
-    Assert.assertEquals(expected.size(), actual.size());
-    Assert.assertEquals(Set.copyOf(expected), Set.copyOf(actual));
+    Assertions.assertEquals(expected.size(), actual.size());
+    Assertions.assertEquals(Set.copyOf(expected), Set.copyOf(actual));
   }
+
 }

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentChangeRequestDropTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentChangeRequestDropTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.segment.IndexIO;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -65,16 +65,16 @@ public class SegmentChangeRequestDropTest
         JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
     );
 
-    Assert.assertEquals(11, objectMap.size());
-    Assert.assertEquals("drop", objectMap.get("action"));
-    Assert.assertEquals("something", objectMap.get("dataSource"));
-    Assert.assertEquals(interval.toString(), objectMap.get("interval"));
-    Assert.assertEquals("1", objectMap.get("version"));
-    Assert.assertEquals(loadSpec, objectMap.get("loadSpec"));
-    Assert.assertEquals("dim1,dim2", objectMap.get("dimensions"));
-    Assert.assertEquals("met1,met2", objectMap.get("metrics"));
-    Assert.assertEquals(ImmutableMap.of("type", "none"), objectMap.get("shardSpec"));
-    Assert.assertEquals(IndexIO.CURRENT_VERSION_ID, objectMap.get("binaryVersion"));
-    Assert.assertEquals(1, objectMap.get("size"));
+    Assertions.assertEquals(11, objectMap.size());
+    Assertions.assertEquals("drop", objectMap.get("action"));
+    Assertions.assertEquals("something", objectMap.get("dataSource"));
+    Assertions.assertEquals(interval.toString(), objectMap.get("interval"));
+    Assertions.assertEquals("1", objectMap.get("version"));
+    Assertions.assertEquals(loadSpec, objectMap.get("loadSpec"));
+    Assertions.assertEquals("dim1,dim2", objectMap.get("dimensions"));
+    Assertions.assertEquals("met1,met2", objectMap.get("metrics"));
+    Assertions.assertEquals(ImmutableMap.of("type", "none"), objectMap.get("shardSpec"));
+    Assertions.assertEquals(IndexIO.CURRENT_VERSION_ID, objectMap.get("binaryVersion"));
+    Assertions.assertEquals(1, objectMap.get("size"));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentChangeRequestLoadTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentChangeRequestLoadTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -70,17 +70,17 @@ public class SegmentChangeRequestLoadTest
         mapper.writeValueAsString(segmentDrop), JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
     );
 
-    Assert.assertEquals(11, objectMap.size());
-    Assert.assertEquals("load", objectMap.get("action"));
-    Assert.assertEquals("something", objectMap.get("dataSource"));
-    Assert.assertEquals(interval.toString(), objectMap.get("interval"));
-    Assert.assertEquals("1", objectMap.get("version"));
-    Assert.assertEquals(loadSpec, objectMap.get("loadSpec"));
-    Assert.assertEquals("dim1,dim2", objectMap.get("dimensions"));
-    Assert.assertEquals("met1,met2", objectMap.get("metrics"));
-    Assert.assertEquals(ImmutableMap.of("type", "none"), objectMap.get("shardSpec"));
-    Assert.assertEquals(IndexIO.CURRENT_VERSION_ID, objectMap.get("binaryVersion"));
-    Assert.assertEquals(1, objectMap.get("size"));
+    Assertions.assertEquals(11, objectMap.size());
+    Assertions.assertEquals("load", objectMap.get("action"));
+    Assertions.assertEquals("something", objectMap.get("dataSource"));
+    Assertions.assertEquals(interval.toString(), objectMap.get("interval"));
+    Assertions.assertEquals("1", objectMap.get("version"));
+    Assertions.assertEquals(loadSpec, objectMap.get("loadSpec"));
+    Assertions.assertEquals("dim1,dim2", objectMap.get("dimensions"));
+    Assertions.assertEquals("met1,met2", objectMap.get("metrics"));
+    Assertions.assertEquals(ImmutableMap.of("type", "none"), objectMap.get("shardSpec"));
+    Assertions.assertEquals(IndexIO.CURRENT_VERSION_ID, objectMap.get("binaryVersion"));
+    Assertions.assertEquals(1, objectMap.get("size"));
   }
 
   @Test
@@ -99,8 +99,8 @@ public class SegmentChangeRequestLoadTest
         mapper.writeValueAsString(load),
         JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
     );
-    Assert.assertFalse(objectMap.containsKey("fingerprint"));
-    Assert.assertFalse(objectMap.containsKey("loadedBytes"));
+    Assertions.assertFalse(objectMap.containsKey("fingerprint"));
+    Assertions.assertFalse(objectMap.containsKey("loadedBytes"));
   }
 
   @Test
@@ -121,9 +121,9 @@ public class SegmentChangeRequestLoadTest
     );
     String json = mapper.writeValueAsString(load);
     SegmentChangeRequestLoad reread = mapper.readValue(json, SegmentChangeRequestLoad.class);
-    Assert.assertEquals(load, reread);
-    Assert.assertEquals("v1:abcdef0123456789", reread.getFingerprint());
-    Assert.assertEquals(Long.valueOf(12345L), reread.getLoadedBytes());
+    Assertions.assertEquals(load, reread);
+    Assertions.assertEquals("v1:abcdef0123456789", reread.getFingerprint());
+    Assertions.assertEquals(Long.valueOf(12345L), reread.getLoadedBytes());
   }
 
   @Test
@@ -137,8 +137,8 @@ public class SegmentChangeRequestLoadTest
         .size(100)
         .build();
     SegmentChangeRequestLoad announcement = SegmentChangeRequestLoad.forAnnouncement(segment);
-    Assert.assertNull(announcement.getFingerprint());
-    Assert.assertNull(announcement.getLoadedBytes());
+    Assertions.assertNull(announcement.getFingerprint());
+    Assertions.assertNull(announcement.getLoadedBytes());
   }
 
   @Test
@@ -161,8 +161,8 @@ public class SegmentChangeRequestLoadTest
         .size(12345)
         .build();
     SegmentChangeRequestLoad announcement = SegmentChangeRequestLoad.forAnnouncement(segment);
-    Assert.assertEquals("v1:abcdef0123456789", announcement.getFingerprint());
-    Assert.assertEquals(Long.valueOf(12345L), announcement.getLoadedBytes());
+    Assertions.assertEquals("v1:abcdef0123456789", announcement.getFingerprint());
+    Assertions.assertEquals(Long.valueOf(12345L), announcement.getLoadedBytes());
   }
 
   @Test
@@ -189,11 +189,11 @@ public class SegmentChangeRequestLoadTest
         PartialLoadProfile.forLoaded(wrapped, "v1:abcdef0123456789", 4321L)
     );
     SegmentChangeRequestLoad announcement = SegmentChangeRequestLoad.forAnnouncement(wrappedSegment);
-    Assert.assertEquals("v1:abcdef0123456789", announcement.getFingerprint());
-    Assert.assertEquals(
-        "loadedBytes must come from the DataSegmentAndLoadProfile's PartialLoadProfile, not segment.getSize()",
+    Assertions.assertEquals("v1:abcdef0123456789", announcement.getFingerprint());
+    Assertions.assertEquals(
         Long.valueOf(4321L),
-        announcement.getLoadedBytes()
+        announcement.getLoadedBytes(),
+        "loadedBytes must come from the DataSegmentAndLoadProfile's PartialLoadProfile, not segment.getSize()"
     );
   }
 
@@ -215,8 +215,8 @@ public class SegmentChangeRequestLoadTest
         .size(7777)
         .build();
     SegmentChangeRequestLoad announcement = SegmentChangeRequestLoad.forAnnouncement(segment);
-    Assert.assertEquals("v1:1111111111111111", announcement.getFingerprint());
-    Assert.assertEquals(Long.valueOf(7777L), announcement.getLoadedBytes());
+    Assertions.assertEquals("v1:1111111111111111", announcement.getFingerprint());
+    Assertions.assertEquals(Long.valueOf(7777L), announcement.getLoadedBytes());
   }
 
   @Test
@@ -237,8 +237,8 @@ public class SegmentChangeRequestLoadTest
         .size(100)
         .build();
     SegmentChangeRequestLoad announcement = SegmentChangeRequestLoad.forAnnouncement(segment);
-    Assert.assertNull(announcement.getFingerprint());
-    Assert.assertNull(announcement.getLoadedBytes());
+    Assertions.assertNull(announcement.getFingerprint());
+    Assertions.assertNull(announcement.getLoadedBytes());
   }
 
   @Test
@@ -258,8 +258,8 @@ public class SegmentChangeRequestLoadTest
         .size(100)
         .build();
     SegmentChangeRequestLoad announcement = SegmentChangeRequestLoad.forAnnouncement(segment);
-    Assert.assertNull(announcement.getFingerprint());
-    Assert.assertNull(announcement.getLoadedBytes());
+    Assertions.assertNull(announcement.getFingerprint());
+    Assertions.assertNull(announcement.getLoadedBytes());
   }
 
   @Test
@@ -275,7 +275,7 @@ public class SegmentChangeRequestLoadTest
         .build();
     String oldJson = mapper.writeValueAsString(new SegmentChangeRequestLoad(segment));
     SegmentChangeRequestLoad reread = mapper.readValue(oldJson, SegmentChangeRequestLoad.class);
-    Assert.assertNull(reread.getFingerprint());
-    Assert.assertNull(reread.getLoadedBytes());
+    Assertions.assertNull(reread.getFingerprint());
+    Assertions.assertNull(reread.getLoadedBytes());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentLoadDropHandlerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentLoadDropHandlerTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -187,7 +188,7 @@ public class SegmentLoadDropHandlerTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testProcessBatch() throws Exception
   {
     final TestSegmentCacheManager cacheManager = new TestSegmentCacheManager();
@@ -227,7 +228,7 @@ public class SegmentLoadDropHandlerTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testProcessBatchDuplicateLoadRequestsWhenFirstRequestFailsSecondRequestShouldSucceed() throws Exception
   {
     final SegmentManager segmentManager = Mockito.mock(SegmentManager.class);
@@ -263,7 +264,7 @@ public class SegmentLoadDropHandlerTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testProcessBatchLoadDropLoadSequenceForSameSegment() throws Exception
   {
     final SegmentManager segmentManager = Mockito.mock(SegmentManager.class);

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentLoadDropHandlerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentLoadDropHandlerTest.java
@@ -32,12 +32,13 @@ import org.apache.druid.server.SegmentManager;
 import org.apache.druid.server.coordination.SegmentChangeStatus.State;
 import org.apache.druid.server.http.SegmentLoadingMode;
 import org.apache.druid.test.utils.TestSegmentCacheManager;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -61,10 +62,10 @@ public class SegmentLoadDropHandlerTest
   private SegmentLoaderConfig segmentLoaderConfig;
   private ScheduledExecutorFactory scheduledExecutorFactory;
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
     final File segmentCacheDir = temporaryFolder.newFolder();
@@ -79,10 +80,10 @@ public class SegmentLoadDropHandlerTest
         .dropSegmentDelayMillis(0)
         .build();
 
-    scheduledExecutorFactory = (corePoolSize, nameFormat) -> {
+    scheduledExecutorFactory = (corePoolSize, nameFormat) ->
       // Override normal behavior by adding the runnable to a list so that you can make sure
       // all the scheduled runnables are executed by explicitly calling run() on each item in the list
-      return new ScheduledThreadPoolExecutor(corePoolSize, Execs.makeThreadFactory(nameFormat))
+      new ScheduledThreadPoolExecutor(corePoolSize, Execs.makeThreadFactory(nameFormat))
       {
         @Override
         public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit)
@@ -91,7 +92,6 @@ public class SegmentLoadDropHandlerTest
           return null;
         }
       };
-    };
 
     EmittingLogger.registerEmitter(new StubServiceEmitter());
   }
@@ -115,7 +115,7 @@ public class SegmentLoadDropHandlerTest
 
     handler.removeSegment(segment, DataSegmentChangeCallback.NOOP);
 
-    Assert.assertFalse(segmentAnnouncer.getObservedSegments().contains(segment));
+    Assertions.assertFalse(segmentAnnouncer.getObservedSegments().contains(segment));
 
     handler.addSegment(segment, DataSegmentChangeCallback.NOOP, null);
 
@@ -125,13 +125,13 @@ public class SegmentLoadDropHandlerTest
     for (Runnable runnable : scheduledRunnable) {
       runnable.run();
     }
-    Assert.assertEquals(ImmutableList.of(segment), cacheManager.getObservedSegments());
-    Assert.assertEquals(ImmutableList.of(), cacheManager.getObservedBootstrapSegments());
+    Assertions.assertEquals(ImmutableList.of(segment), cacheManager.getObservedSegments());
+    Assertions.assertEquals(ImmutableList.of(), cacheManager.getObservedBootstrapSegments());
 
-    Assert.assertEquals(ImmutableList.of(segment), segmentAnnouncer.getObservedSegments());
-    Assert.assertFalse(
-        "segment files shouldn't be deleted",
-        cacheManager.getObservedSegmentsRemovedFromCache().contains(segment.getId())
+    Assertions.assertEquals(ImmutableList.of(segment), segmentAnnouncer.getObservedSegments());
+    Assertions.assertFalse(
+        cacheManager.getObservedSegmentsRemovedFromCache().contains(segment.getId()),
+        "segment files shouldn't be deleted"
     );
   }
 
@@ -159,11 +159,11 @@ public class SegmentLoadDropHandlerTest
 
     handler.addSegment(segment, DataSegmentChangeCallback.NOOP, null);
 
-    Assert.assertTrue(segmentAnnouncer.getObservedSegments().contains(segment));
+    Assertions.assertTrue(segmentAnnouncer.getObservedSegments().contains(segment));
 
     handler.removeSegment(segment, DataSegmentChangeCallback.NOOP);
 
-    Assert.assertFalse(segmentAnnouncer.getObservedSegments().contains(segment));
+    Assertions.assertFalse(segmentAnnouncer.getObservedSegments().contains(segment));
 
     handler.addSegment(segment, DataSegmentChangeCallback.NOOP, null);
 
@@ -176,17 +176,18 @@ public class SegmentLoadDropHandlerTest
 
     // The same segment reference will be fetched more than once in the above sequence, but the segment should
     // be loaded only once onto the page cache.
-    Assert.assertEquals(ImmutableList.of(segment, segment), cacheManager.getObservedSegments());
-    Assert.assertEquals(ImmutableList.of(), cacheManager.getObservedBootstrapSegments());
+    Assertions.assertEquals(ImmutableList.of(segment, segment), cacheManager.getObservedSegments());
+    Assertions.assertEquals(ImmutableList.of(), cacheManager.getObservedBootstrapSegments());
 
-    Assert.assertTrue(segmentAnnouncer.getObservedSegments().contains(segment));
-    Assert.assertFalse(
-        "segment files shouldn't be deleted",
-        cacheManager.getObservedSegmentsRemovedFromCache().contains(segment.getId())
+    Assertions.assertTrue(segmentAnnouncer.getObservedSegments().contains(segment));
+    Assertions.assertFalse(
+        cacheManager.getObservedSegmentsRemovedFromCache().contains(segment.getId()),
+        "segment files shouldn't be deleted"
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testProcessBatch() throws Exception
   {
     final TestSegmentCacheManager cacheManager = new TestSegmentCacheManager();
@@ -208,7 +209,7 @@ public class SegmentLoadDropHandlerTest
     expectedStatusMap.put(batch.get(1), SegmentChangeStatus.success());
     List<DataSegmentChangeResponse> result = future.get();
     for (DataSegmentChangeResponse requestAndStatus : result) {
-      Assert.assertEquals(expectedStatusMap.get(requestAndStatus.getRequest()), requestAndStatus.getStatus());
+      Assertions.assertEquals(expectedStatusMap.get(requestAndStatus.getRequest()), requestAndStatus.getStatus());
     }
 
     for (Runnable runnable : scheduledRunnable) {
@@ -216,16 +217,17 @@ public class SegmentLoadDropHandlerTest
     }
 
     result = handler.processBatch(ImmutableList.of(new SegmentChangeRequestLoad(segment1)), SegmentLoadingMode.TURBO).get();
-    Assert.assertEquals(SegmentChangeStatus.success(SegmentLoadingMode.TURBO), result.get(0).getStatus());
+    Assertions.assertEquals(SegmentChangeStatus.success(SegmentLoadingMode.TURBO), result.get(0).getStatus());
 
-    Assert.assertEquals(ImmutableList.of(segment1), segmentAnnouncer.getObservedSegments());
+    Assertions.assertEquals(ImmutableList.of(segment1), segmentAnnouncer.getObservedSegments());
 
     final ImmutableList<DataSegment> expectedSegments = ImmutableList.of(segment1);
-    Assert.assertEquals(expectedSegments, cacheManager.getObservedSegments());
-    Assert.assertEquals(ImmutableList.of(), cacheManager.getObservedBootstrapSegments());
+    Assertions.assertEquals(expectedSegments, cacheManager.getObservedSegments());
+    Assertions.assertEquals(ImmutableList.of(), cacheManager.getObservedBootstrapSegments());
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testProcessBatchDuplicateLoadRequestsWhenFirstRequestFailsSecondRequestShouldSucceed() throws Exception
   {
     final SegmentManager segmentManager = Mockito.mock(SegmentManager.class);
@@ -247,20 +249,21 @@ public class SegmentLoadDropHandlerTest
       runnable.run();
     }
     List<DataSegmentChangeResponse> result = future.get();
-    Assert.assertEquals(State.FAILED, result.get(0).getStatus().getState());
-    Assert.assertEquals(ImmutableList.of(), segmentAnnouncer.getObservedSegments());
+    Assertions.assertEquals(State.FAILED, result.get(0).getStatus().getState());
+    Assertions.assertEquals(ImmutableList.of(), segmentAnnouncer.getObservedSegments());
 
     future = handler.processBatch(batch, SegmentLoadingMode.NORMAL);
     for (Runnable runnable : scheduledRunnable) {
       runnable.run();
     }
     result = future.get();
-    Assert.assertEquals(SegmentChangeStatus.success(SegmentLoadingMode.NORMAL), result.get(0).getStatus());
-    Assert.assertEquals(ImmutableList.of(segment1, segment1), segmentAnnouncer.getObservedSegments());
+    Assertions.assertEquals(SegmentChangeStatus.success(SegmentLoadingMode.NORMAL), result.get(0).getStatus());
+    Assertions.assertEquals(ImmutableList.of(segment1, segment1), segmentAnnouncer.getObservedSegments());
 
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testProcessBatchLoadDropLoadSequenceForSameSegment() throws Exception
   {
     final SegmentManager segmentManager = Mockito.mock(SegmentManager.class);
@@ -293,8 +296,8 @@ public class SegmentLoadDropHandlerTest
       runnable.run();
     }
     List<DataSegmentChangeResponse> result = future.get();
-    Assert.assertEquals(State.SUCCESS, result.get(0).getStatus().getState());
-    Assert.assertEquals(ImmutableList.of(segment1), segmentAnnouncer.getObservedSegments());
+    Assertions.assertEquals(State.SUCCESS, result.get(0).getStatus().getState());
+    Assertions.assertEquals(ImmutableList.of(segment1), segmentAnnouncer.getObservedSegments());
     scheduledRunnable.clear();
 
     // Request 2: Drop the segment
@@ -304,9 +307,9 @@ public class SegmentLoadDropHandlerTest
       runnable.run();
     }
     result = future.get();
-    Assert.assertEquals(State.SUCCESS, result.get(0).getStatus().getState());
-    Assert.assertEquals(ImmutableList.of(), segmentAnnouncer.getObservedSegments());
-    Assert.assertFalse(segmentAnnouncer.getObservedSegments().contains(segment1)); //
+    Assertions.assertEquals(State.SUCCESS, result.get(0).getStatus().getState());
+    Assertions.assertEquals(ImmutableList.of(), segmentAnnouncer.getObservedSegments());
+    Assertions.assertFalse(segmentAnnouncer.getObservedSegments().contains(segment1)); //
     scheduledRunnable.clear();
 
     // check invocations after a load-drop sequence
@@ -322,8 +325,8 @@ public class SegmentLoadDropHandlerTest
       runnable.run();
     }
     result = future.get();
-    Assert.assertEquals(State.SUCCESS, result.get(0).getStatus().getState());
-    Assert.assertEquals(ImmutableList.of(segment1), segmentAnnouncer.getObservedSegments());
+    Assertions.assertEquals(State.SUCCESS, result.get(0).getStatus().getState());
+    Assertions.assertEquals(ImmutableList.of(segment1), segmentAnnouncer.getObservedSegments());
     scheduledRunnable.clear();
 
     // check invocations - 1 more load has happened
@@ -339,8 +342,8 @@ public class SegmentLoadDropHandlerTest
       runnable.run();
     }
     result = future.get();
-    Assert.assertEquals(State.SUCCESS, result.get(0).getStatus().getState());
-    Assert.assertEquals(ImmutableList.of(segment1, segment1), segmentAnnouncer.getObservedSegments());
+    Assertions.assertEquals(State.SUCCESS, result.get(0).getStatus().getState());
+    Assertions.assertEquals(ImmutableList.of(segment1, segment1), segmentAnnouncer.getObservedSegments());
     scheduledRunnable.clear();
 
     // check invocations - the load segment counter should bump up
@@ -369,4 +372,5 @@ public class SegmentLoadDropHandlerTest
         (ThreadPoolExecutor) scheduledExecutorFactory.create(5, "TurboSegmentLoadDropHandlerTest-[%d]")
     );
   }
+
 }

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentManagerBroadcastJoinIndexedTableTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentManagerBroadcastJoinIndexedTableTest.java
@@ -62,17 +62,16 @@ import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFacto
 import org.apache.druid.server.SegmentManager;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.easymock.EasyMock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.io.IOException;
@@ -94,11 +93,8 @@ public class SegmentManagerBroadcastJoinIndexedTableTest extends InitializedNull
   private static final Set<String> KEY_COLUMNS =
       ImmutableSet.of("market", "longNumericNull", "doubleNumericNull", "floatNumericNull", "partial_null_column");
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   private LocalDataSegmentPuller segmentPuller;
   private ObjectMapper objectMapper;
@@ -109,7 +105,7 @@ public class SegmentManagerBroadcastJoinIndexedTableTest extends InitializedNull
   private SegmentManager segmentManager;
   private BroadcastTableJoinableFactory joinableFactory;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     segmentPuller = new LocalDataSegmentPuller();
@@ -148,7 +144,7 @@ public class SegmentManagerBroadcastJoinIndexedTableTest extends InitializedNull
     EmittingLogger.registerEmitter(new NoopServiceEmitter());
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     FileUtils.deleteDirectory(segmentCacheDir);
@@ -158,7 +154,7 @@ public class SegmentManagerBroadcastJoinIndexedTableTest extends InitializedNull
   public void testLoadIndexedTable() throws IOException, SegmentLoadingException
   {
     final DataSource dataSource = new GlobalTableDataSource(TABLE_NAME);
-    Assert.assertFalse(joinableFactory.isDirectlyJoinable(dataSource));
+    Assertions.assertFalse(joinableFactory.isDirectlyJoinable(dataSource));
 
     final String version = DateTimes.nowUtc().toString();
     IncrementalIndex data = TestIndex.makeSampleNumericIncrementalIndex();
@@ -166,14 +162,14 @@ public class SegmentManagerBroadcastJoinIndexedTableTest extends InitializedNull
     DataSegment segment = createSegment(data, interval, version);
     segmentManager.loadSegment(segment);
 
-    Assert.assertTrue(joinableFactory.isDirectlyJoinable(dataSource));
+    Assertions.assertTrue(joinableFactory.isDirectlyJoinable(dataSource));
     Optional<Joinable> maybeJoinable = makeJoinable(dataSource);
-    Assert.assertTrue(maybeJoinable.isPresent());
+    Assertions.assertTrue(maybeJoinable.isPresent());
     Joinable joinable = maybeJoinable.get();
     // cardinality currently tied to number of rows,
-    Assert.assertEquals(1210, joinable.getCardinality("market"));
-    Assert.assertEquals(1210, joinable.getCardinality("placement"));
-    Assert.assertEquals(
+    Assertions.assertEquals(1210, joinable.getCardinality("market"));
+    Assertions.assertEquals(1210, joinable.getCardinality("placement"));
+    Assertions.assertEquals(
         Optional.of(ImmutableSet.of("preferred")),
         joinable.getCorrelatedColumnValues(
             "market",
@@ -184,7 +180,7 @@ public class SegmentManagerBroadcastJoinIndexedTableTest extends InitializedNull
         )
     );
     Optional<byte[]> bytes = joinableFactory.computeJoinCacheKey(dataSource, JOIN_CONDITION_ANALYSIS);
-    Assert.assertTrue(bytes.isPresent());
+    Assertions.assertTrue(bytes.isPresent());
     assertSegmentIdEquals(segment.getId(), bytes.get());
 
     // dropping the segment should make the table no longer available
@@ -192,17 +188,17 @@ public class SegmentManagerBroadcastJoinIndexedTableTest extends InitializedNull
 
     maybeJoinable = makeJoinable(dataSource);
 
-    Assert.assertFalse(maybeJoinable.isPresent());
+    Assertions.assertFalse(maybeJoinable.isPresent());
 
     bytes = joinableFactory.computeJoinCacheKey(dataSource, JOIN_CONDITION_ANALYSIS);
-    Assert.assertFalse(bytes.isPresent());
+    Assertions.assertFalse(bytes.isPresent());
   }
 
   @Test
   public void testLoadMultipleIndexedTableOverwrite() throws IOException, SegmentLoadingException
   {
     final DataSource dataSource = new GlobalTableDataSource(TABLE_NAME);
-    Assert.assertFalse(joinableFactory.isDirectlyJoinable(dataSource));
+    Assertions.assertFalse(joinableFactory.isDirectlyJoinable(dataSource));
 
     // larger interval overwrites smaller interval
     final String version = DateTimes.nowUtc().toString();
@@ -216,15 +212,15 @@ public class SegmentManagerBroadcastJoinIndexedTableTest extends InitializedNull
     segmentManager.loadSegment(segment1);
     segmentManager.loadSegment(segment2);
 
-    Assert.assertTrue(joinableFactory.isDirectlyJoinable(dataSource));
+    Assertions.assertTrue(joinableFactory.isDirectlyJoinable(dataSource));
     Optional<Joinable> maybeJoinable = makeJoinable(dataSource);
-    Assert.assertTrue(maybeJoinable.isPresent());
+    Assertions.assertTrue(maybeJoinable.isPresent());
 
     Joinable joinable = maybeJoinable.get();
     // cardinality currently tied to number of rows,
-    Assert.assertEquals(733, joinable.getCardinality("market"));
-    Assert.assertEquals(733, joinable.getCardinality("placement"));
-    Assert.assertEquals(
+    Assertions.assertEquals(733, joinable.getCardinality("market"));
+    Assertions.assertEquals(733, joinable.getCardinality("placement"));
+    Assertions.assertEquals(
         Optional.of(ImmutableSet.of("preferred")),
         joinable.getCorrelatedColumnValues(
             "market",
@@ -235,20 +231,20 @@ public class SegmentManagerBroadcastJoinIndexedTableTest extends InitializedNull
         )
     );
     Optional<byte[]> cacheKey = joinableFactory.computeJoinCacheKey(dataSource, JOIN_CONDITION_ANALYSIS);
-    Assert.assertTrue(cacheKey.isPresent());
+    Assertions.assertTrue(cacheKey.isPresent());
     assertSegmentIdEquals(segment2.getId(), cacheKey.get());
 
     segmentManager.dropSegment(segment2);
 
     // if new segment is dropped for some reason that probably never happens, old table should still exist..
     maybeJoinable = makeJoinable(dataSource);
-    Assert.assertTrue(maybeJoinable.isPresent());
+    Assertions.assertTrue(maybeJoinable.isPresent());
 
     joinable = maybeJoinable.get();
     // cardinality currently tied to number of rows,
-    Assert.assertEquals(478, joinable.getCardinality("market"));
-    Assert.assertEquals(478, joinable.getCardinality("placement"));
-    Assert.assertEquals(
+    Assertions.assertEquals(478, joinable.getCardinality("market"));
+    Assertions.assertEquals(478, joinable.getCardinality("placement"));
+    Assertions.assertEquals(
         Optional.of(ImmutableSet.of("preferred")),
         joinable.getCorrelatedColumnValues(
             "market",
@@ -259,56 +255,54 @@ public class SegmentManagerBroadcastJoinIndexedTableTest extends InitializedNull
         )
     );
     cacheKey = joinableFactory.computeJoinCacheKey(dataSource, JOIN_CONDITION_ANALYSIS);
-    Assert.assertTrue(cacheKey.isPresent());
+    Assertions.assertTrue(cacheKey.isPresent());
     assertSegmentIdEquals(segment1.getId(), cacheKey.get());
   }
 
 
   @Test
-  public void testLoadMultipleIndexedTable() throws IOException, SegmentLoadingException
+  public void testLoadMultipleIndexedTable()
   {
-    final DataSource dataSource = new GlobalTableDataSource(TABLE_NAME);
-    Assert.assertFalse(joinableFactory.isDirectlyJoinable(dataSource));
+    Throwable exception = Assertions.assertThrows(ISE.class, () -> {
+      final DataSource dataSource = new GlobalTableDataSource(TABLE_NAME);
+      Assertions.assertFalse(joinableFactory.isDirectlyJoinable(dataSource));
 
-    final String version = DateTimes.nowUtc().toString();
-    final String version2 = DateTimes.nowUtc().plus(1000L).toString();
-    final String interval = "2011-01-12T00:00:00.000Z/2011-05-01T00:00:00.000Z";
-    final String interval2 = "2011-01-12T00:00:00.000Z/2011-03-28T00:00:00.000Z";
-    IncrementalIndex data = TestIndex.makeSampleNumericBottomIncrementalIndex();
-    IncrementalIndex data2 = TestIndex.makeSampleNumericTopIncrementalIndex();
-    segmentManager.loadSegment(createSegment(data, interval, version));
-    Assert.assertTrue(joinableFactory.isDirectlyJoinable(dataSource));
+      final String version = DateTimes.nowUtc().toString();
+      final String version2 = DateTimes.nowUtc().plus(1000L).toString();
+      final String interval = "2011-01-12T00:00:00.000Z/2011-05-01T00:00:00.000Z";
+      final String interval2 = "2011-01-12T00:00:00.000Z/2011-03-28T00:00:00.000Z";
+      IncrementalIndex data = TestIndex.makeSampleNumericBottomIncrementalIndex();
+      IncrementalIndex data2 = TestIndex.makeSampleNumericTopIncrementalIndex();
+      segmentManager.loadSegment(createSegment(data, interval, version));
+      Assertions.assertTrue(joinableFactory.isDirectlyJoinable(dataSource));
 
-    Optional<Joinable> maybeJoinable = makeJoinable(dataSource);
-    Assert.assertTrue(maybeJoinable.isPresent());
+      Optional<Joinable> maybeJoinable = makeJoinable(dataSource);
+      Assertions.assertTrue(maybeJoinable.isPresent());
 
-    Joinable joinable = maybeJoinable.get();
-    // cardinality currently tied to number of rows,
-    Assert.assertEquals(733, joinable.getCardinality("market"));
-    Assert.assertEquals(733, joinable.getCardinality("placement"));
-    Assert.assertEquals(
-        Optional.of(ImmutableSet.of("preferred")),
-        joinable.getCorrelatedColumnValues(
-            "market",
-            "spot",
-            "placement",
-            Long.MAX_VALUE,
-            false
-        )
-    );
+      Joinable joinable = maybeJoinable.get();
+      // cardinality currently tied to number of rows,
+      Assertions.assertEquals(733, joinable.getCardinality("market"));
+      Assertions.assertEquals(733, joinable.getCardinality("placement"));
+      Assertions.assertEquals(
+          Optional.of(ImmutableSet.of("preferred")),
+          joinable.getCorrelatedColumnValues(
+              "market",
+              "spot",
+              "placement",
+              Long.MAX_VALUE,
+              false
+          )
+      );
 
-    // add another segment with smaller interval, only partially overshadows so there will be 2 segments in timeline
-    segmentManager.loadSegment(createSegment(data2, interval2, version2));
-
-    expectedException.expect(ISE.class);
-    expectedException.expectMessage(
-        StringUtils.format(
-            "Currently only single segment datasources are supported for broadcast joins, dataSource[%s] has multiple segments. Reingest the data so that it is entirely contained within a single segment to use in JOIN queries.",
-            TABLE_NAME
-        )
-    );
-    // this will explode because datasource has multiple segments which is an invalid state for the joinable factory
-    makeJoinable(dataSource);
+      // add another segment with smaller interval, only partially overshadows so there will be 2 segments in timeline
+      segmentManager.loadSegment(createSegment(data2, interval2, version2));
+      // this will explode because datasource has multiple segments which is an invalid state for the joinable factory
+      makeJoinable(dataSource);
+    });
+    Assertions.assertTrue(exception.getMessage().contains(StringUtils.format(
+        "Currently only single segment datasources are supported for broadcast joins, dataSource[%s] has multiple segments. Reingest the data so that it is entirely contained within a single segment to use in JOIN queries.",
+        TABLE_NAME
+    )));
   }
 
   @Test
@@ -318,7 +312,7 @@ public class SegmentManagerBroadcastJoinIndexedTableTest extends InitializedNull
     JoinConditionAnalysis condition = EasyMock.mock(JoinConditionAnalysis.class);
     EasyMock.expect(condition.canHashJoin()).andReturn(false);
     EasyMock.replay(condition);
-    Assert.assertNull(joinableFactory.build(dataSource, condition).orElse(null));
+    Assertions.assertNull(joinableFactory.build(dataSource, condition).orElse(null));
   }
 
   private Optional<Joinable> makeJoinable(DataSource dataSource)
@@ -377,6 +371,7 @@ public class SegmentManagerBroadcastJoinIndexedTableTest extends InitializedNull
     String dataSource = StringUtils.fromUtf8(byteBuffer, StringUtils.estimatedBinaryLengthAsUTF8(id.getDataSource()));
     byteBuffer.get();
     int partition = byteBuffer.getInt();
-    Assert.assertEquals(id, SegmentId.of(dataSource, Intervals.utc(start, end), version, partition));
+    Assertions.assertEquals(id, SegmentId.of(dataSource, Intervals.utc(start, end), version, partition));
   }
+
 }

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentManagerThreadSafetyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentManagerThreadSafetyTest.java
@@ -48,16 +48,17 @@ import org.apache.druid.segment.loading.StorageLocation;
 import org.apache.druid.segment.loading.StorageLocationConfig;
 import org.apache.druid.server.SegmentManager;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -70,6 +71,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -77,8 +79,8 @@ public class SegmentManagerThreadSafetyTest
 {
   private static final int NUM_THREAD = 4;
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   private TestSegmentPuller segmentPuller;
   private ObjectMapper objectMapper;
@@ -88,7 +90,7 @@ public class SegmentManagerThreadSafetyTest
   private SegmentManager segmentManager;
   private ExecutorService exec;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     segmentPuller = new TestSegmentPuller();
@@ -118,14 +120,15 @@ public class SegmentManagerThreadSafetyTest
     EmittingLogger.registerEmitter(new NoopServiceEmitter());
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     exec.shutdownNow();
     FileUtils.deleteDirectory(segmentCacheDir);
   }
 
-  @Test(timeout = 6000L)
+  @Test
+  @Timeout(value = 6000L, unit = TimeUnit.MILLISECONDS)
   public void testLoadSameSegment() throws IOException, ExecutionException, InterruptedException
   {
     final DataSegment segment = createSegment("2019-01-01/2019-01-02");
@@ -143,12 +146,13 @@ public class SegmentManagerThreadSafetyTest
     for (Future future : futures) {
       future.get();
     }
-    Assert.assertEquals(1, segmentPuller.numFileLoaded.size());
-    Assert.assertEquals(1, segmentPuller.numFileLoaded.values().iterator().next().intValue());
-    Assert.assertEquals(0, segmentCacheManager.getSegmentLocks().size());
+    Assertions.assertEquals(1, segmentPuller.numFileLoaded.size());
+    Assertions.assertEquals(1, segmentPuller.numFileLoaded.values().iterator().next().intValue());
+    Assertions.assertEquals(0, segmentCacheManager.getSegmentLocks().size());
   }
 
-  @Test(timeout = 6000L)
+  @Test
+  @Timeout(value = 6000L, unit = TimeUnit.MILLISECONDS)
   public void testLoadMultipleSegments() throws IOException, ExecutionException, InterruptedException
   {
     final List<DataSegment> segments = new ArrayList<>(88);
@@ -174,9 +178,9 @@ public class SegmentManagerThreadSafetyTest
     for (Future future : futures) {
       future.get();
     }
-    Assert.assertEquals(11, segmentPuller.numFileLoaded.size());
-    Assert.assertEquals(1, segmentPuller.numFileLoaded.values().iterator().next().intValue());
-    Assert.assertEquals(0, segmentCacheManager.getSegmentLocks().size());
+    Assertions.assertEquals(11, segmentPuller.numFileLoaded.size());
+    Assertions.assertEquals(1, segmentPuller.numFileLoaded.values().iterator().next().intValue());
+    Assertions.assertEquals(0, segmentCacheManager.getSegmentLocks().size());
   }
 
   private DataSegment createSegment(String interval) throws IOException

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentManagerThreadSafetyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentManagerThreadSafetyTest.java
@@ -58,6 +58,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
@@ -128,7 +129,7 @@ public class SegmentManagerThreadSafetyTest
   }
 
   @Test
-  @Timeout(value = 6000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 6000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testLoadSameSegment() throws IOException, ExecutionException, InterruptedException
   {
     final DataSegment segment = createSegment("2019-01-01/2019-01-02");
@@ -152,7 +153,7 @@ public class SegmentManagerThreadSafetyTest
   }
 
   @Test
-  @Timeout(value = 6000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 6000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testLoadMultipleSegments() throws IOException, ExecutionException, InterruptedException
   {
     final List<DataSegment> segments = new ArrayList<>(88);

--- a/server/src/test/java/org/apache/druid/server/coordination/ServerManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/ServerManagerTest.java
@@ -100,10 +100,10 @@ import org.apache.druid.timeline.TimelineObjectHolder;
 import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.PartitionChunk;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -116,7 +116,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ServerManagerTest
 {
@@ -164,7 +163,7 @@ public class ServerManagerTest
   @Inject
   private ServerManager serverManager;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     serviceEmitter = new NoopServiceEmitter();
@@ -320,18 +319,18 @@ public class ServerManagerTest
 
     factory.notifyLatch.await(1000, TimeUnit.MILLISECONDS);
 
-    Assert.assertEquals(1, factory.getReferenceProviders().size());
+    Assertions.assertEquals(1, factory.getReferenceProviders().size());
 
     for (ReferenceCountedSegmentProvider referenceCountingSegment : factory.getReferenceProviders()) {
-      Assert.assertEquals(1, referenceCountingSegment.getNumReferences());
+      Assertions.assertEquals(1, referenceCountingSegment.getNumReferences());
     }
 
     factory.waitYieldLatch.countDown();
 
-    Assert.assertEquals(1, factory.getSegments().size());
+    Assertions.assertEquals(1, factory.getSegments().size());
 
     for (TestSegmentUtils.SegmentForTesting segment : factory.getSegments()) {
-      Assert.assertFalse(segment.isClosed());
+      Assertions.assertFalse(segment.isClosed());
     }
 
     factory.waitLatch.countDown();
@@ -340,7 +339,7 @@ public class ServerManagerTest
     dropQueryable("test", "3", Intervals.of("2011-04-04/2011-04-05"));
 
     for (TestSegmentUtils.SegmentForTesting segment : factory.getSegments()) {
-      Assert.assertTrue(segment.isClosed());
+      Assertions.assertTrue(segment.isClosed());
     }
   }
 
@@ -359,31 +358,31 @@ public class ServerManagerTest
 
     factory.notifyLatch.await(1000, TimeUnit.MILLISECONDS);
 
-    Assert.assertEquals(1, factory.getReferenceProviders().size());
+    Assertions.assertEquals(1, factory.getReferenceProviders().size());
 
     for (ReferenceCountedSegmentProvider referenceCountingSegment : factory.getReferenceProviders()) {
-      Assert.assertEquals(1, referenceCountingSegment.getNumReferences());
+      Assertions.assertEquals(1, referenceCountingSegment.getNumReferences());
     }
 
     factory.waitYieldLatch.countDown();
 
-    Assert.assertEquals(1, factory.getSegments().size());
+    Assertions.assertEquals(1, factory.getSegments().size());
 
     for (TestSegmentUtils.SegmentForTesting segment : factory.getSegments()) {
-      Assert.assertFalse(segment.isClosed());
+      Assertions.assertFalse(segment.isClosed());
     }
 
     dropQueryable("test", "3", Intervals.of("2011-04-04/2011-04-05"));
 
     for (TestSegmentUtils.SegmentForTesting segment : factory.getSegments()) {
-      Assert.assertFalse(segment.isClosed());
+      Assertions.assertFalse(segment.isClosed());
     }
 
     factory.waitLatch.countDown();
     future.get();
 
     for (TestSegmentUtils.SegmentForTesting segment : factory.getSegments()) {
-      Assert.assertTrue(segment.isClosed());
+      Assertions.assertTrue(segment.isClosed());
     }
   }
 
@@ -402,32 +401,32 @@ public class ServerManagerTest
 
     factory.notifyLatch.await(1000, TimeUnit.MILLISECONDS);
 
-    Assert.assertEquals(1, factory.getReferenceProviders().size());
+    Assertions.assertEquals(1, factory.getReferenceProviders().size());
 
     for (ReferenceCountedSegmentProvider referenceCountingSegment : factory.getReferenceProviders()) {
-      Assert.assertEquals(1, referenceCountingSegment.getNumReferences());
+      Assertions.assertEquals(1, referenceCountingSegment.getNumReferences());
     }
 
     factory.waitYieldLatch.countDown();
 
-    Assert.assertEquals(1, factory.getSegments().size());
+    Assertions.assertEquals(1, factory.getSegments().size());
 
     for (TestSegmentUtils.SegmentForTesting segment : factory.getSegments()) {
-      Assert.assertFalse(segment.isClosed());
+      Assertions.assertFalse(segment.isClosed());
     }
 
     dropQueryable("test", "3", Intervals.of("2011-04-04/2011-04-05"));
     dropQueryable("test", "3", Intervals.of("2011-04-04/2011-04-05"));
 
     for (TestSegmentUtils.SegmentForTesting segment : factory.getSegments()) {
-      Assert.assertFalse(segment.isClosed());
+      Assertions.assertFalse(segment.isClosed());
     }
 
     factory.waitLatch.countDown();
     future.get();
 
     for (TestSegmentUtils.SegmentForTesting segment : factory.getSegments()) {
-      Assert.assertTrue(segment.isClosed());
+      Assertions.assertTrue(segment.isClosed());
     }
   }
 
@@ -459,18 +458,18 @@ public class ServerManagerTest
         ImmutableList.of(new Pair<>("1", interval))
     );
 
-    Assert.assertTrue(factory.notifyLatch.await(1000, TimeUnit.MILLISECONDS));
-    Assert.assertEquals(1, factory.getReferenceProviders().size());
+    Assertions.assertTrue(factory.notifyLatch.await(1000, TimeUnit.MILLISECONDS));
+    Assertions.assertEquals(1, factory.getReferenceProviders().size());
     // Expect 2 references here: 1 for query and 1 for queryOnRestricted
-    Assert.assertEquals(2, factory.getReferenceProviders().get(0).getNumReferences());
+    Assertions.assertEquals(2, factory.getReferenceProviders().get(0).getNumReferences());
 
     factory.waitYieldLatch.countDown();
     factory.waitLatch.countDown();
     future.get();
     futureOnRestricted.get();
-    Assert.assertEquals(1, factory.getReferenceProviders().size());
+    Assertions.assertEquals(1, factory.getReferenceProviders().size());
     // no references since both query are finished
-    Assert.assertEquals(0, factory.getReferenceProviders().get(0).getNumReferences());
+    Assertions.assertEquals(0, factory.getReferenceProviders().get(0).getNumReferences());
   }
 
   @Test
@@ -481,7 +480,7 @@ public class ServerManagerTest
         searchQuery("unknown_datasource", interval, Granularities.ALL),
         Collections.singletonList(interval)
     );
-    Assert.assertSame(NoopQueryRunner.class, queryRunner.getClass());
+    Assertions.assertSame(NoopQueryRunner.class, queryRunner.getClass());
   }
 
   @Test
@@ -515,12 +514,12 @@ public class ServerManagerTest
     final List<SegmentDescriptor> unknownSegments = Collections.singletonList(
         new SegmentDescriptor(interval, "unknown_version", 0)
     );
-    DruidException e = assertThrows(
+    DruidException e = Assertions.assertThrows(
         DruidException.class,
         () -> serverManager.getQueryRunnerForSegments(query, unknownSegments)
     );
-    Assert.assertTrue(e.getMessage().startsWith("Base dataSource"));
-    Assert.assertTrue(e.getMessage().endsWith("is not a table!"));
+    Assertions.assertTrue(e.getMessage().startsWith("Base dataSource"));
+    Assertions.assertTrue(e.getMessage().endsWith("is not a table!"));
   }
 
   @Test
@@ -537,9 +536,9 @@ public class ServerManagerTest
                                                                  .run(QueryPlus.wrap(query), responseContext)
                                                                  .toList();
 
-    Assert.assertTrue(results.isEmpty());
-    Assert.assertNotNull(responseContext.getMissingSegments());
-    Assert.assertEquals(unknownSegments, responseContext.getMissingSegments());
+    Assertions.assertTrue(results.isEmpty());
+    Assertions.assertNotNull(responseContext.getMissingSegments());
+    Assertions.assertEquals(unknownSegments, responseContext.getMissingSegments());
   }
 
   @Test
@@ -555,9 +554,9 @@ public class ServerManagerTest
     final List<Result<SearchResultValue>> results = serverManager.getQueryRunnerForSegments(query, unknownSegments)
                                                                  .run(QueryPlus.wrap(query), responseContext)
                                                                  .toList();
-    Assert.assertTrue(results.isEmpty());
-    Assert.assertNotNull(responseContext.getMissingSegments());
-    Assert.assertEquals(unknownSegments, responseContext.getMissingSegments());
+    Assertions.assertTrue(results.isEmpty());
+    Assertions.assertNotNull(responseContext.getMissingSegments());
+    Assertions.assertEquals(unknownSegments, responseContext.getMissingSegments());
   }
 
   @Test
@@ -573,9 +572,9 @@ public class ServerManagerTest
     final List<Result<SearchResultValue>> results = serverManager.getQueryRunnerForSegments(query, unknownSegments)
                                                                  .run(QueryPlus.wrap(query), responseContext)
                                                                  .toList();
-    Assert.assertTrue(results.isEmpty());
-    Assert.assertNotNull(responseContext.getMissingSegments());
-    Assert.assertEquals(unknownSegments, responseContext.getMissingSegments());
+    Assertions.assertTrue(results.isEmpty());
+    Assertions.assertNotNull(responseContext.getMissingSegments());
+    Assertions.assertEquals(unknownSegments, responseContext.getMissingSegments());
   }
 
   @Test
@@ -585,14 +584,14 @@ public class ServerManagerTest
     final SearchQuery query = searchQuery("test", interval, Granularities.ALL);
     final Optional<VersionedIntervalTimeline<String, DataSegment>> maybeTimeline = segmentManager
         .getTimeline(ExecutionVertex.of(query).getBaseTableDataSource());
-    Assume.assumeTrue(maybeTimeline.isPresent());
+    Assumptions.assumeTrue(maybeTimeline.isPresent());
     // close all segments in interval
     final List<TimelineObjectHolder<String, DataSegment>> holders = maybeTimeline.get().lookup(interval);
     final List<SegmentDescriptor> closedSegments = new ArrayList<>();
     for (TimelineObjectHolder<String, DataSegment> holder : holders) {
       for (PartitionChunk<DataSegment> chunk : holder.getObject()) {
         final DataSegment segment = chunk.getObject();
-        Assert.assertNotNull(segment.getId());
+        Assertions.assertNotNull(segment.getId());
         closedSegments.add(
             new SegmentDescriptor(segment.getInterval(), segment.getVersion(), segment.getId().getPartitionNum())
         );
@@ -604,9 +603,9 @@ public class ServerManagerTest
     final List<Result<SearchResultValue>> results = serverManager.getQueryRunnerForSegments(query, closedSegments)
                                                                  .run(QueryPlus.wrap(query), responseContext)
                                                                  .toList();
-    Assert.assertTrue(results.isEmpty());
-    Assert.assertNotNull(responseContext.getMissingSegments());
-    Assert.assertEquals(closedSegments, responseContext.getMissingSegments());
+    Assertions.assertTrue(results.isEmpty());
+    Assertions.assertNotNull(responseContext.getMissingSegments());
+    Assertions.assertEquals(closedSegments, responseContext.getMissingSegments());
   }
 
   @Test
@@ -619,11 +618,11 @@ public class ServerManagerTest
                            .intervals(interval.toString())
                            .build();
     // We only have QueryRunnerFactory for SearchQuery in test.
-    QueryUnsupportedException e = Assert.assertThrows(
+    QueryUnsupportedException e = Assertions.assertThrows(
         QueryUnsupportedException.class,
         () -> serverManager.getQueryRunnerForSegments(query, descriptors)
     );
-    Assert.assertTrue(e.getMessage().startsWith("Unknown query type"));
+    Assertions.assertTrue(e.getMessage().startsWith("Unknown query type"));
   }
 
   @Test
@@ -646,15 +645,15 @@ public class ServerManagerTest
     policyEnforcer = new RestrictAllTablesPolicyEnforcer(ImmutableList.of(NoRestrictionPolicy.class.getName()));
     serverManager = Guice.createInjector(BoundFieldModule.of(this)).getInstance(ServerManager.class);
     // fail on query
-    DruidException e = Assert.assertThrows(
+    DruidException e = Assertions.assertThrows(
         DruidException.class,
         () -> serverManager.getQueryRunnerForIntervals(query, ImmutableList.of(interval))
                            .run(QueryPlus.wrap(query))
                            .toList()
     );
-    Assert.assertEquals(DruidException.Category.FORBIDDEN, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
-    Assert.assertEquals(
+    Assertions.assertEquals(DruidException.Category.FORBIDDEN, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
+    Assertions.assertEquals(
         "Failed security validation with segment [test_2011-03-31T00:00:00.000Z_2011-04-01T00:00:00.000Z_1]",
         e.getMessage()
     );
@@ -740,12 +739,12 @@ public class ServerManagerTest
             Pair<String, Interval> expectedVals = expectedIter.next();
             SegmentForTesting value = adaptersIter.next();
 
-            Assert.assertEquals(expectedVals.lhs, value.getVersion());
-            Assert.assertEquals(expectedVals.rhs, value.getInterval());
+            Assertions.assertEquals(expectedVals.lhs, value.getVersion());
+            Assertions.assertEquals(expectedVals.rhs, value.getInterval());
           }
 
-          Assert.assertFalse(expectedIter.hasNext());
-          Assert.assertFalse(adaptersIter.hasNext());
+          Assertions.assertFalse(expectedIter.hasNext());
+          Assertions.assertFalse(adaptersIter.hasNext());
         }
     );
   }

--- a/server/src/test/java/org/apache/druid/server/coordination/ServerTypeTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/ServerTypeTest.java
@@ -19,41 +19,43 @@
 
 package org.apache.druid.server.coordination;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 
 public class ServerTypeTest
 {
   @Test
   public void testAssignable()
   {
-    Assert.assertTrue(ServerType.HISTORICAL.isSegmentReplicationTarget());
-    Assert.assertTrue(ServerType.BRIDGE.isSegmentReplicationTarget());
-    Assert.assertFalse(ServerType.REALTIME.isSegmentReplicationTarget());
-    Assert.assertFalse(ServerType.INDEXER_EXECUTOR.isSegmentReplicationTarget());
+    Assertions.assertTrue(ServerType.HISTORICAL.isSegmentReplicationTarget());
+    Assertions.assertTrue(ServerType.BRIDGE.isSegmentReplicationTarget());
+    Assertions.assertFalse(ServerType.REALTIME.isSegmentReplicationTarget());
+    Assertions.assertFalse(ServerType.INDEXER_EXECUTOR.isSegmentReplicationTarget());
   }
 
   @Test
   public void testFromString()
   {
-    Assert.assertEquals(ServerType.HISTORICAL, ServerType.fromString("historical"));
-    Assert.assertEquals(ServerType.BRIDGE, ServerType.fromString("bridge"));
-    Assert.assertEquals(ServerType.REALTIME, ServerType.fromString("realtime"));
-    Assert.assertEquals(ServerType.INDEXER_EXECUTOR, ServerType.fromString("indexer-executor"));
+    Assertions.assertEquals(ServerType.HISTORICAL, ServerType.fromString("historical"));
+    Assertions.assertEquals(ServerType.BRIDGE, ServerType.fromString("bridge"));
+    Assertions.assertEquals(ServerType.REALTIME, ServerType.fromString("realtime"));
+    Assertions.assertEquals(ServerType.INDEXER_EXECUTOR, ServerType.fromString("indexer-executor"));
   }
 
   @Test
   public void testToString()
   {
-    Assert.assertEquals(ServerType.HISTORICAL.toString(), "historical");
-    Assert.assertEquals(ServerType.BRIDGE.toString(), "bridge");
-    Assert.assertEquals(ServerType.REALTIME.toString(), "realtime");
-    Assert.assertEquals(ServerType.INDEXER_EXECUTOR.toString(), "indexer-executor");
+    Assertions.assertEquals(ServerType.HISTORICAL.toString(), "historical");
+    Assertions.assertEquals(ServerType.BRIDGE.toString(), "bridge");
+    Assertions.assertEquals(ServerType.REALTIME.toString(), "realtime");
+    Assertions.assertEquals(ServerType.INDEXER_EXECUTOR.toString(), "indexer-executor");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidName()
   {
-    ServerType.fromString("invalid");
+    Assertions.assertThrows(IllegalArgumentException.class, () ->
+      ServerType.fromString("invalid"));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordination/coordination/BatchDataSegmentAnnouncerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/coordination/BatchDataSegmentAnnouncerTest.java
@@ -36,10 +36,11 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,6 +50,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 public class BatchDataSegmentAnnouncerTest
 {
@@ -58,7 +60,7 @@ public class BatchDataSegmentAnnouncerTest
   private Set<DataSegment> testSegments;
   private ExecutorService exec;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     announcer = new BatchDataSegmentAnnouncer();
@@ -69,7 +71,7 @@ public class BatchDataSegmentAnnouncerTest
     exec = Execs.multiThreaded(NUM_THREADS, "BatchDataSegmentAnnouncerTest-%d");
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     announcer.stop();
@@ -90,8 +92,8 @@ public class BatchDataSegmentAnnouncerTest
     // announced segments, which at this point is just segmentB.
     ChangeRequestsSnapshot<DataSegmentChangeRequest> snapshot =
         announcer.getSegmentChangesSince(new ChangeRequestHistory.Counter(-1, -1)).get();
-    Assert.assertEquals(1, snapshot.getRequests().size());
-    Assert.assertTrue(snapshot.getRequests().get(0) instanceof SegmentChangeRequestLoad);
+    Assertions.assertEquals(1, snapshot.getRequests().size());
+    Assertions.assertTrue(snapshot.getRequests().get(0) instanceof SegmentChangeRequestLoad);
   }
 
   @Test
@@ -103,9 +105,9 @@ public class BatchDataSegmentAnnouncerTest
 
     ChangeRequestsSnapshot<DataSegmentChangeRequest> snapshot =
         announcer.getSegmentChangesSince(ChangeRequestHistory.Counter.ZERO).get();
-    Assert.assertEquals(segments.size(), snapshot.getRequests().size());
+    Assertions.assertEquals(segments.size(), snapshot.getRequests().size());
     for (DataSegmentChangeRequest request : snapshot.getRequests()) {
-      Assert.assertTrue(request instanceof SegmentChangeRequestLoad);
+      Assertions.assertTrue(request instanceof SegmentChangeRequestLoad);
     }
   }
 
@@ -119,9 +121,9 @@ public class BatchDataSegmentAnnouncerTest
 
     ChangeRequestsSnapshot<DataSegmentChangeRequest> snapshot =
         announcer.getSegmentChangesSince(ChangeRequestHistory.Counter.ZERO).get();
-    Assert.assertEquals(2, snapshot.getRequests().size());
-    Assert.assertTrue(snapshot.getRequests().get(0) instanceof SegmentChangeRequestLoad);
-    Assert.assertTrue(snapshot.getRequests().get(1) instanceof SegmentChangeRequestDrop);
+    Assertions.assertEquals(2, snapshot.getRequests().size());
+    Assertions.assertTrue(snapshot.getRequests().get(0) instanceof SegmentChangeRequestLoad);
+    Assertions.assertTrue(snapshot.getRequests().get(1) instanceof SegmentChangeRequestDrop);
   }
 
   @Test
@@ -134,7 +136,7 @@ public class BatchDataSegmentAnnouncerTest
 
     ChangeRequestsSnapshot<DataSegmentChangeRequest> snapshot =
         announcer.getSegmentChangesSince(ChangeRequestHistory.Counter.ZERO).get();
-    Assert.assertEquals(1, snapshot.getRequests().size());
+    Assertions.assertEquals(1, snapshot.getRequests().size());
   }
 
   @Test
@@ -188,10 +190,10 @@ public class BatchDataSegmentAnnouncerTest
     snapshot = announcer.getSegmentChangesSince(
         new ChangeRequestHistory.Counter(-1, -1)
     ).get();
-    Assert.assertEquals(1, snapshot.getRequests().size());
-    Assert.assertEquals(1, snapshot.getCounter().getCounter());
+    Assertions.assertEquals(1, snapshot.getRequests().size());
+    Assertions.assertEquals(1, snapshot.getCounter().getCounter());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         absoluteSchema1,
         ((SegmentSchemasChangeRequest) snapshot.getRequests().get(0))
             .getSegmentSchemas()
@@ -206,31 +208,32 @@ public class BatchDataSegmentAnnouncerTest
 
     snapshot = announcer.getSegmentChangesSince(snapshot.getCounter()).get();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         deltaSchema,
         ((SegmentSchemasChangeRequest) snapshot.getRequests().get(0))
             .getSegmentSchemas()
             .getSegmentSchemaList()
             .get(0)
     );
-    Assert.assertEquals(1, snapshot.getRequests().size());
-    Assert.assertEquals(2, snapshot.getCounter().getCounter());
+    Assertions.assertEquals(1, snapshot.getRequests().size());
+    Assertions.assertEquals(2, snapshot.getCounter().getCounter());
 
     snapshot = announcer.getSegmentChangesSince(
         new ChangeRequestHistory.Counter(-1, -1)
     ).get();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         absoluteSchema2,
         ((SegmentSchemasChangeRequest) snapshot.getRequests().get(0))
             .getSegmentSchemas()
             .getSegmentSchemaList()
             .get(0)
     );
-    Assert.assertEquals(1, snapshot.getRequests().size());
-    Assert.assertEquals(2, snapshot.getCounter().getCounter());
+    Assertions.assertEquals(1, snapshot.getRequests().size());
+    Assertions.assertEquals(2, snapshot.getCounter().getCounter());
   }
 
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
   public void testAnnounceSegmentsWithSameSegmentConcurrently() throws ExecutionException, InterruptedException
   {
     final List<Future<?>> futures = new ArrayList<>(NUM_THREADS);
@@ -245,10 +248,11 @@ public class BatchDataSegmentAnnouncerTest
 
     ChangeRequestsSnapshot<DataSegmentChangeRequest> snapshot =
         announcer.getSegmentChangesSince(ChangeRequestHistory.Counter.ZERO).get();
-    Assert.assertEquals(testSegments.size(), snapshot.getRequests().size());
+    Assertions.assertEquals(testSegments.size(), snapshot.getRequests().size());
   }
 
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
   public void testAnnounceSegmentWithSameSegmentConcurrently() throws ExecutionException, InterruptedException
   {
     final List<Future<?>> futures = new ArrayList<>(NUM_THREADS);
@@ -275,7 +279,7 @@ public class BatchDataSegmentAnnouncerTest
 
     ChangeRequestsSnapshot<DataSegmentChangeRequest> snapshot =
         announcer.getSegmentChangesSince(ChangeRequestHistory.Counter.ZERO).get();
-    Assert.assertEquals(4, snapshot.getRequests().size());
+    Assertions.assertEquals(4, snapshot.getRequests().size());
   }
 
   private static DataSegment makeSegment(int offset)

--- a/server/src/test/java/org/apache/druid/server/coordination/coordination/BatchDataSegmentAnnouncerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/coordination/BatchDataSegmentAnnouncerTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -233,7 +234,7 @@ public class BatchDataSegmentAnnouncerTest
   }
 
   @Test
-  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testAnnounceSegmentsWithSameSegmentConcurrently() throws ExecutionException, InterruptedException
   {
     final List<Future<?>> futures = new ArrayList<>(NUM_THREADS);
@@ -252,7 +253,7 @@ public class BatchDataSegmentAnnouncerTest
   }
 
   @Test
-  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testAnnounceSegmentWithSameSegmentConcurrently() throws ExecutionException, InterruptedException
   {
     final List<Future<?>> futures = new ArrayList<>(NUM_THREADS);

--- a/server/src/test/java/org/apache/druid/server/emitter/EmitterModuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/emitter/EmitterModuleTest.java
@@ -55,21 +55,14 @@ import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.metrics.DefaultLoadSpecHolder;
 import org.apache.druid.server.metrics.LoadSpecHolder;
 import org.apache.druid.server.metrics.TestTaskHolder;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Properties;
 
 public class EmitterModuleTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
   public void testParametrizedUriEmitterConfig()
   {
@@ -86,7 +79,7 @@ public class EmitterModuleTest
     final Emitter emitter = makeInjectorWithProperties(props).getInstance(Emitter.class);
 
     // Testing that ParametrizedUriEmitter is successfully deserialized from the above config
-    MatcherAssert.assertThat(emitter, CoreMatchers.instanceOf(ParametrizedUriEmitter.class));
+    Assertions.assertInstanceOf(ParametrizedUriEmitter.class, emitter);
   }
 
   @Test
@@ -96,7 +89,7 @@ public class EmitterModuleTest
     props.setProperty("druid.emitter", "");
 
     final Emitter emitter = makeInjectorWithProperties(props).getInstance(Emitter.class);
-    MatcherAssert.assertThat(emitter, CoreMatchers.instanceOf(NoopEmitter.class));
+    Assertions.assertInstanceOf(NoopEmitter.class, emitter);
   }
 
   @Test
@@ -105,8 +98,11 @@ public class EmitterModuleTest
     final Properties props = new Properties();
     props.setProperty("druid.emitter", "invalid");
 
-    expectedException.expectMessage("Unknown emitter type[druid.emitter]=[invalid]");
-    makeInjectorWithProperties(props).getInstance(Emitter.class);
+    final RuntimeException exception = Assertions.assertThrows(
+        RuntimeException.class,
+        () -> makeInjectorWithProperties(props).getInstance(Emitter.class)
+    );
+    Assertions.assertTrue(exception.getMessage().contains("Unknown emitter type[druid.emitter]=[invalid]"));
   }
 
   @Test
@@ -141,7 +137,7 @@ public class EmitterModuleTest
     );
 
     ServiceEmitter instance = injector.getInstance(ServiceEmitter.class);
-    Assert.assertNotNull(instance);
+    Assertions.assertNotNull(instance);
     instance.start();
     final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder();
     builder.setDimension("foo", "bar");
@@ -149,19 +145,19 @@ public class EmitterModuleTest
     instance.emit(builder);
 
     Emitter instance1 = injector.getInstance(Emitter.class);
-    Assert.assertTrue(instance1 instanceof StubServiceEmitter);
+    Assertions.assertTrue(instance1 instanceof StubServiceEmitter);
     StubServiceEmitter stubEmitter = (StubServiceEmitter) instance1;
 
     stubEmitter.verifyEmitted("metric1", 1);
     List<Event> events = stubEmitter.getEvents();
-    Assert.assertEquals(1, events.size());
+    Assertions.assertEquals(1, events.size());
     ServiceMetricEvent event = (ServiceMetricEvent) events.get(0);
     EventMap map = event.toMap();
-    Assert.assertEquals("id1", map.get(DruidMetrics.TASK_ID));
-    Assert.assertEquals("id1", map.get(DruidMetrics.ID));
-    Assert.assertEquals("type1", map.get(DruidMetrics.TASK_TYPE));
-    Assert.assertEquals("group1", map.get(DruidMetrics.GROUP_ID));
-    Assert.assertEquals("wiki", map.get(DruidMetrics.DATASOURCE));
+    Assertions.assertEquals("id1", map.get(DruidMetrics.TASK_ID));
+    Assertions.assertEquals("id1", map.get(DruidMetrics.ID));
+    Assertions.assertEquals("type1", map.get(DruidMetrics.TASK_TYPE));
+    Assertions.assertEquals("group1", map.get(DruidMetrics.GROUP_ID));
+    Assertions.assertEquals("wiki", map.get(DruidMetrics.DATASOURCE));
     stubEmitter.flush();
 
     // Override a dimension and verify that is emitted
@@ -171,14 +167,14 @@ public class EmitterModuleTest
     instance.emit(builder2);
 
     List<Event> events2 = stubEmitter.getEvents();
-    Assert.assertEquals(1, events2.size());
+    Assertions.assertEquals(1, events2.size());
     ServiceMetricEvent event2 = (ServiceMetricEvent) events2.get(0);
     EventMap map2 = event2.toMap();
-    Assert.assertEquals("id2", map2.get(DruidMetrics.TASK_ID));
-    Assert.assertEquals("id1", map2.get(DruidMetrics.ID));
-    Assert.assertEquals("type1", map2.get(DruidMetrics.TASK_TYPE));
-    Assert.assertEquals("group1", map2.get(DruidMetrics.GROUP_ID));
-    Assert.assertEquals("wiki", map2.get(DruidMetrics.DATASOURCE));
+    Assertions.assertEquals("id2", map2.get(DruidMetrics.TASK_ID));
+    Assertions.assertEquals("id1", map2.get(DruidMetrics.ID));
+    Assertions.assertEquals("type1", map2.get(DruidMetrics.TASK_TYPE));
+    Assertions.assertEquals("group1", map2.get(DruidMetrics.GROUP_ID));
+    Assertions.assertEquals("wiki", map2.get(DruidMetrics.DATASOURCE));
   }
 
   private Injector makeInjectorWithProperties(final Properties props)
@@ -226,7 +222,7 @@ public class EmitterModuleTest
 
     StubServiceEmitter stubEmitter = (StubServiceEmitter) injector.getInstance(Emitter.class);
     EventMap map = ((ServiceMetricEvent) stubEmitter.getEvents().get(0)).toMap();
-    Assert.assertEquals("abc1234def567890", map.get("buildRevision"));
+    Assertions.assertEquals("abc1234def567890", map.get("buildRevision"));
   }
 
   @Test
@@ -248,7 +244,7 @@ public class EmitterModuleTest
 
     StubServiceEmitter stubEmitter = (StubServiceEmitter) injector.getInstance(Emitter.class);
     EventMap map = ((ServiceMetricEvent) stubEmitter.getEvents().get(0)).toMap();
-    Assert.assertEquals("", map.get("buildRevision"));
+    Assertions.assertEquals("", map.get("buildRevision"));
   }
 
   private Injector makeInjectorForEmitterModule(EmitterModule emitterModule)

--- a/server/src/test/java/org/apache/druid/server/log/AlertEventSerdeTest.java
+++ b/server/src/test/java/org/apache/druid/server/log/AlertEventSerdeTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.java.util.emitter.service.AlertEvent;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -60,6 +60,6 @@ public class AlertEventSerdeTest
                       + "\"description\":\"my-description\","
                       + "\"data\":{}"
                       + "}";
-    Assert.assertEquals(mapper.readTree(expected), mapper.readTree(actual));
+    Assertions.assertEquals(mapper.readTree(expected), mapper.readTree(actual));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/log/DefaultRequestLogEventTest.java
+++ b/server/src/test/java/org/apache/druid/server/log/DefaultRequestLogEventTest.java
@@ -39,8 +39,8 @@ import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.server.QueryStats;
 import org.apache.druid.server.RequestLogLine;
 import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -86,7 +86,7 @@ public class DefaultRequestLogEventTest
         + "\"context\":{\"key\":\"value\"}},\"host\":\"127.0.0.1\",\"timestamp\":\"2019-12-12T03:01:00.000Z\","
         + "\"service\":\"druid-service\",\"sql\":null,\"sqlQueryContext\":{},\"remoteAddr\":\"127.0.0.1\","
         + "\"queryStats\":{\"query/time\":13,\"query/bytes\":10,\"success\":true,\"identity\":\"allowAll\"}}";
-    Assert.assertEquals(objectMapper.readTree(expected), objectMapper.readTree(logEventJson));
+    Assertions.assertEquals(objectMapper.readTree(expected), objectMapper.readTree(logEventJson));
   }
 
   @Test
@@ -129,7 +129,7 @@ public class DefaultRequestLogEventTest
     expected.put("remoteAddr", host);
     expected.put("queryStats", queryStats);
 
-    Assert.assertEquals(expected, defaultRequestLogEvent.toMap());
+    Assertions.assertEquals(expected, defaultRequestLogEvent.toMap());
   }
 
   @Test
@@ -177,8 +177,8 @@ public class DefaultRequestLogEventTest
     expected.put("queryStats", queryStats);
 
     final EventMap observedEventMap = defaultRequestLogEvent.toMap();
-    Assert.assertEquals(expected, observedEventMap);
-    Assert.assertEquals(
+    Assertions.assertEquals(expected, observedEventMap);
+    Assertions.assertEquals(
         StringUtils.format(
             "{\"feed\":\"test\",\"timestamp\":\"%s\",\"service\":\"druid-service\",\"host\":\"127.0.0.1\",\"remoteAddr\":\"127.0.0.1\",\"queryStats\":{\"sqlQuery/time\":13,\"sqlQuery/planningTimeMs\":1,\"sqlQuery/bytes\":10,\"success\":true,\"identity\":\"allowAll\"},\"sqlQueryContext\":{},\"sql\":\"select * from foo where x = ?\",\"sqlParameters\":[{\"type\":\"BIGINT\",\"value\":1234}]}",
             timestamp
@@ -220,7 +220,7 @@ public class DefaultRequestLogEventTest
                       + "\"remoteAddr\":\"127.0.0.1\""
                       + "}";
 
-    Assert.assertEquals(mapper.readTree(expected), mapper.readTree(actual));
+    Assertions.assertEquals(mapper.readTree(expected), mapper.readTree(actual));
   }
 
   @Test
@@ -283,7 +283,7 @@ public class DefaultRequestLogEventTest
                       + "\"remoteAddr\":\"127.0.0.1\","
                       + "\"queryStats\":{\"query/time\":13,\"query/bytes\":10,\"success\":true,\"identity\":\"allowAll\"}}";
 
-    Assert.assertEquals(mapper.readTree(expected), mapper.readTree(actual));
+    Assertions.assertEquals(mapper.readTree(expected), mapper.readTree(actual));
   }
 
   @Test
@@ -356,7 +356,7 @@ public class DefaultRequestLogEventTest
                       + "\"text\":\"some text\","
                       + "\"queryStats\":{\"query/time\":13,\"query/bytes\":10,\"success\":true,\"identity\":\"allowAll\"}}";
 
-    Assert.assertEquals(mapper.readTree(expected), mapper.readTree(actual));
+    Assertions.assertEquals(mapper.readTree(expected), mapper.readTree(actual));
   }
 
 }

--- a/server/src/test/java/org/apache/druid/server/log/FileRequestLoggerTest.java
+++ b/server/src/test/java/org/apache/druid/server/log/FileRequestLoggerTest.java
@@ -23,14 +23,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.CharStreams;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.server.RequestLogLine;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -44,11 +43,8 @@ public class FileRequestLoggerTest
   private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
   private static final String HOST = "localhost";
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   @Test
   public void testLog() throws Exception
@@ -82,7 +78,7 @@ public class FileRequestLoggerTest
 
     File logFile = new File(logDir, dateTime.toString("yyyy-MM-dd'.log'"));
     String logString = CharStreams.toString(Files.newBufferedReader(logFile.toPath(), StandardCharsets.UTF_8));
-    Assert.assertTrue(logString.contains(nativeQueryLogString + "\n" + sqlQueryLogString + "\n"));
+    Assertions.assertTrue(logString.contains(nativeQueryLogString + "\n" + sqlQueryLogString + "\n"));
     fileRequestLogger.stop();
   }
 
@@ -112,26 +108,27 @@ public class FileRequestLoggerTest
     fileRequestLogger.logNativeQuery(nativeRequestLogLine);
     File logFile = new File(logDir, dateTime.toString("yyyy-MM-dd'.log'"));
     Thread.sleep(100);
-    Assert.assertFalse(oldLogFile.exists());
-    Assert.assertTrue(logFile.exists());
+    Assertions.assertFalse(oldLogFile.exists());
+    Assertions.assertTrue(logFile.exists());
     fileRequestLogger.stop();
   }
 
   @Test
-  public void testLogRemoveWithInvalidDuration() throws Exception
+  public void testLogRemoveWithInvalidDuration()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("request logs retention period must be atleast as long as roll period");
-    ObjectMapper objectMapper = new ObjectMapper();
-    File logDir = temporaryFolder.newFolder();
-    FileRequestLogger fileRequestLogger = new FileRequestLogger(
-        objectMapper,
-        scheduler,
-        logDir,
-        "yyyy-MM-dd'.log'",
-        Duration.standardMinutes(30),
-        Duration.standardDays(1)
-    );
+    Throwable exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      ObjectMapper objectMapper = new ObjectMapper();
+      File logDir = temporaryFolder.newFolder();
+      FileRequestLogger fileRequestLogger = new FileRequestLogger(
+          objectMapper,
+          scheduler,
+          logDir,
+          "yyyy-MM-dd'.log'",
+          Duration.standardMinutes(30),
+          Duration.standardDays(1)
+      );
+    });
+    Assertions.assertTrue(exception.getMessage().contains("request logs retention period must be atleast as long as roll period"));
   }
 
   @Test
@@ -173,10 +170,11 @@ public class FileRequestLoggerTest
     File dailyLogFile = new File(logDir, dateTime.toString("yyyy-MM-dd-00'.log'"));
     String hourlyLogString = CharStreams.toString(Files.newBufferedReader(hourlyLogFile.toPath(), StandardCharsets.UTF_8));
     String dailyLogString = CharStreams.toString(Files.newBufferedReader(dailyLogFile.toPath(), StandardCharsets.UTF_8));
-    Assert.assertTrue(hourlyLogString.contains(sqlQueryLogString + "\n"));
-    Assert.assertTrue(dailyLogString.contains(sqlQueryLogString + "\n"));
+    Assertions.assertTrue(hourlyLogString.contains(sqlQueryLogString + "\n"));
+    Assertions.assertTrue(dailyLogString.contains(sqlQueryLogString + "\n"));
 
     hourlyLogger.stop();
     dailyLoggerWithHourPattern.stop();
   }
+
 }

--- a/server/src/test/java/org/apache/druid/server/log/FileRequestLoggerTest.java
+++ b/server/src/test/java/org/apache/druid/server/log/FileRequestLoggerTest.java
@@ -119,7 +119,7 @@ public class FileRequestLoggerTest
     Throwable exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
       ObjectMapper objectMapper = new ObjectMapper();
       File logDir = temporaryFolder.newFolder();
-      FileRequestLogger fileRequestLogger = new FileRequestLogger(
+      new FileRequestLogger(
           objectMapper,
           scheduler,
           logDir,

--- a/server/src/test/java/org/apache/druid/server/log/FilteredRequestLoggerTest.java
+++ b/server/src/test/java/org/apache/druid/server/log/FilteredRequestLoggerTest.java
@@ -33,10 +33,8 @@ import org.apache.druid.query.metadata.metadata.SegmentMetadataQuery;
 import org.apache.druid.server.QueryStats;
 import org.apache.druid.server.RequestLogLine;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -44,8 +42,6 @@ import java.util.Set;
 
 public class FilteredRequestLoggerTest
 {
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
   private final DefaultObjectMapper mapper = new DefaultObjectMapper();
   private final SegmentMetadataQuery testSegmentMetadataQuery = new SegmentMetadataQuery(
       new TableDataSource("foo"),
@@ -152,8 +148,8 @@ public class FilteredRequestLoggerTest
     logger.logSqlQuery(sqlRequestLogLine);
     logger.logSqlQuery(sqlRequestLogLine);
 
-    Assert.assertEquals(2, delegate.nativeCount);
-    Assert.assertEquals(2, delegate.sqlCount);
+    Assertions.assertEquals(2, delegate.nativeCount);
+    Assertions.assertEquals(2, delegate.sqlCount);
   }
 
   @Test
@@ -186,8 +182,8 @@ public class FilteredRequestLoggerTest
     logger.logNativeQuery(nativeRequestLogLine);
     logger.logSqlQuery(sqlRequestLogLine);
 
-    Assert.assertEquals(0, delegate.nativeCount);
-    Assert.assertEquals(1, delegate.sqlCount);
+    Assertions.assertEquals(0, delegate.nativeCount);
+    Assertions.assertEquals(1, delegate.sqlCount);
   }
 
   @Test
@@ -215,9 +211,9 @@ public class FilteredRequestLoggerTest
         ((FilteredRequestLoggerProvider.FilteredRequestLogger) provider.get());
     final LoggingRequestLogger delegate = (LoggingRequestLogger) logger.getDelegate();
 
-    Assert.assertEquals(100, logger.getQueryTimeThresholdMs());
-    Assert.assertTrue(delegate.isSetContextMDC());
-    Assert.assertTrue(delegate.isSetMDC());
+    Assertions.assertEquals(100, logger.getQueryTimeThresholdMs());
+    Assertions.assertTrue(delegate.isSetContextMDC());
+    Assertions.assertTrue(delegate.isSetMDC());
   }
 
   @Test
@@ -244,13 +240,13 @@ public class FilteredRequestLoggerTest
         ((FilteredRequestLoggerProvider.FilteredRequestLogger) provider.get());
     final TestRequestLogger delegate = (TestRequestLogger) logger.getDelegate();
 
-    Assert.assertFalse(delegate.isStarted());
+    Assertions.assertFalse(delegate.isStarted());
 
     logger.start();
-    Assert.assertTrue(delegate.isStarted());
+    Assertions.assertTrue(delegate.isStarted());
 
     logger.stop();
-    Assert.assertFalse(delegate.isStarted());
+    Assertions.assertFalse(delegate.isStarted());
   }
 
   @Test
@@ -267,9 +263,11 @@ public class FilteredRequestLoggerTest
                   .getValidator()
     );
 
-    expectedException.expect(ProvisionException.class);
-    expectedException.expectMessage("Could not resolve type id 'nope'");
-    configurator.configurate(properties, "log", RequestLoggerProvider.class);
+    final ProvisionException exception = Assertions.assertThrows(
+        ProvisionException.class,
+        () -> configurator.configurate(properties, "log", RequestLoggerProvider.class)
+    );
+    Assertions.assertTrue(exception.getMessage().contains("Could not resolve type id 'nope'"));
   }
 
   @Test
@@ -285,8 +283,10 @@ public class FilteredRequestLoggerTest
                   .getValidator()
     );
 
-    expectedException.expect(ProvisionException.class);
-    expectedException.expectMessage("log.delegate - must not be null");
-    configurator.configurate(properties, "log", RequestLoggerProvider.class);
+    final ProvisionException exception = Assertions.assertThrows(
+        ProvisionException.class,
+        () -> configurator.configurate(properties, "log", RequestLoggerProvider.class)
+    );
+    Assertions.assertTrue(exception.getMessage().contains("log.delegate - must not be null"));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/log/LoggingRequestLoggerProviderTest.java
+++ b/server/src/test/java/org/apache/druid/server/log/LoggingRequestLoggerProviderTest.java
@@ -31,10 +31,8 @@ import org.apache.druid.guice.JsonConfigurator;
 import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.guice.QueryableModule;
 import org.apache.druid.initialization.Initialization;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 import java.util.UUID;
@@ -55,8 +53,8 @@ public class LoggingRequestLoggerProviderTest
     properties.put(propertyPrefix + ".type", "slf4j");
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
     final LoggingRequestLogger requestLogger = (LoggingRequestLogger) provider.get().get();
-    Assert.assertFalse(requestLogger.isSetContextMDC());
-    Assert.assertFalse(requestLogger.isSetMDC());
+    Assertions.assertFalse(requestLogger.isSetContextMDC());
+    Assertions.assertFalse(requestLogger.isSetMDC());
   }
 
   @Test
@@ -68,8 +66,8 @@ public class LoggingRequestLoggerProviderTest
     properties.put(propertyPrefix + ".setContextMDC", "true");
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
     final LoggingRequestLogger requestLogger = (LoggingRequestLogger) provider.get().get();
-    Assert.assertTrue(requestLogger.isSetContextMDC());
-    Assert.assertTrue(requestLogger.isSetMDC());
+    Assertions.assertTrue(requestLogger.isSetContextMDC());
+    Assertions.assertTrue(requestLogger.isSetMDC());
   }
 
   @Test
@@ -78,7 +76,7 @@ public class LoggingRequestLoggerProviderTest
     final Properties properties = new Properties();
     properties.put(propertyPrefix + ".type", "noop");
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
-    MatcherAssert.assertThat(provider.get().get(), Matchers.instanceOf(NoopRequestLogger.class));
+    Assertions.assertInstanceOf(NoopRequestLogger.class, provider.get().get());
   }
 
   private Injector makeInjector()

--- a/server/src/test/java/org/apache/druid/server/log/LoggingRequestLoggerTest.java
+++ b/server/src/test/java/org/apache/druid/server/log/LoggingRequestLoggerTest.java
@@ -49,11 +49,11 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.layout.JsonLayout;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -158,7 +158,7 @@ public class LoggingRequestLoggerTest
       queryStats
   );
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpStatic()
   {
     LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
@@ -187,13 +187,13 @@ public class LoggingRequestLoggerTest
     logger.addAppender(appender);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     BAOS.reset();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownStatic()
   {
     final Logger logger = (Logger) LogManager.getLogger(
@@ -225,7 +225,7 @@ public class LoggingRequestLoggerTest
     requestLogger.logSqlQuery(sqlLogLine);
     final String observedLogLine = BAOS.toString(StandardCharsets.UTF_8);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "2026-01-01T00:00:00.000Z\t\t\t{\"query/time\":13}\t{\"context\":{\"sqlQueryId\":\"id1\"},\"query\":\"select * from foo WHERE x = ?\",\"parameters\":[{\"type\":\"BIGINT\",\"value\":1234}]}",
         MAPPER.readTree(observedLogLine).get("message").asText()
     );
@@ -237,13 +237,13 @@ public class LoggingRequestLoggerTest
     final LoggingRequestLogger requestLogger = new LoggingRequestLogger(new DefaultObjectMapper(), true, false);
     requestLogger.logNativeQuery(logLine);
     final Map<String, Object> map = readContextMap(BAOS.toByteArray());
-    Assert.assertEquals("datasource", map.get("dataSource"));
-    Assert.assertEquals("PT86400S", map.get("duration"));
-    Assert.assertEquals("false", map.get("hasFilters"));
-    Assert.assertEquals("fake", map.get("queryType"));
-    Assert.assertEquals("some.host.tld", map.get("remoteAddr"));
-    Assert.assertEquals("false", map.get("isNested"));
-    Assert.assertNull(map.get("foo"));
+    Assertions.assertEquals("datasource", map.get("dataSource"));
+    Assertions.assertEquals("PT86400S", map.get("duration"));
+    Assertions.assertEquals("false", map.get("hasFilters"));
+    Assertions.assertEquals("fake", map.get("queryType"));
+    Assertions.assertEquals("some.host.tld", map.get("remoteAddr"));
+    Assertions.assertEquals("false", map.get("isNested"));
+    Assertions.assertNull(map.get("foo"));
   }
 
   @Test
@@ -252,13 +252,13 @@ public class LoggingRequestLoggerTest
     final LoggingRequestLogger requestLogger = new LoggingRequestLogger(new DefaultObjectMapper(), true, true);
     requestLogger.logNativeQuery(logLine);
     final Map<String, Object> map = readContextMap(BAOS.toByteArray());
-    Assert.assertEquals("datasource", map.get("dataSource"));
-    Assert.assertEquals("PT86400S", map.get("duration"));
-    Assert.assertEquals("false", map.get("hasFilters"));
-    Assert.assertEquals("fake", map.get("queryType"));
-    Assert.assertEquals("some.host.tld", map.get("remoteAddr"));
-    Assert.assertEquals("false", map.get("isNested"));
-    Assert.assertEquals("bar", map.get("foo"));
+    Assertions.assertEquals("datasource", map.get("dataSource"));
+    Assertions.assertEquals("PT86400S", map.get("duration"));
+    Assertions.assertEquals("false", map.get("hasFilters"));
+    Assertions.assertEquals("fake", map.get("queryType"));
+    Assertions.assertEquals("some.host.tld", map.get("remoteAddr"));
+    Assertions.assertEquals("false", map.get("isNested"));
+    Assertions.assertEquals("bar", map.get("foo"));
   }
 
   @Test
@@ -272,13 +272,13 @@ public class LoggingRequestLoggerTest
         queryStats
     ));
     final Map<String, Object> map = readContextMap(BAOS.toByteArray());
-    Assert.assertEquals("datasource", map.get("dataSource"));
-    Assert.assertEquals("PT86400S", map.get("duration"));
-    Assert.assertEquals("false", map.get("hasFilters"));
-    Assert.assertEquals("fake", map.get("queryType"));
-    Assert.assertEquals("some.host.tld", map.get("remoteAddr"));
-    Assert.assertEquals("true", map.get("isNested"));
-    Assert.assertNull(map.get("foo"));
+    Assertions.assertEquals("datasource", map.get("dataSource"));
+    Assertions.assertEquals("PT86400S", map.get("duration"));
+    Assertions.assertEquals("false", map.get("hasFilters"));
+    Assertions.assertEquals("fake", map.get("queryType"));
+    Assertions.assertEquals("some.host.tld", map.get("remoteAddr"));
+    Assertions.assertEquals("true", map.get("isNested"));
+    Assertions.assertNull(map.get("foo"));
   }
 
   @Test
@@ -292,13 +292,13 @@ public class LoggingRequestLoggerTest
         queryStats
     ));
     final Map<String, Object> map = readContextMap(BAOS.toByteArray());
-    Assert.assertEquals("datasource", map.get("dataSource"));
-    Assert.assertEquals("PT86400S", map.get("duration"));
-    Assert.assertEquals("false", map.get("hasFilters"));
-    Assert.assertEquals("fake", map.get("queryType"));
-    Assert.assertEquals("some.host.tld", map.get("remoteAddr"));
-    Assert.assertEquals("true", map.get("isNested"));
-    Assert.assertNull(map.get("foo"));
+    Assertions.assertEquals("datasource", map.get("dataSource"));
+    Assertions.assertEquals("PT86400S", map.get("duration"));
+    Assertions.assertEquals("false", map.get("hasFilters"));
+    Assertions.assertEquals("fake", map.get("queryType"));
+    Assertions.assertEquals("some.host.tld", map.get("remoteAddr"));
+    Assertions.assertEquals("true", map.get("isNested"));
+    Assertions.assertNull(map.get("foo"));
   }
 
   @Test
@@ -312,13 +312,13 @@ public class LoggingRequestLoggerTest
         queryStats
     ));
     final Map<String, Object> map = readContextMap(BAOS.toByteArray());
-    Assert.assertEquals("A,B", map.get("dataSource"));
-    Assert.assertEquals("true", map.get("isNested"));
-    Assert.assertEquals("PT86400S", map.get("duration"));
-    Assert.assertEquals("false", map.get("hasFilters"));
-    Assert.assertEquals("fake", map.get("queryType"));
-    Assert.assertEquals("some.host.tld", map.get("remoteAddr"));
-    Assert.assertNull(map.get("foo"));
+    Assertions.assertEquals("A,B", map.get("dataSource"));
+    Assertions.assertEquals("true", map.get("isNested"));
+    Assertions.assertEquals("PT86400S", map.get("duration"));
+    Assertions.assertEquals("false", map.get("hasFilters"));
+    Assertions.assertEquals("fake", map.get("queryType"));
+    Assertions.assertEquals("some.host.tld", map.get("remoteAddr"));
+    Assertions.assertNull(map.get("foo"));
   }
 
   private static Map<String, Object> readContextMap(byte[] bytes) throws Exception

--- a/server/src/test/java/org/apache/druid/server/log/RequestLoggerProviderTest.java
+++ b/server/src/test/java/org/apache/druid/server/log/RequestLoggerProviderTest.java
@@ -25,20 +25,14 @@ import com.google.inject.ProvisionException;
 import jakarta.validation.Validation;
 import org.apache.druid.guice.JsonConfigurator;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
 public class RequestLoggerProviderTest
 {
   private final DefaultObjectMapper mapper = new DefaultObjectMapper();
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   public RequestLoggerProviderTest()
   {
@@ -69,7 +63,7 @@ public class RequestLoggerProviderTest
         RequestLoggerProvider.class,
         NoopRequestLoggerProvider.class
     );
-    MatcherAssert.assertThat(provider, CoreMatchers.instanceOf(NoopRequestLoggerProvider.class));
+    Assertions.assertInstanceOf(NoopRequestLoggerProvider.class, provider);
   }
 
   @Test
@@ -84,14 +78,15 @@ public class RequestLoggerProviderTest
                   .getValidator()
     );
 
-    expectedException.expect(ProvisionException.class);
-    expectedException.expectMessage("missing type id property 'type'");
-
-    configurator.configurate(
-        properties,
-        "log",
-        RequestLoggerProvider.class,
-        NoopRequestLoggerProvider.class
+    final ProvisionException exception = Assertions.assertThrows(
+        ProvisionException.class,
+        () -> configurator.configurate(
+            properties,
+            "log",
+            RequestLoggerProvider.class,
+            NoopRequestLoggerProvider.class
+        )
     );
+    Assertions.assertTrue(exception.getMessage().contains("missing type id property 'type'"));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/log/ServiceMetricEventSerdeTest.java
+++ b/server/src/test/java/org/apache/druid/server/log/ServiceMetricEventSerdeTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ServiceMetricEventSerdeTest
 {
@@ -53,7 +53,7 @@ public class ServiceMetricEventSerdeTest
                       + "\"service\":\"my-service\","
                       + "\"host\":\"my-host\""
                       + "}";
-    Assert.assertEquals(mapper.readTree(expected), mapper.readTree(actual));
+    Assertions.assertEquals(mapper.readTree(expected), mapper.readTree(actual));
   }
 
 }

--- a/server/src/test/java/org/apache/druid/server/metrics/GroupByStatsMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/GroupByStatsMonitorTest.java
@@ -27,10 +27,11 @@ import org.apache.druid.java.util.metrics.StubServiceEmitter;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.QueryResourceId;
 import org.apache.druid.query.groupby.GroupByStatsProvider;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -49,7 +50,7 @@ public class GroupByStatsMonitorTest
   private BlockingPool<ByteBuffer> mergeBufferPool;
   private ExecutorService executorService;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     groupByStatsProvider = new GroupByStatsProvider()
@@ -76,7 +77,7 @@ public class GroupByStatsMonitorTest
     executorService = Executors.newSingleThreadExecutor();
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     executorService.shutdown();
@@ -93,7 +94,7 @@ public class GroupByStatsMonitorTest
     // Trigger metric emission
     monitor.doMonitor(emitter);
 
-    Assert.assertEquals(12, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(12, emitter.getNumEmittedEvents());
     emitter.verifyValue("mergeBuffer/pendingRequests", 0L);
     emitter.verifyValue("mergeBuffer/used", 0L);
     emitter.verifyValue("mergeBuffer/queries", 1L);
@@ -155,14 +156,15 @@ public class GroupByStatsMonitorTest
     final GroupByStatsMonitor monitor = new GroupByStatsMonitor(groupByStatsProvider, mergeBufferPool);
     final StubServiceEmitter emitter = new StubServiceEmitter("DummyService", "DummyHost");
     boolean ret = monitor.doMonitor(emitter);
-    Assert.assertTrue(ret);
+    Assertions.assertTrue(ret);
 
     List<Number> numbers = emitter.getMetricValues("mergeBuffer/used", Collections.emptyMap());
-    Assert.assertEquals(1, numbers.size());
-    Assert.assertEquals(4, numbers.get(0).intValue());
+    Assertions.assertEquals(1, numbers.size());
+    Assertions.assertEquals(4, numbers.get(0).intValue());
   }
 
-  @Test(timeout = 2_000L)
+  @Test
+  @Timeout(value = 2_000L, unit = TimeUnit.MILLISECONDS)
   public void testMonitoringMergeBuffer_pendingRequests()
   {
     executorService.submit(() -> {
@@ -183,11 +185,11 @@ public class GroupByStatsMonitorTest
       final GroupByStatsMonitor monitor = new GroupByStatsMonitor(groupByStatsProvider, mergeBufferPool);
       final StubServiceEmitter emitter = new StubServiceEmitter("DummyService", "DummyHost");
       boolean ret = monitor.doMonitor(emitter);
-      Assert.assertTrue(ret);
+      Assertions.assertTrue(ret);
 
       List<Number> numbers = emitter.getMetricValues("mergeBuffer/pendingRequests", Collections.emptyMap());
-      Assert.assertEquals(1, numbers.size());
-      Assert.assertEquals(1, numbers.get(0).intValue());
+      Assertions.assertEquals(1, numbers.size());
+      Assertions.assertEquals(1, numbers.get(0).intValue());
     }
     catch (InterruptedException e) {
       // do nothing
@@ -246,12 +248,12 @@ public class GroupByStatsMonitorTest
   private void verifyMetricValue(StubServiceEmitter emitter, String metricName, Map<String, Object> dimFilters, Number expectedValue)
   {
     final List<ServiceMetricEvent> observedMetricEvents = emitter.getMetricEvents(metricName);
-    Assert.assertEquals(1, observedMetricEvents.size());
+    Assertions.assertEquals(1, observedMetricEvents.size());
     final ServiceMetricEvent event = observedMetricEvents.get(0);
     final EventMap map = event.toMap();
     final boolean matchesDims = dimFilters.entrySet().stream()
                                           .allMatch(e -> Objects.equals(e.getValue(), map.get(e.getKey())));
-    Assert.assertTrue(matchesDims);
-    Assert.assertEquals(expectedValue, event.getValue());
+    Assertions.assertTrue(matchesDims);
+    Assertions.assertEquals(expectedValue, event.getValue());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/metrics/GroupByStatsMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/GroupByStatsMonitorTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -164,7 +165,7 @@ public class GroupByStatsMonitorTest
   }
 
   @Test
-  @Timeout(value = 2_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 2_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testMonitoringMergeBuffer_pendingRequests()
   {
     executorService.submit(() -> {

--- a/server/src/test/java/org/apache/druid/server/metrics/HistoricalMetricsMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/HistoricalMetricsMonitorTest.java
@@ -29,8 +29,8 @@ import org.apache.druid.server.coordination.SegmentLoadDropHandler;
 import org.apache.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -41,7 +41,7 @@ public class HistoricalMetricsMonitorTest extends EasyMockSupport
   private SegmentLoadDropHandler segmentLoadDropMgr;
   private StubServiceEmitter serviceEmitter;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     druidServerConfig = EasyMock.createStrictMock(DruidServerConfig.class);

--- a/server/src/test/java/org/apache/druid/server/metrics/MetricsModuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/MetricsModuleTest.java
@@ -58,12 +58,9 @@ import org.apache.druid.java.util.metrics.SysMonitor;
 import org.apache.druid.java.util.metrics.TaskHolder;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.server.DruidNode;
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -74,9 +71,6 @@ import java.util.Set;
 public class MetricsModuleTest
 {
   private static final String CPU_ARCH = System.getProperty("os.arch");
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSimpleInjection()
@@ -96,8 +90,8 @@ public class MetricsModuleTest
           }
         })
     );
-    Assert.assertTrue(injector.getInstance(TaskHolder.class) instanceof NoopTaskHolder);
-    Assert.assertTrue(injector.getInstance(LoadSpecHolder.class) instanceof DefaultLoadSpecHolder);
+    Assertions.assertTrue(injector.getInstance(TaskHolder.class) instanceof NoopTaskHolder);
+    Assertions.assertTrue(injector.getInstance(LoadSpecHolder.class) instanceof DefaultLoadSpecHolder);
   }
 
   @Test
@@ -125,10 +119,10 @@ public class MetricsModuleTest
         })
     );
     TaskHolder taskHolder = injector.getInstance(TaskHolder.class);
-    Assert.assertEquals(dataSource, taskHolder.getDataSource());
-    Assert.assertEquals(taskId, taskHolder.getTaskId());
-    Assert.assertEquals(taskType, taskHolder.getTaskType());
-    Assert.assertEquals(groupId, taskHolder.getGroupId());
+    Assertions.assertEquals(dataSource, taskHolder.getDataSource());
+    Assertions.assertEquals(taskId, taskHolder.getTaskId());
+    Assertions.assertEquals(taskType, taskHolder.getTaskType());
+    Assertions.assertEquals(groupId, taskHolder.getGroupId());
     Map<String, String> expectedTaskDims = Map.of(
         DruidMetrics.DATASOURCE, dataSource,
         DruidMetrics.TASK_ID, taskId,
@@ -137,7 +131,7 @@ public class MetricsModuleTest
         DruidMetrics.GROUP_ID, groupId
     );
 
-    Assert.assertEquals(expectedTaskDims, taskHolder.getMetricDimensions());
+    Assertions.assertEquals(expectedTaskDims, taskHolder.getMetricDimensions());
   }
 
   @Test
@@ -145,7 +139,7 @@ public class MetricsModuleTest
   {
     final MonitorScheduler monitorScheduler =
         createInjector(new Properties(), ImmutableSet.of()).getInstance(MonitorScheduler.class);
-    Assert.assertSame(BasicMonitorScheduler.class, monitorScheduler.getClass());
+    Assertions.assertSame(BasicMonitorScheduler.class, monitorScheduler.getClass());
   }
 
   @Test
@@ -158,7 +152,7 @@ public class MetricsModuleTest
     );
     final MonitorScheduler monitorScheduler =
         createInjector(properties, ImmutableSet.of()).getInstance(MonitorScheduler.class);
-    Assert.assertSame(ClockDriftSafeMonitorScheduler.class, monitorScheduler.getClass());
+    Assertions.assertSame(ClockDriftSafeMonitorScheduler.class, monitorScheduler.getClass());
   }
 
   @Test
@@ -171,7 +165,7 @@ public class MetricsModuleTest
     );
     final MonitorScheduler monitorScheduler =
         createInjector(properties, ImmutableSet.of()).getInstance(MonitorScheduler.class);
-    Assert.assertSame(BasicMonitorScheduler.class, monitorScheduler.getClass());
+    Assertions.assertSame(BasicMonitorScheduler.class, monitorScheduler.getClass());
   }
 
   @Test
@@ -231,17 +225,19 @@ public class MetricsModuleTest
         StringUtils.format("%s.schedulerClassName", MetricsModule.MONITORING_PROPERTY_PREFIX),
         "UnknownScheduler"
     );
-    expectedException.expect(CreationException.class);
-    expectedException.expectCause(CoreMatchers.instanceOf(IllegalArgumentException.class));
-    expectedException.expectMessage("Unknown monitor scheduler[UnknownScheduler]");
-    createInjector(properties, ImmutableSet.of()).getInstance(MonitorScheduler.class);
+    final CreationException exception = Assertions.assertThrows(
+        CreationException.class,
+        () -> createInjector(properties, ImmutableSet.of()).getInstance(MonitorScheduler.class)
+    );
+    Assertions.assertInstanceOf(IllegalArgumentException.class, exception.getCause());
+    Assertions.assertTrue(exception.getMessage().contains("Unknown monitor scheduler[UnknownScheduler]"));
   }
 
   @Test
   public void testGetSysMonitorViaInjector()
   {
     // Do not run the tests on ARM64. Sigar library has no binaries for ARM64
-    Assume.assumeFalse("aarch64".equals(CPU_ARCH));
+    Assumptions.assumeFalse("aarch64".equals(CPU_ARCH));
 
     final Properties properties = new Properties();
     properties.setProperty(MetricsModule.PROPERTY_PEON_MANAGED, "true");
@@ -250,7 +246,7 @@ public class MetricsModuleTest
     final ServiceEmitter emitter = Mockito.mock(ServiceEmitter.class);
     sysMonitor.doMonitor(emitter);
 
-    Assert.assertTrue(sysMonitor instanceof NoopSysMonitor);
+    Assertions.assertTrue(sysMonitor instanceof NoopSysMonitor);
     Mockito.verify(emitter, Mockito.never()).emit(ArgumentMatchers.any(ServiceEventBuilder.class));
   }
 
@@ -258,14 +254,14 @@ public class MetricsModuleTest
   public void testGetSysMonitorWhenNull()
   {
     // Do not run the tests on ARM64. Sigar library has no binaries for ARM64
-    Assume.assumeFalse("aarch64".equals(CPU_ARCH));
+    Assumptions.assumeFalse("aarch64".equals(CPU_ARCH));
 
     Injector injector = createInjector(new Properties(), ImmutableSet.of());
     final SysMonitor sysMonitor = injector.getInstance(SysMonitor.class);
     final ServiceEmitter emitter = Mockito.mock(ServiceEmitter.class);
     sysMonitor.doMonitor(emitter);
 
-    Assert.assertFalse(sysMonitor instanceof NoopSysMonitor);
+    Assertions.assertFalse(sysMonitor instanceof NoopSysMonitor);
     Mockito.verify(emitter, Mockito.atLeastOnce()).emit(ArgumentMatchers.any(ServiceEventBuilder.class));
   }
   @Test
@@ -278,7 +274,7 @@ public class MetricsModuleTest
     final ServiceEmitter emitter = Mockito.mock(ServiceEmitter.class);
     sysMonitor.doMonitor(emitter);
 
-    Assert.assertTrue(sysMonitor instanceof NoopOshiSysMonitor);
+    Assertions.assertTrue(sysMonitor instanceof NoopOshiSysMonitor);
     Mockito.verify(emitter, Mockito.never()).emit(ArgumentMatchers.any(ServiceEventBuilder.class));
   }
 
@@ -292,11 +288,11 @@ public class MetricsModuleTest
     final ServiceEmitter emitter = Mockito.mock(ServiceEmitter.class);
     sysMonitor.doMonitor(emitter);
 
-    Assert.assertTrue(sysMonitor instanceof OshiSysMonitor);
+    Assertions.assertTrue(sysMonitor instanceof OshiSysMonitor);
     Mockito.verify(emitter, Mockito.atLeastOnce()).emit(ArgumentMatchers.any(ServiceEventBuilder.class));
 
-    Assert.assertTrue(injector.getInstance(OshiSysMonitorConfig.class).shouldEmitMetricCategory("mem"));
-    Assert.assertFalse(injector.getInstance(OshiSysMonitorConfig.class).shouldEmitMetricCategory("swap"));
+    Assertions.assertTrue(injector.getInstance(OshiSysMonitorConfig.class).shouldEmitMetricCategory("mem"));
+    Assertions.assertFalse(injector.getInstance(OshiSysMonitorConfig.class).shouldEmitMetricCategory("swap"));
   }
 
   @Test
@@ -308,7 +304,7 @@ public class MetricsModuleTest
     final ServiceEmitter emitter = Mockito.mock(ServiceEmitter.class);
     sysMonitor.doMonitor(emitter);
 
-    Assert.assertFalse(sysMonitor instanceof NoopOshiSysMonitor);
+    Assertions.assertFalse(sysMonitor instanceof NoopOshiSysMonitor);
     Mockito.verify(emitter, Mockito.atLeastOnce()).emit(ArgumentMatchers.any(ServiceEventBuilder.class));
   }
 
@@ -339,7 +335,7 @@ public class MetricsModuleTest
     for (NodeRole role : NodeRole.values()) {
       final MonitorScheduler monitorScheduler = createInjector(properties, ImmutableSet.of(role))
           .getInstance(MonitorScheduler.class);
-      Assert.assertEquals(
+      Assertions.assertEquals(
           supportedRoleSet.contains(role),
           monitorScheduler.findMonitor(monitorClass).isPresent()
       );

--- a/server/src/test/java/org/apache/druid/server/metrics/QueryCountStatsMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/QueryCountStatsMonitorTest.java
@@ -22,10 +22,10 @@ package org.apache.druid.server.metrics;
 import org.apache.druid.collections.BlockingPool;
 import org.apache.druid.collections.DefaultBlockingPool;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -41,7 +41,7 @@ public class QueryCountStatsMonitorTest
   private MonitorsConfig monitorsConfig;
   private ExecutorService executorService;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     monitorsConfig = new MonitorsConfig(
@@ -93,7 +93,7 @@ public class QueryCountStatsMonitorTest
     executorService = Executors.newSingleThreadExecutor();
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     executorService.shutdown();
@@ -109,7 +109,7 @@ public class QueryCountStatsMonitorTest
     emitter.flush();
     // Trigger metric emission
     monitor.doMonitor(emitter);
-    Assert.assertEquals(5, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(5, emitter.getNumEmittedEvents());
     emitter.verifyValue("query/success/count", 1L);
     emitter.verifyValue("query/failed/count", 2L);
     emitter.verifyValue("query/interrupted/count", 3L);
@@ -130,7 +130,7 @@ public class QueryCountStatsMonitorTest
     // Trigger metric emission
     monitor.doMonitor(emitter);
 
-    Assert.assertEquals(6, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(6, emitter.getNumEmittedEvents());
     emitter.verifyValue("mergeBuffer/pendingRequests", 0L);
     emitter.verifyValue("query/success/count", 1L);
     emitter.verifyValue("query/failed/count", 2L);

--- a/server/src/test/java/org/apache/druid/server/metrics/SegmentRowCountDistributionTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/SegmentRowCountDistributionTest.java
@@ -19,9 +19,9 @@
 
 package org.apache.druid.server.metrics;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.ObjIntConsumer;
 
@@ -31,7 +31,7 @@ public class SegmentRowCountDistributionTest
 
   private SegmentRowCountDistribution rowCountBucket;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     rowCountBucket = new SegmentRowCountDistribution();
@@ -41,9 +41,8 @@ public class SegmentRowCountDistributionTest
   public void test_bucketCountSanity()
   {
     // test base case
-    rowCountBucket.forEachDimension((final String dimension, final int count) -> {
-      Assert.assertEquals(0, count);
-    });
+    rowCountBucket.forEachDimension((final String dimension, final int count) ->
+      Assertions.assertEquals(0, count));
 
     // tombstones
     // add tombstones
@@ -160,16 +159,16 @@ public class SegmentRowCountDistributionTest
   @Test
   public void test_bucketDimensionFromIndex()
   {
-    Assert.assertEquals("Tombstone", getBucketDimensionFromIndex(0));
-    Assert.assertEquals("0", getBucketDimensionFromIndex(1));
-    Assert.assertEquals("1-10k", getBucketDimensionFromIndex(2));
-    Assert.assertEquals("10k-2M", getBucketDimensionFromIndex(3));
-    Assert.assertEquals("2M-4M", getBucketDimensionFromIndex(4));
-    Assert.assertEquals("4M-6M", getBucketDimensionFromIndex(5));
-    Assert.assertEquals("6M-8M", getBucketDimensionFromIndex(6));
-    Assert.assertEquals("8M-10M", getBucketDimensionFromIndex(7));
-    Assert.assertEquals("10M+", getBucketDimensionFromIndex(8));
-    Assert.assertEquals("NA", getBucketDimensionFromIndex(9));
+    Assertions.assertEquals("Tombstone", getBucketDimensionFromIndex(0));
+    Assertions.assertEquals("0", getBucketDimensionFromIndex(1));
+    Assertions.assertEquals("1-10k", getBucketDimensionFromIndex(2));
+    Assertions.assertEquals("10k-2M", getBucketDimensionFromIndex(3));
+    Assertions.assertEquals("2M-4M", getBucketDimensionFromIndex(4));
+    Assertions.assertEquals("4M-6M", getBucketDimensionFromIndex(5));
+    Assertions.assertEquals("6M-8M", getBucketDimensionFromIndex(6));
+    Assertions.assertEquals("8M-10M", getBucketDimensionFromIndex(7));
+    Assertions.assertEquals("10M+", getBucketDimensionFromIndex(8));
+    Assertions.assertEquals("NA", getBucketDimensionFromIndex(9));
   }
 
   private static class AssertBucketHasValue implements ObjIntConsumer<String>
@@ -193,10 +192,10 @@ public class SegmentRowCountDistributionTest
     public void accept(String s, int value)
     {
       if (s.equals(getBucketDimensionFromIndex(expectedBucket))) {
-        Assert.assertEquals(expectedValue, value);
+        Assertions.assertEquals(expectedValue, value);
       } else {
         // assert all other values are empty
-        Assert.assertEquals(0, value);
+        Assertions.assertEquals(0, value);
       }
     }
   }

--- a/server/src/test/java/org/apache/druid/server/metrics/SegmentStatsMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/SegmentStatsMonitorTest.java
@@ -28,19 +28,21 @@ import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.segment.loading.SegmentLoaderConfig;
 import org.apache.druid.server.coordination.SegmentLoadDropHandler;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
 
 public class SegmentStatsMonitorTest
 {
@@ -54,7 +56,7 @@ public class SegmentStatsMonitorTest
   private SegmentStatsMonitor monitor;
   private final SegmentLoaderConfig segmentLoaderConfig = SegmentLoaderConfig.builder().build();
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     druidServerConfig = Mockito.mock(DruidServerConfig.class);
@@ -69,14 +71,16 @@ public class SegmentStatsMonitorTest
     Mockito.when(druidServerConfig.getPriority()).thenReturn(PRIORITY);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testLazyLoadOnStartThrowsException()
   {
-    SegmentLoaderConfig segmentLoaderConfig = Mockito.mock(SegmentLoaderConfig.class);
-    Mockito.when(segmentLoaderConfig.isLazyLoadOnStart()).thenReturn(true);
+    Assertions.assertThrows(IllegalStateException.class, () -> {
+      SegmentLoaderConfig segmentLoaderConfig = Mockito.mock(SegmentLoaderConfig.class);
+      Mockito.when(segmentLoaderConfig.isLazyLoadOnStart()).thenReturn(true);
 
-    //should throw an exception here
-    new SegmentStatsMonitor(druidServerConfig, segmentLoadDropMgr, segmentLoaderConfig);
+      //should throw an exception here
+      new SegmentStatsMonitor(druidServerConfig, segmentLoadDropMgr, segmentLoaderConfig);
+    });
   }
 
   @Test
@@ -111,7 +115,7 @@ public class SegmentStatsMonitorTest
     List<Map<String, Object>> expectedEventsAsMap = getEventMaps(expectedEvents);
     Map<String, Map<String, Object>> expected = metricKeyedMap(expectedEventsAsMap);
 
-    Assert.assertEquals("different number of metrics were returned", expected.size(), actual.size());
+    Assertions.assertEquals(expected.size(), actual.size(), "different number of metrics were returned");
     for (Map.Entry<String, Map<String, Object>> expectedKeyedEntry : expected.entrySet()) {
       Map<String, Object> actualValue = actual.get(expectedKeyedEntry.getKey());
       assertMetricMapsEqual(expectedKeyedEntry.getKey(), expectedKeyedEntry.getValue(), actualValue);
@@ -155,7 +159,7 @@ public class SegmentStatsMonitorTest
     List<Map<String, Object>> expectedEventsAsMap = getEventMaps(expectedEvents);
     Map<String, Map<String, Object>> expected = metricKeyedMap(expectedEventsAsMap);
 
-    Assert.assertEquals("different number of metrics were returned", expected.size(), actual.size());
+    Assertions.assertEquals(expected.size(), actual.size(), "different number of metrics were returned");
     for (Map.Entry<String, Map<String, Object>> expectedKeyedEntry : expected.entrySet()) {
       Map<String, Object> actualValue = actual.get(expectedKeyedEntry.getKey());
       assertMetricMapsEqual(expectedKeyedEntry.getKey(), expectedKeyedEntry.getValue(), actualValue);
@@ -164,12 +168,12 @@ public class SegmentStatsMonitorTest
 
   private void assertMetricMapsEqual(String messagePrefix, Map<String, Object> expected, Map<String, Object> actual)
   {
-    Assert.assertEquals("different number of expected values for metrics", expected.size(), actual.size());
+    Assertions.assertEquals(expected.size(), actual.size(), "different number of expected values for metrics");
     for (Map.Entry<String, Object> expectedMetricEntry : expected.entrySet()) {
-      Assert.assertEquals(
-          messagePrefix + " " + expectedMetricEntry.getKey(),
+      Assertions.assertEquals(
           expectedMetricEntry.getValue(),
-          actual.get(expectedMetricEntry.getKey())
+          actual.get(expectedMetricEntry.getKey()),
+          messagePrefix + " " + expectedMetricEntry.getKey()
       );
     }
   }

--- a/server/src/test/java/org/apache/druid/server/metrics/ServiceStatusMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/ServiceStatusMonitorTest.java
@@ -21,9 +21,9 @@ package org.apache.druid.server.metrics;
 
 import com.google.common.base.Supplier;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +37,7 @@ public class ServiceStatusMonitorTest
   private final Supplier<Map<String, Object>> heartbeatTagsSupplier = () -> heartbeatTags;
   private static final String HEARTBEAT_METRIC_KEY = "service/heartbeat";
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     emitter = new StubServiceEmitter();
@@ -50,7 +50,7 @@ public class ServiceStatusMonitorTest
   public void testDefaultHeartbeatReported()
   {
     monitor.doMonitor(emitter);
-    Assert.assertEquals(1, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(1, emitter.getNumEmittedEvents());
     emitter.verifyValue(HEARTBEAT_METRIC_KEY, 1);
   }
 
@@ -59,7 +59,7 @@ public class ServiceStatusMonitorTest
   {
     heartbeatTags.put("leader", 1);
     monitor.doMonitor(emitter);
-    Assert.assertEquals(1, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(1, emitter.getNumEmittedEvents());
     emitter.verifyValue(HEARTBEAT_METRIC_KEY, Map.of("leader", 1), 1);
   }
 
@@ -69,7 +69,7 @@ public class ServiceStatusMonitorTest
     heartbeatTags.put("leader", 1);
     heartbeatTags.put("taskRunner", "http");
     monitor.doMonitor(emitter);
-    Assert.assertEquals(1, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(1, emitter.getNumEmittedEvents());
     emitter.verifyValue(HEARTBEAT_METRIC_KEY, Map.of("leader", 1, "taskRunner", "http"), 1);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/metrics/SupervisorStatsMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/SupervisorStatsMonitorTest.java
@@ -21,9 +21,9 @@ package org.apache.druid.server.metrics;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -31,7 +31,7 @@ public class SupervisorStatsMonitorTest
 {
   private SupervisorStatsProvider statsProvider;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     statsProvider = () -> ImmutableList.of(
@@ -49,7 +49,7 @@ public class SupervisorStatsMonitorTest
     final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
     monitor.doMonitor(emitter);
 
-    Assert.assertEquals(4, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(4, emitter.getNumEmittedEvents());
 
     emitter.verifyValue(
         "supervisor/count",
@@ -81,7 +81,7 @@ public class SupervisorStatsMonitorTest
     final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
     monitor.doMonitor(emitter);
 
-    Assert.assertEquals(0, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(0, emitter.getNumEmittedEvents());
   }
 
   @Test
@@ -92,7 +92,7 @@ public class SupervisorStatsMonitorTest
     final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
     monitor.doMonitor(emitter);
 
-    Assert.assertEquals(0, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(0, emitter.getNumEmittedEvents());
   }
 
   @Test
@@ -105,7 +105,7 @@ public class SupervisorStatsMonitorTest
     final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
     monitor.doMonitor(emitter);
 
-    Assert.assertEquals(1, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(1, emitter.getNumEmittedEvents());
     emitter.verifyValue(
         "supervisor/count",
         Map.of("supervisorId", "unknown-supervisor", "type", "scheduled_batch", "state", "UNKNOWN", "dataSource", "compaction-ds", "detailedState", "UNKNOWN"),
@@ -123,7 +123,7 @@ public class SupervisorStatsMonitorTest
     final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
     monitor.doMonitor(emitter);
 
-    Assert.assertEquals(1, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(1, emitter.getNumEmittedEvents());
     emitter.verifyValue(
         "supervisor/count",
         Map.of("supervisorId", "compaction-supervisor", "type", "compaction", "state", "RUNNING", "dataSource", "compaction-ds"),
@@ -141,7 +141,7 @@ public class SupervisorStatsMonitorTest
     final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
     monitor.doMonitor(emitter);
 
-    Assert.assertEquals(1, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(1, emitter.getNumEmittedEvents());
     emitter.verifyValue(
         "supervisor/count",
         Map.of("supervisorId", "multi-ds-supervisor", "type", "kafka", "state", "RUNNING", "dataSource", "[ds1, ds2]", "stream", "multi-topic", "detailedState", "RUNNING"),
@@ -159,7 +159,7 @@ public class SupervisorStatsMonitorTest
     final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
     monitor.doMonitor(emitter);
 
-    Assert.assertEquals(1, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(1, emitter.getNumEmittedEvents());
     emitter.verifyValue(
         "supervisor/count",
         Map.of("supervisorId", "connecting-supervisor", "type", "kafka", "state", "RUNNING", "dataSource", "clicks", "stream", "clicks-topic", "detailedState", "CONNECTING_TO_STREAM"),

--- a/server/src/test/java/org/apache/druid/server/metrics/TaskCountStatsMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/TaskCountStatsMonitorTest.java
@@ -25,9 +25,9 @@ import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.server.coordinator.stats.CoordinatorStat;
 import org.apache.druid.server.coordinator.stats.Dimension;
 import org.apache.druid.server.coordinator.stats.RowKey;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -41,7 +41,7 @@ public class TaskCountStatsMonitorTest
                                                        .with(Dimension.TASK_TYPE, "kill")
                                                        .build();
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     statsProvider = new TaskCountStatsProvider()
@@ -94,7 +94,7 @@ public class TaskCountStatsMonitorTest
     final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
     monitor.doMonitor(emitter);
 
-    Assert.assertEquals(9, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(9, emitter.getNumEmittedEvents());
 
     emitter.verifyValue("task/success/count", Map.of("dataSource", "d1", "taskType", "index"), 1L);
     emitter.verifyValue("task/failed/count", Map.of("dataSource", "d1", "taskType", "index"), 1L);

--- a/server/src/test/java/org/apache/druid/server/metrics/TaskSlotCountStatsMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/TaskSlotCountStatsMonitorTest.java
@@ -21,9 +21,9 @@ package org.apache.druid.server.metrics;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -31,7 +31,7 @@ public class TaskSlotCountStatsMonitorTest
 {
   private TaskSlotCountStatsProvider statsProvider;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     statsProvider = new TaskSlotCountStatsProvider()
@@ -74,7 +74,7 @@ public class TaskSlotCountStatsMonitorTest
     final TaskSlotCountStatsMonitor monitor = new TaskSlotCountStatsMonitor(statsProvider);
     final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
     monitor.doMonitor(emitter);
-    Assert.assertEquals(5, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(5, emitter.getNumEmittedEvents());
     emitter.verifyValue("taskSlot/total/count", 1L);
     emitter.verifyValue("taskSlot/idle/count", 1L);
     emitter.verifyValue("taskSlot/used/count", 1L);

--- a/server/src/test/java/org/apache/druid/server/metrics/WorkerTaskCountStatsMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/WorkerTaskCountStatsMonitorTest.java
@@ -26,11 +26,12 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.util.Map;
 
 public class WorkerTaskCountStatsMonitorTest
@@ -44,7 +45,7 @@ public class WorkerTaskCountStatsMonitorTest
   private IndexerTaskCountStatsProvider indexerTaskStatsProvider;
   private WorkerTaskCountStatsProvider nullStatsProvider;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     statsProvider = new WorkerTaskCountStatsProvider()
@@ -222,7 +223,7 @@ public class WorkerTaskCountStatsMonitorTest
         new WorkerTaskCountStatsMonitor(injectorForMiddleManager, ImmutableSet.of(NodeRole.MIDDLE_MANAGER));
     final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
     monitor.doMonitor(emitter);
-    Assert.assertEquals(5, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(5, emitter.getNumEmittedEvents());
     emitter.verifyValue(
         "worker/task/failed/count",
         ImmutableMap.of("category", "workerCategory", "workerVersion", "workerVersion"),
@@ -257,7 +258,7 @@ public class WorkerTaskCountStatsMonitorTest
         new WorkerTaskCountStatsMonitor(injectorForIndexer, ImmutableSet.of(NodeRole.INDEXER));
     final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
     monitor.doMonitor(emitter);
-    Assert.assertEquals(10, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(10, emitter.getNumEmittedEvents());
     emitter.verifyValue(
         "worker/task/running/count",
         ImmutableMap.of("dataSource", "wikipedia"),
@@ -317,7 +318,7 @@ public class WorkerTaskCountStatsMonitorTest
         new WorkerTaskCountStatsMonitor(injectorForMiddleManagerNullStats, ImmutableSet.of(NodeRole.MIDDLE_MANAGER));
     final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
     monitor.doMonitor(emitter);
-    Assert.assertEquals(0, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(0, emitter.getNumEmittedEvents());
   }
 
   @Test
@@ -327,6 +328,6 @@ public class WorkerTaskCountStatsMonitorTest
             new WorkerTaskCountStatsMonitor(injectorForPeon, ImmutableSet.of(NodeRole.PEON));
     final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
     monitor.doMonitor(emitter);
-    Assert.assertEquals(0, emitter.getNumEmittedEvents());
+    Assertions.assertEquals(0, emitter.getNumEmittedEvents());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/scheduling/HiLoQueryLaningStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/scheduling/HiLoQueryLaningStrategyTest.java
@@ -57,7 +57,7 @@ public class HiLoQueryLaningStrategyTest
   public void testMaxPercentageThreadsRequired()
   {
     Throwable exception = Assertions.assertThrows(NullPointerException.class, () -> {
-      QueryLaningStrategy strategy = new HiLoQueryLaningStrategy(null);
+      new HiLoQueryLaningStrategy(null);
     });
     Assertions.assertTrue(exception.getMessage().contains("maxLowPercent must be set"));
   }
@@ -66,7 +66,7 @@ public class HiLoQueryLaningStrategyTest
   public void testMaxLowPercentMustBeGreaterThanZero()
   {
     Throwable exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
-      QueryLaningStrategy strategy = new HiLoQueryLaningStrategy(-1);
+      new HiLoQueryLaningStrategy(-1);
     });
     Assertions.assertTrue(exception.getMessage().contains("maxLowPercent must be in the range 1 to 100"));
   }
@@ -76,7 +76,7 @@ public class HiLoQueryLaningStrategyTest
   public void testMaxLowPercentMustBeLessThanOrEqual100()
   {
     Throwable exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
-      QueryLaningStrategy strategy = new HiLoQueryLaningStrategy(9000);
+      new HiLoQueryLaningStrategy(9000);
     });
     Assertions.assertTrue(exception.getMessage().contains("maxLowPercent must be in the range 1 to 100"));
   }
@@ -85,7 +85,7 @@ public class HiLoQueryLaningStrategyTest
   public void testMaxLowPercentZero()
   {
     Throwable exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
-      QueryLaningStrategy strategy = new HiLoQueryLaningStrategy(0);
+      new HiLoQueryLaningStrategy(0);
     });
     Assertions.assertTrue(exception.getMessage().contains("maxLowPercent must be in the range 1 to 100"));
   }

--- a/server/src/test/java/org/apache/druid/server/scheduling/HiLoQueryLaningStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/scheduling/HiLoQueryLaningStrategyTest.java
@@ -31,21 +31,17 @@ import org.apache.druid.query.QueryPlus;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.server.QueryLaningStrategy;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class HiLoQueryLaningStrategyTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   private Druids.TimeseriesQueryBuilder queryBuilder;
   private HiLoQueryLaningStrategy strategy;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     this.queryBuilder = Druids.newTimeseriesQueryBuilder()
@@ -60,34 +56,38 @@ public class HiLoQueryLaningStrategyTest
   @Test
   public void testMaxPercentageThreadsRequired()
   {
-    expectedException.expect(NullPointerException.class);
-    expectedException.expectMessage("maxLowPercent must be set");
-    QueryLaningStrategy strategy = new HiLoQueryLaningStrategy(null);
+    Throwable exception = Assertions.assertThrows(NullPointerException.class, () -> {
+      QueryLaningStrategy strategy = new HiLoQueryLaningStrategy(null);
+    });
+    Assertions.assertTrue(exception.getMessage().contains("maxLowPercent must be set"));
   }
 
   @Test
   public void testMaxLowPercentMustBeGreaterThanZero()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("maxLowPercent must be in the range 1 to 100");
-    QueryLaningStrategy strategy = new HiLoQueryLaningStrategy(-1);
+    Throwable exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      QueryLaningStrategy strategy = new HiLoQueryLaningStrategy(-1);
+    });
+    Assertions.assertTrue(exception.getMessage().contains("maxLowPercent must be in the range 1 to 100"));
   }
 
 
   @Test
   public void testMaxLowPercentMustBeLessThanOrEqual100()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("maxLowPercent must be in the range 1 to 100");
-    QueryLaningStrategy strategy = new HiLoQueryLaningStrategy(9000);
+    Throwable exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      QueryLaningStrategy strategy = new HiLoQueryLaningStrategy(9000);
+    });
+    Assertions.assertTrue(exception.getMessage().contains("maxLowPercent must be in the range 1 to 100"));
   }
 
   @Test
   public void testMaxLowPercentZero()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("maxLowPercent must be in the range 1 to 100");
-    QueryLaningStrategy strategy = new HiLoQueryLaningStrategy(0);
+    Throwable exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      QueryLaningStrategy strategy = new HiLoQueryLaningStrategy(0);
+    });
+    Assertions.assertTrue(exception.getMessage().contains("maxLowPercent must be in the range 1 to 100"));
   }
 
   @Test
@@ -95,9 +95,9 @@ public class HiLoQueryLaningStrategyTest
   {
     QueryLaningStrategy strategy = new HiLoQueryLaningStrategy(100);
     Object2IntMap<String> laneConfig = strategy.getLaneLimits(25);
-    Assert.assertEquals(1, laneConfig.size());
-    Assert.assertTrue(laneConfig.containsKey(HiLoQueryLaningStrategy.LOW));
-    Assert.assertEquals(25, laneConfig.getInt(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertEquals(1, laneConfig.size());
+    Assertions.assertTrue(laneConfig.containsKey(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertEquals(25, laneConfig.getInt(HiLoQueryLaningStrategy.LOW));
   }
 
   @Test
@@ -106,68 +106,68 @@ public class HiLoQueryLaningStrategyTest
     // will round up to 1
     QueryLaningStrategy strategyRoundLow = new HiLoQueryLaningStrategy(1);
     Object2IntMap<String> laneConfigRoundLow = strategyRoundLow.getLaneLimits(25);
-    Assert.assertEquals(1, laneConfigRoundLow.size());
-    Assert.assertTrue(laneConfigRoundLow.containsKey(HiLoQueryLaningStrategy.LOW));
-    Assert.assertEquals(1, laneConfigRoundLow.getInt(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertEquals(1, laneConfigRoundLow.size());
+    Assertions.assertTrue(laneConfigRoundLow.containsKey(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertEquals(1, laneConfigRoundLow.getInt(HiLoQueryLaningStrategy.LOW));
 
     // will not round, evenly divides
     QueryLaningStrategy strategy = new HiLoQueryLaningStrategy(96);
     Object2IntMap<String> laneConfig = strategy.getLaneLimits(25);
-    Assert.assertEquals(1, laneConfig.size());
-    Assert.assertTrue(laneConfig.containsKey(HiLoQueryLaningStrategy.LOW));
-    Assert.assertEquals(24, laneConfig.getInt(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertEquals(1, laneConfig.size());
+    Assertions.assertTrue(laneConfig.containsKey(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertEquals(24, laneConfig.getInt(HiLoQueryLaningStrategy.LOW));
 
     // will round up
     QueryLaningStrategy strategyRounded = new HiLoQueryLaningStrategy(97);
     Object2IntMap<String> laneConfigRounded = strategyRounded.getLaneLimits(25);
-    Assert.assertEquals(1, laneConfigRounded.size());
-    Assert.assertTrue(laneConfigRounded.containsKey(HiLoQueryLaningStrategy.LOW));
-    Assert.assertEquals(25, laneConfigRounded.getInt(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertEquals(1, laneConfigRounded.size());
+    Assertions.assertTrue(laneConfigRounded.containsKey(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertEquals(25, laneConfigRounded.getInt(HiLoQueryLaningStrategy.LOW));
   }
 
   @Test
   public void testLaneLimits()
   {
     Object2IntMap<String> laneConfig = strategy.getLaneLimits(5);
-    Assert.assertEquals(1, laneConfig.size());
-    Assert.assertTrue(laneConfig.containsKey(HiLoQueryLaningStrategy.LOW));
-    Assert.assertEquals(2, laneConfig.getInt(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertEquals(1, laneConfig.size());
+    Assertions.assertTrue(laneConfig.containsKey(HiLoQueryLaningStrategy.LOW));
+    Assertions.assertEquals(2, laneConfig.getInt(HiLoQueryLaningStrategy.LOW));
   }
 
   @Test
   public void testLaningNoPriority()
   {
     TimeseriesQuery query = queryBuilder.build();
-    Assert.assertFalse(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
+    Assertions.assertFalse(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
   }
 
   @Test
   public void testLaningZeroPriority()
   {
     TimeseriesQuery query = queryBuilder.context(ImmutableMap.of(QueryContexts.PRIORITY_KEY, 0)).build();
-    Assert.assertFalse(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
+    Assertions.assertFalse(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
   }
 
   @Test
   public void testLaningInteractivePriority()
   {
     TimeseriesQuery query = queryBuilder.context(ImmutableMap.of(QueryContexts.PRIORITY_KEY, 100)).build();
-    Assert.assertFalse(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
+    Assertions.assertFalse(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
   }
 
   @Test
   public void testLaningInteractivePriority_String()
   {
     TimeseriesQuery query = queryBuilder.context(ImmutableMap.of(QueryContexts.PRIORITY_KEY, "100")).build();
-    Assert.assertFalse(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
+    Assertions.assertFalse(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
   }
 
   @Test
   public void testLaningLowPriority()
   {
     TimeseriesQuery query = queryBuilder.context(ImmutableMap.of(QueryContexts.PRIORITY_KEY, -1)).build();
-    Assert.assertTrue(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
-    Assert.assertEquals(
+    Assertions.assertTrue(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
+    Assertions.assertEquals(
         HiLoQueryLaningStrategy.LOW,
         strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).get()
     );
@@ -177,8 +177,8 @@ public class HiLoQueryLaningStrategyTest
   public void testLaningLowPriority_String()
   {
     TimeseriesQuery query = queryBuilder.context(ImmutableMap.of(QueryContexts.PRIORITY_KEY, "-1")).build();
-    Assert.assertTrue(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
-    Assert.assertEquals(
+    Assertions.assertTrue(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
+    Assertions.assertEquals(
         HiLoQueryLaningStrategy.LOW,
         strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).get()
     );
@@ -190,7 +190,7 @@ public class HiLoQueryLaningStrategyTest
     TimeseriesQuery query = queryBuilder.context(
         ImmutableMap.of(QueryContexts.PRIORITY_KEY, 100, QueryContexts.LANE_KEY, "low")
     ).build();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         HiLoQueryLaningStrategy.LOW,
         strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).get()
     );

--- a/server/src/test/java/org/apache/druid/server/scheduling/ManualQueryLaningStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/scheduling/ManualQueryLaningStrategyTest.java
@@ -32,11 +32,9 @@ import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.server.QueryLaningStrategy;
 import org.apache.druid.server.QueryScheduler;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("ResultOfObjectAllocationIgnored")
 public class ManualQueryLaningStrategyTest
@@ -45,10 +43,7 @@ public class ManualQueryLaningStrategyTest
   private QueryLaningStrategy exactStrategy;
   private QueryLaningStrategy percentStrategy;
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
-  @Before
+  @BeforeEach
   public void setup()
   {
     this.queryBuilder = Druids.newTimeseriesQueryBuilder()
@@ -65,82 +60,89 @@ public class ManualQueryLaningStrategyTest
   @Test
   public void testLanesMustBeSet()
   {
-    expectedException.expect(NullPointerException.class);
-    expectedException.expectMessage("lanes must be set");
-    new ManualQueryLaningStrategy(null, null);
+    Throwable exception = Assertions.assertThrows(NullPointerException.class, () -> {
+      new ManualQueryLaningStrategy(null, null);
+    });
+    Assertions.assertTrue(exception.getMessage().contains("lanes must be set"));
   }
 
   @Test
   public void testMustDefineAtLeastOneLane()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("lanes must define at least one lane");
-    new ManualQueryLaningStrategy(ImmutableMap.of(), null);
+    Throwable exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      new ManualQueryLaningStrategy(ImmutableMap.of(), null);
+    });
+    Assertions.assertTrue(exception.getMessage().contains("lanes must define at least one lane"));
   }
 
   @Test
   public void testMustNotUseTotalName()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("Lane cannot be named 'total'");
-    new ManualQueryLaningStrategy(ImmutableMap.of(QueryScheduler.TOTAL, 12), null);
+    Throwable exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      new ManualQueryLaningStrategy(ImmutableMap.of(QueryScheduler.TOTAL, 12), null);
+    });
+    Assertions.assertTrue(exception.getMessage().contains("Lane cannot be named 'total'"));
   }
 
   @Test
   public void testMustNotUseDefaultName()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("Lane cannot be named 'default'");
-    new ManualQueryLaningStrategy(ImmutableMap.of("default", 12), null);
+    Throwable exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      new ManualQueryLaningStrategy(ImmutableMap.of("default", 12), null);
+    });
+    Assertions.assertTrue(exception.getMessage().contains("Lane cannot be named 'default'"));
   }
 
   @Test
   public void testExactLaneLimitsMustBeAboveZero()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("All lane limits must be greater than 0");
-    new ManualQueryLaningStrategy(ImmutableMap.of("zero", 0, "one", 1), null);
+    Throwable exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      new ManualQueryLaningStrategy(ImmutableMap.of("zero", 0, "one", 1), null);
+    });
+    Assertions.assertTrue(exception.getMessage().contains("All lane limits must be greater than 0"));
   }
 
   @Test
   public void testPercentLaneLimitsMustBeAboveZero()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("All lane limits must be in the range 1 to 100");
-    new ManualQueryLaningStrategy(ImmutableMap.of("zero", 0, "one", 25), true);
+    Throwable exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      new ManualQueryLaningStrategy(ImmutableMap.of("zero", 0, "one", 25), true);
+    });
+    Assertions.assertTrue(exception.getMessage().contains("All lane limits must be in the range 1 to 100"));
   }
 
   @Test
   public void testPercentLaneLimitsMustBeLessThanOneHundred()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("All lane limits must be in the range 1 to 100");
-    new ManualQueryLaningStrategy(ImmutableMap.of("one", 1, "one-hundred-and-one", 101), true);
+    Throwable exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      new ManualQueryLaningStrategy(ImmutableMap.of("one", 1, "one-hundred-and-one", 101), true);
+    });
+    Assertions.assertTrue(exception.getMessage().contains("All lane limits must be in the range 1 to 100"));
   }
 
   @Test
   public void testExactLimits()
   {
     Object2IntMap<String> exactLanes = exactStrategy.getLaneLimits(50);
-    Assert.assertEquals(1, exactLanes.getInt("one"));
-    Assert.assertEquals(10, exactLanes.getInt("ten"));
+    Assertions.assertEquals(1, exactLanes.getInt("one"));
+    Assertions.assertEquals(10, exactLanes.getInt("ten"));
   }
 
   @Test
   public void testPercentLimits()
   {
     Object2IntMap<String> exactLanes = percentStrategy.getLaneLimits(50);
-    Assert.assertEquals(1, exactLanes.getInt("one"));
-    Assert.assertEquals(5, exactLanes.getInt("ten"));
-    Assert.assertEquals(50, exactLanes.getInt("one-hundred"));
+    Assertions.assertEquals(1, exactLanes.getInt("one"));
+    Assertions.assertEquals(5, exactLanes.getInt("ten"));
+    Assertions.assertEquals(50, exactLanes.getInt("one-hundred"));
   }
 
   @Test
   public void testDoesntSetLane()
   {
     TimeseriesQuery query = queryBuilder.context(ImmutableMap.of()).build();
-    Assert.assertFalse(exactStrategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
-    Assert.assertFalse(percentStrategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
+    Assertions.assertFalse(exactStrategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
+    Assertions.assertFalse(percentStrategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
   }
 
   @Test
@@ -148,11 +150,11 @@ public class ManualQueryLaningStrategyTest
   {
     final String someLane = "some-lane";
     TimeseriesQuery query = queryBuilder.context(ImmutableMap.of(QueryContexts.LANE_KEY, someLane)).build();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         someLane,
         exactStrategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).get()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         someLane,
         percentStrategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).get()
     );
@@ -163,11 +165,11 @@ public class ManualQueryLaningStrategyTest
   {
     final String someLane = "ten";
     TimeseriesQuery query = queryBuilder.context(ImmutableMap.of(QueryContexts.LANE_KEY, someLane)).build();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         someLane,
         exactStrategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).get()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         someLane,
         percentStrategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).get()
     );

--- a/server/src/test/java/org/apache/druid/server/scheduling/NoQueryLaningStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/scheduling/NoQueryLaningStrategyTest.java
@@ -29,16 +29,16 @@ import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.QueryPlus;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class NoQueryLaningStrategyTest
 {
   private Druids.TimeseriesQueryBuilder queryBuilder;
   private NoQueryLaningStrategy strategy;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     this.queryBuilder = Druids.newTimeseriesQueryBuilder()
@@ -54,7 +54,7 @@ public class NoQueryLaningStrategyTest
   public void testDoesntSetLane()
   {
     TimeseriesQuery query = queryBuilder.context(ImmutableMap.of()).build();
-    Assert.assertFalse(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
+    Assertions.assertFalse(strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).isPresent());
   }
 
   @Test
@@ -64,7 +64,7 @@ public class NoQueryLaningStrategyTest
     TimeseriesQuery query = queryBuilder.context(
         ImmutableMap.of(QueryContexts.PRIORITY_KEY, 100, QueryContexts.LANE_KEY, someLane)
     ).build();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         someLane,
         strategy.computeLane(QueryPlus.wrap(query), ImmutableSet.of()).get()
     );

--- a/server/src/test/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategyTest.java
@@ -34,20 +34,16 @@ import org.apache.druid.server.QueryPrioritizationStrategy;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ThresholdBasedQueryPrioritizationStrategyTest
 {
   private final Integer adjustment = 10;
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
   private Druids.TimeseriesQueryBuilder queryBuilder;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     this.queryBuilder = Druids.newTimeseriesQueryBuilder()
@@ -68,7 +64,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
                                         .context(ImmutableMap.of())
                                         .build();
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         strategy.computePriority(QueryPlus.wrap(query), ImmutableSet.of()).isPresent()
     );
   }
@@ -90,7 +86,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
                                         .context(ImmutableMap.of())
                                         .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         -adjustment,
         (int) strategy.computePriority(QueryPlus.wrap(query), ImmutableSet.of()).get()
     );
@@ -113,7 +109,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
                                         .context(ImmutableMap.of())
                                         .build();
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         strategy.computePriority(QueryPlus.wrap(query), ImmutableSet.of()).isPresent()
     );
   }
@@ -135,7 +131,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
                                         .context(ImmutableMap.of())
                                         .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         -adjustment,
         (int) strategy.computePriority(QueryPlus.wrap(query), ImmutableSet.of()).get()
     );
@@ -158,7 +154,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
                                         .context(ImmutableMap.of())
                                         .build();
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         strategy.computePriority(
             QueryPlus.wrap(query),
             ImmutableSet.of(EasyMock.createMock(SegmentServerSelector.class))
@@ -183,7 +179,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
                                         .context(ImmutableMap.of())
                                         .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         -adjustment,
         (int) strategy.computePriority(
             QueryPlus.wrap(query),
@@ -215,7 +211,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
     SegmentServerSelector segmentServerSelector = EasyMock.createMock(SegmentServerSelector.class);
     EasyMock.expect(segmentServerSelector.getSegmentDescriptor()).andReturn(new SegmentDescriptor(new Interval(startDate, endDate), "", 0)).times(2);
     EasyMock.replay(segmentServerSelector);
-    Assert.assertFalse(
+    Assertions.assertFalse(
             strategy.computePriority(QueryPlus.wrap(query), ImmutableSet.of(segmentServerSelector)).isPresent()
     );
   }
@@ -239,7 +235,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
     SegmentServerSelector segmentServerSelector = EasyMock.createMock(SegmentServerSelector.class);
     EasyMock.expect(segmentServerSelector.getSegmentDescriptor()).andReturn(new SegmentDescriptor(new Interval(startDate, endDate), "", 0)).times(2);
     EasyMock.replay(segmentServerSelector);
-    Assert.assertEquals(
+    Assertions.assertEquals(
             -adjustment,
             (int) strategy.computePriority(QueryPlus.wrap(query), ImmutableSet.of(segmentServerSelector)).get()
     );

--- a/server/src/test/java/org/apache/druid/server/scheduling/WeightedQueryLaningStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/scheduling/WeightedQueryLaningStrategyTest.java
@@ -32,9 +32,9 @@ import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.server.QueryLaningStrategy;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.List;
@@ -51,7 +51,7 @@ public class WeightedQueryLaningStrategyTest
 
   private Druids.TimeseriesQueryBuilder queryBuilder;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     queryBuilder = Druids.newTimeseriesQueryBuilder()
@@ -67,9 +67,9 @@ public class WeightedQueryLaningStrategyTest
     WeightedQueryLaningStrategy strategy = newStrategy(null, null, 10, null);
 
     Object2IntMap<String> limits = strategy.getLaneLimits(100);
-    Assert.assertEquals(2, limits.size());
-    Assert.assertEquals(30, limits.getInt("low"));
-    Assert.assertEquals(10, limits.getInt("very-low"));
+    Assertions.assertEquals(2, limits.size());
+    Assertions.assertEquals(30, limits.getInt("low"));
+    Assertions.assertEquals(10, limits.getInt("very-low"));
   }
 
   @Test
@@ -78,7 +78,7 @@ public class WeightedQueryLaningStrategyTest
     WeightedQueryLaningStrategy strategy = newStrategy(null, null, 10000, null);
     TimeseriesQuery query = queryBuilder.build();
     Optional<String> lane = strategy.computeLane(QueryPlus.wrap(query), Set.of());
-    Assert.assertFalse(lane.isPresent());
+    Assertions.assertFalse(lane.isPresent());
   }
 
   @Test
@@ -89,8 +89,8 @@ public class WeightedQueryLaningStrategyTest
     TimeseriesQuery query = queryBuilder.build();
     Set<SegmentServerSelector> segments = makeSegments(5);
     Optional<String> lane = strategy.computeLane(QueryPlus.wrap(query), segments);
-    Assert.assertTrue(lane.isPresent());
-    Assert.assertEquals("low", lane.get());
+    Assertions.assertTrue(lane.isPresent());
+    Assertions.assertEquals("low", lane.get());
   }
 
   @Test
@@ -108,8 +108,8 @@ public class WeightedQueryLaningStrategyTest
     TimeseriesQuery query = queryBuilder.build();
     Set<SegmentServerSelector> segments = makeSegments(5);
     Optional<String> lane = strategy.computeLane(QueryPlus.wrap(query), segments);
-    Assert.assertTrue(lane.isPresent());
-    Assert.assertEquals("low", lane.get());
+    Assertions.assertTrue(lane.isPresent());
+    Assertions.assertEquals("low", lane.get());
   }
 
   @Test
@@ -126,8 +126,8 @@ public class WeightedQueryLaningStrategyTest
     TimeseriesQuery query = queryBuilder.build();
     Set<SegmentServerSelector> segments = makeSegments(5);
     Optional<String> lane = strategy.computeLane(QueryPlus.wrap(query), segments);
-    Assert.assertTrue(lane.isPresent());
-    Assert.assertEquals("very-low", lane.get());
+    Assertions.assertTrue(lane.isPresent());
+    Assertions.assertEquals("very-low", lane.get());
   }
 
   @Test
@@ -138,8 +138,8 @@ public class WeightedQueryLaningStrategyTest
         .context(Map.of(QueryContexts.LANE_KEY, "custom"))
         .build();
     Optional<String> lane = strategy.computeLane(QueryPlus.wrap(query), Set.of());
-    Assert.assertTrue(lane.isPresent());
-    Assert.assertEquals("custom", lane.get());
+    Assertions.assertTrue(lane.isPresent());
+    Assertions.assertEquals("custom", lane.get());
   }
 
   @Test
@@ -157,8 +157,8 @@ public class WeightedQueryLaningStrategyTest
     ));
     // Total range = 1 day + 1 day = 2 days > 1 second → cost=1 → "low"
     Optional<String> lane = strategy.computeLane(QueryPlus.wrap(query), segments);
-    Assert.assertTrue(lane.isPresent());
-    Assert.assertEquals("low", lane.get());
+    Assertions.assertTrue(lane.isPresent());
+    Assertions.assertEquals("low", lane.get());
   }
 
   @Test
@@ -175,14 +175,14 @@ public class WeightedQueryLaningStrategyTest
         ))
         .build();
     Optional<String> lane = strategy.computeLane(QueryPlus.wrap(query), Set.of());
-    Assert.assertTrue(lane.isPresent());
-    Assert.assertEquals("low", lane.get());
+    Assertions.assertTrue(lane.isPresent());
+    Assertions.assertEquals("low", lane.get());
   }
 
   @Test
   public void testValidation_noThresholds()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> newStrategy(null, null, null, null)
     );
@@ -191,7 +191,7 @@ public class WeightedQueryLaningStrategyTest
   @Test
   public void testValidation_noLanes()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy(
             null,
@@ -206,7 +206,7 @@ public class WeightedQueryLaningStrategyTest
   @Test
   public void testValidation_nullLanes()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy(
             null,
@@ -221,7 +221,7 @@ public class WeightedQueryLaningStrategyTest
   @Test
   public void testValidation_reservedLaneNameTotal()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy(
             null,
@@ -236,7 +236,7 @@ public class WeightedQueryLaningStrategyTest
   @Test
   public void testValidation_reservedLaneNameDefault()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy(
             null,
@@ -251,7 +251,7 @@ public class WeightedQueryLaningStrategyTest
   @Test
   public void testLaneConfig_invalidMinCost()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy.LaneConfig(0, 30)
     );
@@ -260,7 +260,7 @@ public class WeightedQueryLaningStrategyTest
   @Test
   public void testLaneConfig_invalidMaxPercent()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy.LaneConfig(1, 0)
     );
@@ -281,11 +281,11 @@ public class WeightedQueryLaningStrategyTest
                   + "}";
 
     QueryLaningStrategy deserialized = mapper.readValue(json, QueryLaningStrategy.class);
-    Assert.assertTrue(deserialized instanceof WeightedQueryLaningStrategy);
+    Assertions.assertTrue(deserialized instanceof WeightedQueryLaningStrategy);
 
     Object2IntMap<String> limits = deserialized.getLaneLimits(100);
-    Assert.assertEquals(30, limits.getInt("low"));
-    Assert.assertEquals(10, limits.getInt("very-low"));
+    Assertions.assertEquals(30, limits.getInt("low"));
+    Assertions.assertEquals(10, limits.getInt("very-low"));
   }
 
   private static WeightedQueryLaningStrategy newStrategy(
@@ -307,7 +307,7 @@ public class WeightedQueryLaningStrategyTest
   @Test
   public void testValidation_segmentCountThresholdZero()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy(null, null, 0, null, TWO_LANES)
     );
@@ -316,7 +316,7 @@ public class WeightedQueryLaningStrategyTest
   @Test
   public void testValidation_segmentCountThresholdNegative()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy(null, null, -1, null, TWO_LANES)
     );
@@ -325,7 +325,7 @@ public class WeightedQueryLaningStrategyTest
   @Test
   public void testValidation_durationThresholdZero()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy(null, "PT0S", null, null, TWO_LANES)
     );
@@ -334,7 +334,7 @@ public class WeightedQueryLaningStrategyTest
   @Test
   public void testValidation_durationThresholdNegative()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy(null, "-PT1S", null, null, TWO_LANES)
     );
@@ -343,7 +343,7 @@ public class WeightedQueryLaningStrategyTest
   @Test
   public void testValidation_segmentRangeThresholdZero()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy(null, null, null, "PT0S", TWO_LANES)
     );
@@ -352,7 +352,7 @@ public class WeightedQueryLaningStrategyTest
   @Test
   public void testValidation_segmentRangeThresholdNegative()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy(null, null, null, "-PT1S", TWO_LANES)
     );
@@ -361,7 +361,7 @@ public class WeightedQueryLaningStrategyTest
   @Test
   public void testValidation_periodThresholdZero()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy("PT0S", null, null, null, TWO_LANES)
     );
@@ -370,7 +370,7 @@ public class WeightedQueryLaningStrategyTest
   @Test
   public void testValidation_periodThresholdNegative()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy("-PT1S", null, null, null, TWO_LANES)
     );
@@ -384,8 +384,8 @@ public class WeightedQueryLaningStrategyTest
         new WeightedQueryLaningStrategy(null, null, 1, null, TWO_LANES, null, null, 3, null);
     TimeseriesQuery query = queryBuilder.build();
     Optional<String> lane = strategy.computeLane(QueryPlus.wrap(query), makeSegments(5));
-    Assert.assertTrue(lane.isPresent());
-    Assert.assertEquals("very-low", lane.get());
+    Assertions.assertTrue(lane.isPresent());
+    Assertions.assertEquals("very-low", lane.get());
   }
 
   @Test
@@ -394,8 +394,8 @@ public class WeightedQueryLaningStrategyTest
     // Same single segmentCount breach without weights stays "low" (weight defaults to 1).
     WeightedQueryLaningStrategy strategy = new WeightedQueryLaningStrategy(null, null, 1, null, TWO_LANES);
     Optional<String> lane = strategy.computeLane(QueryPlus.wrap(queryBuilder.build()), makeSegments(5));
-    Assert.assertTrue(lane.isPresent());
-    Assert.assertEquals("low", lane.get());
+    Assertions.assertTrue(lane.isPresent());
+    Assertions.assertEquals("low", lane.get());
   }
 
   @Test
@@ -405,8 +405,8 @@ public class WeightedQueryLaningStrategyTest
     WeightedQueryLaningStrategy strategy =
         new WeightedQueryLaningStrategy(null, "PT1S", 1, null, TWO_LANES, null, 2, 2, null);
     Optional<String> lane = strategy.computeLane(QueryPlus.wrap(queryBuilder.build()), makeSegments(5));
-    Assert.assertTrue(lane.isPresent());
-    Assert.assertEquals("very-low", lane.get());
+    Assertions.assertTrue(lane.isPresent());
+    Assertions.assertEquals("very-low", lane.get());
   }
 
   @Test
@@ -427,8 +427,8 @@ public class WeightedQueryLaningStrategyTest
         null
     );
     Optional<String> lane = strategy.computeLane(QueryPlus.wrap(queryBuilder.build()), makeSegments(5));
-    Assert.assertTrue(lane.isPresent());
-    Assert.assertEquals("very-low", lane.get());
+    Assertions.assertTrue(lane.isPresent());
+    Assertions.assertEquals("very-low", lane.get());
   }
 
   @Test
@@ -445,20 +445,20 @@ public class WeightedQueryLaningStrategyTest
                   + "  }\n"
                   + "}";
     QueryLaningStrategy deserialized = mapper.readValue(json, QueryLaningStrategy.class);
-    Assert.assertTrue(deserialized instanceof WeightedQueryLaningStrategy);
+    Assertions.assertTrue(deserialized instanceof WeightedQueryLaningStrategy);
     // weight 3 applied to the single segmentCount breach -> cost 3 -> "very-low"
     Optional<String> lane = deserialized.computeLane(QueryPlus.wrap(queryBuilder.build()), makeSegments(5));
-    Assert.assertEquals("very-low", lane.orElse(null));
+    Assertions.assertEquals("very-low", lane.orElse(null));
   }
 
   @Test
   public void testValidation_weightBelowOne()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy(null, null, 1, null, TWO_LANES, null, null, 0, null)
     );
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy(null, null, 1, null, TWO_LANES, null, null, -1, null)
     );
@@ -468,7 +468,7 @@ public class WeightedQueryLaningStrategyTest
   public void testValidation_weightForUnsetThreshold()
   {
     // periodWeight set but no periodThreshold configured -> reject (weight would be inert).
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new WeightedQueryLaningStrategy(null, null, 1, null, TWO_LANES, 5, null, null, null)
     );

--- a/server/src/test/java/org/apache/druid/server/security/AllowHttpMethodsResourceFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/security/AllowHttpMethodsResourceFilterTest.java
@@ -20,37 +20,34 @@
 package org.apache.druid.server.security;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 
-@RunWith(MockitoJUnitRunner.class)
 public class AllowHttpMethodsResourceFilterTest
 {
   private static final String METHOD_ALLOWED = "METHOD_ALLOWED";
   private static final String METHOD_NOT_ALLOWED = "METHOD_NOT_ALLOWED";
 
-  @Mock
   private HttpServletRequest request;
-  @Mock
   private HttpServletResponse response;
-  @Mock
   private FilterChain filterChain;
 
   private AllowHttpMethodsResourceFilter target;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
+    request = Mockito.mock(HttpServletRequest.class);
+    response = Mockito.mock(HttpServletResponse.class);
+    filterChain = Mockito.mock(FilterChain.class);
     target = new AllowHttpMethodsResourceFilter(ImmutableList.of(METHOD_ALLOWED));
   }
 

--- a/server/src/test/java/org/apache/druid/server/security/AllowHttpMethodsResourceFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/security/AllowHttpMethodsResourceFilterTest.java
@@ -22,7 +22,12 @@ package org.apache.druid.server.security;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -31,13 +36,18 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class AllowHttpMethodsResourceFilterTest
 {
   private static final String METHOD_ALLOWED = "METHOD_ALLOWED";
   private static final String METHOD_NOT_ALLOWED = "METHOD_NOT_ALLOWED";
 
+  @Mock
   private HttpServletRequest request;
+  @Mock
   private HttpServletResponse response;
+  @Mock
   private FilterChain filterChain;
 
   private AllowHttpMethodsResourceFilter target;
@@ -45,9 +55,6 @@ public class AllowHttpMethodsResourceFilterTest
   @BeforeEach
   public void setUp()
   {
-    request = Mockito.mock(HttpServletRequest.class);
-    response = Mockito.mock(HttpServletResponse.class);
-    filterChain = Mockito.mock(FilterChain.class);
     target = new AllowHttpMethodsResourceFilter(ImmutableList.of(METHOD_ALLOWED));
   }
 

--- a/server/src/test/java/org/apache/druid/server/security/AuthConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/security/AuthConfigTest.java
@@ -22,13 +22,10 @@ package org.apache.druid.server.security;
 import com.google.common.collect.ImmutableSet;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.query.QueryContexts;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class AuthConfigTest
 {
@@ -41,14 +38,14 @@ public class AuthConfigTest
   @Test
   public void testEmitAuthMetricsDefaultsFalse()
   {
-    assertFalse(new AuthConfig().isEmitAuthMetrics());
-    assertFalse(AuthConfig.newBuilder().build().isEmitAuthMetrics());
+    Assertions.assertFalse(new AuthConfig().isEmitAuthMetrics());
+    Assertions.assertFalse(AuthConfig.newBuilder().build().isEmitAuthMetrics());
   }
 
   @Test
   public void testEmitAuthMetricsCanBeEnabled()
   {
-    assertTrue(AuthConfig.newBuilder().setEmitAuthMetrics(true).build().isEmitAuthMetrics());
+    Assertions.assertTrue(AuthConfig.newBuilder().setEmitAuthMetrics(true).build().isEmitAuthMetrics());
   }
 
   @Test
@@ -58,7 +55,7 @@ public class AuthConfigTest
     {
       AuthConfig config = new AuthConfig();
       Set<String> keys = ImmutableSet.of("a", "b", QueryContexts.CTX_SQL_QUERY_ID);
-      assertTrue(config.contextKeysToAuthorize(keys).isEmpty());
+      Assertions.assertTrue(config.contextKeysToAuthorize(keys).isEmpty());
     }
 
     // Default security
@@ -67,7 +64,7 @@ public class AuthConfigTest
           .setAuthorizeQueryContextParams(true)
           .build();
       Set<String> keys = ImmutableSet.of("a", "b", QueryContexts.CTX_SQL_QUERY_ID);
-      assertEquals(ImmutableSet.of("a", "b"), config.contextKeysToAuthorize(keys));
+      Assertions.assertEquals(ImmutableSet.of("a", "b"), config.contextKeysToAuthorize(keys));
     }
 
     // Specify unsecured keys (white-list)
@@ -77,7 +74,7 @@ public class AuthConfigTest
           .setUnsecuredContextKeys(ImmutableSet.of("a"))
           .build();
       Set<String> keys = ImmutableSet.of("a", "b", QueryContexts.CTX_SQL_QUERY_ID);
-      assertEquals(ImmutableSet.of("b"), config.contextKeysToAuthorize(keys));
+      Assertions.assertEquals(ImmutableSet.of("b"), config.contextKeysToAuthorize(keys));
     }
 
     // Specify secured keys (black-list)
@@ -87,7 +84,7 @@ public class AuthConfigTest
           .setSecuredContextKeys(ImmutableSet.of("a"))
           .build();
       Set<String> keys = ImmutableSet.of("a", "b", QueryContexts.CTX_SQL_QUERY_ID);
-      assertEquals(ImmutableSet.of("a"), config.contextKeysToAuthorize(keys));
+      Assertions.assertEquals(ImmutableSet.of("a"), config.contextKeysToAuthorize(keys));
     }
 
     // Specify both
@@ -98,7 +95,7 @@ public class AuthConfigTest
           .setSecuredContextKeys(ImmutableSet.of("b", "c"))
           .build();
       Set<String> keys = ImmutableSet.of("a", "b", "c", "d", QueryContexts.CTX_SQL_QUERY_ID);
-      assertEquals(ImmutableSet.of("c"), config.contextKeysToAuthorize(keys));
+      Assertions.assertEquals(ImmutableSet.of("c"), config.contextKeysToAuthorize(keys));
     }
   }
 }

--- a/server/src/test/java/org/apache/druid/server/security/AuthValidatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/security/AuthValidatorTest.java
@@ -20,19 +20,15 @@
 package org.apache.druid.server.security;
 
 import org.apache.druid.error.DruidExceptionMatcher;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class AuthValidatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   public AuthValidator target;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     target = new AuthValidator();

--- a/server/src/test/java/org/apache/druid/server/security/AuthorizationUtilsTest.java
+++ b/server/src/test/java/org/apache/druid/server/security/AuthorizationUtilsTest.java
@@ -28,10 +28,11 @@ import org.apache.druid.query.policy.NoRestrictionPolicy;
 import org.apache.druid.query.policy.RowFilterPolicy;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.server.mocks.MockHttpServletRequest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -89,11 +90,11 @@ public class AuthorizationUtilsTest
     Iterator<String> itr = filteredResults.iterator();
     // Validate that resource "filteredResource" is not present because null was returned for it.
     // Also validate that calling the filterAuthorizedResources method doesn't get rid of duplicate resources
-    Assert.assertTrue(itr.hasNext());
-    Assert.assertEquals("duplicate", itr.next());
-    Assert.assertEquals("duplicate", itr.next());
-    Assert.assertEquals("hello", itr.next());
-    Assert.assertFalse(itr.hasNext());
+    Assertions.assertTrue(itr.hasNext());
+    Assertions.assertEquals("duplicate", itr.next());
+    Assertions.assertEquals("duplicate", itr.next());
+    Assertions.assertEquals("hello", itr.next());
+    Assertions.assertFalse(itr.hasNext());
   }
 
   @Test
@@ -105,7 +106,7 @@ public class AuthorizationUtilsTest
     // every type and action should have a wildcard pattern
     for (String type : ResourceType.knownTypes()) {
       for (Action action : Action.values()) {
-        Assert.assertTrue(
+        Assertions.assertTrue(
             permissions.stream()
                        .filter(ra -> Objects.equals(type, ra.getResource().getType()))
                        .anyMatch(ra -> action == ra.getAction() && ".*".equals(ra.getResource().getName()))
@@ -114,7 +115,7 @@ public class AuthorizationUtilsTest
     }
     // custom type should be there too
     for (Action action : Action.values()) {
-      Assert.assertTrue(
+      Assertions.assertTrue(
           permissions.stream()
                      .filter(ra -> Objects.equals(customType, ra.getResource().getType()))
                      .anyMatch(ra -> action == ra.getAction() && ".*".equals(ra.getResource().getName()))
@@ -127,47 +128,47 @@ public class AuthorizationUtilsTest
   {
     MockHttpServletRequest request = new MockHttpServletRequest();
     AuthorizationUtils.setRequestAuthorizationAttributeIfNeeded(request);
-    Assert.assertEquals(true, request.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED));
+    Assertions.assertEquals(true, request.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED));
   }
 
   @Test
   public void testShouldApplyPolicy_readDatasource()
   {
     final Resource datasourceResource = new Resource("test", ResourceType.DATASOURCE);
-    Assert.assertTrue(AuthorizationUtils.shouldApplyPolicy(datasourceResource, Action.READ));
+    Assertions.assertTrue(AuthorizationUtils.shouldApplyPolicy(datasourceResource, Action.READ));
   }
 
   @Test
   public void testShouldApplyPolicy_writeDatasource()
   {
     final Resource datasourceResource = new Resource("test", ResourceType.DATASOURCE);
-    Assert.assertFalse(AuthorizationUtils.shouldApplyPolicy(datasourceResource, Action.WRITE));
+    Assertions.assertFalse(AuthorizationUtils.shouldApplyPolicy(datasourceResource, Action.WRITE));
   }
 
   @Test
   public void testShouldApplyPolicy_readState()
   {
-    Assert.assertFalse(AuthorizationUtils.shouldApplyPolicy(Resource.STATE_RESOURCE, Action.READ));
+    Assertions.assertFalse(AuthorizationUtils.shouldApplyPolicy(Resource.STATE_RESOURCE, Action.READ));
   }
 
   @Test
   public void testShouldApplyPolicy_writeState()
   {
-    Assert.assertFalse(AuthorizationUtils.shouldApplyPolicy(Resource.STATE_RESOURCE, Action.WRITE));
+    Assertions.assertFalse(AuthorizationUtils.shouldApplyPolicy(Resource.STATE_RESOURCE, Action.WRITE));
   }
 
   @Test
   public void testShouldApplyPolicy_readExternal()
   {
     final Resource externalResource = new Resource("test", ResourceType.EXTERNAL);
-    Assert.assertFalse(AuthorizationUtils.shouldApplyPolicy(externalResource, Action.READ));
+    Assertions.assertFalse(AuthorizationUtils.shouldApplyPolicy(externalResource, Action.READ));
   }
 
   @Test
   public void testShouldApplyPolicy_writeExternal()
   {
     final Resource externalResource = new Resource("test", ResourceType.EXTERNAL);
-    Assert.assertFalse(AuthorizationUtils.shouldApplyPolicy(externalResource, Action.WRITE));
+    Assertions.assertFalse(AuthorizationUtils.shouldApplyPolicy(externalResource, Action.WRITE));
   }
 
   @Test
@@ -208,9 +209,9 @@ public class AuthorizationUtilsTest
         mapper
     );
 
-    Assert.assertTrue(result.allowBasicAccess());
+    Assertions.assertTrue(result.allowBasicAccess());
     // Verify that the policy was captured for the READ action
-    Assert.assertEquals(Map.of("test", Optional.of(policy)), result.getPolicyMap());
+    Assertions.assertEquals(Map.of("test", Optional.of(policy)), result.getPolicyMap());
   }
 
   @Test
@@ -242,16 +243,16 @@ public class AuthorizationUtilsTest
         mapper
     );
 
-    Assert.assertFalse(result.allowBasicAccess());
+    Assertions.assertFalse(result.allowBasicAccess());
 
     final List<ServiceMetricEvent> events = emitter.getMetricEvents("auth/forbidden");
-    Assert.assertEquals(1, events.size());
+    Assertions.assertEquals(1, events.size());
     final Map<String, Object> dims = events.get(0).getUserDims();
-    Assert.assertEquals("someUser", dims.get("identity"));
-    Assert.assertEquals(authorizerName, dims.get("authorizerName"));
-    Assert.assertEquals("myDatasource", dims.get("resourceName"));
-    Assert.assertEquals(ResourceType.DATASOURCE, dims.get("resourceType"));
-    Assert.assertEquals(Action.READ.toString(), dims.get("action"));
+    Assertions.assertEquals("someUser", dims.get("identity"));
+    Assertions.assertEquals(authorizerName, dims.get("authorizerName"));
+    Assertions.assertEquals("myDatasource", dims.get("resourceName"));
+    Assertions.assertEquals(ResourceType.DATASOURCE, dims.get("resourceType"));
+    Assertions.assertEquals(Action.READ.toString(), dims.get("action"));
   }
 
   @Test
@@ -280,8 +281,8 @@ public class AuthorizationUtilsTest
         mapper
     );
 
-    Assert.assertTrue(result.allowBasicAccess());
-    Assert.assertEquals(0, emitter.getMetricEventCount("auth/forbidden"));
+    Assertions.assertTrue(result.allowBasicAccess());
+    Assertions.assertEquals(0, emitter.getMetricEventCount("auth/forbidden"));
   }
 
   @Test
@@ -310,8 +311,8 @@ public class AuthorizationUtilsTest
         mapper
     );
 
-    Assert.assertFalse(result.allowBasicAccess());
-    Assert.assertNull(mapper.getServiceEmitter());
+    Assertions.assertFalse(result.allowBasicAccess());
+    Assertions.assertNull(mapper.getServiceEmitter());
   }
 
   @Test
@@ -328,7 +329,7 @@ public class AuthorizationUtilsTest
     final ResourceAction resourceAction =
         new ResourceAction(new Resource("myDatasource", ResourceType.DATASOURCE), Action.WRITE);
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> AuthorizationUtils.authorizeAllResourceActions(
             authResult,
@@ -337,13 +338,13 @@ public class AuthorizationUtilsTest
         )
     );
 
-    Assert.assertEquals(1, emitter.getMetricEventCount("auth/exception"));
-    Assert.assertEquals(0, emitter.getMetricEventCount("auth/forbidden"));
+    Assertions.assertEquals(1, emitter.getMetricEventCount("auth/exception"));
+    Assertions.assertEquals(0, emitter.getMetricEventCount("auth/forbidden"));
     final Map<String, Object> dims = emitter.getMetricEvents("auth/exception").get(0).getUserDims();
-    Assert.assertEquals("someUser", dims.get("identity"));
-    Assert.assertEquals(authorizerName, dims.get("authorizerName"));
-    Assert.assertEquals("myDatasource", dims.get("resourceName"));
-    Assert.assertEquals(Action.WRITE.toString(), dims.get("action"));
+    Assertions.assertEquals("someUser", dims.get("identity"));
+    Assertions.assertEquals(authorizerName, dims.get("authorizerName"));
+    Assertions.assertEquals("myDatasource", dims.get("resourceName"));
+    Assertions.assertEquals(Action.WRITE.toString(), dims.get("action"));
   }
 
   @Test
@@ -360,7 +361,7 @@ public class AuthorizationUtilsTest
     final ResourceAction resourceAction =
         new ResourceAction(new Resource("myDatasource", ResourceType.DATASOURCE), Action.WRITE);
 
-    final DruidException e = Assert.assertThrows(
+    final DruidException e = Assertions.assertThrows(
         DruidException.class,
         () -> AuthorizationUtils.authorizeAllResourceActions(
             authResult,
@@ -370,14 +371,14 @@ public class AuthorizationUtilsTest
     );
 
     final List<ServiceMetricEvent> events = emitter.getMetricEvents("auth/exception");
-    Assert.assertEquals(1, events.size());
-    Assert.assertEquals(0, emitter.getMetricEventCount("auth/forbidden"));
+    Assertions.assertEquals(1, events.size());
+    Assertions.assertEquals(0, emitter.getMetricEventCount("auth/forbidden"));
     final Map<String, Object> dims = events.get(0).getUserDims();
-    Assert.assertEquals("someUser", dims.get("identity"));
-    Assert.assertEquals(authorizerName, dims.get("authorizerName"));
-    Assert.assertEquals("myDatasource", dims.get("resourceName"));
-    Assert.assertEquals(Action.WRITE.toString(), dims.get("action"));
-    Assert.assertEquals(e.getMessage(), dims.get("errorMessage"));
+    Assertions.assertEquals("someUser", dims.get("identity"));
+    Assertions.assertEquals(authorizerName, dims.get("authorizerName"));
+    Assertions.assertEquals("myDatasource", dims.get("resourceName"));
+    Assertions.assertEquals(Action.WRITE.toString(), dims.get("action"));
+    Assertions.assertEquals(e.getMessage(), dims.get("errorMessage"));
   }
 
   @Test
@@ -404,22 +405,22 @@ public class AuthorizationUtilsTest
     request.method = "GET";
     request.attributes.put(AuthConfig.DRUID_AUTHENTICATION_RESULT, authenticationResult);
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         ForbiddenException.class,
         () -> AuthorizationUtils.verifyUnrestrictedAccessToDatasource(request, "myDatasource", mapper)
     );
 
     // The policy deny path in verifyUnrestrictedAccessToDatasource should emit auth/forbidden.
     // auth/forbidden is NOT emitted by authorizeAllResourceActions here because basic access was allowed.
-    Assert.assertEquals(1, emitter.getMetricEventCount("auth/forbidden"));
-    Assert.assertEquals(0, emitter.getMetricEventCount("auth/exception"));
+    Assertions.assertEquals(1, emitter.getMetricEventCount("auth/forbidden"));
+    Assertions.assertEquals(0, emitter.getMetricEventCount("auth/exception"));
 
     final Map<String, Object> dims = emitter.getMetricEvents("auth/forbidden").get(0).getUserDims();
-    Assert.assertEquals("someUser", dims.get("identity"));
-    Assert.assertEquals(authorizerName, dims.get("authorizerName"));
-    Assert.assertEquals("myDatasource", dims.get("resourceName"));
-    Assert.assertEquals(ResourceType.DATASOURCE, dims.get("resourceType"));
-    Assert.assertEquals(Action.READ.toString(), dims.get("action"));
+    Assertions.assertEquals("someUser", dims.get("identity"));
+    Assertions.assertEquals(authorizerName, dims.get("authorizerName"));
+    Assertions.assertEquals("myDatasource", dims.get("resourceName"));
+    Assertions.assertEquals(ResourceType.DATASOURCE, dims.get("resourceType"));
+    Assertions.assertEquals(Action.READ.toString(), dims.get("action"));
   }
 
   @Test
@@ -448,10 +449,10 @@ public class AuthorizationUtilsTest
         new ResourceAction(new Resource("test", ResourceType.DATASOURCE), Action.WRITE)
     );
 
-    final DruidException exception = Assert.assertThrows(
+    final DruidException exception = Assertions.assertThrows(
         DruidException.class,
         () -> AuthorizationUtils.authorizeAllResourceActions(authenticationResult, resourceActions, mapper)
     );
-    Assert.assertTrue(exception.getMessage().contains("Policy should only present when reading a table"));
+    Assertions.assertTrue(exception.getMessage().contains("Policy should only present when reading a table"));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/security/EscalatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/security/EscalatorTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.server.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class EscalatorTest
 {
@@ -30,7 +30,7 @@ public class EscalatorTest
   public void testSerde() throws Exception
   {
     final ObjectMapper objectMapper = TestHelper.makeJsonMapper();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         NoopEscalator.getInstance(),
         objectMapper.readValue(
             objectMapper.writeValueAsString(NoopEscalator.getInstance()),

--- a/server/src/test/java/org/apache/druid/server/security/ForbiddenExceptionTest.java
+++ b/server/src/test/java/org/apache/druid/server/security/ForbiddenExceptionTest.java
@@ -20,24 +20,26 @@
 package org.apache.druid.server.security;
 
 import org.apache.druid.query.policy.NoRestrictionPolicy;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.function.Function;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ForbiddenExceptionTest
 {
   private static final String ERROR_MESSAGE_ORIGINAL = "aaaa";
   private static final String ERROR_MESSAGE_TRANSFORMED = "bbbb";
 
-  @Mock
   private Function<String, String> trasformFunction;
+
+  @BeforeEach
+  public void setUp()
+  {
+    trasformFunction = Mockito.mock(Function.class);
+  }
 
   @Test
   public void testSanitizeWithTransformFunctionReturningNull()
@@ -45,8 +47,8 @@ public class ForbiddenExceptionTest
     Mockito.when(trasformFunction.apply(ArgumentMatchers.eq(ERROR_MESSAGE_ORIGINAL))).thenReturn(null);
     ForbiddenException forbiddenException = new ForbiddenException(ERROR_MESSAGE_ORIGINAL);
     ForbiddenException actual = forbiddenException.sanitize(trasformFunction);
-    Assert.assertNotNull(actual);
-    Assert.assertEquals(actual.getMessage(), Access.DEFAULT_ERROR_MESSAGE);
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals(actual.getMessage(), Access.DEFAULT_ERROR_MESSAGE);
     Mockito.verify(trasformFunction).apply(ArgumentMatchers.eq(ERROR_MESSAGE_ORIGINAL));
     Mockito.verifyNoMoreInteractions(trasformFunction);
   }
@@ -58,8 +60,8 @@ public class ForbiddenExceptionTest
            .thenReturn(ERROR_MESSAGE_TRANSFORMED);
     ForbiddenException forbiddenException = new ForbiddenException(ERROR_MESSAGE_ORIGINAL);
     ForbiddenException actual = forbiddenException.sanitize(trasformFunction);
-    Assert.assertNotNull(actual);
-    Assert.assertEquals(actual.getMessage(), ERROR_MESSAGE_TRANSFORMED);
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals(actual.getMessage(), ERROR_MESSAGE_TRANSFORMED);
     Mockito.verify(trasformFunction).apply(ArgumentMatchers.eq(ERROR_MESSAGE_ORIGINAL));
     Mockito.verifyNoMoreInteractions(trasformFunction);
   }
@@ -69,23 +71,23 @@ public class ForbiddenExceptionTest
   public void testAccess()
   {
     Access access = Access.deny(null);
-    Assert.assertFalse(access.isAllowed());
-    Assert.assertEquals("Allowed:false, Message:, Policy: null", access.toString());
-    Assert.assertEquals(Access.DEFAULT_ERROR_MESSAGE, access.getMessage());
+    Assertions.assertFalse(access.isAllowed());
+    Assertions.assertEquals("Allowed:false, Message:, Policy: null", access.toString());
+    Assertions.assertEquals(Access.DEFAULT_ERROR_MESSAGE, access.getMessage());
 
     access = Access.deny("oops");
-    Assert.assertFalse(access.isAllowed());
-    Assert.assertEquals("Allowed:false, Message:oops, Policy: null", access.toString());
-    Assert.assertEquals("Unauthorized, oops", access.getMessage());
+    Assertions.assertFalse(access.isAllowed());
+    Assertions.assertEquals("Allowed:false, Message:oops, Policy: null", access.toString());
+    Assertions.assertEquals("Unauthorized, oops", access.getMessage());
 
     access = Access.allow();
-    Assert.assertTrue(access.isAllowed());
-    Assert.assertEquals("Allowed:true, Message:, Policy: Optional.empty", access.toString());
-    Assert.assertEquals("Authorized", access.getMessage());
+    Assertions.assertTrue(access.isAllowed());
+    Assertions.assertEquals("Allowed:true, Message:, Policy: Optional.empty", access.toString());
+    Assertions.assertEquals("Authorized", access.getMessage());
 
     access = Access.allowWithRestriction(NoRestrictionPolicy.instance());
-    Assert.assertTrue(access.isAllowed());
-    Assert.assertEquals("Allowed:true, Message:, Policy: Optional[NO_RESTRICTION]", access.toString());
-    Assert.assertEquals("Authorized, with restriction [NO_RESTRICTION]", access.getMessage());
+    Assertions.assertTrue(access.isAllowed());
+    Assertions.assertEquals("Allowed:true, Message:, Policy: Optional[NO_RESTRICTION]", access.toString());
+    Assertions.assertEquals("Authorized, with restriction [NO_RESTRICTION]", access.getMessage());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/security/ForbiddenExceptionTest.java
+++ b/server/src/test/java/org/apache/druid/server/security/ForbiddenExceptionTest.java
@@ -21,25 +21,26 @@ package org.apache.druid.server.security;
 
 import org.apache.druid.query.policy.NoRestrictionPolicy;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.util.function.Function;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class ForbiddenExceptionTest
 {
   private static final String ERROR_MESSAGE_ORIGINAL = "aaaa";
   private static final String ERROR_MESSAGE_TRANSFORMED = "bbbb";
 
+  @Mock
   private Function<String, String> trasformFunction;
-
-  @BeforeEach
-  public void setUp()
-  {
-    trasformFunction = Mockito.mock(Function.class);
-  }
 
   @Test
   public void testSanitizeWithTransformFunctionReturningNull()

--- a/server/src/test/java/org/apache/druid/server/security/TrustedDomainAuthenticatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/security/TrustedDomainAuthenticatorTest.java
@@ -20,13 +20,14 @@
 package org.apache.druid.server.security;
 
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 
 public class TrustedDomainAuthenticatorTest


### PR DESCRIPTION
## Summary

- Migrate 49 owned server tests under audit, broker, coordination, log, metrics, scheduling, and security to JUnit 5.
- Preserve parameterized invalid-input coverage, test lifecycles, timeouts, and execution counts.
- Use the shared Jupiter Derby connector and Druid temporary-folder extension; leave POMs, shared helpers, coordinator, and HTTP/initialization scopes unchanged.

## Validation

- `mvn -ntp -pl server -am -DskipTests -Dweb.console.skip=true -T1C -Pskip-static-checks test-compile` — PASS
- `mvn -ntp -pl server -am -Dtest="org.apache.druid.server.audit.**,org.apache.druid.server.broker.**,org.apache.druid.server.coordination.**,org.apache.druid.server.log.**,org.apache.druid.server.metrics.**,org.apache.druid.server.scheduling.**,org.apache.druid.server.security.**" -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks -Dweb.console.skip=true -T1C test` — PASS (298 tests, 0 failures, 0 errors, 2 skipped)
- `mvn -ntp -pl server -am -DskipTests -Dweb.console.skip=true -T1C checkstyle:check` — PASS (0 violations)
- `mvn -ntp -pl server -am -DskipTests -Dweb.console.skip=true -T1C spotbugs:check` — PASS (0 bug instances, 0 errors; analyzer emitted an existing missing MarkerManager class warning while processing)
- `git diff --check offical/master` — PASS
- No static imports added.

Part of #13948