### PR TITLE
test(server): migrate coordinator tests to JUnit 5

### DIFF
--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientPerfTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientPerfTest.java
@@ -62,6 +62,7 @@ import org.joda.time.Interval;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -82,7 +83,7 @@ public class CachingClusteredClientPerfTest
 {
 
   @Test
-  @Timeout(value = 10_000, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 10_000, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testGetQueryRunnerForSegments_singleIntervalLargeSegments()
   {
     final int segmentCount = 30_000;

--- a/server/src/test/java/org/apache/druid/client/HttpServerInventoryViewTest.java
+++ b/server/src/test/java/org/apache/druid/client/HttpServerInventoryViewTest.java
@@ -58,6 +58,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -233,7 +234,7 @@ public class HttpServerInventoryViewTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testSyncSegmentLoadAndDrop()
   {
     httpServerInventoryView.start();
@@ -406,7 +407,7 @@ public class HttpServerInventoryViewTest
   }
 
   @Test
-  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testInitWaitsForServerToSync()
   {
     httpServerInventoryView.start();
@@ -442,7 +443,7 @@ public class HttpServerInventoryViewTest
   }
 
   @Test
-  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testInitDoesNotWaitForRemovedServerToSync()
   {
     httpServerInventoryView.start();

--- a/server/src/test/java/org/apache/druid/client/cache/CachePopulatorTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/CachePopulatorTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -85,7 +86,7 @@ public class CachePopulatorTest
   }
 
   @Test
-  @Timeout(value = 60000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testBackgroundPopulator() throws InterruptedException
   {
     final CachePopulator populator = new BackgroundCachePopulator(exec, objectMapper, stats, -1);
@@ -105,7 +106,7 @@ public class CachePopulatorTest
   }
 
   @Test
-  @Timeout(value = 60000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testBackgroundPopulatorMaxEntrySize() throws InterruptedException
   {
     final CachePopulator populator = new BackgroundCachePopulator(exec, objectMapper, stats, 30);

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
@@ -510,7 +511,7 @@ public class LookupReferencesManagerTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testRealModeWithMainThread() throws Exception
   {
     LookupReferencesManager lookupReferencesManager = new LookupReferencesManager(

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -108,6 +108,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -1234,7 +1235,7 @@ public class QueryResourceTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testSecuredCancelQuery() throws Exception
   {
     final CountDownLatch waitForCancellationLatch = new CountDownLatch(1);
@@ -1349,7 +1350,7 @@ public class QueryResourceTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testDenySecuredCancelQuery() throws Exception
   {
     final CountDownLatch waitForCancellationLatch = new CountDownLatch(1);
@@ -1457,7 +1458,7 @@ public class QueryResourceTest
   }
 
   @Test
-  @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testTooManyQuery() throws InterruptedException, ExecutionException
   {
     expectPermissiveHappyPathAuth();
@@ -1535,7 +1536,7 @@ public class QueryResourceTest
   }
 
   @Test
-  @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testTooManyQueryInLane() throws InterruptedException, ExecutionException
   {
     expectPermissiveHappyPathAuth();
@@ -1616,7 +1617,7 @@ public class QueryResourceTest
   }
 
   @Test
-  @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testTooManyQueryInLaneImplicitFromDurationThreshold() throws InterruptedException, ExecutionException
   {
     expectPermissiveHappyPathAuth();

--- a/server/src/test/java/org/apache/druid/server/compaction/CompactionRunSimulatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/CompactionRunSimulatorTest.java
@@ -39,8 +39,8 @@ import org.apache.druid.server.coordinator.InlineSchemaDataSourceCompactionConfi
 import org.apache.druid.server.coordinator.simulate.TestSegmentsMetadataManager;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -78,20 +78,20 @@ public class CompactionRunSimulatorTest
         CompactionEngine.NATIVE
     );
 
-    Assert.assertNotNull(simulateResult);
+    Assertions.assertNotNull(simulateResult);
 
     final Map<CompactionStatus.State, Table> compactionStates = simulateResult.getCompactionStates();
-    Assert.assertNotNull(compactionStates);
+    Assertions.assertNotNull(compactionStates);
 
-    Assert.assertNull(compactionStates.get(CompactionStatus.State.COMPLETE));
-    Assert.assertNull(compactionStates.get(CompactionStatus.State.RUNNING));
+    Assertions.assertNull(compactionStates.get(CompactionStatus.State.COMPLETE));
+    Assertions.assertNull(compactionStates.get(CompactionStatus.State.RUNNING));
 
     final Table queuedTable = compactionStates.get(CompactionStatus.State.PENDING);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList("dataSource", "interval", "numSegments", "bytes", "maxTaskSlots", "reasonToCompact"),
         queuedTable.getColumnNames()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(
             Arrays.asList("wiki", Intervals.of("2013-01-09/P1D"), 10, 1_000_000_000L, 1, "not compacted yet"),
             Arrays.asList("wiki", Intervals.of("2013-01-08/P1D"), 10, 1_000_000_000L, 1, "not compacted yet"),
@@ -107,11 +107,11 @@ public class CompactionRunSimulatorTest
     );
 
     final Table skippedTable = compactionStates.get(CompactionStatus.State.SKIPPED);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList("dataSource", "interval", "numSegments", "bytes", "reasonToSkip"),
         skippedTable.getColumnNames()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singletonList(
             List.of("wiki", Intervals.of("2013-01-10/P1D"), 10, 1_000_000_000L, 1, "skip offset from latest[P1D]")
         ),
@@ -151,20 +151,20 @@ public class CompactionRunSimulatorTest
         CompactionEngine.NATIVE
     );
 
-    Assert.assertNotNull(simulateResult);
+    Assertions.assertNotNull(simulateResult);
 
     final Map<CompactionStatus.State, Table> compactionStates = simulateResult.getCompactionStates();
-    Assert.assertNotNull(compactionStates);
+    Assertions.assertNotNull(compactionStates);
 
-    Assert.assertNull(compactionStates.get(CompactionStatus.State.COMPLETE));
-    Assert.assertNull(compactionStates.get(CompactionStatus.State.RUNNING));
+    Assertions.assertNull(compactionStates.get(CompactionStatus.State.COMPLETE));
+    Assertions.assertNull(compactionStates.get(CompactionStatus.State.RUNNING));
 
     final Table pendingTable = compactionStates.get(CompactionStatus.State.PENDING);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of("dataSource", "interval", "numSegments", "bytes", "maxTaskSlots", "reasonToCompact"),
         pendingTable.getColumnNames()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(
             List.of("wiki", Intervals.of("2013-01-08/P1D"), 10, 1_000_000_000L, 1, "not compacted yet"),
             List.of("wiki", Intervals.of("2013-01-04/P1D"), 10, 1_000_000_000L, 1, "not compacted yet")
@@ -173,13 +173,13 @@ public class CompactionRunSimulatorTest
     );
 
     final Table skippedTable = compactionStates.get(CompactionStatus.State.SKIPPED);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of("dataSource", "interval", "numSegments", "bytes", "reasonToSkip"),
         skippedTable.getColumnNames()
     );
     final String rejectedMessage
         = "Rejected by search policy: Datasource/Interval is not in the list of 'eligibleCandidates'";
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(
             List.of("wiki", Intervals.of("2013-01-02/P1D"), 10, 1_000_000_000L, 1, rejectedMessage),
             List.of("wiki", Intervals.of("2013-01-03/P1D"), 10, 1_000_000_000L, 1, rejectedMessage),

--- a/server/src/test/java/org/apache/druid/server/compaction/CompactionStatusTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/CompactionStatusTest.java
@@ -61,9 +61,9 @@ import org.apache.druid.server.coordinator.UserCompactionTaskQueryTuningConfig;
 import org.apache.druid.timeline.CompactionState;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -83,7 +83,7 @@ public class CompactionStatusTest
   private IndexingStateCache indexingStateCache;
   private IndexingStateFingerprintMapper fingerprintMapper;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     indexingStateStorage = new HeapMemoryIndexingStateStorage();
@@ -107,7 +107,7 @@ public class CompactionStatusTest
   {
     final ClientCompactionTaskQueryTuningConfig tuningConfig
         = ClientCompactionTaskQueryTuningConfig.from(null);
-    Assert.assertNull(
+    Assertions.assertNull(
         CompactionStatus.findPartitionsSpecFromConfig(tuningConfig)
     );
   }
@@ -118,7 +118,7 @@ public class CompactionStatusTest
     final PartitionsSpec partitionsSpec = new DynamicPartitionsSpec(null, null);
     final ClientCompactionTaskQueryTuningConfig tuningConfig
         = ClientCompactionTaskQueryTuningConfig.from(createCompactionConfig(partitionsSpec));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new DynamicPartitionsSpec(null, Long.MAX_VALUE),
         CompactionStatus.findPartitionsSpecFromConfig(tuningConfig)
     );
@@ -130,7 +130,7 @@ public class CompactionStatusTest
     final PartitionsSpec partitionsSpec = new DynamicPartitionsSpec(null, 1000L);
     final ClientCompactionTaskQueryTuningConfig tuningConfig
         = ClientCompactionTaskQueryTuningConfig.from(createCompactionConfig(partitionsSpec));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         partitionsSpec,
         CompactionStatus.findPartitionsSpecFromConfig(tuningConfig)
     );
@@ -142,7 +142,7 @@ public class CompactionStatusTest
     final PartitionsSpec partitionsSpec = new DynamicPartitionsSpec(100, 1000L);
     final ClientCompactionTaskQueryTuningConfig tuningConfig
         = ClientCompactionTaskQueryTuningConfig.from(createCompactionConfig(partitionsSpec));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         partitionsSpec,
         CompactionStatus.findPartitionsSpecFromConfig(tuningConfig)
     );
@@ -179,7 +179,7 @@ public class CompactionStatusTest
                                                   )
                                               )
                                               .build();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new DynamicPartitionsSpec(100, 1000L),
         CompactionStatus.findPartitionsSpecFromConfig(
             ClientCompactionTaskQueryTuningConfig.from(config)
@@ -194,7 +194,7 @@ public class CompactionStatusTest
         new HashedPartitionsSpec(null, 100, Collections.singletonList("dim"));
     final ClientCompactionTaskQueryTuningConfig tuningConfig
         = ClientCompactionTaskQueryTuningConfig.from(createCompactionConfig(partitionsSpec));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         partitionsSpec,
         CompactionStatus.findPartitionsSpecFromConfig(tuningConfig)
     );
@@ -207,7 +207,7 @@ public class CompactionStatusTest
         new DimensionRangePartitionsSpec(null, 10000, Collections.singletonList("dim"), false);
     final ClientCompactionTaskQueryTuningConfig tuningConfig
         = ClientCompactionTaskQueryTuningConfig.from(createCompactionConfig(partitionsSpec));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         partitionsSpec,
         CompactionStatus.findPartitionsSpecFromConfig(tuningConfig)
     );
@@ -220,7 +220,7 @@ public class CompactionStatusTest
         new DimensionRangePartitionsSpec(10000, null, Collections.singletonList("dim"), false);
     final ClientCompactionTaskQueryTuningConfig tuningConfig
         = ClientCompactionTaskQueryTuningConfig.from(createCompactionConfig(partitionsSpec));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new DimensionRangePartitionsSpec(null, 15000, Collections.singletonList("dim"), false),
         CompactionStatus.findPartitionsSpecFromConfig(tuningConfig)
     );
@@ -361,7 +361,7 @@ public class CompactionStatusTest
         compactionConfig,
         fingerprintMapper
     );
-    Assert.assertTrue(status.isComplete());
+    Assertions.assertTrue(status.isComplete());
   }
 
   @Test
@@ -408,7 +408,7 @@ public class CompactionStatusTest
         compactionConfig,
         fingerprintMapper
     );
-    Assert.assertTrue(status.isComplete());
+    Assertions.assertTrue(status.isComplete());
   }
 
   @Test
@@ -448,7 +448,7 @@ public class CompactionStatusTest
         compactionConfig,
         fingerprintMapper
     );
-    Assert.assertTrue(status.isComplete());
+    Assertions.assertTrue(status.isComplete());
   }
 
   @Test
@@ -500,7 +500,7 @@ public class CompactionStatusTest
         compactionConfig,
         fingerprintMapper
     );
-    Assert.assertFalse(status.isComplete());
+    Assertions.assertFalse(status.isComplete());
   }
 
   @Test
@@ -527,7 +527,7 @@ public class CompactionStatusTest
     CompactionStatus status = CompactionStatus.compute(
         List.of(segment), compactionConfig, fingerprintMapper
     );
-    Assert.assertTrue(status.isComplete());
+    Assertions.assertTrue(status.isComplete());
   }
 
   @Test
@@ -560,8 +560,8 @@ public class CompactionStatusTest
     CompactionStatus status = CompactionStatus.compute(
         List.of(segment), compactionConfig, fingerprintMapper
     );
-    Assert.assertFalse(status.isComplete());
-    Assert.assertTrue(status.getReason().startsWith("'transformSpec' mismatch"));
+    Assertions.assertFalse(status.isComplete());
+    Assertions.assertTrue(status.getReason().startsWith("'transformSpec' mismatch"));
   }
 
   @Test
@@ -593,8 +593,8 @@ public class CompactionStatusTest
         DataSegment.builder(WIKI_SEGMENT).indexingStateFingerprint(oldFingerprint).build()
     );
     CompactionStatus status = CompactionStatus.compute(segments, newConfig, fingerprintMapper);
-    Assert.assertFalse(status.isComplete());
-    Assert.assertTrue(status.getReason().startsWith("'transformSpec' mismatch"));
+    Assertions.assertFalse(status.isComplete());
+    Assertions.assertTrue(status.getReason().startsWith("'transformSpec' mismatch"));
   }
 
   @Test
@@ -650,7 +650,7 @@ public class CompactionStatusTest
         compactionConfig,
         fingerprintMapper
     );
-    Assert.assertTrue(status.isComplete());
+    Assertions.assertTrue(status.isComplete());
   }
 
   @Test
@@ -705,7 +705,7 @@ public class CompactionStatusTest
         compactionConfig,
         fingerprintMapper
     );
-    Assert.assertFalse(status.isComplete());
+    Assertions.assertFalse(status.isComplete());
   }
 
   @Test
@@ -796,7 +796,7 @@ public class CompactionStatusTest
         compactionConfig,
         fingerprintMapper
     );
-    Assert.assertTrue(status.isComplete());
+    Assertions.assertTrue(status.isComplete());
   }
 
   @Test
@@ -841,7 +841,7 @@ public class CompactionStatusTest
         compactionConfig,
         fingerprintMapper
     );
-    Assert.assertTrue(status.isComplete());
+    Assertions.assertTrue(status.isComplete());
   }
 
   @Test
@@ -895,7 +895,7 @@ public class CompactionStatusTest
         compactionConfig,
         fingerprintMapper
     );
-    Assert.assertTrue(status.isComplete());
+    Assertions.assertTrue(status.isComplete());
   }
 
   // ============================
@@ -926,11 +926,11 @@ public class CompactionStatusTest
         fingerprintMapper
     );
 
-    Assert.assertFalse(status.isComplete());
-    Assert.assertTrue(status.isSkipped());
-    Assert.assertTrue(status.getReason().contains("'inputSegmentSize' exceeded"));
-    Assert.assertTrue(status.getReason().contains("200000000"));
-    Assert.assertTrue(status.getReason().contains("150000000"));
+    Assertions.assertFalse(status.isComplete());
+    Assertions.assertTrue(status.isSkipped());
+    Assertions.assertTrue(status.getReason().contains("'inputSegmentSize' exceeded"));
+    Assertions.assertTrue(status.getReason().contains("200000000"));
+    Assertions.assertTrue(status.getReason().contains("150000000"));
   }
 
   /**
@@ -949,8 +949,8 @@ public class CompactionStatusTest
         fingerprintMapper
     );
 
-    Assert.assertFalse(status.isComplete());
-    Assert.assertEquals(expectedReason, status.getReason());
+    Assertions.assertFalse(status.isComplete());
+    Assertions.assertEquals(expectedReason, status.getReason());
   }
 
   private void verifyCompactionStatusIsPendingBecause(
@@ -969,8 +969,8 @@ public class CompactionStatusTest
         fingerprintMapper
     );
 
-    Assert.assertFalse(status.isComplete());
-    Assert.assertEquals(expectedReason, status.getReason());
+    Assertions.assertFalse(status.isComplete());
+    Assertions.assertEquals(expectedReason, status.getReason());
   }
 
   private static DataSourceCompactionConfig createCompactionConfig(

--- a/server/src/test/java/org/apache/druid/server/compaction/CompactionStatusTrackerTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/CompactionStatusTrackerTest.java
@@ -25,9 +25,9 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.segment.TestDataSource;
 import org.apache.druid.server.coordinator.CreateDataSegments;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -38,7 +38,7 @@ public class CompactionStatusTrackerTest
 
   private CompactionStatusTracker statusTracker;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     statusTracker = new CompactionStatusTracker();
@@ -52,7 +52,7 @@ public class CompactionStatusTrackerTest
     statusTracker.onTaskSubmitted("task1", candidateSegments);
 
     CompactionTaskStatus status = statusTracker.getLatestTaskStatus(candidateSegments);
-    Assert.assertEquals(TaskState.RUNNING, status.getState());
+    Assertions.assertEquals(TaskState.RUNNING, status.getState());
   }
 
   @Test
@@ -64,7 +64,7 @@ public class CompactionStatusTrackerTest
     statusTracker.onTaskFinished("task1", TaskStatus.success("task1"));
 
     CompactionTaskStatus status = statusTracker.getLatestTaskStatus(candidateSegments);
-    Assert.assertEquals(TaskState.SUCCESS, status.getState());
+    Assertions.assertEquals(TaskState.SUCCESS, status.getState());
   }
 
   @Test
@@ -76,8 +76,8 @@ public class CompactionStatusTrackerTest
     statusTracker.onTaskFinished("task1", TaskStatus.failure("task1", "some failure"));
 
     CompactionTaskStatus status = statusTracker.getLatestTaskStatus(candidateSegments);
-    Assert.assertEquals(TaskState.FAILED, status.getState());
-    Assert.assertEquals(1, status.getNumConsecutiveFailures());
+    Assertions.assertEquals(TaskState.FAILED, status.getState());
+    Assertions.assertEquals(1, status.getNumConsecutiveFailures());
   }
 
   @Test
@@ -91,14 +91,14 @@ public class CompactionStatusTrackerTest
 
     statusTracker.onTaskSubmitted("task2", candidateSegments);
     CompactionTaskStatus status = statusTracker.getLatestTaskStatus(candidateSegments);
-    Assert.assertEquals(TaskState.RUNNING, status.getState());
-    Assert.assertEquals(1, status.getNumConsecutiveFailures());
+    Assertions.assertEquals(TaskState.RUNNING, status.getState());
+    Assertions.assertEquals(1, status.getNumConsecutiveFailures());
 
     statusTracker.onTaskFinished("task2", TaskStatus.failure("task2", "second failure"));
 
     status = statusTracker.getLatestTaskStatus(candidateSegments);
-    Assert.assertEquals(TaskState.FAILED, status.getState());
-    Assert.assertEquals(2, status.getNumConsecutiveFailures());
+    Assertions.assertEquals(TaskState.FAILED, status.getState());
+    Assertions.assertEquals(2, status.getNumConsecutiveFailures());
   }
 
   @Test
@@ -111,8 +111,8 @@ public class CompactionStatusTrackerTest
     // Verify that interval is originally eligible for compaction
     CompactionStatus status
         = statusTracker.computeCompactionStatus(candidateSegments, policy);
-    Assert.assertEquals(CompactionStatus.State.PENDING, status.getState());
-    Assert.assertEquals("Not compacted yet", status.getReason());
+    Assertions.assertEquals(CompactionStatus.State.PENDING, status.getState());
+    Assertions.assertEquals("Not compacted yet", status.getReason());
 
     // Verify that interval is skipped for compaction after task has finished
     statusTracker.onSegmentTimelineUpdated(DateTimes.nowUtc().minusMinutes(1));
@@ -120,8 +120,8 @@ public class CompactionStatusTrackerTest
     statusTracker.onTaskFinished("task1", TaskStatus.success("task1"));
 
     status = statusTracker.computeCompactionStatus(candidateSegments, policy);
-    Assert.assertEquals(CompactionStatus.State.SKIPPED, status.getState());
-    Assert.assertEquals(
+    Assertions.assertEquals(CompactionStatus.State.SKIPPED, status.getState());
+    Assertions.assertEquals(
         "Segment timeline not updated since last compaction task succeeded",
         status.getReason()
     );
@@ -129,6 +129,6 @@ public class CompactionStatusTrackerTest
     // Verify that interval becomes eligible again after timeline has been updated
     statusTracker.onSegmentTimelineUpdated(DateTimes.nowUtc());
     status = statusTracker.computeCompactionStatus(candidateSegments, policy);
-    Assert.assertEquals(CompactionStatus.State.PENDING, status.getState());
+    Assertions.assertEquals(CompactionStatus.State.PENDING, status.getState());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIteratorTest.java
@@ -35,8 +35,8 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentTimeline;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 import java.util.List;
@@ -68,7 +68,7 @@ public class DataSourceCompactibleSegmentIteratorTest
         )
     );
 
-    Assert.assertEquals(expectedSkipIntervals, skipIntervals);
+    Assertions.assertEquals(expectedSkipIntervals, skipIntervals);
   }
 
   @Test
@@ -99,8 +99,8 @@ public class DataSourceCompactibleSegmentIteratorTest
     // Expected: Total interval is 2018-01-01T00:00:00/2018-01-01T12:00:00
     // Skip interval: 2018-01-01T08:00:00/2018-01-01T12:00:00 (computed from 4h offset)
     // Search interval should be: [2018-01-01T00:00:00/2018-01-01T08:00:00]
-    Assert.assertEquals(1, searchIntervals.size());
-    Assert.assertEquals(Intervals.of("2018-01-01T00:00:00/2018-01-01T08:00:00"), searchIntervals.get(0));
+    Assertions.assertEquals(1, searchIntervals.size());
+    Assertions.assertEquals(Intervals.of("2018-01-01T00:00:00/2018-01-01T08:00:00"), searchIntervals.get(0));
   }
 
   @Test
@@ -136,7 +136,7 @@ public class DataSourceCompactibleSegmentIteratorTest
     // The three configured skip intervals and the 4h-offset skip interval (18:30-21:00 and
     // 20:00-00:00 merge) leave three search windows. The last window is clipped to 18:00
     // since segments are hourly and the 18:00-19:00 segment overlaps the 18:30 skip start.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(
             Intervals.of("2018-01-01T00:00:00/PT6H"),
             Intervals.of("2018-01-01T08:00:00/PT4H"),

--- a/server/src/test/java/org/apache/druid/server/compaction/MostFragmentedIntervalFirstPolicyTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/MostFragmentedIntervalFirstPolicyTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.segment.TestDataSource;
 import org.apache.druid.server.coordinator.CreateDataSegments;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;

--- a/server/src/test/java/org/apache/druid/server/compaction/NewestSegmentFirstPolicyTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/NewestSegmentFirstPolicyTest.java
@@ -67,8 +67,8 @@ import org.apache.druid.utils.Streams;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -206,15 +206,15 @@ public class NewestSegmentFirstPolicyTest
       Interval prevInterval = null;
       for (DataSegment segment : segments) {
         if (prevInterval != null && !prevInterval.getStart().equals(segment.getInterval().getStart())) {
-          Assert.assertEquals(prevInterval.getEnd(), segment.getInterval().getStart());
+          Assertions.assertEquals(prevInterval.getEnd(), segment.getInterval().getStart());
         }
 
         prevInterval = segment.getInterval();
       }
     }
 
-    Assert.assertNotNull(lastInterval);
-    Assert.assertEquals(Intervals.of("2017-11-05T00:00:00/2017-11-05T01:00:00"), lastInterval);
+    Assertions.assertNotNull(lastInterval);
+    Assertions.assertEquals(Intervals.of("2017-11-05T00:00:00/2017-11-05T01:00:00"), lastInterval);
   }
 
   @Test
@@ -246,15 +246,15 @@ public class NewestSegmentFirstPolicyTest
       Interval prevInterval = null;
       for (DataSegment segment : segments) {
         if (prevInterval != null && !prevInterval.getStart().equals(segment.getInterval().getStart())) {
-          Assert.assertEquals(prevInterval.getEnd(), segment.getInterval().getStart());
+          Assertions.assertEquals(prevInterval.getEnd(), segment.getInterval().getStart());
         }
 
         prevInterval = segment.getInterval();
       }
     }
 
-    Assert.assertNotNull(lastInterval);
-    Assert.assertEquals(Intervals.of("2017-12-03T11:00:00/2017-12-03T12:00:00"), lastInterval);
+    Assertions.assertNotNull(lastInterval);
+    Assertions.assertEquals(Intervals.of("2017-12-03T11:00:00/2017-12-03T12:00:00"), lastInterval);
   }
 
   @Test
@@ -337,7 +337,7 @@ public class NewestSegmentFirstPolicyTest
     Set<List<DataSegment>> observedSegments = Streams.sequentialStreamFrom(iterator)
                                                      .map(CompactionCandidate::getSegments)
                                                      .collect(Collectors.toSet());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(expectedSegmentsToCompact, expectedSegmentsToCompact2),
         observedSegments
     );
@@ -358,7 +358,7 @@ public class NewestSegmentFirstPolicyTest
         timeline
     );
 
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -376,7 +376,7 @@ public class NewestSegmentFirstPolicyTest
         timeline
     );
 
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -404,11 +404,11 @@ public class NewestSegmentFirstPolicyTest
         timeline.findNonOvershadowedObjectsInInterval(Intervals.of("2017-10-14/2017-12-02"), Partitions.ONLY_COMPLETE)
     );
 
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     Set<DataSegment> observedSegmentsToCompact = Streams.sequentialStreamFrom(iterator)
                                                         .flatMap(s -> s.getSegments().stream())
                                                         .collect(Collectors.toSet());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         observedSegmentsToCompact
     );
@@ -443,11 +443,11 @@ public class NewestSegmentFirstPolicyTest
         timeline.findNonOvershadowedObjectsInInterval(Intervals.of("2017-10-14/P1D"), Partitions.ONLY_COMPLETE)
     );
 
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     List<DataSegment> actual = iterator.next().getSegments();
-    Assert.assertEquals(expectedSegmentsToCompact.size(), actual.size());
-    Assert.assertEquals(ImmutableSet.copyOf(expectedSegmentsToCompact), ImmutableSet.copyOf(actual));
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertEquals(expectedSegmentsToCompact.size(), actual.size());
+    Assertions.assertEquals(ImmutableSet.copyOf(expectedSegmentsToCompact), ImmutableSet.copyOf(actual));
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -478,11 +478,11 @@ public class NewestSegmentFirstPolicyTest
         )
     );
 
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     Set<DataSegment> observedSegmentsToCompact = Streams.sequentialStreamFrom(iterator)
                                                         .flatMap(s -> s.getSegments().stream())
                                                         .collect(Collectors.toSet());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         observedSegmentsToCompact
     );
@@ -557,11 +557,11 @@ public class NewestSegmentFirstPolicyTest
         timeline.findNonOvershadowedObjectsInInterval(Intervals.of("2017-12-03/2017-12-05"), Partitions.ONLY_COMPLETE)
     );
 
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     final Set<DataSegment> observedSegmentsToCompact = Streams.sequentialStreamFrom(iterator)
                                                               .flatMap(s -> s.getSegments().stream())
                                                               .collect(Collectors.toSet());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         observedSegmentsToCompact
     );
@@ -634,43 +634,43 @@ public class NewestSegmentFirstPolicyTest
     // However, we only need to iterator 3 times (once for each month) since the new configured segmentGranularity is MONTH.
     // and hence iterator would return all segments bucketed to the configured segmentGranularity
     // Month of Dec
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     List<DataSegment> expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-12-01T00:00:00/2017-12-31T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // Month of Nov
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-11-01T00:00:00/2017-12-01T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // Month of Oct
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-01T00:00:00/2017-11-01T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -693,20 +693,20 @@ public class NewestSegmentFirstPolicyTest
     List<DataSegment> expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(Intervals.of("2020-01-28/2020-02-15"), Partitions.ONLY_COMPLETE)
     );
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     List<DataSegment> actual = iterator.next().getSegments();
-    Assert.assertEquals(expectedSegmentsToCompact.size(), actual.size());
-    Assert.assertEquals(ImmutableSet.copyOf(expectedSegmentsToCompact), ImmutableSet.copyOf(actual));
+    Assertions.assertEquals(expectedSegmentsToCompact.size(), actual.size());
+    Assertions.assertEquals(ImmutableSet.copyOf(expectedSegmentsToCompact), ImmutableSet.copyOf(actual));
     // Month of Jan
     expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(Intervals.of("2020-01-01/2020-02-03"), Partitions.ONLY_COMPLETE)
     );
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     actual = iterator.next().getSegments();
-    Assert.assertEquals(expectedSegmentsToCompact.size(), actual.size());
-    Assert.assertEquals(ImmutableSet.copyOf(expectedSegmentsToCompact), ImmutableSet.copyOf(actual));
+    Assertions.assertEquals(expectedSegmentsToCompact.size(), actual.size());
+    Assertions.assertEquals(ImmutableSet.copyOf(expectedSegmentsToCompact), ImmutableSet.copyOf(actual));
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -727,13 +727,13 @@ public class NewestSegmentFirstPolicyTest
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertTrue(iterator.hasNext());
-    Assert.assertEquals(
+    Assertions.assertTrue(iterator.hasNext());
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // Iterator should return only once since all the "minute" interval of the iterator contains the same interval
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -752,19 +752,19 @@ public class NewestSegmentFirstPolicyTest
     );
 
     // We should get all segments in timeline back since skip offset is P0D.
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     List<DataSegment> expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -803,7 +803,7 @@ public class NewestSegmentFirstPolicyTest
         createConfigWithSegmentGranularity(Granularities.DAY),
         timeline
     );
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -838,7 +838,7 @@ public class NewestSegmentFirstPolicyTest
         createConfigWithSegmentGranularity(Granularities.DAY),
         timeline
     );
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -870,19 +870,19 @@ public class NewestSegmentFirstPolicyTest
         timeline
     );
     // We should get all segments in timeline back since skip offset is P0D.
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     List<DataSegment> expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-01T00:00:00/2017-10-03T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -918,19 +918,19 @@ public class NewestSegmentFirstPolicyTest
         timeline
     );
     // We should get all segments in timeline back since skip offset is P0D.
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     List<DataSegment> expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-01T00:00:00/2017-10-03T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -973,19 +973,19 @@ public class NewestSegmentFirstPolicyTest
         timeline
     );
     // We should get all segments in timeline back since skip offset is P0D.
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     List<DataSegment> expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-01T00:00:00/2017-10-03T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -1027,19 +1027,19 @@ public class NewestSegmentFirstPolicyTest
         timeline
     );
     // We should get all segments in timeline back since skip offset is P0D.
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     List<DataSegment> expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-01T00:00:00/2017-10-03T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -1099,30 +1099,30 @@ public class NewestSegmentFirstPolicyTest
         timeline
     );
     // We should get interval 2017-10-01T00:00:00/2017-10-02T00:00:00 and interval 2017-10-03T00:00:00/2017-10-04T00:00:00.
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     List<DataSegment> expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-03T00:00:00/2017-10-04T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -1188,30 +1188,30 @@ public class NewestSegmentFirstPolicyTest
         timeline
     );
     // We should get interval 2017-10-01T00:00:00/2017-10-02T00:00:00 and interval 2017-10-03T00:00:00/2017-10-04T00:00:00.
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     List<DataSegment> expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-03T00:00:00/2017-10-04T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -1282,41 +1282,41 @@ public class NewestSegmentFirstPolicyTest
         timeline
     );
     // We should get interval 2017-10-01T00:00:00/2017-10-02T00:00:00, interval 2017-10-04T00:00:00/2017-10-05T00:00:00, and interval 2017-10-03T00:00:00/2017-10-04T00:00:00.
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     List<DataSegment> expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-04T00:00:00/2017-10-05T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-03T00:00:00/2017-10-04T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
 
     // Auto compaction config sets Dimensions=null
     iterator = createIterator(
@@ -1326,7 +1326,7 @@ public class NewestSegmentFirstPolicyTest
         timeline
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -1416,19 +1416,19 @@ public class NewestSegmentFirstPolicyTest
     );
     // We should get only interval 2017-10-01T00:00:00/2017-10-02T00:00:00 since 2017-10-02T00:00:00/2017-10-03T00:00:00
     // has dimension order as expected post reordering of partition dimensions.
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     List<DataSegment> expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -1501,41 +1501,41 @@ public class NewestSegmentFirstPolicyTest
         timeline
     );
     // We should get interval 2017-10-01T00:00:00/2017-10-02T00:00:00, interval 2017-10-04T00:00:00/2017-10-05T00:00:00, and interval 2017-10-03T00:00:00/2017-10-04T00:00:00.
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     List<DataSegment> expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-04T00:00:00/2017-10-05T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-03T00:00:00/2017-10-04T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
 
     // Auto compaction config sets filter=null
     iterator = createIterator(
@@ -1545,7 +1545,7 @@ public class NewestSegmentFirstPolicyTest
         timeline
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -1619,41 +1619,41 @@ public class NewestSegmentFirstPolicyTest
         timeline
     );
     // We should get interval 2017-10-01T00:00:00/2017-10-02T00:00:00, interval 2017-10-04T00:00:00/2017-10-05T00:00:00, and interval 2017-10-03T00:00:00/2017-10-04T00:00:00.
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     List<DataSegment> expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-04T00:00:00/2017-10-05T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-03T00:00:00/2017-10-04T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
 
     // Auto compaction config sets metricsSpec=null
     iterator = createIterator(
@@ -1661,7 +1661,7 @@ public class NewestSegmentFirstPolicyTest
         timeline
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -1683,19 +1683,19 @@ public class NewestSegmentFirstPolicyTest
     // Although the first iteration only covers the last hour of 2017-10-01 (2017-10-01T23:00:00/2017-10-02T00:00:00),
     // the iterator will returns all segment as the umbrella interval the DAY segment (2017-10-01T00:00:00/2017-10-02T00:00:00)
     // also convers the HOUR segment (2017-10-01T01:00:00/2017-10-01T02:00:00)
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     List<DataSegment> expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -1736,19 +1736,19 @@ public class NewestSegmentFirstPolicyTest
         timeline
     );
     // We should get all segments in timeline back since indexSpec changed
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     List<DataSegment> expectedSegmentsToCompact = new ArrayList<>(
         timeline.findNonOvershadowedObjectsInInterval(
             Intervals.of("2017-10-01T00:00:00/2017-10-03T00:00:00"),
             Partitions.ONLY_COMPLETE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.copyOf(expectedSegmentsToCompact),
         ImmutableSet.copyOf(iterator.next().getSegments())
     );
     // No more
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -1795,7 +1795,7 @@ public class NewestSegmentFirstPolicyTest
         ).build(),
         timeline
     );
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
 
     iterator = createIterator(
         configBuilder().withTuningConfig(
@@ -1823,7 +1823,7 @@ public class NewestSegmentFirstPolicyTest
         ).build(),
         timeline
     );
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -1847,7 +1847,7 @@ public class NewestSegmentFirstPolicyTest
         )
     );
 
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -1871,7 +1871,7 @@ public class NewestSegmentFirstPolicyTest
         )
     );
 
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -1895,7 +1895,7 @@ public class NewestSegmentFirstPolicyTest
         )
     );
 
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -1921,7 +1921,7 @@ public class NewestSegmentFirstPolicyTest
         )
     );
 
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -1947,7 +1947,7 @@ public class NewestSegmentFirstPolicyTest
         )
     );
 
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -1996,7 +1996,7 @@ public class NewestSegmentFirstPolicyTest
 
     // Skips 2024/2025 since it has a single tombstone and no data.
     // Return all segments in 2023/2024 since at least one of them has data despite there being a tombstone.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(tombstone2023, dataSegment2023),
         iterator.next().getSegments()
     );
@@ -2048,7 +2048,7 @@ public class NewestSegmentFirstPolicyTest
         ))
     );
     // Does not skip the tombstones in 2025 since there are multiple of them which could potentially be condensed to one
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(tombstone2025Jan, tombstone2025Feb, tombstone2025Mar),
         iterator.next().getSegments()
     );
@@ -2087,15 +2087,15 @@ public class NewestSegmentFirstPolicyTest
     );
 
     // Verify that the segments of WIKI are preferred even though they are older
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     CompactionCandidate next = iterator.next();
-    Assert.assertEquals(TestDataSource.WIKI, next.getDataSource());
-    Assert.assertEquals(Intervals.of("2012-01-01/P1D"), next.getUmbrellaInterval());
+    Assertions.assertEquals(TestDataSource.WIKI, next.getDataSource());
+    Assertions.assertEquals(Intervals.of("2012-01-01/P1D"), next.getUmbrellaInterval());
 
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
     next = iterator.next();
-    Assert.assertEquals(TestDataSource.KOALA, next.getDataSource());
-    Assert.assertEquals(Intervals.of("2013-01-01/P1D"), next.getUmbrellaInterval());
+    Assertions.assertEquals(TestDataSource.KOALA, next.getDataSource());
+    Assertions.assertEquals(Intervals.of("2013-01-01/P1D"), next.getUmbrellaInterval());
   }
 
   private CompactionSegmentIterator createIterator(DataSourceCompactionConfig config, SegmentTimeline timeline)
@@ -2122,11 +2122,11 @@ public class NewestSegmentFirstPolicyTest
       final List<DataSegment> segments = iterator.next().getSegments();
 
       final Interval firstInterval = segments.get(0).getInterval();
-      Assert.assertTrue(
-          "Intervals should be same or abutting",
+      Assertions.assertTrue(
           segments.stream().allMatch(
               segment -> segment.getInterval().isEqual(firstInterval) || segment.getInterval().abuts(firstInterval)
-          )
+          ),
+          "Intervals should be same or abutting"
       );
 
       final List<Interval> expectedIntervals = new ArrayList<>(segments.size());
@@ -2138,7 +2138,7 @@ public class NewestSegmentFirstPolicyTest
       }
       expectedIntervals.sort(Comparators.intervalsByStartThenEnd());
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           expectedIntervals,
           segments.stream().map(DataSegment::getInterval).collect(Collectors.toList())
       );
@@ -2150,7 +2150,7 @@ public class NewestSegmentFirstPolicyTest
     }
 
     if (assertLast) {
-      Assert.assertFalse(iterator.hasNext());
+      Assertions.assertFalse(iterator.hasNext());
     }
   }
 

--- a/server/src/test/java/org/apache/druid/server/coordinator/AutoCompactionSnapshotTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/AutoCompactionSnapshotTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.server.coordinator;
 
 import org.apache.druid.server.compaction.CompactionStatistics;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class AutoCompactionSnapshotTest
 {
@@ -41,19 +41,19 @@ public class AutoCompactionSnapshotTest
 
     final AutoCompactionSnapshot actual = builder.withMessage(expectedMessage).build();
 
-    Assert.assertNotNull(actual);
-    Assert.assertEquals(26, actual.getSegmentCountSkipped());
-    Assert.assertEquals(26, actual.getIntervalCountSkipped());
-    Assert.assertEquals(26, actual.getBytesSkipped());
-    Assert.assertEquals(26, actual.getBytesCompacted());
-    Assert.assertEquals(26, actual.getIntervalCountCompacted());
-    Assert.assertEquals(26, actual.getSegmentCountCompacted());
-    Assert.assertEquals(26, actual.getBytesAwaitingCompaction());
-    Assert.assertEquals(26, actual.getIntervalCountAwaitingCompaction());
-    Assert.assertEquals(26, actual.getSegmentCountAwaitingCompaction());
-    Assert.assertEquals(AutoCompactionSnapshot.ScheduleStatus.RUNNING, actual.getScheduleStatus());
-    Assert.assertEquals(expectedDataSource, actual.getDataSource());
-    Assert.assertEquals(expectedMessage, actual.getMessage());
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals(26, actual.getSegmentCountSkipped());
+    Assertions.assertEquals(26, actual.getIntervalCountSkipped());
+    Assertions.assertEquals(26, actual.getBytesSkipped());
+    Assertions.assertEquals(26, actual.getBytesCompacted());
+    Assertions.assertEquals(26, actual.getIntervalCountCompacted());
+    Assertions.assertEquals(26, actual.getSegmentCountCompacted());
+    Assertions.assertEquals(26, actual.getBytesAwaitingCompaction());
+    Assertions.assertEquals(26, actual.getIntervalCountAwaitingCompaction());
+    Assertions.assertEquals(26, actual.getSegmentCountAwaitingCompaction());
+    Assertions.assertEquals(AutoCompactionSnapshot.ScheduleStatus.RUNNING, actual.getScheduleStatus());
+    Assertions.assertEquals(expectedDataSource, actual.getDataSource());
+    Assertions.assertEquals(expectedMessage, actual.getMessage());
 
     AutoCompactionSnapshot expected = new AutoCompactionSnapshot(
         expectedDataSource,
@@ -69,6 +69,6 @@ public class AutoCompactionSnapshotTest
         26,
         26
     );
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/BalanceSegmentsProfiler.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/BalanceSegmentsProfiler.java
@@ -41,7 +41,7 @@ import org.easymock.EasyMock;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -63,7 +63,7 @@ public class BalanceSegmentsProfiler
   PeriodLoadRule loadRule = new PeriodLoadRule(new Period("P5000Y"), null, ImmutableMap.of("normal", 3), null);
   List<Rule> rules = ImmutableList.of(loadRule);
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     loadQueueManager = new SegmentLoadQueueManager(null, null);

--- a/server/src/test/java/org/apache/druid/server/coordinator/ClusterCompactionConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/ClusterCompactionConfigTest.java
@@ -24,8 +24,8 @@ import org.apache.druid.error.DruidException;
 import org.apache.druid.indexer.CompactionEngine;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.server.compaction.NewestSegmentFirstPolicy;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ClusterCompactionConfigTest
 {
@@ -36,12 +36,12 @@ public class ClusterCompactionConfigTest
   {
     ClusterCompactionConfig config = new ClusterCompactionConfig(null, null, null, null, null, null);
 
-    Assert.assertEquals(0.1, config.getCompactionTaskSlotRatio(), 0.0001);
-    Assert.assertEquals(Integer.MAX_VALUE, config.getMaxCompactionTaskSlots());
-    Assert.assertTrue(config.isUseSupervisors());
-    Assert.assertEquals(CompactionEngine.NATIVE, config.getEngine());
-    Assert.assertNotNull(config.getCompactionPolicy());
-    Assert.assertTrue(config.isStoreCompactionStatePerSegment());
+    Assertions.assertEquals(0.1, config.getCompactionTaskSlotRatio(), 0.0001);
+    Assertions.assertEquals(Integer.MAX_VALUE, config.getMaxCompactionTaskSlots());
+    Assertions.assertTrue(config.isUseSupervisors());
+    Assertions.assertEquals(CompactionEngine.NATIVE, config.getEngine());
+    Assertions.assertNotNull(config.getCompactionPolicy());
+    Assertions.assertTrue(config.isStoreCompactionStatePerSegment());
   }
 
   @Test
@@ -58,7 +58,7 @@ public class ClusterCompactionConfigTest
     String json = MAPPER.writeValueAsString(config);
     ClusterCompactionConfig deserialized = MAPPER.readValue(json, ClusterCompactionConfig.class);
 
-    Assert.assertEquals(config, deserialized);
+    Assertions.assertEquals(config, deserialized);
   }
 
   @Test
@@ -74,12 +74,12 @@ public class ClusterCompactionConfigTest
                                                             .storeCompactionStatePerSegment(true)
                                                             .build();
 
-    Assert.assertEquals(0.3, config.getCompactionTaskSlotRatio(), 0.0001);
-    Assert.assertEquals(5, config.getMaxCompactionTaskSlots());
-    Assert.assertTrue(config.isUseSupervisors());
-    Assert.assertEquals(CompactionEngine.MSQ, config.getEngine());
-    Assert.assertEquals(policy, config.getCompactionPolicy());
-    Assert.assertTrue(config.isStoreCompactionStatePerSegment());
+    Assertions.assertEquals(0.3, config.getCompactionTaskSlotRatio(), 0.0001);
+    Assertions.assertEquals(5, config.getMaxCompactionTaskSlots());
+    Assertions.assertTrue(config.isUseSupervisors());
+    Assertions.assertEquals(CompactionEngine.MSQ, config.getEngine());
+    Assertions.assertEquals(policy, config.getCompactionPolicy());
+    Assertions.assertTrue(config.isStoreCompactionStatePerSegment());
   }
 
   @Test
@@ -97,20 +97,20 @@ public class ClusterCompactionConfigTest
                                                .compactionTaskSlotRatio(0.8)
                                                .build();
 
-    Assert.assertEquals(0.8, modified.getCompactionTaskSlotRatio(), 0.0001);
-    Assert.assertEquals(20, modified.getMaxCompactionTaskSlots());
-    Assert.assertFalse(modified.isUseSupervisors());
+    Assertions.assertEquals(0.8, modified.getCompactionTaskSlotRatio(), 0.0001);
+    Assertions.assertEquals(20, modified.getMaxCompactionTaskSlots());
+    Assertions.assertFalse(modified.isUseSupervisors());
   }
 
   @Test
   public void testMsqEngineRequiresSupervisors()
   {
-    DruidException e = Assert.assertThrows(
+    DruidException e = Assertions.assertThrows(
         DruidException.class,
         () -> ClusterCompactionConfig.builder().useSupervisors(false).engine(CompactionEngine.MSQ).build()
     );
-    Assert.assertEquals("MSQ Compaction engine can be used only with compaction supervisors.", e.getMessage());
-    Assert.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
+    Assertions.assertEquals("MSQ Compaction engine can be used only with compaction supervisors.", e.getMessage());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
   }
 
   @Test
@@ -131,9 +131,9 @@ public class ClusterCompactionConfigTest
                                                              .maxCompactionTaskSlots(10)
                                                              .build();
 
-    Assert.assertEquals(config1, config2);
-    Assert.assertEquals(config1.hashCode(), config2.hashCode());
-    Assert.assertNotEquals(config1, config3);
-    Assert.assertNotEquals(config3, config2);
+    Assertions.assertEquals(config1, config2);
+    Assertions.assertEquals(config1.hashCode(), config2.hashCode());
+    Assertions.assertNotEquals(config1, config3);
+    Assertions.assertNotEquals(config3, config2);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/CoordinatorOverlordServiceConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/CoordinatorOverlordServiceConfigTest.java
@@ -19,19 +19,19 @@
 
 package org.apache.druid.server.coordinator;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CoordinatorOverlordServiceConfigTest
 {
   @Test
   public void testOverlordServiceIsRequiredIfEnabled()
   {
-    IllegalArgumentException e = Assert.assertThrows(
+    IllegalArgumentException e = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new CoordinatorOverlordServiceConfig(true, null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "'overlordService' must be specified when running Coordinator as Overlord.",
         e.getMessage()
     );

--- a/server/src/test/java/org/apache/druid/server/coordinator/CoordinatorRunStatsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/CoordinatorRunStatsTest.java
@@ -24,10 +24,10 @@ import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.server.coordinator.stats.CoordinatorStat;
 import org.apache.druid.server.coordinator.stats.Dimension;
 import org.apache.druid.server.coordinator.stats.RowKey;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,13 +36,13 @@ public class CoordinatorRunStatsTest
 {
   private CoordinatorRunStats stats;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     stats = new CoordinatorRunStats();
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     stats = null;
@@ -51,11 +51,11 @@ public class CoordinatorRunStatsTest
   @Test
   public void testAdd()
   {
-    Assert.assertEquals(0, stats.get(Stat.ERROR_1));
+    Assertions.assertEquals(0, stats.get(Stat.ERROR_1));
     stats.add(Stat.ERROR_1, 1);
-    Assert.assertEquals(1, stats.get(Stat.ERROR_1));
+    Assertions.assertEquals(1, stats.get(Stat.ERROR_1));
     stats.add(Stat.ERROR_1, -11);
-    Assert.assertEquals(-10, stats.get(Stat.ERROR_1));
+    Assertions.assertEquals(-10, stats.get(Stat.ERROR_1));
   }
 
   @Test
@@ -67,11 +67,11 @@ public class CoordinatorRunStatsTest
     stats.add(Stat.INFO_1, Key.TIER_1, 1);
     stats.add(Stat.ERROR_1, Key.TIER_2, 1);
 
-    Assert.assertFalse(stats.hasStat(Stat.INFO_2));
+    Assertions.assertFalse(stats.hasStat(Stat.INFO_2));
 
-    Assert.assertEquals(-4, stats.get(Stat.ERROR_1, Key.TIER_1));
-    Assert.assertEquals(2, stats.get(Stat.ERROR_1, Key.TIER_2));
-    Assert.assertEquals(1, stats.get(Stat.INFO_1, Key.TIER_1));
+    Assertions.assertEquals(-4, stats.get(Stat.ERROR_1, Key.TIER_1));
+    Assertions.assertEquals(2, stats.get(Stat.ERROR_1, Key.TIER_2));
+    Assertions.assertEquals(1, stats.get(Stat.INFO_1, Key.TIER_1));
   }
 
   @Test
@@ -89,11 +89,11 @@ public class CoordinatorRunStatsTest
     stats.updateMax(Stat.ERROR_1, Key.TIER_2, 9);
     stats.updateMax(Stat.ERROR_1, Key.TIER_2, 10);
 
-    Assert.assertFalse(stats.hasStat(Stat.INFO_2));
+    Assertions.assertFalse(stats.hasStat(Stat.INFO_2));
 
-    Assert.assertEquals(6, stats.get(Stat.ERROR_1, Key.TIER_1));
-    Assert.assertEquals(5, stats.get(Stat.INFO_1, Key.TIER_1));
-    Assert.assertEquals(10, stats.get(Stat.ERROR_1, Key.TIER_2));
+    Assertions.assertEquals(6, stats.get(Stat.ERROR_1, Key.TIER_1));
+    Assertions.assertEquals(5, stats.get(Stat.INFO_1, Key.TIER_1));
+    Assertions.assertEquals(10, stats.get(Stat.ERROR_1, Key.TIER_2));
   }
 
   @Test
@@ -105,10 +105,10 @@ public class CoordinatorRunStatsTest
     stats.add(Stat.INFO_1, Key.DUTY_1, 1);
     stats.add(Stat.ERROR_1, Key.DUTY_2, 1);
 
-    Assert.assertFalse(stats.hasStat(Stat.INFO_2));
-    Assert.assertEquals(-4, stats.get(Stat.ERROR_1, Key.DUTY_1));
-    Assert.assertEquals(2, stats.get(Stat.ERROR_1, Key.DUTY_2));
-    Assert.assertEquals(1, stats.get(Stat.INFO_1, Key.DUTY_1));
+    Assertions.assertFalse(stats.hasStat(Stat.INFO_2));
+    Assertions.assertEquals(-4, stats.get(Stat.ERROR_1, Key.DUTY_1));
+    Assertions.assertEquals(2, stats.get(Stat.ERROR_1, Key.DUTY_2));
+    Assertions.assertEquals(1, stats.get(Stat.INFO_1, Key.DUTY_1));
   }
 
   @Test
@@ -132,7 +132,7 @@ public class CoordinatorRunStatsTest
           }
         }
     );
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -146,7 +146,7 @@ public class CoordinatorRunStatsTest
         = "\nError: {duty=duty1} ==> {error1=10}"
           + "\nInfo : {duty=duty1} ==> {info1=20}";
 
-    Assert.assertEquals(expectedTable, stats.buildStatsTable());
+    Assertions.assertEquals(expectedTable, stats.buildStatsTable());
   }
 
   @Test
@@ -162,26 +162,26 @@ public class CoordinatorRunStatsTest
           + "\nInfo : {duty=duty1} ==> {info1=20}"
           + "\nDebug: {duty=duty1} ==> {debug1=30}";
 
-    Assert.assertEquals(expectedTable, debugStats.buildStatsTable());
+    Assertions.assertEquals(expectedTable, debugStats.buildStatsTable());
   }
 
   @Test
   public void testAddToEmptyThrowsException()
   {
     CoordinatorRunStats runStats = CoordinatorRunStats.empty();
-    Assert.assertThrows(
+    Assertions.assertThrows(
         UnsupportedOperationException.class,
         () -> runStats.add(Stat.ERROR_1, 10)
     );
-    Assert.assertThrows(
+    Assertions.assertThrows(
         UnsupportedOperationException.class,
         () -> runStats.add(Stat.ERROR_1, Key.DUTY_1, 10)
     );
-    Assert.assertThrows(
+    Assertions.assertThrows(
         UnsupportedOperationException.class,
         () -> runStats.addToSegmentStat(Stat.ERROR_1, "t", "ds", 10)
     );
-    Assert.assertThrows(
+    Assertions.assertThrows(
         UnsupportedOperationException.class,
         () -> runStats.updateMax(Stat.INFO_1, Key.TIER_1, 10)
     );

--- a/server/src/test/java/org/apache/druid/server/coordinator/CostBalancerStrategyBenchmark.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/CostBalancerStrategyBenchmark.java
@@ -30,10 +30,10 @@ import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.balancer.CostBalancerStrategy;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Interval;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,11 +42,11 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-@Ignore
-@RunWith(Parameterized.class)
+@Disabled
+@ParameterizedClass
+@MethodSource("factoryClasses")
 public class CostBalancerStrategyBenchmark extends AbstractBenchmark
 {
-  @Parameterized.Parameters
   public static List<CostBalancerStrategy[]> factoryClasses()
   {
     return Arrays.asList(

--- a/server/src/test/java/org/apache/druid/server/coordinator/DataSourceCompactionConfigAuditEntryTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DataSourceCompactionConfigAuditEntryTest.java
@@ -22,12 +22,9 @@ package org.apache.druid.server.coordinator;
 import org.apache.druid.audit.AuditInfo;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.segment.TestDataSource;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-@RunWith(MockitoJUnitRunner.class)
 public class DataSourceCompactionConfigAuditEntryTest
 {
   private final AuditInfo auditInfo = new AuditInfo("author", "identity", "comment", "ip");
@@ -48,8 +45,8 @@ public class DataSourceCompactionConfigAuditEntryTest
         auditInfo,
         DateTimes.nowUtc()
     );
-    Assert.assertTrue(firstEntry.hasSameConfig(secondEntry));
-    Assert.assertTrue(secondEntry.hasSameConfig(firstEntry));
+    Assertions.assertTrue(firstEntry.hasSameConfig(secondEntry));
+    Assertions.assertTrue(secondEntry.hasSameConfig(firstEntry));
   }
 
   @Test
@@ -61,8 +58,8 @@ public class DataSourceCompactionConfigAuditEntryTest
         auditInfo,
         DateTimes.nowUtc()
     );
-    Assert.assertFalse(firstEntry.hasSameConfig(secondEntry));
-    Assert.assertFalse(secondEntry.hasSameConfig(firstEntry));
+    Assertions.assertFalse(firstEntry.hasSameConfig(secondEntry));
+    Assertions.assertFalse(secondEntry.hasSameConfig(firstEntry));
 
     secondEntry = new DataSourceCompactionConfigAuditEntry(
         new ClusterCompactionConfig(0.1, 10, null, null, null, null),
@@ -70,8 +67,8 @@ public class DataSourceCompactionConfigAuditEntryTest
         auditInfo,
         DateTimes.nowUtc()
     );
-    Assert.assertFalse(firstEntry.hasSameConfig(secondEntry));
-    Assert.assertFalse(secondEntry.hasSameConfig(firstEntry));
+    Assertions.assertFalse(firstEntry.hasSameConfig(secondEntry));
+    Assertions.assertFalse(secondEntry.hasSameConfig(firstEntry));
   }
 
   @Test
@@ -83,8 +80,8 @@ public class DataSourceCompactionConfigAuditEntryTest
         auditInfo,
         DateTimes.nowUtc()
     );
-    Assert.assertFalse(firstEntry.hasSameConfig(secondEntry));
-    Assert.assertFalse(secondEntry.hasSameConfig(firstEntry));
+    Assertions.assertFalse(firstEntry.hasSameConfig(secondEntry));
+    Assertions.assertFalse(secondEntry.hasSameConfig(firstEntry));
   }
 
   @Test
@@ -96,7 +93,7 @@ public class DataSourceCompactionConfigAuditEntryTest
         auditInfo,
         DateTimes.nowUtc()
     );
-    Assert.assertFalse(firstEntry.hasSameConfig(secondEntry));
-    Assert.assertFalse(secondEntry.hasSameConfig(firstEntry));
+    Assertions.assertFalse(firstEntry.hasSameConfig(secondEntry));
+    Assertions.assertFalse(secondEntry.hasSameConfig(firstEntry));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/DataSourceCompactionConfigHistoryTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DataSourceCompactionConfigHistoryTest.java
@@ -24,15 +24,12 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.segment.TestDataSource;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-@RunWith(MockitoJUnitRunner.class)
 public class DataSourceCompactionConfigHistoryTest
 {
   private final AuditInfo auditInfo = new AuditInfo("author", "identity", "comment", "ip");
@@ -41,7 +38,7 @@ public class DataSourceCompactionConfigHistoryTest
 
   private DataSourceCompactionConfigHistory wikiAuditHistory;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     wikiAuditHistory = new DataSourceCompactionConfigHistory(TestDataSource.WIKI);
@@ -57,11 +54,11 @@ public class DataSourceCompactionConfigHistoryTest
         auditTime
     );
 
-    Assert.assertEquals(1, wikiAuditHistory.getEntries().size());
+    Assertions.assertEquals(1, wikiAuditHistory.getEntries().size());
     DataSourceCompactionConfigAuditEntry auditEntry = wikiAuditHistory.getEntries().get(0);
-    Assert.assertEquals(wikiCompactionConfig, auditEntry.getCompactionConfig());
-    Assert.assertEquals(auditInfo, auditEntry.getAuditInfo());
-    Assert.assertEquals(auditTime, auditEntry.getAuditTime());
+    Assertions.assertEquals(wikiCompactionConfig, auditEntry.getCompactionConfig());
+    Assertions.assertEquals(auditInfo, auditEntry.getAuditInfo());
+    Assertions.assertEquals(auditTime, auditEntry.getAuditTime());
   }
 
   @Test
@@ -76,18 +73,18 @@ public class DataSourceCompactionConfigHistoryTest
     wikiAuditHistory.add(DruidCompactionConfig.empty(), auditInfo, auditTime.plusHours(2));
 
     final List<DataSourceCompactionConfigAuditEntry> entries = wikiAuditHistory.getEntries();
-    Assert.assertEquals(2, entries.size());
+    Assertions.assertEquals(2, entries.size());
 
     final DataSourceCompactionConfigAuditEntry firstEntry = entries.get(0);
-    Assert.assertEquals(wikiCompactionConfig, firstEntry.getCompactionConfig());
-    Assert.assertEquals(auditInfo, firstEntry.getAuditInfo());
-    Assert.assertEquals(auditTime, firstEntry.getAuditTime());
+    Assertions.assertEquals(wikiCompactionConfig, firstEntry.getCompactionConfig());
+    Assertions.assertEquals(auditInfo, firstEntry.getAuditInfo());
+    Assertions.assertEquals(auditTime, firstEntry.getAuditTime());
 
     final DataSourceCompactionConfigAuditEntry secondEntry = entries.get(1);
-    Assert.assertNull(secondEntry.getCompactionConfig());
-    Assert.assertEquals(firstEntry.getGlobalConfig(), secondEntry.getGlobalConfig());
-    Assert.assertEquals(auditInfo, secondEntry.getAuditInfo());
-    Assert.assertEquals(auditTime.plusHours(2), secondEntry.getAuditTime());
+    Assertions.assertNull(secondEntry.getCompactionConfig());
+    Assertions.assertEquals(firstEntry.getGlobalConfig(), secondEntry.getGlobalConfig());
+    Assertions.assertEquals(auditInfo, secondEntry.getAuditInfo());
+    Assertions.assertEquals(auditTime.plusHours(2), secondEntry.getAuditTime());
   }
 
   @Test
@@ -103,7 +100,7 @@ public class DataSourceCompactionConfigHistoryTest
     );
     wikiAuditHistory.add(DruidCompactionConfig.empty(), auditInfo, DateTimes.nowUtc());
 
-    Assert.assertTrue(wikiAuditHistory.getEntries().isEmpty());
+    Assertions.assertTrue(wikiAuditHistory.getEntries().isEmpty());
   }
 
   @Test
@@ -127,11 +124,11 @@ public class DataSourceCompactionConfigHistoryTest
     );
 
     final List<DataSourceCompactionConfigAuditEntry> entries = wikiAuditHistory.getEntries();
-    Assert.assertEquals(3, entries.size());
+    Assertions.assertEquals(3, entries.size());
 
     final DataSourceCompactionConfigAuditEntry firstEntry = entries.get(0);
     final DataSourceCompactionConfigAuditEntry thirdEntry = entries.get(2);
-    Assert.assertTrue(firstEntry.hasSameConfig(thirdEntry));
+    Assertions.assertTrue(firstEntry.hasSameConfig(thirdEntry));
   }
 
   @Test
@@ -157,15 +154,15 @@ public class DataSourceCompactionConfigHistoryTest
     );
 
     final List<DataSourceCompactionConfigAuditEntry> entries = wikiAuditHistory.getEntries();
-    Assert.assertEquals(2, entries.size());
+    Assertions.assertEquals(2, entries.size());
 
     final DataSourceCompactionConfigAuditEntry firstEntry = entries.get(0);
     final DataSourceCompactionConfigAuditEntry secondEntry = entries.get(1);
-    Assert.assertEquals(firstEntry.getGlobalConfig(), secondEntry.getGlobalConfig());
+    Assertions.assertEquals(firstEntry.getGlobalConfig(), secondEntry.getGlobalConfig());
 
-    Assert.assertEquals(wikiCompactionConfig, firstEntry.getCompactionConfig());
-    Assert.assertEquals(updatedWikiConfig, secondEntry.getCompactionConfig());
-    Assert.assertFalse(firstEntry.hasSameConfig(secondEntry));
+    Assertions.assertEquals(wikiCompactionConfig, firstEntry.getCompactionConfig());
+    Assertions.assertEquals(updatedWikiConfig, secondEntry.getCompactionConfig());
+    Assertions.assertFalse(firstEntry.hasSameConfig(secondEntry));
   }
 
   @Test
@@ -182,14 +179,14 @@ public class DataSourceCompactionConfigHistoryTest
     wikiAuditHistory.add(updatedConfig, auditInfo, DateTimes.nowUtc());
 
     final List<DataSourceCompactionConfigAuditEntry> entries = wikiAuditHistory.getEntries();
-    Assert.assertEquals(2, entries.size());
+    Assertions.assertEquals(2, entries.size());
 
     final DataSourceCompactionConfigAuditEntry firstEntry = entries.get(0);
     final DataSourceCompactionConfigAuditEntry secondEntry = entries.get(1);
-    Assert.assertEquals(secondEntry.getCompactionConfig(), firstEntry.getCompactionConfig());
+    Assertions.assertEquals(secondEntry.getCompactionConfig(), firstEntry.getCompactionConfig());
 
-    Assert.assertEquals(originalConfig.clusterConfig(), firstEntry.getGlobalConfig());
-    Assert.assertEquals(updatedConfig.clusterConfig(), secondEntry.getGlobalConfig());
-    Assert.assertFalse(firstEntry.hasSameConfig(secondEntry));
+    Assertions.assertEquals(originalConfig.clusterConfig(), firstEntry.getGlobalConfig());
+    Assertions.assertEquals(updatedConfig.clusterConfig(), secondEntry.getGlobalConfig());
+    Assertions.assertFalse(firstEntry.hasSameConfig(secondEntry));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidClusterTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidClusterTest.java
@@ -24,9 +24,9 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.loading.TestLoadQueuePeon;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.List;
@@ -58,7 +58,7 @@ public class DruidClusterTest
 
   private DruidCluster.Builder clusterBuilder;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     clusterBuilder = DruidCluster
@@ -83,18 +83,18 @@ public class DruidClusterTest
   public void testAdd()
   {
     DruidCluster cluster = clusterBuilder.build();
-    Assert.assertEquals(1, cluster.getHistoricals().values().stream().mapToInt(Collection::size).sum());
-    Assert.assertEquals(1, cluster.getRealtimes().size());
+    Assertions.assertEquals(1, cluster.getHistoricals().values().stream().mapToInt(Collection::size).sum());
+    Assertions.assertEquals(1, cluster.getRealtimes().size());
 
     clusterBuilder.add(NEW_REALTIME);
     cluster = clusterBuilder.build();
-    Assert.assertEquals(1, cluster.getHistoricals().values().stream().mapToInt(Collection::size).sum());
-    Assert.assertEquals(2, cluster.getRealtimes().size());
+    Assertions.assertEquals(1, cluster.getHistoricals().values().stream().mapToInt(Collection::size).sum());
+    Assertions.assertEquals(2, cluster.getRealtimes().size());
 
     clusterBuilder.add(NEW_HISTORICAL);
     cluster = clusterBuilder.build();
-    Assert.assertEquals(2, cluster.getHistoricals().values().stream().mapToInt(Collection::size).sum());
-    Assert.assertEquals(2, cluster.getRealtimes().size());
+    Assertions.assertEquals(2, cluster.getHistoricals().values().stream().mapToInt(Collection::size).sum());
+    Assertions.assertEquals(2, cluster.getRealtimes().size());
   }
 
   @Test
@@ -108,9 +108,9 @@ public class DruidClusterTest
     final Map<String, NavigableSet<ServerHolder>> expectedHistoricals = cluster.getHistoricals();
 
     final Collection<ServerHolder> allServers = cluster.getAllManagedServers();
-    Assert.assertEquals(4, allServers.size());
-    Assert.assertTrue(allServers.containsAll(cluster.getRealtimes()));
-    Assert.assertTrue(
+    Assertions.assertEquals(4, allServers.size());
+    Assertions.assertTrue(allServers.containsAll(cluster.getRealtimes()));
+    Assertions.assertTrue(
         allServers.containsAll(
             cluster.getHistoricals().values().stream()
                    .flatMap(Collection::stream)
@@ -118,15 +118,15 @@ public class DruidClusterTest
         )
     );
 
-    Assert.assertEquals(expectedHistoricals, cluster.getHistoricals());
-    Assert.assertEquals(expectedRealtimes, cluster.getRealtimes());
+    Assertions.assertEquals(expectedHistoricals, cluster.getHistoricals());
+    Assertions.assertEquals(expectedRealtimes, cluster.getRealtimes());
   }
 
   @Test
   public void testIsEmpty()
   {
     final DruidCluster emptyCluster = DruidCluster.EMPTY;
-    Assert.assertFalse(clusterBuilder.build().isEmpty());
-    Assert.assertTrue(emptyCluster.isEmpty());
+    Assertions.assertFalse(clusterBuilder.build().isEmpty());
+    Assertions.assertTrue(emptyCluster.isEmpty());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCompactionConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCompactionConfigTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.segment.TestDataSource;
 import org.apache.druid.server.compaction.NewestSegmentFirstPolicy;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,14 +42,14 @@ public class DruidCompactionConfigTest
     final String json = MAPPER.writeValueAsString(defaultConfig);
 
     DruidCompactionConfig deserialized = MAPPER.readValue(json, DruidCompactionConfig.class);
-    Assert.assertEquals(defaultConfig, deserialized);
+    Assertions.assertEquals(defaultConfig, deserialized);
   }
 
   @Test
   public void testSerdeWithLegacyConfig() throws Exception
   {
     final String json = "{\"compactionConfigs\":[],\"useSupervisors\":false,\"engine\":\"native\"}";
-    Assert.assertEquals(DruidCompactionConfig.legacy(), MAPPER.readValue(json, DruidCompactionConfig.class));
+    Assertions.assertEquals(DruidCompactionConfig.legacy(), MAPPER.readValue(json, DruidCompactionConfig.class));
   }
 
   @Test
@@ -78,7 +78,7 @@ public class DruidCompactionConfigTest
 
     final String json = MAPPER.writeValueAsString(config);
     DruidCompactionConfig deserialized = MAPPER.readValue(json, DruidCompactionConfig.class);
-    Assert.assertEquals(config, deserialized);
+    Assertions.assertEquals(config, deserialized);
   }
 
   @Test
@@ -96,15 +96,15 @@ public class DruidCompactionConfigTest
     );
     final DruidCompactionConfig copy = config.withClusterConfig(clusterConfig);
 
-    Assert.assertEquals(clusterConfig, copy.clusterConfig());
-    Assert.assertNotEquals(clusterConfig, config.clusterConfig());
+    Assertions.assertEquals(clusterConfig, copy.clusterConfig());
+    Assertions.assertNotEquals(clusterConfig, config.clusterConfig());
   }
 
   @Test
   public void testCopyWithDatasourceConfigs()
   {
     final DruidCompactionConfig config = DruidCompactionConfig.empty();
-    Assert.assertTrue(config.getCompactionConfigs().isEmpty());
+    Assertions.assertTrue(config.getCompactionConfigs().isEmpty());
 
     final DataSourceCompactionConfig dataSourceConfig = InlineSchemaDataSourceCompactionConfig
         .builder()
@@ -114,20 +114,20 @@ public class DruidCompactionConfigTest
     final DruidCompactionConfig copy
         = config.withDatasourceConfigs(Collections.singletonList(dataSourceConfig));
 
-    Assert.assertEquals(1, copy.getCompactionConfigs().size());
-    Assert.assertEquals(dataSourceConfig, copy.findConfigForDatasource(TestDataSource.WIKI).orNull());
+    Assertions.assertEquals(1, copy.getCompactionConfigs().size());
+    Assertions.assertEquals(dataSourceConfig, copy.findConfigForDatasource(TestDataSource.WIKI).orNull());
   }
 
   @Test
   public void testDefaultConfigValues()
   {
     final DruidCompactionConfig config = DruidCompactionConfig.empty();
-    Assert.assertTrue(config.getCompactionConfigs().isEmpty());
-    Assert.assertTrue(config.getCompactionPolicy() instanceof NewestSegmentFirstPolicy);
-    Assert.assertEquals(CompactionEngine.NATIVE, config.getEngine());
-    Assert.assertTrue(config.isUseSupervisors());
-    Assert.assertEquals(0.1, config.getCompactionTaskSlotRatio(), 1e-9);
-    Assert.assertEquals(Integer.MAX_VALUE, config.getMaxCompactionTaskSlots());
-    Assert.assertTrue(config.isStoreCompactionStatePerSegment());
+    Assertions.assertTrue(config.getCompactionConfigs().isEmpty());
+    Assertions.assertTrue(config.getCompactionPolicy() instanceof NewestSegmentFirstPolicy);
+    Assertions.assertEquals(CompactionEngine.NATIVE, config.getEngine());
+    Assertions.assertTrue(config.isUseSupervisors());
+    Assertions.assertEquals(0.1, config.getCompactionTaskSlotRatio(), 1e-9);
+    Assertions.assertEquals(Integer.MAX_VALUE, config.getMaxCompactionTaskSlots());
+    Assertions.assertTrue(config.isStoreCompactionStatePerSegment());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorConfigTest.java
@@ -36,8 +36,8 @@ import org.apache.druid.server.coordinator.config.KillUnusedSegmentsConfig;
 import org.apache.druid.server.coordinator.config.MetadataCleanupConfig;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -50,8 +50,8 @@ public class DruidCoordinatorConfigTest
     final Properties props = new Properties();
     final CoordinatorRunConfig config = deserializeFrom(props, "druid.coordinator", CoordinatorRunConfig.class);
 
-    Assert.assertEquals(Duration.standardMinutes(1), config.getPeriod());
-    Assert.assertEquals(Duration.standardMinutes(5), config.getStartDelay());
+    Assertions.assertEquals(Duration.standardMinutes(1), config.getPeriod());
+    Assertions.assertEquals(Duration.standardMinutes(5), config.getStartDelay());
   }
 
   @Test
@@ -62,8 +62,8 @@ public class DruidCoordinatorConfigTest
     props.setProperty("druid.coordinator.period", "PT30S");
     final CoordinatorRunConfig config = deserializeFrom(props, "druid.coordinator", CoordinatorRunConfig.class);
 
-    Assert.assertEquals(Duration.standardSeconds(30), config.getPeriod());
-    Assert.assertEquals(Duration.standardMinutes(10), config.getStartDelay());
+    Assertions.assertEquals(Duration.standardSeconds(30), config.getPeriod());
+    Assertions.assertEquals(Duration.standardMinutes(10), config.getStartDelay());
   }
 
   @Test
@@ -73,8 +73,8 @@ public class DruidCoordinatorConfigTest
     final CoordinatorPeriodConfig config
         = deserializeFrom(props, "druid.coordinator.period", CoordinatorPeriodConfig.class);
 
-    Assert.assertEquals(Duration.standardMinutes(30), config.getIndexingPeriod());
-    Assert.assertEquals(Duration.standardMinutes(60), config.getMetadataStoreManagementPeriod());
+    Assertions.assertEquals(Duration.standardMinutes(30), config.getIndexingPeriod());
+    Assertions.assertEquals(Duration.standardMinutes(60), config.getMetadataStoreManagementPeriod());
   }
 
   @Test
@@ -86,8 +86,8 @@ public class DruidCoordinatorConfigTest
     final CoordinatorPeriodConfig config
         = deserializeFrom(props, "druid.coordinator.period", CoordinatorPeriodConfig.class);
 
-    Assert.assertEquals(Duration.standardMinutes(1), config.getIndexingPeriod());
-    Assert.assertEquals(Duration.standardMinutes(3), config.getMetadataStoreManagementPeriod());
+    Assertions.assertEquals(Duration.standardMinutes(1), config.getIndexingPeriod());
+    Assertions.assertEquals(Duration.standardMinutes(3), config.getMetadataStoreManagementPeriod());
   }
 
   @Test
@@ -97,10 +97,10 @@ public class DruidCoordinatorConfigTest
     final HttpLoadQueuePeonConfig config
         = deserializeFrom(props, "druid.coordinator.loadqueuepeon.http", HttpLoadQueuePeonConfig.class);
 
-    Assert.assertEquals(Duration.standardMinutes(1), config.getRepeatDelay());
-    Assert.assertEquals(Duration.standardMinutes(5), config.getHostTimeout());
-    Assert.assertEquals(Duration.standardMinutes(15), config.getLoadTimeout());
-    Assert.assertNull(config.getBatchSize());
+    Assertions.assertEquals(Duration.standardMinutes(1), config.getRepeatDelay());
+    Assertions.assertEquals(Duration.standardMinutes(5), config.getHostTimeout());
+    Assertions.assertEquals(Duration.standardMinutes(15), config.getLoadTimeout());
+    Assertions.assertNull(config.getBatchSize());
   }
 
   @Test
@@ -114,10 +114,10 @@ public class DruidCoordinatorConfigTest
     final HttpLoadQueuePeonConfig config
         = deserializeFrom(props, "druid.coordinator.loadqueuepeon.http", HttpLoadQueuePeonConfig.class);
 
-    Assert.assertEquals(Duration.standardMinutes(20), config.getRepeatDelay());
-    Assert.assertEquals(Duration.standardMinutes(10), config.getHostTimeout());
-    Assert.assertEquals(Duration.standardMinutes(15), config.getLoadTimeout());
-    Assert.assertEquals(Integer.valueOf(100), config.getBatchSize());
+    Assertions.assertEquals(Duration.standardMinutes(20), config.getRepeatDelay());
+    Assertions.assertEquals(Duration.standardMinutes(10), config.getHostTimeout());
+    Assertions.assertEquals(Duration.standardMinutes(15), config.getLoadTimeout());
+    Assertions.assertEquals(Integer.valueOf(100), config.getBatchSize());
   }
 
   @Test
@@ -125,9 +125,9 @@ public class DruidCoordinatorConfigTest
   {
     final MetadataCleanupConfig config = new MetadataCleanupConfig(null, null, null);
 
-    Assert.assertTrue(config.isCleanupEnabled());
-    Assert.assertEquals(Duration.standardDays(1), config.getCleanupPeriod());
-    Assert.assertEquals(Duration.standardDays(90), config.getDurationToRetain());
+    Assertions.assertTrue(config.isCleanupEnabled());
+    Assertions.assertEquals(Duration.standardDays(1), config.getCleanupPeriod());
+    Assertions.assertEquals(Duration.standardDays(90), config.getDurationToRetain());
   }
 
   @Test
@@ -139,9 +139,9 @@ public class DruidCoordinatorConfigTest
         Period.parse("P1D").toStandardDuration()
     );
 
-    Assert.assertFalse(config.isCleanupEnabled());
-    Assert.assertEquals(Duration.standardHours(5), config.getCleanupPeriod());
-    Assert.assertEquals(Duration.standardHours(24), config.getDurationToRetain());
+    Assertions.assertFalse(config.isCleanupEnabled());
+    Assertions.assertEquals(Duration.standardHours(5), config.getCleanupPeriod());
+    Assertions.assertEquals(Duration.standardHours(24), config.getDurationToRetain());
   }
 
   @Test
@@ -150,12 +150,12 @@ public class DruidCoordinatorConfigTest
     CoordinatorKillConfigs killConfigs = createKillConfig().build();
     final KillUnusedSegmentsConfig config = killConfigs.unusedSegments(null);
 
-    Assert.assertFalse(config.isCleanupEnabled());
-    Assert.assertFalse(config.isIgnoreDurationToRetain());
-    Assert.assertEquals(Duration.standardDays(1), config.getCleanupPeriod());
-    Assert.assertEquals(Duration.standardDays(30), config.getBufferPeriod());
-    Assert.assertEquals(Duration.standardDays(90), config.getDurationToRetain());
-    Assert.assertEquals(100, config.getMaxSegments());
+    Assertions.assertFalse(config.isCleanupEnabled());
+    Assertions.assertFalse(config.isIgnoreDurationToRetain());
+    Assertions.assertEquals(Duration.standardDays(1), config.getCleanupPeriod());
+    Assertions.assertEquals(Duration.standardDays(30), config.getBufferPeriod());
+    Assertions.assertEquals(Duration.standardDays(90), config.getDurationToRetain());
+    Assertions.assertEquals(100, config.getMaxSegments());
   }
 
   @Test
@@ -173,12 +173,12 @@ public class DruidCoordinatorConfigTest
     CoordinatorKillConfigs killConfigs = createKillConfig().unusedSegments(inputConfig).build();
 
     final KillUnusedSegmentsConfig config = killConfigs.unusedSegments(null);
-    Assert.assertTrue(config.isCleanupEnabled());
-    Assert.assertTrue(config.isIgnoreDurationToRetain());
-    Assert.assertEquals(Duration.standardMinutes(30), config.getCleanupPeriod());
-    Assert.assertEquals(Duration.standardMinutes(60), config.getBufferPeriod());
-    Assert.assertEquals(Duration.standardHours(12), config.getDurationToRetain());
-    Assert.assertEquals(500, config.getMaxSegments());
+    Assertions.assertTrue(config.isCleanupEnabled());
+    Assertions.assertTrue(config.isIgnoreDurationToRetain());
+    Assertions.assertEquals(Duration.standardMinutes(30), config.getCleanupPeriod());
+    Assertions.assertEquals(Duration.standardMinutes(60), config.getBufferPeriod());
+    Assertions.assertEquals(Duration.standardHours(12), config.getDurationToRetain());
+    Assertions.assertEquals(500, config.getMaxSegments());
   }
 
   @Test
@@ -216,13 +216,13 @@ public class DruidCoordinatorConfigTest
     final CoordinatorKillConfigs killConfigs
         = deserializeFrom(new Properties(), "druid.coordinator.kill", CoordinatorKillConfigs.class);
 
-    Assert.assertEquals(MetadataCleanupConfig.DEFAULT, killConfigs.auditLogs());
-    Assert.assertEquals(MetadataCleanupConfig.DEFAULT, killConfigs.supervisors());
-    Assert.assertEquals(MetadataCleanupConfig.DEFAULT, killConfigs.compactionConfigs());
-    Assert.assertEquals(MetadataCleanupConfig.DEFAULT, killConfigs.datasources());
-    Assert.assertEquals(MetadataCleanupConfig.DEFAULT, killConfigs.rules());
-    Assert.assertEquals(MetadataCleanupConfig.DEFAULT, killConfigs.pendingSegments());
-    Assert.assertEquals(MetadataCleanupConfig.DEFAULT, killConfigs.segmentSchemas());
+    Assertions.assertEquals(MetadataCleanupConfig.DEFAULT, killConfigs.auditLogs());
+    Assertions.assertEquals(MetadataCleanupConfig.DEFAULT, killConfigs.supervisors());
+    Assertions.assertEquals(MetadataCleanupConfig.DEFAULT, killConfigs.compactionConfigs());
+    Assertions.assertEquals(MetadataCleanupConfig.DEFAULT, killConfigs.datasources());
+    Assertions.assertEquals(MetadataCleanupConfig.DEFAULT, killConfigs.rules());
+    Assertions.assertEquals(MetadataCleanupConfig.DEFAULT, killConfigs.pendingSegments());
+    Assertions.assertEquals(MetadataCleanupConfig.DEFAULT, killConfigs.segmentSchemas());
   }
 
   @Test
@@ -258,31 +258,31 @@ public class DruidCoordinatorConfigTest
     final CoordinatorKillConfigs killConfigs
         = deserializeFrom(props, "druid.coordinator.kill", CoordinatorKillConfigs.class);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new MetadataCleanupConfig(false, Duration.standardHours(10), Duration.standardHours(20)),
         killConfigs.auditLogs()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new MetadataCleanupConfig(false, Duration.standardHours(20), Duration.standardHours(30)),
         killConfigs.compactionConfigs()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new MetadataCleanupConfig(false, Duration.standardHours(5), Duration.standardHours(10)),
         killConfigs.datasources()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new MetadataCleanupConfig(false, Duration.standardHours(11), Duration.standardHours(12)),
         killConfigs.rules()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new MetadataCleanupConfig(false, Duration.standardHours(1), Duration.standardHours(2)),
         killConfigs.supervisors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new MetadataCleanupConfig(false, Duration.standardHours(2), Duration.standardHours(8)),
         killConfigs.segmentSchemas()
     );
-    Assert.assertFalse(killConfigs.pendingSegments().isCleanupEnabled());
+    Assertions.assertFalse(killConfigs.pendingSegments().isCleanupEnabled());
   }
 
   @Test
@@ -435,7 +435,7 @@ public class DruidCoordinatorConfigTest
       Object... args
   )
   {
-    DruidException exception = Assert.assertThrows(
+    DruidException exception = Assertions.assertThrows(
         DruidException.class,
         () -> new DruidCoordinatorConfig(
             new CoordinatorRunConfig(null, null),

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
@@ -76,9 +76,10 @@ import org.apache.druid.server.lookup.cache.LookupCoordinatorManager;
 import org.apache.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -86,6 +87,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -109,7 +111,7 @@ public class DruidCoordinatorTest
   private CompactionStatusTracker statusTracker;
   private LatchableServiceEmitter serviceEmitter;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     serverInventoryView = EasyMock.createMock(ServerInventoryView.class);
@@ -198,7 +200,8 @@ public class DruidCoordinatorTest
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCoordinatorRun() throws Exception
   {
     String dataSource = "dataSource1";
@@ -249,67 +252,68 @@ public class DruidCoordinatorTest
 
     coordinator.start();
 
-    Assert.assertNull(coordinator.getReplicationFactor(dataSegment.getId()));
-    Assert.assertNull(coordinator.getBroadcastSegments());
+    Assertions.assertNull(coordinator.getReplicationFactor(dataSegment.getId()));
+    Assertions.assertNull(coordinator.getBroadcastSegments());
 
     // Wait for this coordinator to become leader
 
     // This coordinator should be leader by now
-    Assert.assertTrue(coordinator.isLeader());
-    Assert.assertEquals(druidNode.getHostAndPort(), coordinator.getCurrentLeader());
+    Assertions.assertTrue(coordinator.isLeader());
+    Assertions.assertEquals(druidNode.getHostAndPort(), coordinator.getCurrentLeader());
 
     serviceEmitter.coordinatorRunLatch.await();
 
-    Assert.assertEquals(ImmutableMap.of(dataSource, 100.0), coordinator.getDatasourceToLoadStatus());
+    Assertions.assertEquals(ImmutableMap.of(dataSource, 100.0), coordinator.getDatasourceToLoadStatus());
 
     Object2IntMap<String> numsUnavailableUsedSegmentsPerDataSource =
         coordinator.getDatasourceToUnavailableSegmentCount();
-    Assert.assertEquals(1, numsUnavailableUsedSegmentsPerDataSource.size());
-    Assert.assertEquals(0, numsUnavailableUsedSegmentsPerDataSource.getInt(dataSource));
-    Assert.assertEquals(0, coordinator.getBroadcastSegments().size());
+    Assertions.assertEquals(1, numsUnavailableUsedSegmentsPerDataSource.size());
+    Assertions.assertEquals(0, numsUnavailableUsedSegmentsPerDataSource.getInt(dataSource));
+    Assertions.assertEquals(0, coordinator.getBroadcastSegments().size());
 
     Map<String, Object2LongMap<String>> underReplicationCountsPerDataSourcePerTier =
         coordinator.getTierToDatasourceToUnderReplicatedCount(false);
-    Assert.assertNotNull(underReplicationCountsPerDataSourcePerTier);
-    Assert.assertEquals(1, underReplicationCountsPerDataSourcePerTier.size());
+    Assertions.assertNotNull(underReplicationCountsPerDataSourcePerTier);
+    Assertions.assertEquals(1, underReplicationCountsPerDataSourcePerTier.size());
 
     Object2LongMap<String> underRepliicationCountsPerDataSource = underReplicationCountsPerDataSourcePerTier.get(tier);
-    Assert.assertNotNull(underRepliicationCountsPerDataSource);
-    Assert.assertEquals(1, underRepliicationCountsPerDataSource.size());
+    Assertions.assertNotNull(underRepliicationCountsPerDataSource);
+    Assertions.assertEquals(1, underRepliicationCountsPerDataSource.size());
     //noinspection deprecation
-    Assert.assertNotNull(underRepliicationCountsPerDataSource.get(dataSource));
+    Assertions.assertNotNull(underRepliicationCountsPerDataSource.get(dataSource));
     // Simulated the adding of segment to druidServer during SegmentChangeRequestLoad event
     // The load rules asks for 2 replicas, therefore 1 replica should still be pending
-    Assert.assertEquals(1L, underRepliicationCountsPerDataSource.getLong(dataSource));
+    Assertions.assertEquals(1L, underRepliicationCountsPerDataSource.getLong(dataSource));
 
     Map<String, Object2LongMap<String>> underReplicationCountsPerDataSourcePerTierUsingClusterView =
         coordinator.getTierToDatasourceToUnderReplicatedCount(true);
-    Assert.assertNotNull(underReplicationCountsPerDataSourcePerTier);
-    Assert.assertEquals(1, underReplicationCountsPerDataSourcePerTier.size());
+    Assertions.assertNotNull(underReplicationCountsPerDataSourcePerTier);
+    Assertions.assertEquals(1, underReplicationCountsPerDataSourcePerTier.size());
 
     Object2LongMap<String> underRepliicationCountsPerDataSourceUsingClusterView =
         underReplicationCountsPerDataSourcePerTierUsingClusterView.get(tier);
-    Assert.assertNotNull(underRepliicationCountsPerDataSourceUsingClusterView);
-    Assert.assertEquals(1, underRepliicationCountsPerDataSourceUsingClusterView.size());
+    Assertions.assertNotNull(underRepliicationCountsPerDataSourceUsingClusterView);
+    Assertions.assertEquals(1, underRepliicationCountsPerDataSourceUsingClusterView.size());
     //noinspection deprecation
-    Assert.assertNotNull(underRepliicationCountsPerDataSourceUsingClusterView.get(dataSource));
+    Assertions.assertNotNull(underRepliicationCountsPerDataSourceUsingClusterView.get(dataSource));
     // Simulated the adding of segment to druidServer during SegmentChangeRequestLoad event
     // The load rules asks for 2 replicas, but only 1 historical server in cluster. Since computing using cluster view
     // the segments are replicated as many times as they can be given state of cluster, therefore should not be
     // under-replicated.
-    Assert.assertEquals(0L, underRepliicationCountsPerDataSourceUsingClusterView.getLong(dataSource));
-    Assert.assertEquals(Integer.valueOf(2), coordinator.getReplicationFactor(dataSegment.getId()));
+    Assertions.assertEquals(0L, underRepliicationCountsPerDataSourceUsingClusterView.getLong(dataSource));
+    Assertions.assertEquals(Integer.valueOf(2), coordinator.getReplicationFactor(dataSegment.getId()));
 
     coordinator.stop();
 
-    Assert.assertFalse(coordinator.isLeader());
-    Assert.assertNull(coordinator.getCurrentLeader());
+    Assertions.assertFalse(coordinator.isLeader());
+    Assertions.assertNull(coordinator.getCurrentLeader());
 
     EasyMock.verify(serverInventoryView);
     EasyMock.verify(metadataRuleManager);
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCoordinatorTieredRun() throws Exception
   {
     final String dataSource = "dataSource", hotTierName = "hot", coldTierName = "cold";
@@ -350,21 +354,21 @@ public class DruidCoordinatorTest
 
     serviceEmitter.coordinatorRunLatch.await();
 
-    Assert.assertEquals(ImmutableMap.of(dataSource, 100.0), coordinator.getDatasourceToLoadStatus());
+    Assertions.assertEquals(ImmutableMap.of(dataSource, 100.0), coordinator.getDatasourceToLoadStatus());
 
     Map<String, Object2LongMap<String>> underReplicationCountsPerDataSourcePerTier =
         coordinator.getTierToDatasourceToUnderReplicatedCount(false);
-    Assert.assertEquals(2, underReplicationCountsPerDataSourcePerTier.size());
-    Assert.assertEquals(0L, underReplicationCountsPerDataSourcePerTier.get(hotTierName).getLong(dataSource));
-    Assert.assertEquals(0L, underReplicationCountsPerDataSourcePerTier.get(coldTierName).getLong(dataSource));
+    Assertions.assertEquals(2, underReplicationCountsPerDataSourcePerTier.size());
+    Assertions.assertEquals(0L, underReplicationCountsPerDataSourcePerTier.get(hotTierName).getLong(dataSource));
+    Assertions.assertEquals(0L, underReplicationCountsPerDataSourcePerTier.get(coldTierName).getLong(dataSource));
 
     Map<String, Object2LongMap<String>> underReplicationCountsPerDataSourcePerTierUsingClusterView =
         coordinator.getTierToDatasourceToUnderReplicatedCount(true);
-    Assert.assertEquals(2, underReplicationCountsPerDataSourcePerTierUsingClusterView.size());
-    Assert.assertEquals(0L, underReplicationCountsPerDataSourcePerTierUsingClusterView.get(hotTierName).getLong(dataSource));
-    Assert.assertEquals(0L, underReplicationCountsPerDataSourcePerTierUsingClusterView.get(coldTierName).getLong(dataSource));
+    Assertions.assertEquals(2, underReplicationCountsPerDataSourcePerTierUsingClusterView.size());
+    Assertions.assertEquals(0L, underReplicationCountsPerDataSourcePerTierUsingClusterView.get(hotTierName).getLong(dataSource));
+    Assertions.assertEquals(0L, underReplicationCountsPerDataSourcePerTierUsingClusterView.get(coldTierName).getLong(dataSource));
 
-    dataSegments.forEach(dataSegment -> Assert.assertEquals(Integer.valueOf(1), coordinator.getReplicationFactor(dataSegment.getId())));
+    dataSegments.forEach(dataSegment -> Assertions.assertEquals(Integer.valueOf(1), coordinator.getReplicationFactor(dataSegment.getId())));
 
     coordinator.stop();
 
@@ -373,7 +377,8 @@ public class DruidCoordinatorTest
     EasyMock.verify(metadataRuleManager);
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testComputeUnderReplicationCountsPerDataSourcePerTierForSegmentsWithBroadcastRule() throws Exception
   {
     final String dataSource = "dataSource";
@@ -432,25 +437,25 @@ public class DruidCoordinatorTest
 
     serviceEmitter.coordinatorRunLatch.await();
 
-    Assert.assertEquals(ImmutableMap.of(dataSource, 100.0), coordinator.getDatasourceToLoadStatus());
-    Assert.assertEquals(dataSegments, coordinator.getBroadcastSegments());
+    Assertions.assertEquals(ImmutableMap.of(dataSource, 100.0), coordinator.getDatasourceToLoadStatus());
+    Assertions.assertEquals(dataSegments, coordinator.getBroadcastSegments());
 
     // Under-replicated counts are updated only after the next coordinator run
     Map<String, Object2LongMap<String>> underReplicationCountsPerDataSourcePerTier =
         coordinator.getTierToDatasourceToUnderReplicatedCount(false);
-    Assert.assertEquals(4, underReplicationCountsPerDataSourcePerTier.size());
-    Assert.assertEquals(0L, underReplicationCountsPerDataSourcePerTier.get(hotTierName).getLong(dataSource));
-    Assert.assertEquals(0L, underReplicationCountsPerDataSourcePerTier.get(coldTierName).getLong(dataSource));
-    Assert.assertEquals(0L, underReplicationCountsPerDataSourcePerTier.get(tierName1).getLong(dataSource));
-    Assert.assertEquals(0L, underReplicationCountsPerDataSourcePerTier.get(tierName2).getLong(dataSource));
+    Assertions.assertEquals(4, underReplicationCountsPerDataSourcePerTier.size());
+    Assertions.assertEquals(0L, underReplicationCountsPerDataSourcePerTier.get(hotTierName).getLong(dataSource));
+    Assertions.assertEquals(0L, underReplicationCountsPerDataSourcePerTier.get(coldTierName).getLong(dataSource));
+    Assertions.assertEquals(0L, underReplicationCountsPerDataSourcePerTier.get(tierName1).getLong(dataSource));
+    Assertions.assertEquals(0L, underReplicationCountsPerDataSourcePerTier.get(tierName2).getLong(dataSource));
 
     Map<String, Object2LongMap<String>> underReplicationCountsPerDataSourcePerTierUsingClusterView =
         coordinator.getTierToDatasourceToUnderReplicatedCount(true);
-    Assert.assertEquals(4, underReplicationCountsPerDataSourcePerTierUsingClusterView.size());
-    Assert.assertEquals(0L, underReplicationCountsPerDataSourcePerTierUsingClusterView.get(hotTierName).getLong(dataSource));
-    Assert.assertEquals(0L, underReplicationCountsPerDataSourcePerTierUsingClusterView.get(coldTierName).getLong(dataSource));
-    Assert.assertEquals(0L, underReplicationCountsPerDataSourcePerTierUsingClusterView.get(tierName1).getLong(dataSource));
-    Assert.assertEquals(0L, underReplicationCountsPerDataSourcePerTierUsingClusterView.get(tierName2).getLong(dataSource));
+    Assertions.assertEquals(4, underReplicationCountsPerDataSourcePerTierUsingClusterView.size());
+    Assertions.assertEquals(0L, underReplicationCountsPerDataSourcePerTierUsingClusterView.get(hotTierName).getLong(dataSource));
+    Assertions.assertEquals(0L, underReplicationCountsPerDataSourcePerTierUsingClusterView.get(coldTierName).getLong(dataSource));
+    Assertions.assertEquals(0L, underReplicationCountsPerDataSourcePerTierUsingClusterView.get(tierName1).getLong(dataSource));
+    Assertions.assertEquals(0L, underReplicationCountsPerDataSourcePerTierUsingClusterView.get(tierName2).getLong(dataSource));
 
     coordinator.stop();
 
@@ -491,18 +496,18 @@ public class DruidCoordinatorTest
 
     // Since CompactSegments is not enabled in Custom Duty Group, then CompactSegments must be created in IndexingServiceDuties
     final List<DutyGroupStatus> duties = coordinator.getStatusOfDuties();
-    Assert.assertEquals(3, duties.size());
+    Assertions.assertEquals(3, duties.size());
 
-    Assert.assertEquals("HistoricalManagementDuties", duties.get(0).getName());
-    Assert.assertEquals("IndexingServiceDuties", duties.get(1).getName());
-    Assert.assertEquals("MetadataStoreManagementDuties", duties.get(2).getName());
+    Assertions.assertEquals("HistoricalManagementDuties", duties.get(0).getName());
+    Assertions.assertEquals("IndexingServiceDuties", duties.get(1).getName());
+    Assertions.assertEquals("MetadataStoreManagementDuties", duties.get(2).getName());
 
     final String compactDutyName = CompactSegments.class.getName();
-    Assert.assertTrue(duties.get(1).getDutyNames().contains(compactDutyName));
+    Assertions.assertTrue(duties.get(1).getDutyNames().contains(compactDutyName));
 
     // CompactSegments should not exist in other duty groups
-    Assert.assertFalse(duties.get(0).getDutyNames().contains(compactDutyName));
-    Assert.assertFalse(duties.get(2).getDutyNames().contains(compactDutyName));
+    Assertions.assertFalse(duties.get(0).getDutyNames().contains(compactDutyName));
+    Assertions.assertFalse(duties.get(2).getDutyNames().contains(compactDutyName));
 
     coordinator.stop();
   }
@@ -541,19 +546,19 @@ public class DruidCoordinatorTest
     coordinator.start();
     // Since CompactSegments is not enabled in Custom Duty Group, then CompactSegments must be created in IndexingServiceDuties
     final List<DutyGroupStatus> duties = coordinator.getStatusOfDuties();
-    Assert.assertEquals(4, duties.size());
+    Assertions.assertEquals(4, duties.size());
 
-    Assert.assertEquals("HistoricalManagementDuties", duties.get(0).getName());
-    Assert.assertEquals("IndexingServiceDuties", duties.get(1).getName());
-    Assert.assertEquals("MetadataStoreManagementDuties", duties.get(2).getName());
-    Assert.assertEquals("group1", duties.get(3).getName());
+    Assertions.assertEquals("HistoricalManagementDuties", duties.get(0).getName());
+    Assertions.assertEquals("IndexingServiceDuties", duties.get(1).getName());
+    Assertions.assertEquals("MetadataStoreManagementDuties", duties.get(2).getName());
+    Assertions.assertEquals("group1", duties.get(3).getName());
 
     final String compactDutyName = CompactSegments.class.getName();
-    Assert.assertTrue(duties.get(1).getDutyNames().contains(compactDutyName));
+    Assertions.assertTrue(duties.get(1).getDutyNames().contains(compactDutyName));
 
     // CompactSegments should not exist in other duty groups
-    Assert.assertFalse(duties.get(0).getDutyNames().contains(compactDutyName));
-    Assert.assertFalse(duties.get(2).getDutyNames().contains(compactDutyName));
+    Assertions.assertFalse(duties.get(0).getDutyNames().contains(compactDutyName));
+    Assertions.assertFalse(duties.get(2).getDutyNames().contains(compactDutyName));
 
     coordinator.stop();
   }
@@ -593,26 +598,27 @@ public class DruidCoordinatorTest
 
     // Since CompactSegments is enabled in Custom Duty Group, then CompactSegments must not be created in IndexingServiceDuties
     final List<DutyGroupStatus> duties = coordinator.getStatusOfDuties();
-    Assert.assertEquals(4, duties.size());
+    Assertions.assertEquals(4, duties.size());
 
-    Assert.assertEquals("HistoricalManagementDuties", duties.get(0).getName());
-    Assert.assertEquals("IndexingServiceDuties", duties.get(1).getName());
-    Assert.assertEquals("MetadataStoreManagementDuties", duties.get(2).getName());
-    Assert.assertEquals("group1", duties.get(3).getName());
+    Assertions.assertEquals("HistoricalManagementDuties", duties.get(0).getName());
+    Assertions.assertEquals("IndexingServiceDuties", duties.get(1).getName());
+    Assertions.assertEquals("MetadataStoreManagementDuties", duties.get(2).getName());
+    Assertions.assertEquals("group1", duties.get(3).getName());
 
     // CompactSegments should exist in Custom Duty Group
     final String compactDutyName = CompactSegments.class.getName();
-    Assert.assertTrue(duties.get(3).getDutyNames().contains(compactDutyName));
+    Assertions.assertTrue(duties.get(3).getDutyNames().contains(compactDutyName));
 
     // CompactSegments should not exist in other duty groups
-    Assert.assertFalse(duties.get(0).getDutyNames().contains(compactDutyName));
-    Assert.assertFalse(duties.get(1).getDutyNames().contains(compactDutyName));
-    Assert.assertFalse(duties.get(2).getDutyNames().contains(compactDutyName));
+    Assertions.assertFalse(duties.get(0).getDutyNames().contains(compactDutyName));
+    Assertions.assertFalse(duties.get(1).getDutyNames().contains(compactDutyName));
+    Assertions.assertFalse(duties.get(2).getDutyNames().contains(compactDutyName));
 
     coordinator.stop();
   }
 
-  @Test(timeout = 3000)
+  @Test
+  @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
   public void testCoordinatorCustomDutyGroupsRunAsExpected() throws Exception
   {
     // Some nessesary setup to start the Coordinator
@@ -710,7 +716,8 @@ public class DruidCoordinatorTest
     }
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCoordinatorRun_queryFromDeepStorage() throws Exception
   {
     String dataSource = "dataSource1";
@@ -783,39 +790,39 @@ public class DruidCoordinatorTest
     // Wait for this coordinator to become leader
 
     // This coordinator should be leader by now
-    Assert.assertTrue(coordinator.isLeader());
-    Assert.assertEquals(druidNode.getHostAndPort(), coordinator.getCurrentLeader());
+    Assertions.assertTrue(coordinator.isLeader());
+    Assertions.assertEquals(druidNode.getHostAndPort(), coordinator.getCurrentLeader());
 
     serviceEmitter.coordinatorRunLatch.await();
 
     Object2IntMap<String> numsUnavailableUsedSegmentsPerDataSource =
         coordinator.getDatasourceToUnavailableSegmentCount();
-    Assert.assertEquals(1, numsUnavailableUsedSegmentsPerDataSource.size());
+    Assertions.assertEquals(1, numsUnavailableUsedSegmentsPerDataSource.size());
     // The cold tier segment should not be unavailable, the hot one should be unavailable
-    Assert.assertEquals(1, numsUnavailableUsedSegmentsPerDataSource.getInt(dataSource));
+    Assertions.assertEquals(1, numsUnavailableUsedSegmentsPerDataSource.getInt(dataSource));
 
     Map<String, Object2LongMap<String>> underReplicationCountsPerDataSourcePerTier =
         coordinator.getTierToDatasourceToUnderReplicatedCount(false);
-    Assert.assertNotNull(underReplicationCountsPerDataSourcePerTier);
-    Assert.assertEquals(2, underReplicationCountsPerDataSourcePerTier.size());
+    Assertions.assertNotNull(underReplicationCountsPerDataSourcePerTier);
+    Assertions.assertEquals(2, underReplicationCountsPerDataSourcePerTier.size());
 
     Object2LongMap<String> underRepliicationCountsPerDataSourceHotTier = underReplicationCountsPerDataSourcePerTier.get(hotTier);
-    Assert.assertNotNull(underRepliicationCountsPerDataSourceHotTier);
-    Assert.assertEquals(1, underRepliicationCountsPerDataSourceHotTier.getLong(dataSource));
+    Assertions.assertNotNull(underRepliicationCountsPerDataSourceHotTier);
+    Assertions.assertEquals(1, underRepliicationCountsPerDataSourceHotTier.getLong(dataSource));
 
     Object2LongMap<String> underRepliicationCountsPerDataSourceColdTier = underReplicationCountsPerDataSourcePerTier.get(coldTier);
-    Assert.assertNotNull(underRepliicationCountsPerDataSourceColdTier);
-    Assert.assertEquals(0, underRepliicationCountsPerDataSourceColdTier.getLong(dataSource));
+    Assertions.assertNotNull(underRepliicationCountsPerDataSourceColdTier);
+    Assertions.assertEquals(0, underRepliicationCountsPerDataSourceColdTier.getLong(dataSource));
 
     Object2IntMap<String> numsDeepStorageOnlySegmentsPerDataSource =
             coordinator.getDatasourceToDeepStorageQueryOnlySegmentCount();
 
-    Assert.assertEquals(1, numsDeepStorageOnlySegmentsPerDataSource.getInt(dataSource));
+    Assertions.assertEquals(1, numsDeepStorageOnlySegmentsPerDataSource.getInt(dataSource));
 
     coordinator.stop();
 
-    Assert.assertFalse(coordinator.isLeader());
-    Assert.assertNull(coordinator.getCurrentLeader());
+    Assertions.assertFalse(coordinator.isLeader());
+    Assertions.assertNull(coordinator.getCurrentLeader());
 
     EasyMock.verify(serverInventoryView);
     EasyMock.verify(metadataRuleManager);
@@ -833,7 +840,7 @@ public class DruidCoordinatorTest
     CompactionSimulateResult result = coordinator.simulateRunWithConfigUpdate(
         new ClusterCompactionConfig(0.2, null, null, null, null, null)
     );
-    Assert.assertEquals(Collections.emptyMap(), result.getCompactionStates());
+    Assertions.assertEquals(Collections.emptyMap(), result.getCompactionStates());
   }
 
   private void setupSegmentsMetadataMock(DruidDataSource dataSource)

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
@@ -80,6 +80,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -201,7 +202,7 @@ public class DruidCoordinatorTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testCoordinatorRun() throws Exception
   {
     String dataSource = "dataSource1";
@@ -313,7 +314,7 @@ public class DruidCoordinatorTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testCoordinatorTieredRun() throws Exception
   {
     final String dataSource = "dataSource", hotTierName = "hot", coldTierName = "cold";
@@ -378,7 +379,7 @@ public class DruidCoordinatorTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testComputeUnderReplicationCountsPerDataSourcePerTierForSegmentsWithBroadcastRule() throws Exception
   {
     final String dataSource = "dataSource";
@@ -618,7 +619,7 @@ public class DruidCoordinatorTest
   }
 
   @Test
-  @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testCoordinatorCustomDutyGroupsRunAsExpected() throws Exception
   {
     // Some nessesary setup to start the Coordinator
@@ -717,7 +718,7 @@ public class DruidCoordinatorTest
   }
 
   @Test
-  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testCoordinatorRun_queryFromDeepStorage() throws Exception
   {
     String dataSource = "dataSource1";

--- a/server/src/test/java/org/apache/druid/server/coordinator/InlineSchemaDataSourceCompactionConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/InlineSchemaDataSourceCompactionConfigTest.java
@@ -51,8 +51,8 @@ import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
@@ -82,16 +82,16 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(config);
     final InlineSchemaDataSourceCompactionConfig fromJson = OBJECT_MAPPER.readValue(json, InlineSchemaDataSourceCompactionConfig.class);
 
-    Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(25, fromJson.getTaskPriority());
-    Assert.assertEquals(100_000_000_000_000L, fromJson.getInputSegmentSizeBytes());
-    Assert.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
-    Assert.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
-    Assert.assertEquals(config.getSkipIntervals(), fromJson.getSkipIntervals());
-    Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
-    Assert.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
-    Assert.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
-    Assert.assertEquals(config.getEngine(), fromJson.getEngine());
+    Assertions.assertEquals(config.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(25, fromJson.getTaskPriority());
+    Assertions.assertEquals(100_000_000_000_000L, fromJson.getInputSegmentSizeBytes());
+    Assertions.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
+    Assertions.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
+    Assertions.assertEquals(config.getSkipIntervals(), fromJson.getSkipIntervals());
+    Assertions.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
+    Assertions.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
+    Assertions.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
+    Assertions.assertEquals(config.getEngine(), fromJson.getEngine());
   }
 
   @Test
@@ -110,14 +110,14 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(config);
     final InlineSchemaDataSourceCompactionConfig fromJson = OBJECT_MAPPER.readValue(json, InlineSchemaDataSourceCompactionConfig.class);
 
-    Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(25, fromJson.getTaskPriority());
-    Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
-    Assert.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
-    Assert.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
-    Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
-    Assert.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
-    Assert.assertEquals(config.getEngine(), fromJson.getEngine());
+    Assertions.assertEquals(config.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(25, fromJson.getTaskPriority());
+    Assertions.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
+    Assertions.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
+    Assertions.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
+    Assertions.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
+    Assertions.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
+    Assertions.assertEquals(config.getEngine(), fromJson.getEngine());
   }
 
   @Test
@@ -135,14 +135,14 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(config);
     final InlineSchemaDataSourceCompactionConfig fromJson = OBJECT_MAPPER.readValue(json, InlineSchemaDataSourceCompactionConfig.class);
 
-    Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(25, fromJson.getTaskPriority());
-    Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
-    Assert.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
-    Assert.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
-    Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
-    Assert.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
-    Assert.assertEquals(config.getEngine(), fromJson.getEngine());
+    Assertions.assertEquals(config.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(25, fromJson.getTaskPriority());
+    Assertions.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
+    Assertions.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
+    Assertions.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
+    Assertions.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
+    Assertions.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
+    Assertions.assertEquals(config.getEngine(), fromJson.getEngine());
   }
 
   @Test
@@ -160,13 +160,13 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(config);
     final InlineSchemaDataSourceCompactionConfig fromJson = OBJECT_MAPPER.readValue(json, InlineSchemaDataSourceCompactionConfig.class);
 
-    Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(25, fromJson.getTaskPriority());
-    Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
-    Assert.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
-    Assert.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
-    Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
-    Assert.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
+    Assertions.assertEquals(config.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(25, fromJson.getTaskPriority());
+    Assertions.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
+    Assertions.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
+    Assertions.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
+    Assertions.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
+    Assertions.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
   }
 
   @Test
@@ -205,7 +205,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(tuningConfig);
     final UserCompactionTaskQueryTuningConfig fromJson =
         OBJECT_MAPPER.readValue(json, UserCompactionTaskQueryTuningConfig.class);
-    Assert.assertEquals(tuningConfig, fromJson);
+    Assertions.assertEquals(tuningConfig, fromJson);
   }
 
   @Test
@@ -244,7 +244,7 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(tuningConfig);
     final UserCompactionTaskQueryTuningConfig fromJson =
         OBJECT_MAPPER.readValue(json, UserCompactionTaskQueryTuningConfig.class);
-    Assert.assertEquals(tuningConfig, fromJson);
+    Assertions.assertEquals(tuningConfig, fromJson);
   }
 
   @Test
@@ -262,14 +262,14 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(config);
     final InlineSchemaDataSourceCompactionConfig fromJson = OBJECT_MAPPER.readValue(json, InlineSchemaDataSourceCompactionConfig.class);
 
-    Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(25, fromJson.getTaskPriority());
-    Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
-    Assert.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
-    Assert.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
-    Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
-    Assert.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
-    Assert.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
+    Assertions.assertEquals(config.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(25, fromJson.getTaskPriority());
+    Assertions.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
+    Assertions.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
+    Assertions.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
+    Assertions.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
+    Assertions.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
+    Assertions.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
   }
 
   @Test
@@ -287,17 +287,17 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(config);
     final InlineSchemaDataSourceCompactionConfig fromJson = OBJECT_MAPPER.readValue(json, InlineSchemaDataSourceCompactionConfig.class);
 
-    Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(25, fromJson.getTaskPriority());
-    Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
-    Assert.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
-    Assert.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
-    Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
-    Assert.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
-    Assert.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
-    Assert.assertNotNull(config.getGranularitySpec());
-    Assert.assertNotNull(fromJson.getGranularitySpec());
-    Assert.assertEquals(config.getGranularitySpec().getQueryGranularity(), fromJson.getGranularitySpec().getQueryGranularity());
+    Assertions.assertEquals(config.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(25, fromJson.getTaskPriority());
+    Assertions.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
+    Assertions.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
+    Assertions.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
+    Assertions.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
+    Assertions.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
+    Assertions.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
+    Assertions.assertNotNull(config.getGranularitySpec());
+    Assertions.assertNotNull(fromJson.getGranularitySpec());
+    Assertions.assertEquals(config.getGranularitySpec().getQueryGranularity(), fromJson.getGranularitySpec().getQueryGranularity());
   }
 
   @Test
@@ -314,14 +314,14 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(config);
     final InlineSchemaDataSourceCompactionConfig fromJson = OBJECT_MAPPER.readValue(json, InlineSchemaDataSourceCompactionConfig.class);
 
-    Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(25, fromJson.getTaskPriority());
-    Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
-    Assert.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
-    Assert.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
-    Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
-    Assert.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
-    Assert.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
+    Assertions.assertEquals(config.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(25, fromJson.getTaskPriority());
+    Assertions.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
+    Assertions.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
+    Assertions.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
+    Assertions.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
+    Assertions.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
+    Assertions.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
   }
 
   @Test
@@ -339,14 +339,14 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(config);
     final InlineSchemaDataSourceCompactionConfig fromJson = OBJECT_MAPPER.readValue(json, InlineSchemaDataSourceCompactionConfig.class);
 
-    Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(25, fromJson.getTaskPriority());
-    Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
-    Assert.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
-    Assert.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
-    Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
-    Assert.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
-    Assert.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
+    Assertions.assertEquals(config.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(25, fromJson.getTaskPriority());
+    Assertions.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
+    Assertions.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
+    Assertions.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
+    Assertions.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
+    Assertions.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
+    Assertions.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
   }
 
   @Test
@@ -364,17 +364,17 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(config);
     final InlineSchemaDataSourceCompactionConfig fromJson = OBJECT_MAPPER.readValue(json, InlineSchemaDataSourceCompactionConfig.class);
 
-    Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(25, fromJson.getTaskPriority());
-    Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
-    Assert.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
-    Assert.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
-    Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
-    Assert.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
-    Assert.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
-    Assert.assertNotNull(config.getGranularitySpec());
-    Assert.assertNotNull(fromJson.getGranularitySpec());
-    Assert.assertEquals(config.getGranularitySpec().isRollup(), fromJson.getGranularitySpec().isRollup());
+    Assertions.assertEquals(config.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(25, fromJson.getTaskPriority());
+    Assertions.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
+    Assertions.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
+    Assertions.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
+    Assertions.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
+    Assertions.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
+    Assertions.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
+    Assertions.assertNotNull(config.getGranularitySpec());
+    Assertions.assertNotNull(fromJson.getGranularitySpec());
+    Assertions.assertEquals(config.getGranularitySpec().isRollup(), fromJson.getGranularitySpec().isRollup());
   }
 
   @Test
@@ -393,15 +393,15 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(config);
     final InlineSchemaDataSourceCompactionConfig fromJson = OBJECT_MAPPER.readValue(json, InlineSchemaDataSourceCompactionConfig.class);
 
-    Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(25, fromJson.getTaskPriority());
-    Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
-    Assert.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
-    Assert.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
-    Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
-    Assert.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
-    Assert.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
-    Assert.assertEquals(config.getIoConfig(), fromJson.getIoConfig());
+    Assertions.assertEquals(config.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(25, fromJson.getTaskPriority());
+    Assertions.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
+    Assertions.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
+    Assertions.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
+    Assertions.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
+    Assertions.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
+    Assertions.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
+    Assertions.assertEquals(config.getIoConfig(), fromJson.getIoConfig());
   }
 
   @Test
@@ -420,15 +420,15 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(config);
     final InlineSchemaDataSourceCompactionConfig fromJson = OBJECT_MAPPER.readValue(json, InlineSchemaDataSourceCompactionConfig.class);
 
-    Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(25, fromJson.getTaskPriority());
-    Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
-    Assert.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
-    Assert.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
-    Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
-    Assert.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
-    Assert.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
-    Assert.assertEquals(config.getIoConfig(), fromJson.getIoConfig());
+    Assertions.assertEquals(config.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(25, fromJson.getTaskPriority());
+    Assertions.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
+    Assertions.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
+    Assertions.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
+    Assertions.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
+    Assertions.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
+    Assertions.assertEquals(config.getGranularitySpec(), fromJson.getGranularitySpec());
+    Assertions.assertEquals(config.getIoConfig(), fromJson.getIoConfig());
   }
 
   @Test
@@ -450,14 +450,14 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(config);
     final InlineSchemaDataSourceCompactionConfig fromJson = OBJECT_MAPPER.readValue(json, InlineSchemaDataSourceCompactionConfig.class);
 
-    Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(25, fromJson.getTaskPriority());
-    Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
-    Assert.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
-    Assert.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
-    Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
-    Assert.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
-    Assert.assertEquals(config.getDimensionsSpec(), fromJson.getDimensionsSpec());
+    Assertions.assertEquals(config.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(25, fromJson.getTaskPriority());
+    Assertions.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
+    Assertions.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
+    Assertions.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
+    Assertions.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
+    Assertions.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
+    Assertions.assertEquals(config.getDimensionsSpec(), fromJson.getDimensionsSpec());
   }
 
   @Test
@@ -487,14 +487,14 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(config);
     final InlineSchemaDataSourceCompactionConfig fromJson = OBJECT_MAPPER.readValue(json, InlineSchemaDataSourceCompactionConfig.class);
 
-    Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(25, fromJson.getTaskPriority());
-    Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
-    Assert.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
-    Assert.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
-    Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
-    Assert.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
-    Assert.assertEquals(config.getTransformSpec(), fromJson.getTransformSpec());
+    Assertions.assertEquals(config.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(25, fromJson.getTaskPriority());
+    Assertions.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
+    Assertions.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
+    Assertions.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
+    Assertions.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
+    Assertions.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
+    Assertions.assertEquals(config.getTransformSpec(), fromJson.getTransformSpec());
   }
 
   @Test
@@ -512,14 +512,14 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(config);
     final InlineSchemaDataSourceCompactionConfig fromJson = OBJECT_MAPPER.readValue(json, InlineSchemaDataSourceCompactionConfig.class);
 
-    Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(25, fromJson.getTaskPriority());
-    Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
-    Assert.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
-    Assert.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
-    Assert.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
-    Assert.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
-    Assert.assertEquals(config.getMetricsSpec(), fromJson.getMetricsSpec());
+    Assertions.assertEquals(config.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(25, fromJson.getTaskPriority());
+    Assertions.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
+    Assertions.assertEquals(config.getMaxRowsPerSegment(), fromJson.getMaxRowsPerSegment());
+    Assertions.assertEquals(config.getSkipOffsetFromLatest(), fromJson.getSkipOffsetFromLatest());
+    Assertions.assertEquals(config.getTuningConfig(), fromJson.getTuningConfig());
+    Assertions.assertEquals(config.getTaskContext(), fromJson.getTaskContext());
+    Assertions.assertArrayEquals(config.getMetricsSpec(), fromJson.getMetricsSpec());
   }
 
   @Test
@@ -545,9 +545,9 @@ public class InlineSchemaDataSourceCompactionConfigTest extends InitializedNullH
     final String json = OBJECT_MAPPER.writeValueAsString(config);
     final InlineSchemaDataSourceCompactionConfig fromJson = OBJECT_MAPPER.readValue(json, InlineSchemaDataSourceCompactionConfig.class);
 
-    Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(config.getBaseTable(), fromJson.getBaseTable());
-    Assert.assertEquals(baseTable, fromJson.getBaseTable());
-    Assert.assertEquals(config, fromJson);
+    Assertions.assertEquals(config.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(config.getBaseTable(), fromJson.getBaseTable());
+    Assertions.assertEquals(baseTable, fromJson.getBaseTable());
+    Assertions.assertEquals(config, fromJson);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/ServerCloneStatusTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/ServerCloneStatusTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.server.coordinator;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ServerCloneStatusTest
 {
@@ -32,7 +32,7 @@ public class ServerCloneStatusTest
     ServerCloneStatus metrics = new ServerCloneStatus("host2", "host1", ServerCloneStatus.State.IN_PROGRESS, 3012, 10, 100);
     byte[] bytes = DefaultObjectMapper.INSTANCE.writeValueAsBytes(metrics);
     ServerCloneStatus deserialized = DefaultObjectMapper.INSTANCE.readValue(bytes, ServerCloneStatus.class);
-    Assert.assertEquals(deserialized, metrics);
+    Assertions.assertEquals(deserialized, metrics);
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/coordinator/ServerHolderTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/ServerHolderTest.java
@@ -29,8 +29,8 @@ import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.loading.TestLoadQueuePeon;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -115,9 +115,9 @@ public class ServerHolderTest
         new TestLoadQueuePeon()
     );
 
-    Assert.assertEquals(0, h1.compareTo(h2));
-    Assert.assertEquals(1, h3.compareTo(h1));
-    Assert.assertEquals(1, h3.compareTo(h4));
+    Assertions.assertEquals(0, h1.compareTo(h2));
+    Assertions.assertEquals(1, h3.compareTo(h1));
+    Assertions.assertEquals(1, h3.compareTo(h4));
   }
 
   @Test
@@ -173,10 +173,10 @@ public class ServerHolderTest
         new TestLoadQueuePeon()
     );
 
-    Assert.assertEquals(h1, h2);
-    Assert.assertNotEquals(h1, h3);
-    Assert.assertNotEquals(h1, h4);
-    Assert.assertNotEquals(h1, h5);
+    Assertions.assertEquals(h1, h2);
+    Assertions.assertNotEquals(h1, h3);
+    Assertions.assertNotEquals(h1, h4);
+    Assertions.assertNotEquals(h1, h5);
   }
 
   @Test
@@ -191,8 +191,8 @@ public class ServerHolderTest
         ),
         new TestLoadQueuePeon()
     );
-    Assert.assertTrue(h1.isServingSegment(SEGMENTS.get(0)));
-    Assert.assertFalse(h1.isServingSegment(SEGMENTS.get(1)));
-    Assert.assertFalse(h1.isLoadQueueFull());
+    Assertions.assertTrue(h1.isServingSegment(SEGMENTS.get(0)));
+    Assertions.assertFalse(h1.isServingSegment(SEGMENTS.get(1)));
+    Assertions.assertFalse(h1.isLoadQueueFull());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/UserCompactionTaskDimensionsConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/UserCompactionTaskDimensionsConfigTest.java
@@ -26,8 +26,8 @@ import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -58,14 +58,17 @@ public class UserCompactionTaskDimensionsConfigTest
         json,
         UserCompactionTaskDimensionsConfig.class
     );
-    Assert.assertEquals(expected, fromJson);
+    Assertions.assertEquals(expected, fromJson);
   }
 
-  @Test(expected = ParseException.class)
+  @Test
   public void testInvalidDimensionsField()
   {
-    final UserCompactionTaskDimensionsConfig expected = new UserCompactionTaskDimensionsConfig(
-        DimensionsSpec.getDefaultSchemas(ImmutableList.of("ts", "dim", "dim"))
+    Assertions.assertThrows(
+        ParseException.class,
+        () -> new UserCompactionTaskDimensionsConfig(
+            DimensionsSpec.getDefaultSchemas(ImmutableList.of("ts", "dim", "dim"))
+        )
     );
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/UserCompactionTaskQueryTuningConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/UserCompactionTaskQueryTuningConfigTest.java
@@ -30,8 +30,8 @@ import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -46,10 +46,10 @@ public class UserCompactionTaskQueryTuningConfigTest
         UserCompactionTaskQueryTuningConfig.builder().build();
     final String json = OBJECT_MAPPER.writeValueAsString(config);
     // Check maxRowsPerSegment doesn't exist in the JSON string
-    Assert.assertFalse(json.contains("maxRowsPerSegment"));
+    Assertions.assertFalse(json.contains("maxRowsPerSegment"));
     final UserCompactionTaskQueryTuningConfig fromJson =
         OBJECT_MAPPER.readValue(json, UserCompactionTaskQueryTuningConfig.class);
-    Assert.assertEquals(config, fromJson);
+    Assertions.assertEquals(config, fromJson);
   }
 
   @Test
@@ -87,6 +87,6 @@ public class UserCompactionTaskQueryTuningConfigTest
     final String json = OBJECT_MAPPER.writeValueAsString(tuningConfig);
     final UserCompactionTaskQueryTuningConfig fromJson =
         OBJECT_MAPPER.readValue(json, UserCompactionTaskQueryTuningConfig.class);
-    Assert.assertEquals(tuningConfig, fromJson);
+    Assertions.assertEquals(tuningConfig, fromJson);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyFactoryTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyFactoryTest.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BalancerStrategyFactoryTest
 {
@@ -37,8 +37,8 @@ public class BalancerStrategyFactoryTest
     BalancerStrategyFactory factory = MAPPER.readValue(json, BalancerStrategyFactory.class);
     BalancerStrategy strategy = factory.createBalancerStrategy(1);
 
-    Assert.assertTrue(strategy instanceof CostBalancerStrategy);
-    Assert.assertFalse(strategy instanceof CachingCostBalancerStrategy);
+    Assertions.assertTrue(strategy instanceof CostBalancerStrategy);
+    Assertions.assertFalse(strategy instanceof CachingCostBalancerStrategy);
 
     factory.stopExecutor();
   }
@@ -50,16 +50,16 @@ public class BalancerStrategyFactoryTest
     ListeningExecutorService exec1 = factory.getOrCreateBalancerExecutor(1);
     ListeningExecutorService exec2 = factory.getOrCreateBalancerExecutor(2);
 
-    Assert.assertTrue(exec1.isShutdown());
-    Assert.assertNotSame(exec1, exec2);
+    Assertions.assertTrue(exec1.isShutdown());
+    Assertions.assertNotSame(exec1, exec2);
 
     ListeningExecutorService exec3 = factory.getOrCreateBalancerExecutor(3);
-    Assert.assertTrue(exec2.isShutdown());
-    Assert.assertNotSame(exec2, exec3);
+    Assertions.assertTrue(exec2.isShutdown());
+    Assertions.assertNotSame(exec2, exec3);
 
     ListeningExecutorService exec4 = factory.getOrCreateBalancerExecutor(3);
-    Assert.assertFalse(exec3.isShutdown());
-    Assert.assertSame(exec3, exec4);
+    Assertions.assertFalse(exec3.isShutdown());
+    Assertions.assertSame(exec3, exec4);
 
     factory.stopExecutor();
   }

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -105,7 +106,7 @@ public class BalancerStrategyTest
   }
 
   @Test
-  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void findNewSegmentHomeReplicatorNotEnoughNodesForReplication()
   {
     final ServerHolder serverHolder1 = new ServerHolder(

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyTest.java
@@ -27,26 +27,28 @@ import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.server.coordinator.loading.TestLoadQueuePeon;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "{index}: BalancerStrategy:{0}")
+@MethodSource("data")
 public class BalancerStrategyTest
 {
   private final BalancerStrategy balancerStrategy;
   private DataSegment proposedDataSegment;
   private List<ServerHolder> serverHolders;
 
-  @Parameterized.Parameters(name = "{index}: BalancerStrategy:{0}")
   public static Iterable<Object[]> data()
   {
     return Arrays.asList(
@@ -62,7 +64,7 @@ public class BalancerStrategyTest
     this.balancerStrategy = balancerStrategy;
   }
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     this.proposedDataSegment = new DataSegment(
@@ -94,7 +96,7 @@ public class BalancerStrategyTest
             0
         ).addDataSegment(proposedDataSegment).toImmutableDruidServer(),
         new TestLoadQueuePeon());
-    Assert.assertFalse(
+    Assertions.assertFalse(
         balancerStrategy.findServersToLoadSegment(
             proposedDataSegment,
             Collections.singletonList(serverHolder)
@@ -102,7 +104,8 @@ public class BalancerStrategyTest
     );
   }
 
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
   public void findNewSegmentHomeReplicatorNotEnoughNodesForReplication()
   {
     final ServerHolder serverHolder1 = new ServerHolder(
@@ -120,7 +123,7 @@ public class BalancerStrategyTest
     serverHolders.add(serverHolder2);
 
     // since there is not enough nodes to load 3 replicas of segment
-    Assert.assertFalse(balancerStrategy.findServersToLoadSegment(proposedDataSegment, serverHolders).hasNext());
+    Assertions.assertFalse(balancerStrategy.findServersToLoadSegment(proposedDataSegment, serverHolders).hasNext());
   }
 
   @Test
@@ -143,6 +146,6 @@ public class BalancerStrategyTest
     final ServerHolder foundServerHolder = balancerStrategy
         .findServersToLoadSegment(proposedDataSegment, serverHolders).next();
     // since there is enough space on server it should be selected
-    Assert.assertEquals(serverHolder, foundServerHolder);
+    Assertions.assertEquals(serverHolder, foundServerHolder);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/CachingCostBalancerStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/CachingCostBalancerStrategyTest.java
@@ -30,10 +30,10 @@ import org.apache.druid.server.coordinator.loading.TestLoadQueuePeon;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -56,7 +56,7 @@ public class CachingCostBalancerStrategyTest
   private List<DataSegment> segmentQueries;
   private ListeningExecutorService executorService;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     Random random = new Random(0);
@@ -80,7 +80,7 @@ public class CachingCostBalancerStrategyTest
     executorService = MoreExecutors.listeningDecorator(Execs.singleThreaded(""));
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     executorService.shutdownNow();
@@ -107,7 +107,7 @@ public class CachingCostBalancerStrategyTest
             }
         )
         .sum();
-    Assert.assertTrue(((double) notEqual / (double) segmentQueries.size()) < 0.01);
+    Assertions.assertTrue(((double) notEqual / (double) segmentQueries.size()) < 0.01);
   }
 
   private CachingCostBalancerStrategy createCachingCostBalancerStrategy(

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/CostBalancerStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/CostBalancerStrategyTest.java
@@ -35,10 +35,10 @@ import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.server.coordinator.stats.Stats;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,7 +58,7 @@ public class CostBalancerStrategyTest
   private CostBalancerStrategy strategy;
   private int uniqueServerId;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     balancerExecutor = Execs.singleThreaded("test-balance-exec-%d");
@@ -68,7 +68,7 @@ public class CostBalancerStrategyTest
     EmittingLogger.registerEmitter(serviceEmitter);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     if (balancerExecutor != null) {
@@ -79,19 +79,19 @@ public class CostBalancerStrategyTest
   @Test
   public void testIntervalCostAdditivity()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         intervalCost(1, 1, 3),
         intervalCost(1, 1, 2) + intervalCost(1, 2, 3),
         DELTA
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         intervalCost(2, 1, 3),
         intervalCost(2, 1, 2) + intervalCost(2, 2, 3),
         DELTA
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         intervalCost(3, 1, 2),
         intervalCost(1, 0, 1) + intervalCost(1, 1, 2) + intervalCost(1, 1, 2),
         DELTA
@@ -108,25 +108,25 @@ public class CostBalancerStrategyTest
   {
     // no overlap
     // [0, 1) [1, 2)
-    Assert.assertEquals(0.3995764, intervalCost(1, 1, 2), DELTA);
+    Assertions.assertEquals(0.3995764, intervalCost(1, 1, 2), DELTA);
     // [0, 1) [-1, 0)
-    Assert.assertEquals(0.3995764, intervalCost(1, -1, 0), DELTA);
+    Assertions.assertEquals(0.3995764, intervalCost(1, -1, 0), DELTA);
 
     // exact overlap
     // [0, 1), [0, 1)
-    Assert.assertEquals(0.7357589, intervalCost(1, 0, 1), DELTA);
+    Assertions.assertEquals(0.7357589, intervalCost(1, 0, 1), DELTA);
     // [0, 2), [0, 2)
-    Assert.assertEquals(2.270671, intervalCost(2, 0, 2), DELTA);
+    Assertions.assertEquals(2.270671, intervalCost(2, 0, 2), DELTA);
 
     // partial overlap
     // [0, 2), [1, 3)
-    Assert.assertEquals(1.681908, intervalCost(2, 1, 3), DELTA);
+    Assertions.assertEquals(1.681908, intervalCost(2, 1, 3), DELTA);
     // [0, 2), [1, 2)
-    Assert.assertEquals(1.135335, intervalCost(2, 1, 2), DELTA);
+    Assertions.assertEquals(1.135335, intervalCost(2, 1, 2), DELTA);
     // [0, 2), [0, 1)
-    Assert.assertEquals(1.135335, intervalCost(2, 0, 1), DELTA);
+    Assertions.assertEquals(1.135335, intervalCost(2, 0, 1), DELTA);
     // [0, 3), [1, 2)
-    Assert.assertEquals(1.534912, intervalCost(3, 1, 2), DELTA);
+    Assertions.assertEquals(1.534912, intervalCost(3, 1, 2), DELTA);
   }
 
   @Test
@@ -163,7 +163,7 @@ public class CostBalancerStrategyTest
                                                    .startingAt("2010-01-01")
                                                    .eachOfSizeInMb(100).get(0);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         CostBalancerStrategy.computeJointSegmentsCost(segmentA, segmentB),
         CostBalancerStrategy.computeJointSegmentsCost(segmentB, segmentA),
         DELTA
@@ -185,12 +185,12 @@ public class CostBalancerStrategyTest
     // Verify that cross datasource cost is twice that of same datasource cost
     final double crossDatasourceCost =
         CostBalancerStrategy.computeJointSegmentsCost(koalaSegment, wikiSegment);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2 * crossDatasourceCost,
         CostBalancerStrategy.computeJointSegmentsCost(wikiSegment, wikiSegment),
         DELTA
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2 * crossDatasourceCost,
         CostBalancerStrategy.computeJointSegmentsCost(koalaSegment, koalaSegment),
         DELTA
@@ -237,7 +237,7 @@ public class CostBalancerStrategyTest
         segmentAllGranularity,
         segmentAllGranularity
     );
-    Assert.assertTrue(cost >= 3.548e14 && cost <= 3.549e14);
+    Assertions.assertTrue(cost >= 3.548e14 && cost <= 3.549e14);
   }
 
   @Test
@@ -332,11 +332,11 @@ public class CostBalancerStrategyTest
     strategy.findServersToLoadSegment(segment, Arrays.asList(serverA, serverB));
     CoordinatorRunStats computeStats = strategy.getStats();
 
-    Assert.assertEquals(1L, computeStats.get(Stats.Balancer.COMPUTATION_COUNT));
+    Assertions.assertEquals(1L, computeStats.get(Stats.Balancer.COMPUTATION_COUNT));
 
     long computeTime = computeStats.get(Stats.Balancer.COMPUTATION_TIME);
-    Assert.assertTrue(computeTime >= 0 && computeTime <= 100);
-    Assert.assertFalse(computeStats.hasStat(Stats.Balancer.COMPUTATION_ERRORS));
+    Assertions.assertTrue(computeTime >= 0 && computeTime <= 100);
+    Assertions.assertFalse(computeStats.hasStat(Stats.Balancer.COMPUTATION_ERRORS));
   }
 
   @Test
@@ -352,7 +352,7 @@ public class CostBalancerStrategyTest
     ServerHolder serverB = new ServerHolder(createHistorical().toImmutableDruidServer(), peon);
 
     balancerExecutor.shutdownNow();
-    Assert.assertThrows(
+    Assertions.assertThrows(
         RejectedExecutionException.class,
         () -> strategy.findServersToLoadSegment(segment, Arrays.asList(serverA, serverB))
     );
@@ -366,7 +366,7 @@ public class CostBalancerStrategyTest
   private void verifyPlacementCost(DataSegment segment, ServerHolder server, double expectedCost)
   {
     double observedCost = strategy.computePlacementCost(segment, server);
-    Assert.assertEquals(expectedCost, observedCost, DELTA);
+    Assertions.assertEquals(expectedCost, observedCost, DELTA);
 
     double totalJointSegmentCost = 0;
     for (DataSegment segmentOnServer : server.getServer().iterateAllSegments()) {
@@ -375,7 +375,7 @@ public class CostBalancerStrategyTest
     if (server.isServingSegment(segment)) {
       totalJointSegmentCost -= CostBalancerStrategy.computeJointSegmentsCost(segment, segment);
     }
-    Assert.assertEquals(totalJointSegmentCost, observedCost, DELTA);
+    Assertions.assertEquals(totalJointSegmentCost, observedCost, DELTA);
   }
 
   private void verifyJointSegmentsCost(
@@ -399,7 +399,7 @@ public class CostBalancerStrategyTest
                           .eachOfSizeInMb(100).get(0);
 
     double observedCost = CostBalancerStrategy.computeJointSegmentsCost(segmentX, segmentY);
-    Assert.assertEquals(expectedCost, observedCost, DELTA);
+    Assertions.assertEquals(expectedCost, observedCost, DELTA);
   }
 
   private DruidServer createHistorical()

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/DiskNormalizedCostBalancerStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/DiskNormalizedCostBalancerStrategyTest.java
@@ -33,8 +33,8 @@ import org.apache.druid.server.coordinator.loading.TestLoadQueuePeon;
 import org.apache.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -151,8 +151,8 @@ public class DiskNormalizedCostBalancerStrategyTest
         MoreExecutors.listeningDecorator(Execs.multiThreaded(4, "DiskNormalizedCostBalancerStrategyTest-%d"))
     );
     ServerHolder holder = strategy.findServersToLoadSegment(segment, serverHolderList).next();
-    Assert.assertNotNull("Should be able to find a place for new segment!!", holder);
-    Assert.assertEquals("Best Server should be BEST_SERVER", "BEST_SERVER", holder.getServer().getName());
+    Assertions.assertNotNull(holder, "Should be able to find a place for new segment!!");
+    Assertions.assertEquals("BEST_SERVER", holder.getServer().getName(), "Best Server should be BEST_SERVER");
   }
 
   @Test
@@ -165,8 +165,8 @@ public class DiskNormalizedCostBalancerStrategyTest
         MoreExecutors.listeningDecorator(Execs.multiThreaded(1, "DiskNormalizedCostBalancerStrategyTest-%d"))
     );
     ServerHolder holder = strategy.findServersToLoadSegment(segment, serverHolderList).next();
-    Assert.assertNotNull("Should be able to find a place for new segment!!", holder);
-    Assert.assertEquals("Best Server should be BEST_SERVER", "BEST_SERVER", holder.getServer().getName());
+    Assertions.assertNotNull(holder, "Should be able to find a place for new segment!!");
+    Assertions.assertEquals("BEST_SERVER", holder.getServer().getName(), "Best Server should be BEST_SERVER");
   }
 
   /**
@@ -237,18 +237,18 @@ public class DiskNormalizedCostBalancerStrategyTest
     servers.add(emptier);
 
     // Pure CostBalancerStrategy picks A (it has the cheapest raw cost).
-    Assert.assertEquals(
-        "Pure CostBalancerStrategy should pick the fuller server",
+    Assertions.assertEquals(
         "A",
-        newCostStrategy().findServersToLoadSegment(proposal, servers).next().getServer().getName()
+        newCostStrategy().findServersToLoadSegment(proposal, servers).next().getServer().getName(),
+        "Pure CostBalancerStrategy should pick the fuller server"
     );
 
     // DiskNormalized penalizes A because its projected utilization is more than
     // the threshold above B's projected utilization.
-    Assert.assertEquals(
-        "DiskNormalizedCostBalancerStrategy must prefer the emptier server",
+    Assertions.assertEquals(
         "B",
-        newDiskNormalizedStrategy().findServersToLoadSegment(proposal, servers).next().getServer().getName()
+        newDiskNormalizedStrategy().findServersToLoadSegment(proposal, servers).next().getServer().getName(),
+        "DiskNormalizedCostBalancerStrategy must prefer the emptier server"
     );
   }
 
@@ -272,9 +272,9 @@ public class DiskNormalizedCostBalancerStrategyTest
     //   A (source, 20 segs, self-cost subtracted): 38 * K
     //   B (dest,   20 segs, no self-cost):          40 * K
     // A is cheaper by 2K, so the cluster stays skewed forever.
-    Assert.assertNull(
-        "Pure CostBalancerStrategy cannot correct the disk skew: no move from A to B",
-        newCostStrategy().findDestinationServerToMoveSegment(segmentToMove, heavy, servers)
+    Assertions.assertNull(
+        newCostStrategy().findDestinationServerToMoveSegment(segmentToMove, heavy, servers),
+        "Pure CostBalancerStrategy cannot correct the disk skew: no move from A to B"
     );
 
     // DiskNormalizedCostBalancerStrategy (default 5% utilization threshold):
@@ -283,11 +283,11 @@ public class DiskNormalizedCostBalancerStrategyTest
     // the skew.
     final ServerHolder diskNormalizedResult =
         newDiskNormalizedStrategy().findDestinationServerToMoveSegment(segmentToMove, heavy, servers);
-    Assert.assertNotNull(
-        "DiskNormalized must correct the skew by moving the segment off the heavier server",
-        diskNormalizedResult
+    Assertions.assertNotNull(
+        diskNormalizedResult,
+        "DiskNormalized must correct the skew by moving the segment off the heavier server"
     );
-    Assert.assertEquals("B", diskNormalizedResult.getServer().getName());
+    Assertions.assertEquals("B", diskNormalizedResult.getServer().getName());
   }
 
   @Test
@@ -304,9 +304,9 @@ public class DiskNormalizedCostBalancerStrategyTest
 
     // Default threshold (5%): source and dest are inside the utilization
     // deadband, so normal cost decides and the segment stays put.
-    Assert.assertNull(
-        "Default threshold must block a marginal move to prevent ping-ponging",
-        newDiskNormalizedStrategy().findDestinationServerToMoveSegment(segmentToMove, source, servers)
+    Assertions.assertNull(
+        newDiskNormalizedStrategy().findDestinationServerToMoveSegment(segmentToMove, source, servers),
+        "Default threshold must block a marginal move to prevent ping-ponging"
     );
 
     // Lowering the threshold to 1% makes the same utilization difference fall
@@ -317,8 +317,8 @@ public class DiskNormalizedCostBalancerStrategyTest
     );
     final ServerHolder movedTo =
         onePercentUtilizationThreshold.findDestinationServerToMoveSegment(segmentToMove, source, servers);
-    Assert.assertNotNull("With threshold=0.01, the marginal move should fire", movedTo);
-    Assert.assertEquals("DEST", movedTo.getServer().getName());
+    Assertions.assertNotNull(movedTo, "With threshold=0.01, the marginal move should fire");
+    Assertions.assertEquals("DEST", movedTo.getServer().getName());
   }
 
   @Test
@@ -336,18 +336,18 @@ public class DiskNormalizedCostBalancerStrategyTest
     servers.add(partial);
 
     // CostBalancerStrategy picks A because raw cost 10K < 40K.
-    Assert.assertEquals(
-        "Pure CostBalancerStrategy must pick the near-full server (lower raw cost)",
+    Assertions.assertEquals(
         "A",
-        newCostStrategy().findServersToLoadSegment(newSegment, servers).next().getServer().getName()
+        newCostStrategy().findServersToLoadSegment(newSegment, servers).next().getServer().getName(),
+        "Pure CostBalancerStrategy must pick the near-full server (lower raw cost)"
     );
 
     // A's projected utilization is more than the threshold above B's, so the
     // exponential penalty makes B cheaper.
-    Assert.assertEquals(
-        "DiskNormalized must prefer the emptier server despite its higher raw cost",
+    Assertions.assertEquals(
         "B",
-        newDiskNormalizedStrategy().findServersToLoadSegment(newSegment, servers).next().getServer().getName()
+        newDiskNormalizedStrategy().findServersToLoadSegment(newSegment, servers).next().getServer().getName(),
+        "DiskNormalized must prefer the emptier server despite its higher raw cost"
     );
   }
 
@@ -366,19 +366,19 @@ public class DiskNormalizedCostBalancerStrategyTest
     servers.add(moreHeadroomAfterLoad);
 
     // CostBalancerStrategy picks A because raw cost 10K < 40K.
-    Assert.assertEquals(
-        "Pure CostBalancerStrategy must pick the lower raw-cost server",
+    Assertions.assertEquals(
         "A",
-        newCostStrategy().findServersToLoadSegment(largeSegment, servers).next().getServer().getName()
+        newCostStrategy().findServersToLoadSegment(largeSegment, servers).next().getServer().getName(),
+        "Pure CostBalancerStrategy must pick the lower raw-cost server"
     );
 
     // If diskNormalized used current utilization, A and B would be inside the
     // threshold band and A would win by raw cost. With projected utilization,
     // A falls outside the band and B wins.
-    Assert.assertEquals(
-        "DiskNormalized must account for the proposal size before choosing a server",
+    Assertions.assertEquals(
         "B",
-        newDiskNormalizedStrategy().findServersToLoadSegment(largeSegment, servers).next().getServer().getName()
+        newDiskNormalizedStrategy().findServersToLoadSegment(largeSegment, servers).next().getServer().getName(),
+        "DiskNormalized must account for the proposal size before choosing a server"
     );
   }
 
@@ -399,14 +399,14 @@ public class DiskNormalizedCostBalancerStrategyTest
     // CostBalancerStrategy: DEST raw cost (10K) < SOURCE raw cost (38K) -> recommends the move.
     final ServerHolder costResult =
         newCostStrategy().findDestinationServerToMoveSegment(segmentToMove, source, servers);
-    Assert.assertNotNull("CostBalancerStrategy must recommend moving to the near-full DEST", costResult);
-    Assert.assertEquals("DEST", costResult.getServer().getName());
+    Assertions.assertNotNull(costResult, "CostBalancerStrategy must recommend moving to the near-full DEST");
+    Assertions.assertEquals("DEST", costResult.getServer().getName());
 
     // DEST is outside the utilization threshold band and receives an
     // exponential penalty, so the move is blocked.
-    Assert.assertNull(
-        "DiskNormalized must block the move to the near-full server",
-        newDiskNormalizedStrategy().findDestinationServerToMoveSegment(segmentToMove, source, servers)
+    Assertions.assertNull(
+        newDiskNormalizedStrategy().findDestinationServerToMoveSegment(segmentToMove, source, servers),
+        "DiskNormalized must block the move to the near-full server"
     );
   }
 
@@ -433,27 +433,27 @@ public class DiskNormalizedCostBalancerStrategyTest
     // CostBalancerStrategy recommends the move because DEST raw cost (10K) < SOURCE raw cost (38K).
     final ServerHolder costResult =
         newCostStrategy().findDestinationServerToMoveSegment(largeSegment, source, servers);
-    Assert.assertNotNull("CostBalancerStrategy must recommend moving to the lower raw-cost DEST", costResult);
-    Assert.assertEquals("DEST", costResult.getServer().getName());
+    Assertions.assertNotNull(costResult, "CostBalancerStrategy must recommend moving to the lower raw-cost DEST");
+    Assertions.assertEquals("DEST", costResult.getServer().getName());
 
     // If diskNormalized used current utilization, DEST would be inside the
     // threshold band and win by raw cost. With projected utilization, DEST is
     // outside the band and the move is blocked.
-    Assert.assertNull(
-        "DiskNormalized must not move a large segment to a server that would become too full",
-        newDiskNormalizedStrategy().findDestinationServerToMoveSegment(largeSegment, source, servers)
+    Assertions.assertNull(
+        newDiskNormalizedStrategy().findDestinationServerToMoveSegment(largeSegment, source, servers),
+        "DiskNormalized must not move a large segment to a server that would become too full"
     );
   }
 
   @Test
   public void testConfigUsesUtilizationThreshold()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0.05,
         new DiskNormalizedCostBalancerStrategyConfig().getUtilizationThreshold(),
         0.0
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0.01,
         new DiskNormalizedCostBalancerStrategyConfig(0.01).getUtilizationThreshold(),
         0.0
@@ -472,7 +472,7 @@ public class DiskNormalizedCostBalancerStrategyTest
           MoreExecutors.listeningDecorator(Execs.multiThreaded(1, "DiskNormalizedCostBalancerStrategyTest-%d")),
           0.0
       );
-      Assert.fail("Expected IllegalArgumentException for threshold=0.0");
+      Assertions.fail("Expected IllegalArgumentException for threshold=0.0");
     }
     catch (IllegalArgumentException expected) {
       // expected
@@ -483,7 +483,7 @@ public class DiskNormalizedCostBalancerStrategyTest
           MoreExecutors.listeningDecorator(Execs.multiThreaded(1, "DiskNormalizedCostBalancerStrategyTest-%d")),
           1.0
       );
-      Assert.fail("Expected IllegalArgumentException for threshold=1.0");
+      Assertions.fail("Expected IllegalArgumentException for threshold=1.0");
     }
     catch (IllegalArgumentException expected) {
       // expected
@@ -494,7 +494,7 @@ public class DiskNormalizedCostBalancerStrategyTest
           MoreExecutors.listeningDecorator(Execs.multiThreaded(1, "DiskNormalizedCostBalancerStrategyTest-%d")),
           -0.01
       );
-      Assert.fail("Expected IllegalArgumentException for negative threshold");
+      Assertions.fail("Expected IllegalArgumentException for negative threshold");
     }
     catch (IllegalArgumentException expected) {
       // expected
@@ -505,7 +505,7 @@ public class DiskNormalizedCostBalancerStrategyTest
   {
     try {
       new DiskNormalizedCostBalancerStrategyConfig(threshold);
-      Assert.fail("Expected IllegalArgumentException for threshold=" + threshold);
+      Assertions.fail("Expected IllegalArgumentException for threshold=" + threshold);
     }
     catch (IllegalArgumentException expected) {
       // expected

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/ReservoirSegmentSamplerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/ReservoirSegmentSamplerTest.java
@@ -29,9 +29,10 @@ import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.server.coordinator.loading.SegmentAction;
 import org.apache.druid.server.coordinator.loading.TestLoadQueuePeon;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,6 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -57,7 +59,7 @@ public class ReservoirSegmentSamplerTest
                         .withNumPartitions(10)
                         .eachOfSizeInMb(100);
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
   }
@@ -86,7 +88,7 @@ public class ReservoirSegmentSamplerTest
     }
 
     // Verify that each segment has been chosen at least once
-    Assert.assertEquals(4, segmentCountMap.size());
+    Assertions.assertEquals(4, segmentCountMap.size());
   }
 
   /**
@@ -119,8 +121,8 @@ public class ReservoirSegmentSamplerTest
     }
 
     // Verify that the segment on server4 is never chosen because of limit
-    Assert.assertFalse(segmentCountMap.containsKey(excludedSegment));
-    Assert.assertEquals(3, segmentCountMap.size());
+    Assertions.assertFalse(segmentCountMap.containsKey(excludedSegment));
+    Assertions.assertEquals(3, segmentCountMap.size());
   }
 
   @Test
@@ -146,8 +148,8 @@ public class ReservoirSegmentSamplerTest
         .stream().map(BalancerSegmentHolder::getSegment).collect(Collectors.toSet());
 
     // Verify that only loading segments are picked
-    Assert.assertEquals(loadingSegments.size(), pickedSegments.size());
-    Assert.assertTrue(pickedSegments.containsAll(loadingSegments));
+    Assertions.assertEquals(loadingSegments.size(), pickedSegments.size());
+    Assertions.assertTrue(pickedSegments.containsAll(loadingSegments));
 
     // Pick only loaded segments
     List<BalancerSegmentHolder> pickedHolders = ReservoirSegmentSampler.pickMovableSegmentsFrom(
@@ -162,8 +164,8 @@ public class ReservoirSegmentSamplerTest
         .collect(Collectors.toSet());
 
     // Verify that only loaded segments are picked
-    Assert.assertEquals(loadedSegments.size(), pickedSegments.size());
-    Assert.assertTrue(pickedSegments.containsAll(loadedSegments));
+    Assertions.assertEquals(loadedSegments.size(), pickedSegments.size());
+    Assertions.assertTrue(pickedSegments.containsAll(loadedSegments));
   }
 
   @Test
@@ -188,9 +190,9 @@ public class ReservoirSegmentSamplerTest
     );
 
     // Verify that only the segments on the historical are picked
-    Assert.assertEquals(2, pickedSegments.size());
+    Assertions.assertEquals(2, pickedSegments.size());
     for (BalancerSegmentHolder holder : pickedSegments) {
-      Assert.assertEquals(historical, holder.getServer());
+      Assertions.assertEquals(historical, holder.getServer());
     }
   }
 
@@ -220,9 +222,9 @@ public class ReservoirSegmentSamplerTest
     );
 
     // Verify that none of the broadcast segments are picked
-    Assert.assertEquals(2, pickedSegments.size());
+    Assertions.assertEquals(2, pickedSegments.size());
     for (BalancerSegmentHolder holder : pickedSegments) {
-      Assert.assertNotEquals(broadcastDatasource, holder.getSegment().getDataSource());
+      Assertions.assertNotEquals(broadcastDatasource, holder.getSegment().getDataSource());
     }
   }
 
@@ -247,7 +249,7 @@ public class ReservoirSegmentSamplerTest
       final double expectedPickedSegments = totalSegmentsPicked * 0.25;
       final double error = totalSegmentsPicked * 0.02;
       for (int pickedSegments : numSegmentsPickedFromServer) {
-        Assert.assertEquals(expectedPickedSegments, pickedSegments, error);
+        Assertions.assertEquals(expectedPickedSegments, pickedSegments, error);
       }
     }
   }
@@ -277,15 +279,16 @@ public class ReservoirSegmentSamplerTest
       // Number of segments picked from server0 are ~40% of total and
       // number of segments picked from other servers are each ~20% of total
       double error = totalSegmentsPicked * 0.02;
-      Assert.assertEquals(totalSegmentsPicked * 0.40, numSegmentsPickedFromServer[0], error);
+      Assertions.assertEquals(totalSegmentsPicked * 0.40, numSegmentsPickedFromServer[0], error);
 
       for (int serverId = 1; serverId < servers.size(); ++serverId) {
-        Assert.assertEquals(totalSegmentsPicked * 0.20, numSegmentsPickedFromServer[serverId], error);
+        Assertions.assertEquals(totalSegmentsPicked * 0.20, numSegmentsPickedFromServer[serverId], error);
       }
     }
   }
 
-  @Test(timeout = 60_000)
+  @Test
+  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS)
   public void testNumberOfSamplingsRequiredToPickAllSegments()
   {
     // The number of sampling iterations required for each sample percentage
@@ -305,7 +308,7 @@ public class ReservoirSegmentSamplerTest
     // Compute the avg value from the 50 observations for each sample percentage
     for (int j = 0; j < samplePercentages.length; ++j) {
       double avgObservedIterations = totalObservedIterations[j] / 50.0;
-      Assert.assertTrue(avgObservedIterations <= expectedIterations[j]);
+      Assertions.assertTrue(avgObservedIterations <= expectedIterations[j]);
     }
 
   }

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/ReservoirSegmentSamplerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/ReservoirSegmentSamplerTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -288,7 +289,7 @@ public class ReservoirSegmentSamplerTest
   }
 
   @Test
-  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60_000, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testNumberOfSamplingsRequiredToPickAllSegments()
   {
     // The number of sampling iterations required for each sample percentage

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/SegmentToMoveCalculatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/SegmentToMoveCalculatorTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.server.coordinator.loading.TestLoadQueuePeon;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -63,91 +63,91 @@ public class SegmentToMoveCalculatorTest
   @Test
   public void testMaxSegmentsToMove1Thread()
   {
-    Assert.assertEquals(0, computeMaxSegmentsToMove(0, 1));
-    Assert.assertEquals(50, computeMaxSegmentsToMove(50, 1));
-    Assert.assertEquals(100, computeMaxSegmentsToMove(100, 1));
+    Assertions.assertEquals(0, computeMaxSegmentsToMove(0, 1));
+    Assertions.assertEquals(50, computeMaxSegmentsToMove(50, 1));
+    Assertions.assertEquals(100, computeMaxSegmentsToMove(100, 1));
 
-    Assert.assertEquals(100, computeMaxSegmentsToMove(512, 1));
-    Assert.assertEquals(200, computeMaxSegmentsToMove(1_024, 1));
-    Assert.assertEquals(300, computeMaxSegmentsToMove(1_536, 1));
+    Assertions.assertEquals(100, computeMaxSegmentsToMove(512, 1));
+    Assertions.assertEquals(200, computeMaxSegmentsToMove(1_024, 1));
+    Assertions.assertEquals(300, computeMaxSegmentsToMove(1_536, 1));
 
-    Assert.assertEquals(1_900, computeMaxSegmentsToMove(10_000, 1));
-    Assert.assertEquals(9_700, computeMaxSegmentsToMove(50_000, 1));
-    Assert.assertEquals(19_500, computeMaxSegmentsToMove(100_000, 1));
+    Assertions.assertEquals(1_900, computeMaxSegmentsToMove(10_000, 1));
+    Assertions.assertEquals(9_700, computeMaxSegmentsToMove(50_000, 1));
+    Assertions.assertEquals(19_500, computeMaxSegmentsToMove(100_000, 1));
 
-    Assert.assertEquals(10_000, computeMaxSegmentsToMove(200_000, 1));
-    Assert.assertEquals(4_000, computeMaxSegmentsToMove(500_000, 1));
-    Assert.assertEquals(2_000, computeMaxSegmentsToMove(1_000_000, 1));
+    Assertions.assertEquals(10_000, computeMaxSegmentsToMove(200_000, 1));
+    Assertions.assertEquals(4_000, computeMaxSegmentsToMove(500_000, 1));
+    Assertions.assertEquals(2_000, computeMaxSegmentsToMove(1_000_000, 1));
   }
 
   @Test
   public void testMaxSegmentsToMoveIncreasesWithCoordinatorPeriod()
   {
-    Assert.assertEquals(100, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(0)));
-    Assert.assertEquals(100, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(10_000)));
-    Assert.assertEquals(100, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(20_000)));
+    Assertions.assertEquals(100, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(0)));
+    Assertions.assertEquals(100, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(10_000)));
+    Assertions.assertEquals(100, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(20_000)));
 
-    Assert.assertEquals(5_000, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(30_000)));
-    Assert.assertEquals(10_000, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(60_000)));
-    Assert.assertEquals(15_000, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(90_000)));
-    Assert.assertEquals(20_000, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(120_000)));
+    Assertions.assertEquals(5_000, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(30_000)));
+    Assertions.assertEquals(10_000, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(60_000)));
+    Assertions.assertEquals(15_000, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(90_000)));
+    Assertions.assertEquals(20_000, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(120_000)));
 
-    Assert.assertEquals(2_000, computeMaxSegmentsToMoveInPeriod(500_000, Duration.millis(30_000)));
-    Assert.assertEquals(4_000, computeMaxSegmentsToMoveInPeriod(500_000, Duration.millis(60_000)));
-    Assert.assertEquals(6_000, computeMaxSegmentsToMoveInPeriod(500_000, Duration.millis(90_000)));
-    Assert.assertEquals(8_000, computeMaxSegmentsToMoveInPeriod(500_000, Duration.millis(120_000)));
+    Assertions.assertEquals(2_000, computeMaxSegmentsToMoveInPeriod(500_000, Duration.millis(30_000)));
+    Assertions.assertEquals(4_000, computeMaxSegmentsToMoveInPeriod(500_000, Duration.millis(60_000)));
+    Assertions.assertEquals(6_000, computeMaxSegmentsToMoveInPeriod(500_000, Duration.millis(90_000)));
+    Assertions.assertEquals(8_000, computeMaxSegmentsToMoveInPeriod(500_000, Duration.millis(120_000)));
   }
 
   @Test
   public void testMaxSegmentsToMove8Threads()
   {
-    Assert.assertEquals(0, computeMaxSegmentsToMove(0, 8));
-    Assert.assertEquals(50, computeMaxSegmentsToMove(50, 8));
-    Assert.assertEquals(100, computeMaxSegmentsToMove(100, 8));
+    Assertions.assertEquals(0, computeMaxSegmentsToMove(0, 8));
+    Assertions.assertEquals(50, computeMaxSegmentsToMove(50, 8));
+    Assertions.assertEquals(100, computeMaxSegmentsToMove(100, 8));
 
-    Assert.assertEquals(100, computeMaxSegmentsToMove(512, 8));
-    Assert.assertEquals(200, computeMaxSegmentsToMove(1_024, 8));
-    Assert.assertEquals(300, computeMaxSegmentsToMove(1_536, 8));
+    Assertions.assertEquals(100, computeMaxSegmentsToMove(512, 8));
+    Assertions.assertEquals(200, computeMaxSegmentsToMove(1_024, 8));
+    Assertions.assertEquals(300, computeMaxSegmentsToMove(1_536, 8));
 
-    Assert.assertEquals(33_000, computeMaxSegmentsToMove(500_000, 8));
-    Assert.assertEquals(16_000, computeMaxSegmentsToMove(1_000_000, 8));
-    Assert.assertEquals(8_000, computeMaxSegmentsToMove(2_000_000, 8));
-    Assert.assertEquals(3_000, computeMaxSegmentsToMove(5_000_000, 8));
-    Assert.assertEquals(1_000, computeMaxSegmentsToMove(10_000_000, 8));
+    Assertions.assertEquals(33_000, computeMaxSegmentsToMove(500_000, 8));
+    Assertions.assertEquals(16_000, computeMaxSegmentsToMove(1_000_000, 8));
+    Assertions.assertEquals(8_000, computeMaxSegmentsToMove(2_000_000, 8));
+    Assertions.assertEquals(3_000, computeMaxSegmentsToMove(5_000_000, 8));
+    Assertions.assertEquals(1_000, computeMaxSegmentsToMove(10_000_000, 8));
   }
 
   @Test
   public void testMinSegmentsToMove()
   {
-    Assert.assertEquals(0, computeMinSegmentsToMove(0));
-    Assert.assertEquals(50, computeMinSegmentsToMove(50));
+    Assertions.assertEquals(0, computeMinSegmentsToMove(0));
+    Assertions.assertEquals(50, computeMinSegmentsToMove(50));
 
-    Assert.assertEquals(100, computeMinSegmentsToMove(100));
-    Assert.assertEquals(100, computeMinSegmentsToMove(1_000));
+    Assertions.assertEquals(100, computeMinSegmentsToMove(100));
+    Assertions.assertEquals(100, computeMinSegmentsToMove(1_000));
 
-    Assert.assertEquals(100, computeMinSegmentsToMove(20_000));
-    Assert.assertEquals(100, computeMinSegmentsToMove(50_000));
-    Assert.assertEquals(100, computeMinSegmentsToMove(100_000));
-    Assert.assertEquals(300, computeMinSegmentsToMove(200_000));
-    Assert.assertEquals(700, computeMinSegmentsToMove(500_000));
-    Assert.assertEquals(1_500, computeMinSegmentsToMove(1_000_000));
-    Assert.assertEquals(15_200, computeMinSegmentsToMove(10_000_000));
+    Assertions.assertEquals(100, computeMinSegmentsToMove(20_000));
+    Assertions.assertEquals(100, computeMinSegmentsToMove(50_000));
+    Assertions.assertEquals(100, computeMinSegmentsToMove(100_000));
+    Assertions.assertEquals(300, computeMinSegmentsToMove(200_000));
+    Assertions.assertEquals(700, computeMinSegmentsToMove(500_000));
+    Assertions.assertEquals(1_500, computeMinSegmentsToMove(1_000_000));
+    Assertions.assertEquals(15_200, computeMinSegmentsToMove(10_000_000));
   }
 
   @Test
   public void testMinSegmentsToMoveIncreasesInSteps()
   {
-    Assert.assertEquals(100, computeMinSegmentsToMove(131_071));
-    Assert.assertEquals(200, computeMinSegmentsToMove(131_072));
+    Assertions.assertEquals(100, computeMinSegmentsToMove(131_071));
+    Assertions.assertEquals(200, computeMinSegmentsToMove(131_072));
 
-    Assert.assertEquals(500, computeMinSegmentsToMove(393_215));
-    Assert.assertEquals(600, computeMinSegmentsToMove(393_216));
+    Assertions.assertEquals(500, computeMinSegmentsToMove(393_215));
+    Assertions.assertEquals(600, computeMinSegmentsToMove(393_216));
 
-    Assert.assertEquals(900, computeMinSegmentsToMove(655_359));
-    Assert.assertEquals(1000, computeMinSegmentsToMove(655_360));
+    Assertions.assertEquals(900, computeMinSegmentsToMove(655_359));
+    Assertions.assertEquals(1000, computeMinSegmentsToMove(655_360));
 
-    Assert.assertEquals(9_900, computeMinSegmentsToMove(6_553_599));
-    Assert.assertEquals(10_000, computeMinSegmentsToMove(6_553_600));
+    Assertions.assertEquals(9_900, computeMinSegmentsToMove(6_553_599));
+    Assertions.assertEquals(10_000, computeMinSegmentsToMove(6_553_600));
   }
 
   @Test
@@ -159,17 +159,17 @@ public class SegmentToMoveCalculatorTest
     );
 
     final int minSegmentsToMove = SegmentToMoveCalculator.computeMinSegmentsToMoveInTier(20_000);
-    Assert.assertEquals(100, minSegmentsToMove);
+    Assertions.assertEquals(100, minSegmentsToMove);
 
     final int segmentsToMoveToFixSkew = SegmentToMoveCalculator
         .computeNumSegmentsToMoveToBalanceTier(TIER, historicals);
-    Assert.assertEquals(0, segmentsToMoveToFixSkew);
+    Assertions.assertEquals(0, segmentsToMoveToFixSkew);
 
     // Find segmentsToMove with no limit on maxSegmentsToMove
     final int segmentsToMove = SegmentToMoveCalculator
         .computeNumSegmentsToMoveInTier(TIER, historicals, Integer.MAX_VALUE);
 
-    Assert.assertEquals(minSegmentsToMove, segmentsToMove);
+    Assertions.assertEquals(minSegmentsToMove, segmentsToMove);
   }
 
   @Test
@@ -181,17 +181,17 @@ public class SegmentToMoveCalculatorTest
     );
 
     final int minSegmentsToMove = SegmentToMoveCalculator.computeMinSegmentsToMoveInTier(10_000);
-    Assert.assertEquals(100, minSegmentsToMove);
+    Assertions.assertEquals(100, minSegmentsToMove);
 
     final int segmentsToMoveToFixSkew = SegmentToMoveCalculator
         .computeNumSegmentsToMoveToBalanceTier(TIER, historicals);
-    Assert.assertEquals(5_000, segmentsToMoveToFixSkew);
+    Assertions.assertEquals(5_000, segmentsToMoveToFixSkew);
 
     // Find segmentsToMove with no limit on maxSegmentsToMove
     final int segmentsToMove = SegmentToMoveCalculator
         .computeNumSegmentsToMoveInTier(TIER, historicals, Integer.MAX_VALUE);
 
-    Assert.assertEquals(segmentsToMoveToFixSkew, segmentsToMove);
+    Assertions.assertEquals(segmentsToMoveToFixSkew, segmentsToMove);
   }
 
   @Test
@@ -209,7 +209,7 @@ public class SegmentToMoveCalculatorTest
     // Verify that half the wiki segments need to be moved for balance
     int numToMoveToBalanceCount = SegmentToMoveCalculator
         .computeSegmentsToMoveToBalanceCountsPerDatasource(TIER, historicals);
-    Assert.assertEquals(WIKI_SEGMENTS.size() / 2, numToMoveToBalanceCount);
+    Assertions.assertEquals(WIKI_SEGMENTS.size() / 2, numToMoveToBalanceCount);
   }
 
   private static int computeMaxSegmentsToMove(int totalSegments, int numThreads)

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/SegmentsCostCacheTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/SegmentsCostCacheTest.java
@@ -23,8 +23,8 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,7 +46,7 @@ public class SegmentsCostCacheTest
     SegmentsCostCache.Builder cacheBuilder = SegmentsCostCache.builder();
     cacheBuilder.addSegment(createSegment(DATA_SOURCE, shifted1HInterval(REFERENCE_TIME, 0), 100));
     SegmentsCostCache cache = cacheBuilder.build();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         7.8735899489011E-4,
         cache.cost(createSegment(DATA_SOURCE, shifted1HInterval(REFERENCE_TIME, -2), 100)),
         EPSILON
@@ -61,7 +61,7 @@ public class SegmentsCostCacheTest
         createSegment(DATA_SOURCE, shifted1HInterval(REFERENCE_TIME, 0), 100)
     );
     SegmentsCostCache cache = cacheBuilder.build();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         cache.cost(createSegment(DATA_SOURCE, shifted1HInterval(REFERENCE_TIME, (int) TimeUnit.DAYS.toHours(50)), 100)),
         EPSILON
@@ -83,7 +83,7 @@ public class SegmentsCostCacheTest
     SegmentsCostCache.Bucket bucket = prototype.build();
 
     double segmentCost = bucket.cost(segmentB);
-    Assert.assertEquals(7.8735899489011E-4, segmentCost, EPSILON);
+    Assertions.assertEquals(7.8735899489011E-4, segmentCost, EPSILON);
   }
 
   @Test
@@ -102,8 +102,8 @@ public class SegmentsCostCacheTest
     prototype.addSegment(segmentA);
     SegmentsCostCache.Bucket bucket = prototype.build();
 
-    Assert.assertTrue(bucket.inCalculationInterval(segmentA));
-    Assert.assertFalse(bucket.inCalculationInterval(segmentB));
+    Assertions.assertTrue(bucket.inCalculationInterval(segmentA));
+    Assertions.assertFalse(bucket.inCalculationInterval(segmentB));
   }
 
   @Test
@@ -121,7 +121,7 @@ public class SegmentsCostCacheTest
     SegmentsCostCache.Bucket bucket = prototype.build();
 
     double segmentCost = bucket.cost(segmentB);
-    Assert.assertEquals(8.26147353873985E-4, segmentCost, EPSILON);
+    Assertions.assertEquals(8.26147353873985E-4, segmentCost, EPSILON);
   }
 
   @Test
@@ -142,7 +142,7 @@ public class SegmentsCostCacheTest
 
     double segmentCost = bucket.cost(segmentB);
 
-    Assert.assertEquals(0.001574717989780039, segmentCost, EPSILON);
+    Assertions.assertEquals(0.001574717989780039, segmentCost, EPSILON);
   }
 
   @Test
@@ -164,7 +164,7 @@ public class SegmentsCostCacheTest
     SegmentsCostCache.Bucket bucket = prototype.build();
 
     double cost = bucket.cost(referenceSegment);
-    Assert.assertEquals(0.7065117101966677, cost, EPSILON);
+    Assertions.assertEquals(0.7065117101966677, cost, EPSILON);
   }
 
   private static Interval shifted1HInterval(DateTime REFERENCE_TIME, int shiftInHours)

--- a/server/src/test/java/org/apache/druid/server/coordinator/config/HttpLoadQueuePeonConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/config/HttpLoadQueuePeonConfigTest.java
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.google.common.base.Throwables;
 import org.apache.druid.error.DruidExceptionMatcher;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class HttpLoadQueuePeonConfigTest
 {
@@ -36,7 +36,7 @@ public class HttpLoadQueuePeonConfigTest
 
     DruidExceptionMatcher.assertThat(
         Throwables.getRootCause(
-            Assert.assertThrows(ValueInstantiationException.class, () ->
+            Assertions.assertThrows(ValueInstantiationException.class, () ->
                 jsonMapper.readValue("{\"batchSize\":0}", HttpLoadQueuePeonConfig.class)
             )
         ),
@@ -49,12 +49,12 @@ public class HttpLoadQueuePeonConfigTest
         "{}",
         HttpLoadQueuePeonConfig.class
     );
-    Assert.assertNull(emptyConfig.getBatchSize());
+    Assertions.assertNull(emptyConfig.getBatchSize());
 
     HttpLoadQueuePeonConfig config = jsonMapper.readValue(
         "{\"batchSize\":2}",
         HttpLoadQueuePeonConfig.class
     );
-    Assert.assertEquals(Integer.valueOf(2), config.getBatchSize());
+    Assertions.assertEquals(Integer.valueOf(2), config.getBatchSize());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/config/KillUnusedSegmentsConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/config/KillUnusedSegmentsConfigTest.java
@@ -20,7 +20,7 @@
 package org.apache.druid.server.coordinator.config;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class KillUnusedSegmentsConfigTest
 {

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/BalanceSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/BalanceSegmentsTest.java
@@ -40,10 +40,10 @@ import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Set;
@@ -69,7 +69,7 @@ public class BalanceSegmentsTest
   private DruidServer server3;
   private DruidServer server4;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     loadQueueManager = new SegmentLoadQueueManager(null, null);
@@ -97,7 +97,7 @@ public class BalanceSegmentsTest
     broadcastDatasources = Collections.singleton("datasourceBroadcast");
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     balancerStrategyExecutor.shutdownNow();
@@ -118,7 +118,7 @@ public class BalanceSegmentsTest
     CoordinatorRunStats stats = runBalancer(params);
     long totalMoved = stats.getSegmentStat(Stats.Segments.MOVED, "normal", "datasource1")
                       + stats.getSegmentStat(Stats.Segments.MOVED, "normal", "datasource2");
-    Assert.assertEquals(2L, totalMoved);
+    Assertions.assertEquals(2L, totalMoved);
   }
 
   @Test
@@ -138,9 +138,9 @@ public class BalanceSegmentsTest
     CoordinatorRunStats stats = runBalancer(params);
 
     // Verify that either segment3 or segment4 is chosen for move
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.MOVED, "normal", segment3.getDataSource()));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.MOVED, "normal", segment3.getDataSource()));
     DataSegment movingSegment = holder3.getPeon().getSegmentsToLoad().iterator().next();
-    Assert.assertEquals(segment3.getDataSource(), movingSegment.getDataSource());
+    Assertions.assertEquals(segment3.getDataSource(), movingSegment.getDataSource());
   }
 
   @Test
@@ -164,8 +164,8 @@ public class BalanceSegmentsTest
     CoordinatorRunStats stats = runBalancer(params);
     long totalMoved = stats.getSegmentStat(Stats.Segments.MOVED, "normal", "datasource1")
                       + stats.getSegmentStat(Stats.Segments.MOVED, "normal", "datasource2");
-    Assert.assertEquals(2L, totalMoved);
-    Assert.assertEquals(2, serverHolder2.getPeon().getSegmentsToLoad().size());
+    Assertions.assertEquals(2L, totalMoved);
+    Assertions.assertEquals(2, serverHolder2.getPeon().getSegmentsToLoad().size());
   }
 
   /**
@@ -184,7 +184,7 @@ public class BalanceSegmentsTest
             .build();
 
     CoordinatorRunStats stats = runBalancer(params);
-    Assert.assertFalse(stats.hasStat(Stats.Segments.MOVED));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.MOVED));
   }
 
   @Test
@@ -204,8 +204,8 @@ public class BalanceSegmentsTest
         .build();
 
     runBalancer(params);
-    Assert.assertEquals(0, decommissioningServer.getPeon().getSegmentsToLoad().size());
-    Assert.assertEquals(3, activeServer.getPeon().getSegmentsToLoad().size());
+    Assertions.assertEquals(0, decommissioningServer.getPeon().getSegmentsToLoad().size());
+    Assertions.assertEquals(3, activeServer.getPeon().getSegmentsToLoad().size());
   }
 
   @Test
@@ -228,7 +228,7 @@ public class BalanceSegmentsTest
     CoordinatorRunStats stats = runBalancer(params);
 
     // max to move is 5, all segments on server 1, but only expect to move 1 to server 2 since max node load queue is 1
-    Assert.assertEquals(maxSegmentsInQueue, stats.getSegmentStat(Stats.Segments.MOVED, "normal", "datasource1"));
+    Assertions.assertEquals(maxSegmentsInQueue, stats.getSegmentStat(Stats.Segments.MOVED, "normal", "datasource1"));
   }
 
   @Test
@@ -241,7 +241,7 @@ public class BalanceSegmentsTest
     ).build();
 
     CoordinatorRunStats stats = runBalancer(params);
-    Assert.assertTrue(stats.getSegmentStat(Stats.Segments.MOVED, "normal", "datasource1") > 0);
+    Assertions.assertTrue(stats.getSegmentStat(Stats.Segments.MOVED, "normal", "datasource1") > 0);
   }
 
   @Test
@@ -256,7 +256,7 @@ public class BalanceSegmentsTest
     ).build();
 
     CoordinatorRunStats stats = runBalancer(params);
-    Assert.assertTrue(stats.getSegmentStat(Stats.Segments.MOVED, "normal", "datasource1") > 0);
+    Assertions.assertTrue(stats.getSegmentStat(Stats.Segments.MOVED, "normal", "datasource1") > 0);
   }
 
   @Test
@@ -282,8 +282,8 @@ public class BalanceSegmentsTest
     CoordinatorRunStats stats = runBalancer(params);
     long totalMoved = stats.getSegmentStat(Stats.Segments.MOVED, "normal", "datasource1")
                       + stats.getSegmentStat(Stats.Segments.MOVED, "normal", "datasource2");
-    Assert.assertEquals(1L, totalMoved);
-    Assert.assertEquals(1, holder3.getPeon().getSegmentsToLoad().size());
+    Assertions.assertEquals(1L, totalMoved);
+    Assertions.assertEquals(1, holder3.getPeon().getSegmentsToLoad().size());
   }
 
   @Test
@@ -307,14 +307,14 @@ public class BalanceSegmentsTest
     CoordinatorRunStats stats = runBalancer(params);
     long totalMoved = stats.getSegmentStat(Stats.Segments.MOVED, "normal", "datasource1")
                       + stats.getSegmentStat(Stats.Segments.MOVED, "normal", "datasource2");
-    Assert.assertEquals(2L, totalMoved);
+    Assertions.assertEquals(2L, totalMoved);
   }
 
   private CoordinatorRunStats runBalancer(DruidCoordinatorRuntimeParams params)
   {
     params = new BalanceSegments(Duration.standardMinutes(1)).run(params);
     if (params == null) {
-      Assert.fail("BalanceSegments duty returned null params");
+      Assertions.fail("BalanceSegments duty returned null params");
       return new CoordinatorRunStats();
     } else {
       return params.getCoordinatorStats();

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
@@ -113,11 +113,11 @@ import org.apache.druid.timeline.partition.SingleDimensionShardSpec;
 import org.apache.druid.utils.Streams;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -136,7 +136,8 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "partitionsSpec:{0}, engine:{2}")
+@MethodSource("constructorFeeder")
 public class CompactSegmentsTest
 {
   private static final ObjectMapper JSON_MAPPER = new DefaultObjectMapper();
@@ -149,7 +150,6 @@ public class CompactSegmentsTest
   private static final int TOTAL_INTERVAL_PER_DATASOURCE = 11;
   private static final int MAXIMUM_CAPACITY_WITH_AUTO_SCALE = 10;
 
-  @Parameterized.Parameters(name = "partitionsSpec:{0}, engine:{2}")
   public static Collection<Object[]> constructorFeeder()
   {
     final MutableInt nextRangePartitionBoundary = new MutableInt(0);
@@ -211,7 +211,7 @@ public class CompactSegmentsTest
     this.engine = engine;
   }
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     allSegments.clear();
@@ -283,8 +283,8 @@ public class CompactSegmentsTest
     String compactSegmentString = JSON_MAPPER.writeValueAsString(compactSegments);
     CompactSegments serdeCompactSegments = JSON_MAPPER.readValue(compactSegmentString, CompactSegments.class);
 
-    Assert.assertNotNull(serdeCompactSegments);
-    Assert.assertSame(overlordClient, serdeCompactSegments.getOverlordClient());
+    Assertions.assertNotNull(serdeCompactSegments);
+    Assertions.assertSame(overlordClient, serdeCompactSegments.getOverlordClient());
   }
 
   @Test
@@ -378,14 +378,14 @@ public class CompactSegmentsTest
 
     // Before any compaction, we do not have any snapshot of compactions
     Map<String, AutoCompactionSnapshot> autoCompactionSnapshots = compactSegments.getAutoCompactionSnapshot();
-    Assert.assertEquals(0, autoCompactionSnapshots.size());
+    Assertions.assertEquals(0, autoCompactionSnapshots.size());
 
     for (int compactionRunCount = 0; compactionRunCount < 11; compactionRunCount++) {
       doCompactionAndAssertCompactSegmentStatistics(compactSegments, compactionRunCount);
     }
     // Test that stats does not change (and is still correct) when auto compaction runs with everything is fully compacted
     final CoordinatorRunStats stats = doCompactSegments(compactSegments);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         stats.get(Stats.Compaction.SUBMITTED_TASKS)
     );
@@ -431,11 +431,11 @@ public class CompactSegmentsTest
     // Run auto compaction without any dataSource in the compaction config
     // Snapshot should be empty
     doCompactSegments(compactSegments, new ArrayList<>());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         stats.get(Stats.Compaction.SUBMITTED_TASKS)
     );
-    Assert.assertTrue(compactSegments.getAutoCompactionSnapshot().isEmpty());
+    Assertions.assertTrue(compactSegments.getAutoCompactionSnapshot().isEmpty());
 
     assertLastSegmentNotCompacted(compactSegments);
   }
@@ -490,13 +490,13 @@ public class CompactSegmentsTest
 
     // Before any compaction, we do not have any snapshot of compactions
     Map<String, AutoCompactionSnapshot> autoCompactionSnapshots = compactSegments.getAutoCompactionSnapshot();
-    Assert.assertEquals(0, autoCompactionSnapshots.size());
+    Assertions.assertEquals(0, autoCompactionSnapshots.size());
 
     // 3 intervals, 120 byte, 12 segments already compacted before the run
     for (int compactionRunCount = 0; compactionRunCount < 8; compactionRunCount++) {
       // Do a cycle of auto compaction which creates one compaction task
       final CoordinatorRunStats stats = doCompactSegments(compactSegments);
-      Assert.assertEquals(
+      Assertions.assertEquals(
           1,
           stats.get(Stats.Compaction.SUBMITTED_TASKS)
       );
@@ -522,7 +522,7 @@ public class CompactSegmentsTest
 
     // Test that stats does not change (and is still correct) when auto compaction runs with everything is fully compacted
     final CoordinatorRunStats stats = doCompactSegments(compactSegments);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         stats.get(Stats.Compaction.SUBMITTED_TASKS)
     );
@@ -552,14 +552,14 @@ public class CompactSegmentsTest
 
     // Before any compaction, we do not have any snapshot of compactions
     Map<String, AutoCompactionSnapshot> autoCompactionSnapshots = compactSegments.getAutoCompactionSnapshot();
-    Assert.assertEquals(0, autoCompactionSnapshots.size());
+    Assertions.assertEquals(0, autoCompactionSnapshots.size());
 
     for (int compactionRunCount = 0; compactionRunCount < 11; compactionRunCount++) {
       doCompactionAndAssertCompactSegmentStatistics(compactSegments, compactionRunCount);
     }
     // Test that stats does not change (and is still correct) when auto compaction runs with everything is fully compacted
     final CoordinatorRunStats stats = doCompactSegments(compactSegments);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         stats.get(Stats.Compaction.SUBMITTED_TASKS)
     );
@@ -604,10 +604,10 @@ public class CompactSegmentsTest
       );
     }
 
-    Assert.assertEquals(2, compactSegments.getAutoCompactionSnapshot().size());
-    Assert.assertTrue(compactSegments.getAutoCompactionSnapshot().containsKey(DATA_SOURCE_PREFIX + 1));
-    Assert.assertTrue(compactSegments.getAutoCompactionSnapshot().containsKey(DATA_SOURCE_PREFIX + 2));
-    Assert.assertFalse(compactSegments.getAutoCompactionSnapshot().containsKey(DATA_SOURCE_PREFIX + 0));
+    Assertions.assertEquals(2, compactSegments.getAutoCompactionSnapshot().size());
+    Assertions.assertTrue(compactSegments.getAutoCompactionSnapshot().containsKey(DATA_SOURCE_PREFIX + 1));
+    Assertions.assertTrue(compactSegments.getAutoCompactionSnapshot().containsKey(DATA_SOURCE_PREFIX + 2));
+    Assertions.assertFalse(compactSegments.getAutoCompactionSnapshot().containsKey(DATA_SOURCE_PREFIX + 0));
   }
 
   @Test
@@ -644,13 +644,13 @@ public class CompactSegmentsTest
 
     // Before any compaction, we do not have any snapshot of compactions
     Map<String, AutoCompactionSnapshot> autoCompactionSnapshots = compactSegments.getAutoCompactionSnapshot();
-    Assert.assertEquals(0, autoCompactionSnapshots.size());
+    Assertions.assertEquals(0, autoCompactionSnapshots.size());
 
     // 3 intervals, 1200 byte (each segment is 100 bytes), 12 segments will be skipped by auto compaction
     for (int compactionRunCount = 0; compactionRunCount < 8; compactionRunCount++) {
       // Do a cycle of auto compaction which creates one compaction task
       final CoordinatorRunStats stats = doCompactSegments(compactSegments);
-      Assert.assertEquals(
+      Assertions.assertEquals(
           1,
           stats.get(Stats.Compaction.SUBMITTED_TASKS)
       );
@@ -674,7 +674,7 @@ public class CompactSegmentsTest
 
     // Test that stats does not change (and is still correct) when auto compaction runs with everything is fully compacted
     final CoordinatorRunStats stats = doCompactSegments(compactSegments);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         stats.get(Stats.Compaction.SUBMITTED_TASKS)
     );
@@ -702,14 +702,14 @@ public class CompactSegmentsTest
     final CompactSegments compactSegments = new CompactSegments(statusTracker, overlordClient);
 
     final CoordinatorRunStats stats = doCompactSegments(compactSegments, 3);
-    Assert.assertEquals(3, stats.get(Stats.Compaction.AVAILABLE_SLOTS));
-    Assert.assertEquals(3, stats.get(Stats.Compaction.MAX_SLOTS));
+    Assertions.assertEquals(3, stats.get(Stats.Compaction.AVAILABLE_SLOTS));
+    Assertions.assertEquals(3, stats.get(Stats.Compaction.MAX_SLOTS));
     // Native takes up 1 task slot by default whereas MSQ takes up all available upto 5. Since there are 3 available
     // slots, there are 3 submitted tasks for native whereas 1 for MSQ.
     if (engine == CompactionEngine.NATIVE) {
-      Assert.assertEquals(3, stats.get(Stats.Compaction.SUBMITTED_TASKS));
+      Assertions.assertEquals(3, stats.get(Stats.Compaction.SUBMITTED_TASKS));
     } else {
-      Assert.assertEquals(1, stats.get(Stats.Compaction.SUBMITTED_TASKS));
+      Assertions.assertEquals(1, stats.get(Stats.Compaction.SUBMITTED_TASKS));
     }
   }
 
@@ -721,14 +721,14 @@ public class CompactSegmentsTest
     final CompactSegments compactSegments = new CompactSegments(statusTracker, overlordClient);
     final CoordinatorRunStats stats =
         doCompactSegments(compactSegments, createCompactionConfigs(), maxCompactionSlot);
-    Assert.assertEquals(maxCompactionSlot, stats.get(Stats.Compaction.AVAILABLE_SLOTS));
-    Assert.assertEquals(maxCompactionSlot, stats.get(Stats.Compaction.MAX_SLOTS));
+    Assertions.assertEquals(maxCompactionSlot, stats.get(Stats.Compaction.AVAILABLE_SLOTS));
+    Assertions.assertEquals(maxCompactionSlot, stats.get(Stats.Compaction.MAX_SLOTS));
     // Native takes up 1 task slot by default whereas MSQ takes up all available upto 5. Since there are 3 available
     // slots, there are 3 submitted tasks for native whereas 1 for MSQ.
     if (engine == CompactionEngine.NATIVE) {
-      Assert.assertEquals(maxCompactionSlot, stats.get(Stats.Compaction.SUBMITTED_TASKS));
+      Assertions.assertEquals(maxCompactionSlot, stats.get(Stats.Compaction.SUBMITTED_TASKS));
     } else {
-      Assert.assertEquals(1, stats.get(Stats.Compaction.SUBMITTED_TASKS));
+      Assertions.assertEquals(1, stats.get(Stats.Compaction.SUBMITTED_TASKS));
     }
   }
 
@@ -740,14 +740,14 @@ public class CompactSegmentsTest
     final CompactSegments compactSegments = new CompactSegments(statusTracker, overlordClient);
     final CoordinatorRunStats stats =
         doCompactSegments(compactSegments, createCompactionConfigs(), maxCompactionSlot);
-    Assert.assertEquals(MAXIMUM_CAPACITY_WITH_AUTO_SCALE, stats.get(Stats.Compaction.AVAILABLE_SLOTS));
-    Assert.assertEquals(MAXIMUM_CAPACITY_WITH_AUTO_SCALE, stats.get(Stats.Compaction.MAX_SLOTS));
+    Assertions.assertEquals(MAXIMUM_CAPACITY_WITH_AUTO_SCALE, stats.get(Stats.Compaction.AVAILABLE_SLOTS));
+    Assertions.assertEquals(MAXIMUM_CAPACITY_WITH_AUTO_SCALE, stats.get(Stats.Compaction.MAX_SLOTS));
     // Native takes up 1 task slot by default whereas MSQ takes up all available upto 5. Since there are 10 available
     // slots, there are 10 submitted tasks for native whereas 2 for MSQ.
     if (engine == CompactionEngine.NATIVE) {
-      Assert.assertEquals(MAXIMUM_CAPACITY_WITH_AUTO_SCALE, stats.get(Stats.Compaction.SUBMITTED_TASKS));
+      Assertions.assertEquals(MAXIMUM_CAPACITY_WITH_AUTO_SCALE, stats.get(Stats.Compaction.SUBMITTED_TASKS));
     } else {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           MAXIMUM_CAPACITY_WITH_AUTO_SCALE / ClientMSQContext.MAX_TASK_SLOTS_FOR_MSQ_COMPACTION_TASK,
           stats.get(Stats.Compaction.SUBMITTED_TASKS)
       );
@@ -776,13 +776,13 @@ public class CompactSegmentsTest
 
     ClientCompactionTaskQuery taskPayload = (ClientCompactionTaskQuery) payloadCaptor.getValue();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Intervals.of("2017-01-09T12:00:00.000Z/2017-01-10T00:00:00.000Z"),
         taskPayload.getIoConfig().getInputSpec().getInterval()
     );
-    Assert.assertNull(taskPayload.getGranularitySpec().getSegmentGranularity());
-    Assert.assertNull(taskPayload.getGranularitySpec().getQueryGranularity());
-    Assert.assertNull(taskPayload.getGranularitySpec().isRollup());
+    Assertions.assertNull(taskPayload.getGranularitySpec().getSegmentGranularity());
+    Assertions.assertNull(taskPayload.getGranularitySpec().getQueryGranularity());
+    Assertions.assertNull(taskPayload.getGranularitySpec().isRollup());
   }
 
   @Test
@@ -806,7 +806,7 @@ public class CompactSegmentsTest
     );
     doCompactSegments(compactSegments, compactionConfigs);
     ClientCompactionTaskQuery taskPayload = (ClientCompactionTaskQuery) payloadCaptor.getValue();
-    Assert.assertTrue(taskPayload.getIoConfig().isDropExisting());
+    Assertions.assertTrue(taskPayload.getIoConfig().isDropExisting());
   }
 
   @Test
@@ -830,9 +830,9 @@ public class CompactSegmentsTest
     doCompactSegments(compactSegments, compactionConfigs);
     ClientCompactionTaskQuery taskPayload = (ClientCompactionTaskQuery) payloadCaptor.getValue();
     if (CompactionEngine.NATIVE.equals(engine)) {
-      Assert.assertEquals(BatchIOConfig.DEFAULT_DROP_EXISTING, taskPayload.getIoConfig().isDropExisting());
+      Assertions.assertEquals(BatchIOConfig.DEFAULT_DROP_EXISTING, taskPayload.getIoConfig().isDropExisting());
     } else {
-      Assert.assertTrue(taskPayload.getIoConfig().isDropExisting());
+      Assertions.assertTrue(taskPayload.getIoConfig().isDropExisting());
     }
   }
 
@@ -863,14 +863,14 @@ public class CompactSegmentsTest
 
     // All segments is compact at the same time since we changed the segment granularity to YEAR and all segment
     // are within the same year
-    Assert.assertEquals(
+    Assertions.assertEquals(
         CompactionCandidate.getCompactionInterval(datasourceToSegments.get(dataSource), Granularities.YEAR),
         taskPayload.getIoConfig().getInputSpec().getInterval()
     );
 
     ClientCompactionTaskGranularitySpec expectedGranularitySpec =
         new ClientCompactionTaskGranularitySpec(Granularities.YEAR, null, null);
-    Assert.assertEquals(expectedGranularitySpec, taskPayload.getGranularitySpec());
+    Assertions.assertEquals(expectedGranularitySpec, taskPayload.getGranularitySpec());
   }
 
   @Test
@@ -898,7 +898,7 @@ public class CompactSegmentsTest
     );
     doCompactSegments(compactSegments, compactionConfigs);
     ClientCompactionTaskQuery taskPayload = (ClientCompactionTaskQuery) payloadCaptor.getValue();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         DimensionsSpec.getDefaultSchemas(ImmutableList.of("bar", "foo")),
         taskPayload.getDimensionsSpec().getDimensions()
     );
@@ -924,7 +924,7 @@ public class CompactSegmentsTest
     );
     doCompactSegments(compactSegments, compactionConfigs);
     ClientCompactionTaskQuery taskPayload = (ClientCompactionTaskQuery) payloadCaptor.getValue();
-    Assert.assertNull(taskPayload.getDimensionsSpec());
+    Assertions.assertNull(taskPayload.getDimensionsSpec());
   }
 
   @Test
@@ -966,7 +966,7 @@ public class CompactSegmentsTest
     );
     doCompactSegments(compactSegments, compactionConfigs);
     ClientCompactionTaskQuery taskPayload = (ClientCompactionTaskQuery) payloadCaptor.getValue();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         projections,
         taskPayload.getProjections()
     );
@@ -1003,7 +1003,7 @@ public class CompactSegmentsTest
     );
     doCompactSegments(compactSegments, compactionConfigs);
     ClientCompactionTaskQuery taskPayload = (ClientCompactionTaskQuery) payloadCaptor.getValue();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         baseTable,
         taskPayload.getBaseTable()
     );
@@ -1060,7 +1060,7 @@ public class CompactSegmentsTest
     );
     doCompactSegments(compactSegments, compactionConfigs);
     ClientCompactionTaskQuery taskPayload = (ClientCompactionTaskQuery) payloadCaptor.getValue();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(projectionSpec),
         taskPayload.getProjections()
     );
@@ -1096,14 +1096,14 @@ public class CompactSegmentsTest
 
     // All segments is compact at the same time since we changed the segment granularity to YEAR and all segment
     // are within the same year
-    Assert.assertEquals(
+    Assertions.assertEquals(
         CompactionCandidate.getCompactionInterval(datasourceToSegments.get(dataSource), Granularities.YEAR),
         taskPayload.getIoConfig().getInputSpec().getInterval()
     );
 
     ClientCompactionTaskGranularitySpec expectedGranularitySpec =
         new ClientCompactionTaskGranularitySpec(Granularities.YEAR, null, true);
-    Assert.assertEquals(expectedGranularitySpec, taskPayload.getGranularitySpec());
+    Assertions.assertEquals(expectedGranularitySpec, taskPayload.getGranularitySpec());
   }
 
   @Test
@@ -1196,14 +1196,14 @@ public class CompactSegmentsTest
 
     // All segments is compact at the same time since we changed the segment granularity to YEAR and all segment
     // are within the same year
-    Assert.assertEquals(
+    Assertions.assertEquals(
         CompactionCandidate.getCompactionInterval(datasourceToSegments.get(dataSource), Granularities.YEAR),
         taskPayload.getIoConfig().getInputSpec().getInterval()
     );
 
     ClientCompactionTaskGranularitySpec expectedGranularitySpec =
         new ClientCompactionTaskGranularitySpec(Granularities.YEAR, null, null);
-    Assert.assertEquals(expectedGranularitySpec, taskPayload.getGranularitySpec());
+    Assertions.assertEquals(expectedGranularitySpec, taskPayload.getGranularitySpec());
   }
 
   @Test
@@ -1224,12 +1224,12 @@ public class CompactSegmentsTest
         compactSegments,
         ImmutableList.of(compactionConfig)
     );
-    Assert.assertEquals(1, stats.get(Stats.Compaction.SUBMITTED_TASKS));
-    Assert.assertEquals(1, overlordClient.submittedCompactionTasks.size());
+    Assertions.assertEquals(1, stats.get(Stats.Compaction.SUBMITTED_TASKS));
+    Assertions.assertEquals(1, overlordClient.submittedCompactionTasks.size());
 
     ClientCompactionTaskQuery submittedTask = overlordClient.submittedCompactionTasks.get(0);
-    Assert.assertEquals(submittedTask.getDataSource(), dataSource);
-    Assert.assertEquals(
+    Assertions.assertEquals(submittedTask.getDataSource(), dataSource);
+    Assertions.assertEquals(
         Intervals.of("2017-01-09/P1D"),
         submittedTask.getIoConfig().getInputSpec().getInterval()
     );
@@ -1240,13 +1240,13 @@ public class CompactSegmentsTest
         compactSegments,
         ImmutableList.of(compactionConfig)
     );
-    Assert.assertEquals(1, stats.get(Stats.Compaction.SUBMITTED_TASKS));
-    Assert.assertEquals(2, overlordClient.submittedCompactionTasks.size());
+    Assertions.assertEquals(1, stats.get(Stats.Compaction.SUBMITTED_TASKS));
+    Assertions.assertEquals(2, overlordClient.submittedCompactionTasks.size());
 
     // Verify that the latest interval is compacted again
     submittedTask = overlordClient.submittedCompactionTasks.get(1);
-    Assert.assertEquals(submittedTask.getDataSource(), dataSource);
-    Assert.assertEquals(
+    Assertions.assertEquals(submittedTask.getDataSource(), dataSource);
+    Assertions.assertEquals(
         Intervals.of("2017-01-09/P1D"),
         submittedTask.getIoConfig().getInputSpec().getInterval()
     );
@@ -1264,9 +1264,9 @@ public class CompactSegmentsTest
     } else {
       stats = doCompactSegments(compactSegments, createcompactionConfigsForMSQ(2), 4);
     }
-    Assert.assertEquals(4, stats.get(Stats.Compaction.AVAILABLE_SLOTS));
-    Assert.assertEquals(4, stats.get(Stats.Compaction.MAX_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Compaction.SUBMITTED_TASKS));
+    Assertions.assertEquals(4, stats.get(Stats.Compaction.AVAILABLE_SLOTS));
+    Assertions.assertEquals(4, stats.get(Stats.Compaction.MAX_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Compaction.SUBMITTED_TASKS));
   }
 
   @Test
@@ -1296,12 +1296,12 @@ public class CompactSegmentsTest
     CompactSegments compactSegments = new CompactSegments(statusTracker, overlordClient);
     final CoordinatorRunStats stats =
         doCompactSegments(compactSegments, createcompactionConfigsForNative(2), 4);
-    Assert.assertEquals(1, stats.get(Stats.Compaction.SUBMITTED_TASKS));
-    Assert.assertEquals(1, overlordClient.submittedCompactionTasks.size());
+    Assertions.assertEquals(1, stats.get(Stats.Compaction.SUBMITTED_TASKS));
+    Assertions.assertEquals(1, overlordClient.submittedCompactionTasks.size());
 
     final ClientCompactionTaskQuery compactionTask = overlordClient.submittedCompactionTasks.get(0);
-    Assert.assertEquals(datasource0, compactionTask.getDataSource());
-    Assert.assertEquals(
+    Assertions.assertEquals(datasource0, compactionTask.getDataSource());
+    Assertions.assertEquals(
         Intervals.of("2017-01-01T00:00:00/2017-01-01T12:00:00"),
         compactionTask.getIoConfig().getInputSpec().getInterval()
     );
@@ -1333,8 +1333,8 @@ public class CompactSegmentsTest
     );
     doCompactSegments(compactSegments, compactionConfigs);
     ClientCompactionTaskQuery taskPayload = (ClientCompactionTaskQuery) payloadCaptor.getValue();
-    Assert.assertNotNull(taskPayload.getTransformSpec());
-    Assert.assertEquals(new SelectorDimFilter("dim1", "foo", null), taskPayload.getTransformSpec().getFilter());
+    Assertions.assertNotNull(taskPayload.getTransformSpec());
+    Assertions.assertEquals(new SelectorDimFilter("dim1", "foo", null), taskPayload.getTransformSpec().getFilter());
   }
 
   @Test
@@ -1357,8 +1357,8 @@ public class CompactSegmentsTest
     );
     doCompactSegments(compactSegments, compactionConfigs);
     ClientCompactionTaskQuery taskPayload = (ClientCompactionTaskQuery) payloadCaptor.getValue();
-    Assert.assertNull(taskPayload.getTransformSpec());
-    Assert.assertNull(taskPayload.getMetricsSpec());
+    Assertions.assertNull(taskPayload.getTransformSpec());
+    Assertions.assertNull(taskPayload.getMetricsSpec());
   }
 
   @Test
@@ -1384,8 +1384,8 @@ public class CompactSegmentsTest
     doCompactSegments(compactSegments, compactionConfigs);
     ClientCompactionTaskQuery taskPayload = (ClientCompactionTaskQuery) payloadCaptor.getValue();
     AggregatorFactory[] actual = taskPayload.getMetricsSpec();
-    Assert.assertNotNull(actual);
-    Assert.assertArrayEquals(aggregatorFactories, actual);
+    Assertions.assertNotNull(actual);
+    Assertions.assertArrayEquals(aggregatorFactories, actual);
   }
 
   @Test
@@ -1438,14 +1438,14 @@ public class CompactSegmentsTest
     doCompactSegments(compactSegments, compactionConfigs);
     ClientCompactionTaskQuery taskPayload = (ClientCompactionTaskQuery) payloadCaptor.getValue();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         CompactionCandidate.getCompactionInterval(segments, Granularities.DAY),
         taskPayload.getIoConfig().getInputSpec().getInterval()
     );
 
     ClientCompactionTaskGranularitySpec expectedGranularitySpec =
         new ClientCompactionTaskGranularitySpec(Granularities.DAY, null, null);
-    Assert.assertEquals(expectedGranularitySpec, taskPayload.getGranularitySpec());
+    Assertions.assertEquals(expectedGranularitySpec, taskPayload.getGranularitySpec());
   }
 
   @Test
@@ -1505,14 +1505,14 @@ public class CompactSegmentsTest
     doCompactSegments(compactSegments, compactionConfigs);
     ClientCompactionTaskQuery taskPayload = (ClientCompactionTaskQuery) payloadCaptor.getValue();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         CompactionCandidate.getCompactionInterval(segments, Granularities.YEAR),
         taskPayload.getIoConfig().getInputSpec().getInterval()
     );
 
     ClientCompactionTaskGranularitySpec expectedGranularitySpec =
         new ClientCompactionTaskGranularitySpec(Granularities.YEAR, null, null);
-    Assert.assertEquals(expectedGranularitySpec, taskPayload.getGranularitySpec());
+    Assertions.assertEquals(expectedGranularitySpec, taskPayload.getGranularitySpec());
   }
 
   @Test
@@ -1536,9 +1536,9 @@ public class CompactSegmentsTest
     );
     doCompactSegments(compactSegments, compactionConfigs);
     ClientCompactionTaskQuery taskPayload = (ClientCompactionTaskQuery) payloadCaptor.getValue();
-    Assert.assertNotNull(taskPayload.getTuningConfig());
-    Assert.assertNotNull(taskPayload.getTuningConfig().getAppendableIndexSpec());
-    Assert.assertTrue(((OnheapIncrementalIndex.Spec) taskPayload.getTuningConfig()
+    Assertions.assertNotNull(taskPayload.getTuningConfig());
+    Assertions.assertNotNull(taskPayload.getTuningConfig().getAppendableIndexSpec());
+    Assertions.assertTrue(((OnheapIncrementalIndex.Spec) taskPayload.getTuningConfig()
                                                                 .getAppendableIndexSpec()).isPreserveExistingMetrics());
   }
 
@@ -1562,9 +1562,9 @@ public class CompactSegmentsTest
     );
     doCompactSegments(compactSegments, compactionConfigs);
     ClientCompactionTaskQuery taskPayload = (ClientCompactionTaskQuery) payloadCaptor.getValue();
-    Assert.assertNotNull(taskPayload.getTuningConfig());
-    Assert.assertNotNull(taskPayload.getTuningConfig().getAppendableIndexSpec());
-    Assert.assertFalse(((OnheapIncrementalIndex.Spec) taskPayload.getTuningConfig()
+    Assertions.assertNotNull(taskPayload.getTuningConfig());
+    Assertions.assertNotNull(taskPayload.getTuningConfig().getAppendableIndexSpec());
+    Assertions.assertFalse(((OnheapIncrementalIndex.Spec) taskPayload.getTuningConfig()
                                                                  .getAppendableIndexSpec()).isPreserveExistingMetrics());
   }
 
@@ -1585,17 +1585,17 @@ public class CompactSegmentsTest
   {
     Map<String, AutoCompactionSnapshot> autoCompactionSnapshots = compactSegments.getAutoCompactionSnapshot();
     AutoCompactionSnapshot snapshot = autoCompactionSnapshots.get(dataSourceName);
-    Assert.assertEquals(dataSourceName, snapshot.getDataSource());
-    Assert.assertEquals(scheduleStatus, snapshot.getScheduleStatus());
-    Assert.assertEquals(expectedByteCountAwaitingCompaction, snapshot.getBytesAwaitingCompaction());
-    Assert.assertEquals(expectedByteCountCompressed, snapshot.getBytesCompacted());
-    Assert.assertEquals(expectedByteCountSkipped, snapshot.getBytesSkipped());
-    Assert.assertEquals(expectedIntervalCountAwaitingCompaction, snapshot.getIntervalCountAwaitingCompaction());
-    Assert.assertEquals(expectedIntervalCountCompressed, snapshot.getIntervalCountCompacted());
-    Assert.assertEquals(expectedIntervalCountSkipped, snapshot.getIntervalCountSkipped());
-    Assert.assertEquals(expectedSegmentCountAwaitingCompaction, snapshot.getSegmentCountAwaitingCompaction());
-    Assert.assertEquals(expectedSegmentCountCompressed, snapshot.getSegmentCountCompacted());
-    Assert.assertEquals(expectedSegmentCountSkipped, snapshot.getSegmentCountSkipped());
+    Assertions.assertEquals(dataSourceName, snapshot.getDataSource());
+    Assertions.assertEquals(scheduleStatus, snapshot.getScheduleStatus());
+    Assertions.assertEquals(expectedByteCountAwaitingCompaction, snapshot.getBytesAwaitingCompaction());
+    Assertions.assertEquals(expectedByteCountCompressed, snapshot.getBytesCompacted());
+    Assertions.assertEquals(expectedByteCountSkipped, snapshot.getBytesSkipped());
+    Assertions.assertEquals(expectedIntervalCountAwaitingCompaction, snapshot.getIntervalCountAwaitingCompaction());
+    Assertions.assertEquals(expectedIntervalCountCompressed, snapshot.getIntervalCountCompacted());
+    Assertions.assertEquals(expectedIntervalCountSkipped, snapshot.getIntervalCountSkipped());
+    Assertions.assertEquals(expectedSegmentCountAwaitingCompaction, snapshot.getSegmentCountAwaitingCompaction());
+    Assertions.assertEquals(expectedSegmentCountCompressed, snapshot.getSegmentCountCompacted());
+    Assertions.assertEquals(expectedSegmentCountSkipped, snapshot.getSegmentCountSkipped());
   }
 
   private void doCompactionAndAssertCompactSegmentStatistics(CompactSegments compactSegments, int compactionRunCount)
@@ -1603,7 +1603,7 @@ public class CompactSegmentsTest
     for (int dataSourceIndex = 0; dataSourceIndex < 3; dataSourceIndex++) {
       // One compaction task triggered
       final CoordinatorRunStats stats = doCompactSegments(compactSegments);
-      Assert.assertEquals(
+      Assertions.assertEquals(
           1,
           stats.get(Stats.Compaction.SUBMITTED_TASKS)
       );
@@ -1736,7 +1736,7 @@ public class CompactSegmentsTest
 
     for (int i = 0; i < 3; i++) {
       final CoordinatorRunStats stats = doCompactSegments(compactSegments);
-      Assert.assertEquals(
+      Assertions.assertEquals(
           expectedCompactTaskCount,
           stats.get(Stats.Compaction.SUBMITTED_TASKS)
       );
@@ -1755,9 +1755,9 @@ public class CompactSegmentsTest
       );
 
       if (expectedRemainingSegments > 0) {
-        Assert.assertEquals(i + 1, numDatasources.get());
+        Assertions.assertEquals(i + 1, numDatasources.get());
       } else {
-        Assert.assertEquals(2 - i, numDatasources.get());
+        Assertions.assertEquals(2 - i, numDatasources.get());
       }
     }
 
@@ -1766,13 +1766,13 @@ public class CompactSegmentsTest
     for (int i = 0; i < 3; i++) {
       final String dataSource = DATA_SOURCE_PREFIX + i;
       List<TimelineObjectHolder<String, DataSegment>> holders = dataSourceToTimeline.get(dataSource).lookup(expectedInterval);
-      Assert.assertEquals(1, holders.size());
+      Assertions.assertEquals(1, holders.size());
       List<PartitionChunk<DataSegment>> chunks = Lists.newArrayList(holders.get(0).getObject());
-      Assert.assertEquals(2, chunks.size());
+      Assertions.assertEquals(2, chunks.size());
       final String expectedVersion = expectedVersionSupplier.get();
       for (PartitionChunk<DataSegment> chunk : chunks) {
-        Assert.assertEquals(expectedInterval, chunk.getObject().getInterval());
-        Assert.assertEquals(expectedVersion, chunk.getObject().getVersion());
+        Assertions.assertEquals(expectedInterval, chunk.getObject().getInterval());
+        Assertions.assertEquals(expectedVersion, chunk.getObject().getVersion());
       }
     }
   }
@@ -1786,14 +1786,14 @@ public class CompactSegmentsTest
       final String dataSource = DATA_SOURCE_PREFIX + i;
       final Interval interval = Intervals.of(StringUtils.format("2017-01-09T12:00:00/2017-01-10"));
       List<TimelineObjectHolder<String, DataSegment>> holders = dataSourceToTimeline.get(dataSource).lookup(interval);
-      Assert.assertEquals(1, holders.size());
+      Assertions.assertEquals(1, holders.size());
       for (TimelineObjectHolder<String, DataSegment> holder : holders) {
         List<PartitionChunk<DataSegment>> chunks = Lists.newArrayList(holder.getObject());
-        Assert.assertEquals(4, chunks.size());
+        Assertions.assertEquals(4, chunks.size());
         for (PartitionChunk<DataSegment> chunk : chunks) {
           DataSegment segment = chunk.getObject();
-          Assert.assertEquals(interval, segment.getInterval());
-          Assert.assertEquals("version", segment.getVersion());
+          Assertions.assertEquals(interval, segment.getInterval());
+          Assertions.assertEquals("version", segment.getVersion());
         }
       }
     }
@@ -1803,7 +1803,7 @@ public class CompactSegmentsTest
     addMoreData(dataSource, 9);
 
     CoordinatorRunStats stats = doCompactSegments(compactSegments);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         stats.get(Stats.Compaction.SUBMITTED_TASKS)
     );
@@ -1811,7 +1811,7 @@ public class CompactSegmentsTest
     addMoreData(dataSource, 10);
 
     stats = doCompactSegments(compactSegments);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         stats.get(Stats.Compaction.SUBMITTED_TASKS)
     );
@@ -2052,7 +2052,7 @@ public class CompactSegmentsTest
     @Test
     public void testIsParalleModeNullTuningConfigReturnFalse()
     {
-      Assert.assertFalse(CompactionSlotManager.isParallelMode(null));
+      Assertions.assertFalse(CompactionSlotManager.isParallelMode(null));
     }
 
     @Test
@@ -2060,7 +2060,7 @@ public class CompactSegmentsTest
     {
       ClientCompactionTaskQueryTuningConfig tuningConfig = Mockito.mock(ClientCompactionTaskQueryTuningConfig.class);
       Mockito.when(tuningConfig.getPartitionsSpec()).thenReturn(null);
-      Assert.assertFalse(CompactionSlotManager.isParallelMode(tuningConfig));
+      Assertions.assertFalse(CompactionSlotManager.isParallelMode(tuningConfig));
     }
 
     @Test
@@ -2070,13 +2070,13 @@ public class CompactSegmentsTest
       Mockito.when(tuningConfig.getPartitionsSpec()).thenReturn(Mockito.mock(PartitionsSpec.class));
 
       Mockito.when(tuningConfig.getMaxNumConcurrentSubTasks()).thenReturn(null);
-      Assert.assertFalse(CompactionSlotManager.isParallelMode(tuningConfig));
+      Assertions.assertFalse(CompactionSlotManager.isParallelMode(tuningConfig));
 
       Mockito.when(tuningConfig.getMaxNumConcurrentSubTasks()).thenReturn(1);
-      Assert.assertFalse(CompactionSlotManager.isParallelMode(tuningConfig));
+      Assertions.assertFalse(CompactionSlotManager.isParallelMode(tuningConfig));
 
       Mockito.when(tuningConfig.getMaxNumConcurrentSubTasks()).thenReturn(2);
-      Assert.assertTrue(CompactionSlotManager.isParallelMode(tuningConfig));
+      Assertions.assertTrue(CompactionSlotManager.isParallelMode(tuningConfig));
     }
 
     @Test
@@ -2086,13 +2086,13 @@ public class CompactSegmentsTest
       Mockito.when(tuningConfig.getPartitionsSpec()).thenReturn(Mockito.mock(SingleDimensionPartitionsSpec.class));
 
       Mockito.when(tuningConfig.getMaxNumConcurrentSubTasks()).thenReturn(null);
-      Assert.assertFalse(CompactionSlotManager.isParallelMode(tuningConfig));
+      Assertions.assertFalse(CompactionSlotManager.isParallelMode(tuningConfig));
 
       Mockito.when(tuningConfig.getMaxNumConcurrentSubTasks()).thenReturn(1);
-      Assert.assertTrue(CompactionSlotManager.isParallelMode(tuningConfig));
+      Assertions.assertTrue(CompactionSlotManager.isParallelMode(tuningConfig));
 
       Mockito.when(tuningConfig.getMaxNumConcurrentSubTasks()).thenReturn(2);
-      Assert.assertTrue(CompactionSlotManager.isParallelMode(tuningConfig));
+      Assertions.assertTrue(CompactionSlotManager.isParallelMode(tuningConfig));
     }
 
     @Test
@@ -2101,7 +2101,7 @@ public class CompactSegmentsTest
       ClientCompactionTaskQueryTuningConfig tuningConfig = Mockito.mock(ClientCompactionTaskQueryTuningConfig.class);
       Mockito.when(tuningConfig.getPartitionsSpec()).thenReturn(Mockito.mock(PartitionsSpec.class));
       Mockito.when(tuningConfig.getMaxNumConcurrentSubTasks()).thenReturn(2);
-      Assert.assertEquals(3, CompactionSlotManager.getMaxTaskSlotsForNativeCompactionTask(tuningConfig));
+      Assertions.assertEquals(3, CompactionSlotManager.getMaxTaskSlotsForNativeCompactionTask(tuningConfig));
     }
 
     @Test
@@ -2110,7 +2110,7 @@ public class CompactSegmentsTest
       ClientCompactionTaskQueryTuningConfig tuningConfig = Mockito.mock(ClientCompactionTaskQueryTuningConfig.class);
       Mockito.when(tuningConfig.getPartitionsSpec()).thenReturn(Mockito.mock(PartitionsSpec.class));
       Mockito.when(tuningConfig.getMaxNumConcurrentSubTasks()).thenReturn(1);
-      Assert.assertEquals(1, CompactionSlotManager.getMaxTaskSlotsForNativeCompactionTask(tuningConfig));
+      Assertions.assertEquals(1, CompactionSlotManager.getMaxTaskSlotsForNativeCompactionTask(tuningConfig));
     }
   }
 

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillAuditLogTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillAuditLogTest.java
@@ -25,16 +25,15 @@ import org.apache.druid.server.coordinator.config.MetadataCleanupConfig;
 import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.server.coordinator.stats.Stats;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 
-@RunWith(MockitoJUnitRunner.class)
 public class KillAuditLogTest
 {
   @Mock
@@ -45,12 +44,20 @@ public class KillAuditLogTest
 
   private KillAuditLog killAuditLog;
   private CoordinatorRunStats runStats;
+  private AutoCloseable mocks;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
+    mocks = MockitoAnnotations.openMocks(this);
     runStats = new CoordinatorRunStats();
     Mockito.when(mockDruidCoordinatorRuntimeParams.getCoordinatorStats()).thenReturn(runStats);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception
+  {
+    mocks.close();
   }
 
   @Test
@@ -71,6 +78,6 @@ public class KillAuditLogTest
     killAuditLog = new KillAuditLog(config, mockAuditManager);
     killAuditLog.run(mockDruidCoordinatorRuntimeParams);
     Mockito.verify(mockAuditManager).removeAuditLogsOlderThan(ArgumentMatchers.anyLong());
-    Assert.assertTrue(runStats.hasStat(Stats.Kill.AUDIT_LOGS));
+    Assertions.assertTrue(runStats.hasStat(Stats.Kill.AUDIT_LOGS));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillCompactionConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillCompactionConfigTest.java
@@ -39,17 +39,16 @@ import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.server.coordinator.stats.Stats;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 
-@RunWith(MockitoJUnitRunner.class)
 public class KillCompactionConfigTest
 {
   @Mock
@@ -70,10 +69,12 @@ public class KillCompactionConfigTest
   private CoordinatorConfigManager coordinatorConfigManager;
   private KillCompactionConfig killCompactionConfig;
   private CoordinatorRunStats runStats;
+  private AutoCloseable mocks;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
+    mocks = MockitoAnnotations.openMocks(this);
     runStats = new CoordinatorRunStats();
     Mockito.when(mockConnectorConfig.getConfigTable()).thenReturn("druid_config");
     Mockito.when(mockDruidCoordinatorRuntimeParams.getCoordinatorStats()).thenReturn(runStats);
@@ -83,6 +84,12 @@ public class KillCompactionConfigTest
         mockConnectorConfig,
         null
     );
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception
+  {
+    mocks.close();
   }
 
   @Test
@@ -98,7 +105,7 @@ public class KillCompactionConfigTest
     killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
     Mockito.verifyNoInteractions(mockStorageCoordinator);
     Mockito.verifyNoInteractions(mockJacksonConfigManager);
-    Assert.assertEquals(0, runStats.rowCount());
+    Assertions.assertEquals(0, runStats.rowCount());
   }
 
   @Test
@@ -126,8 +133,8 @@ public class KillCompactionConfigTest
     );
     killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
     Mockito.verifyNoInteractions(mockStorageCoordinator);
-    Assert.assertTrue(runStats.hasStat(Stats.Kill.COMPACTION_CONFIGS));
-    Assert.assertEquals(0, runStats.get(Stats.Kill.COMPACTION_CONFIGS));
+    Assertions.assertTrue(runStats.hasStat(Stats.Kill.COMPACTION_CONFIGS));
+    Assertions.assertEquals(0, runStats.get(Stats.Kill.COMPACTION_CONFIGS));
 
     Mockito.verify(mockJacksonConfigManager).convertByteToConfig(
         ArgumentMatchers.eq(null),
@@ -212,14 +219,14 @@ public class KillCompactionConfigTest
     killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
 
     // Verify and Assert
-    Assert.assertNotNull(oldConfigCaptor.getValue());
-    Assert.assertEquals(oldConfigCaptor.getValue(), originalCurrentConfigBytes);
-    Assert.assertNotNull(newConfigCaptor.getValue());
+    Assertions.assertNotNull(oldConfigCaptor.getValue());
+    Assertions.assertEquals(oldConfigCaptor.getValue(), originalCurrentConfigBytes);
+    Assertions.assertNotNull(newConfigCaptor.getValue());
     // The updated config should only contains one compaction config for the active datasource
-    Assert.assertEquals(1, newConfigCaptor.getValue().getCompactionConfigs().size());
+    Assertions.assertEquals(1, newConfigCaptor.getValue().getCompactionConfigs().size());
 
-    Assert.assertEquals(activeDatasourceConfig, newConfigCaptor.getValue().getCompactionConfigs().get(0));
-    Assert.assertEquals(1, runStats.get(Stats.Kill.COMPACTION_CONFIGS));
+    Assertions.assertEquals(activeDatasourceConfig, newConfigCaptor.getValue().getCompactionConfigs().get(0));
+    Assertions.assertEquals(1, runStats.get(Stats.Kill.COMPACTION_CONFIGS));
 
     Mockito.verify(mockJacksonConfigManager).convertByteToConfig(
         ArgumentMatchers.eq(originalCurrentConfigBytes),
@@ -302,7 +309,7 @@ public class KillCompactionConfigTest
     killCompactionConfig.run(mockDruidCoordinatorRuntimeParams);
 
     // Verify that 1 config has been deleted
-    Assert.assertEquals(1, runStats.get(Stats.Kill.COMPACTION_CONFIGS));
+    Assertions.assertEquals(1, runStats.get(Stats.Kill.COMPACTION_CONFIGS));
 
     // Should call convertByteToConfig and lookup (to refresh current compaction config) four times due to RetryableException when failed
     Mockito.verify(mockJacksonConfigManager, Mockito.times(4)).convertByteToConfig(

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillDatasourceMetadataTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillDatasourceMetadataTest.java
@@ -27,16 +27,15 @@ import org.apache.druid.server.coordinator.config.MetadataCleanupConfig;
 import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.server.coordinator.stats.Stats;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 
-@RunWith(MockitoJUnitRunner.class)
 public class KillDatasourceMetadataTest
 {
   @Mock
@@ -50,12 +49,20 @@ public class KillDatasourceMetadataTest
 
   private KillDatasourceMetadata killDatasourceMetadata;
   private CoordinatorRunStats runStats;
+  private AutoCloseable mocks;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
+    mocks = MockitoAnnotations.openMocks(this);
     runStats = new CoordinatorRunStats();
     Mockito.when(mockDruidCoordinatorRuntimeParams.getCoordinatorStats()).thenReturn(runStats);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception
+  {
+    mocks.close();
   }
 
   @Test
@@ -83,7 +90,7 @@ public class KillDatasourceMetadataTest
     );
     killDatasourceMetadata.run(mockDruidCoordinatorRuntimeParams);
     Mockito.verify(mockIndexerMetadataStorageCoordinator).removeDataSourceMetadataOlderThan(ArgumentMatchers.anyLong(), ArgumentMatchers.anySet());
-    Assert.assertTrue(runStats.hasStat(Stats.Kill.DATASOURCES));
+    Assertions.assertTrue(runStats.hasStat(Stats.Kill.DATASOURCES));
   }
 
   @Test
@@ -94,6 +101,6 @@ public class KillDatasourceMetadataTest
     killDatasourceMetadata = new KillDatasourceMetadata(config, mockIndexerMetadataStorageCoordinator, mockMetadataSupervisorManager);
     killDatasourceMetadata.run(mockDruidCoordinatorRuntimeParams);
     Mockito.verify(mockIndexerMetadataStorageCoordinator).removeDataSourceMetadataOlderThan(ArgumentMatchers.anyLong(), ArgumentMatchers.eq(ImmutableSet.of()));
-    Assert.assertTrue(runStats.hasStat(Stats.Kill.DATASOURCES));
+    Assertions.assertTrue(runStats.hasStat(Stats.Kill.DATASOURCES));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillRulesTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillRulesTest.java
@@ -25,16 +25,15 @@ import org.apache.druid.server.coordinator.config.MetadataCleanupConfig;
 import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.server.coordinator.stats.Stats;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 
-@RunWith(MockitoJUnitRunner.class)
 public class KillRulesTest
 {
   @Mock
@@ -45,12 +44,20 @@ public class KillRulesTest
 
   private KillRules killRules;
   private CoordinatorRunStats runStats;
+  private AutoCloseable mocks;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
+    mocks = MockitoAnnotations.openMocks(this);
     runStats = new CoordinatorRunStats();
     Mockito.when(mockDruidCoordinatorRuntimeParams.getCoordinatorStats()).thenReturn(runStats);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception
+  {
+    mocks.close();
   }
 
   @Test
@@ -71,6 +78,6 @@ public class KillRulesTest
     killRules = new KillRules(config, mockRuleManager);
     killRules.run(mockDruidCoordinatorRuntimeParams);
     Mockito.verify(mockRuleManager).removeRulesForEmptyDatasourcesOlderThan(ArgumentMatchers.anyLong());
-    Assert.assertTrue(runStats.hasStat(Stats.Kill.RULES));
+    Assertions.assertTrue(runStats.hasStat(Stats.Kill.RULES));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillStalePendingSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillStalePendingSegmentsTest.java
@@ -41,9 +41,9 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -59,7 +59,7 @@ public class KillStalePendingSegmentsTest
   private TestOverlordClient overlordClient;
   private KillStalePendingSegments killDuty;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     this.overlordClient = new TestOverlordClient();
@@ -73,11 +73,11 @@ public class KillStalePendingSegmentsTest
     killDuty.run(params);
 
     final Interval observedKillInterval = overlordClient.observedKillIntervals.get(TestDataSource.WIKI);
-    Assert.assertEquals(DateTimes.MIN, observedKillInterval.getStart());
+    Assertions.assertEquals(DateTimes.MIN, observedKillInterval.getStart());
 
     // Verify that the cutoff time is no later than 1 day ago from now
     DateTime expectedCutoffTime = DateTimes.nowUtc().minusDays(1);
-    Assert.assertTrue(
+    Assertions.assertTrue(
         expectedCutoffTime.getMillis() - observedKillInterval.getEnd().getMillis() <= 100
     );
   }
@@ -95,8 +95,8 @@ public class KillStalePendingSegmentsTest
     killDuty.run(params);
 
     final Interval observedKillInterval = overlordClient.observedKillIntervals.get(TestDataSource.WIKI);
-    Assert.assertEquals(DateTimes.MIN, observedKillInterval.getStart());
-    Assert.assertEquals(startOfEarliestActiveTask.minusDays(1), observedKillInterval.getEnd());
+    Assertions.assertEquals(DateTimes.MIN, observedKillInterval.getStart());
+    Assertions.assertEquals(startOfEarliestActiveTask.minusDays(1), observedKillInterval.getEnd());
   }
 
   @Test
@@ -112,11 +112,11 @@ public class KillStalePendingSegmentsTest
     killDuty.run(params);
 
     final Interval observedKillInterval = overlordClient.observedKillIntervals.get(TestDataSource.WIKI);
-    Assert.assertEquals(DateTimes.MIN, observedKillInterval.getStart());
-    Assert.assertEquals(startOfLatestCompletedTask.minusDays(1), observedKillInterval.getEnd());
+    Assertions.assertEquals(DateTimes.MIN, observedKillInterval.getStart());
+    Assertions.assertEquals(startOfLatestCompletedTask.minusDays(1), observedKillInterval.getEnd());
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertEquals(2, stats.get(Stats.Kill.PENDING_SEGMENTS, RowKey.of(Dimension.DATASOURCE, TestDataSource.WIKI)));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.PENDING_SEGMENTS, RowKey.of(Dimension.DATASOURCE, TestDataSource.WIKI)));
   }
 
   @Test
@@ -133,12 +133,12 @@ public class KillStalePendingSegmentsTest
 
     DateTime earliestEligibleTask = DateTimes.earlierOf(startOfEarliestActiveTask, startOfLatestCompletedTask);
     final Interval wikiKillInterval = overlordClient.observedKillIntervals.get(TestDataSource.WIKI);
-    Assert.assertEquals(DateTimes.MIN, wikiKillInterval.getStart());
-    Assert.assertEquals(earliestEligibleTask.minusDays(1), wikiKillInterval.getEnd());
+    Assertions.assertEquals(DateTimes.MIN, wikiKillInterval.getStart());
+    Assertions.assertEquals(earliestEligibleTask.minusDays(1), wikiKillInterval.getEnd());
 
     final Interval koalaKillInterval = overlordClient.observedKillIntervals.get(TestDataSource.KOALA);
-    Assert.assertEquals(DateTimes.MIN, koalaKillInterval.getStart());
-    Assert.assertEquals(earliestEligibleTask.minusDays(1), wikiKillInterval.getEnd());
+    Assertions.assertEquals(DateTimes.MIN, koalaKillInterval.getStart());
+    Assertions.assertEquals(earliestEligibleTask.minusDays(1), wikiKillInterval.getEnd());
   }
 
   @Test
@@ -166,11 +166,11 @@ public class KillStalePendingSegmentsTest
 
     // Verify that stale pending segments are killed in "wiki" but not in "koala"
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertTrue(overlordClient.observedKillIntervals.containsKey(TestDataSource.WIKI));
-    Assert.assertEquals(2, stats.get(Stats.Kill.PENDING_SEGMENTS, RowKey.of(Dimension.DATASOURCE, TestDataSource.WIKI)));
+    Assertions.assertTrue(overlordClient.observedKillIntervals.containsKey(TestDataSource.WIKI));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.PENDING_SEGMENTS, RowKey.of(Dimension.DATASOURCE, TestDataSource.WIKI)));
 
-    Assert.assertFalse(overlordClient.observedKillIntervals.containsKey(TestDataSource.KOALA));
-    Assert.assertEquals(0, stats.get(Stats.Kill.PENDING_SEGMENTS, RowKey.of(Dimension.DATASOURCE, TestDataSource.KOALA)));
+    Assertions.assertFalse(overlordClient.observedKillIntervals.containsKey(TestDataSource.KOALA));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.PENDING_SEGMENTS, RowKey.of(Dimension.DATASOURCE, TestDataSource.KOALA)));
   }
 
   private DruidCoordinatorRuntimeParams.Builder createParamsWithDatasources(String... datasources)

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillSupervisorsCustomDutyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillSupervisorsCustomDutyTest.java
@@ -24,15 +24,15 @@ import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.server.coordinator.stats.Stats;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 
-@RunWith(MockitoJUnitRunner.class)
 public class KillSupervisorsCustomDutyTest
 {
   @Mock
@@ -42,6 +42,19 @@ public class KillSupervisorsCustomDutyTest
   private DruidCoordinatorRuntimeParams mockDruidCoordinatorRuntimeParams;
 
   private KillSupervisorsCustomDuty killSupervisors;
+  private AutoCloseable mocks;
+
+  @BeforeEach
+  public void setUp()
+  {
+    mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception
+  {
+    mocks.close();
+  }
 
   @Test
   public void testConstructorSuccess()
@@ -50,7 +63,7 @@ public class KillSupervisorsCustomDutyTest
         new Duration("PT1S"),
         mockMetadataSupervisorManager
     );
-    Assert.assertNotNull(killSupervisors);
+    Assertions.assertNotNull(killSupervisors);
   }
 
   @Test
@@ -64,6 +77,6 @@ public class KillSupervisorsCustomDutyTest
     );
     killSupervisors.run(mockDruidCoordinatorRuntimeParams);
     Mockito.verify(mockMetadataSupervisorManager).removeTerminatedSupervisorsOlderThan(ArgumentMatchers.anyLong());
-    Assert.assertTrue(runStats.hasStat(Stats.Kill.SUPERVISOR_SPECS));
+    Assertions.assertTrue(runStats.hasStat(Stats.Kill.SUPERVISOR_SPECS));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillSupervisorsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillSupervisorsTest.java
@@ -25,16 +25,15 @@ import org.apache.druid.server.coordinator.config.MetadataCleanupConfig;
 import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.server.coordinator.stats.Stats;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 
-@RunWith(MockitoJUnitRunner.class)
 public class KillSupervisorsTest
 {
   @Mock
@@ -45,12 +44,20 @@ public class KillSupervisorsTest
 
   private KillSupervisors killSupervisors;
   private CoordinatorRunStats runStats;
+  private AutoCloseable mocks;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
+    mocks = MockitoAnnotations.openMocks(this);
     runStats = new CoordinatorRunStats();
     Mockito.when(mockDruidCoordinatorRuntimeParams.getCoordinatorStats()).thenReturn(runStats);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception
+  {
+    mocks.close();
   }
 
   @Test
@@ -71,6 +78,6 @@ public class KillSupervisorsTest
     killSupervisors = new KillSupervisors(config, mockMetadataSupervisorManager);
     killSupervisors.run(mockDruidCoordinatorRuntimeParams);
     Mockito.verify(mockMetadataSupervisorManager).removeTerminatedSupervisorsOlderThan(ArgumentMatchers.anyLong());
-    Assert.assertTrue(runStats.hasStat(Stats.Kill.SUPERVISOR_SPECS));
+    Assertions.assertTrue(runStats.hasStat(Stats.Kill.SUPERVISOR_SPECS));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnreferencedSegmentSchemaTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnreferencedSegmentSchemaTest.java
@@ -44,14 +44,13 @@ import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 import org.skife.jdbi.v2.Update;
 import org.skife.jdbi.v2.tweak.HandleCallback;
 
@@ -61,11 +60,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-@RunWith(MockitoJUnitRunner.class)
 public class KillUnreferencedSegmentSchemaTest
 {
-  @Rule
-  public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule =
+  private final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule =
       new TestDerbyConnector.DerbyConnectorRule(CentralizedDatasourceSchemaConfig.enabled(true));
 
   private final ObjectMapper mapper = TestHelper.makeJsonMapper();
@@ -75,12 +72,15 @@ public class KillUnreferencedSegmentSchemaTest
   private SegmentSchemaManager segmentSchemaManager;
   private FingerprintGenerator fingerprintGenerator;
   private SegmentSchemaTestUtils segmentSchemaTestUtils;
+  private AutoCloseable mocks;
   @Mock
   private DruidCoordinatorRuntimeParams mockDruidCoordinatorRuntimeParams;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
+    mocks = MockitoAnnotations.openMocks(this);
+    derbyConnectorRule.before();
     derbyConnector = derbyConnectorRule.getConnector();
     tablesConfig = derbyConnectorRule.metadataTablesConfigSupplier().get();
 
@@ -92,6 +92,17 @@ public class KillUnreferencedSegmentSchemaTest
     segmentSchemaTestUtils = new SegmentSchemaTestUtils(derbyConnectorRule, derbyConnector, mapper);
     CoordinatorRunStats runStats = new CoordinatorRunStats();
     Mockito.when(mockDruidCoordinatorRuntimeParams.getCoordinatorStats()).thenReturn(runStats);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception
+  {
+    try {
+      derbyConnectorRule.after();
+    }
+    finally {
+      mocks.close();
+    }
   }
 
   @Test
@@ -183,7 +194,7 @@ public class KillUnreferencedSegmentSchemaTest
     // this call should do nothing
     duty.run(mockDruidCoordinatorRuntimeParams);
 
-    Assert.assertEquals(Boolean.TRUE, getSchemaUsedStatus(fingerprint));
+    Assertions.assertEquals(Boolean.TRUE, getSchemaUsedStatus(fingerprint));
 
     // delete segment2
     deleteSegment(schemaMetadataPluses.get(1).getSegmentId());
@@ -191,13 +202,13 @@ public class KillUnreferencedSegmentSchemaTest
     // this call should mark the schema unused
     duty.run(mockDruidCoordinatorRuntimeParams);
 
-    Assert.assertEquals(Boolean.FALSE, getSchemaUsedStatus(fingerprint));
+    Assertions.assertEquals(Boolean.FALSE, getSchemaUsedStatus(fingerprint));
 
     // this call should delete the schema
     duty.run(mockDruidCoordinatorRuntimeParams);
 
 
-    Assert.assertNull(getSchemaUsedStatus(fingerprint));
+    Assertions.assertNull(getSchemaUsedStatus(fingerprint));
   }
 
   @Test
@@ -236,12 +247,12 @@ public class KillUnreferencedSegmentSchemaTest
         }
     );
 
-    Assert.assertEquals(Boolean.TRUE, getSchemaUsedStatus(fingerprint));
+    Assertions.assertEquals(Boolean.TRUE, getSchemaUsedStatus(fingerprint));
 
     // this call should mark the schema as unused
     duty.run(mockDruidCoordinatorRuntimeParams);
 
-    Assert.assertEquals(Boolean.FALSE, getSchemaUsedStatus(fingerprint));
+    Assertions.assertEquals(Boolean.FALSE, getSchemaUsedStatus(fingerprint));
 
     // associate a segment to the schema
     DataSegment segment1 = new DataSegment(
@@ -269,7 +280,7 @@ public class KillUnreferencedSegmentSchemaTest
     // this call should make the schema used
     duty.run(mockDruidCoordinatorRuntimeParams);
 
-    Assert.assertEquals(Boolean.TRUE, getSchemaUsedStatus(fingerprint));
+    Assertions.assertEquals(Boolean.TRUE, getSchemaUsedStatus(fingerprint));
   }
 
   @Test
@@ -328,8 +339,8 @@ public class KillUnreferencedSegmentSchemaTest
     // this call should mark both the schema as unused
     duty.run(mockDruidCoordinatorRuntimeParams);
 
-    Assert.assertEquals(Boolean.FALSE, getSchemaUsedStatus(fingerprintOldVersion));
-    Assert.assertEquals(Boolean.FALSE, getSchemaUsedStatus(fingerprintNewVersion));
+    Assertions.assertEquals(Boolean.FALSE, getSchemaUsedStatus(fingerprintOldVersion));
+    Assertions.assertEquals(Boolean.FALSE, getSchemaUsedStatus(fingerprintNewVersion));
 
     // associate a segment to the schema
     DataSegment segment1 = new DataSegment(
@@ -357,11 +368,11 @@ public class KillUnreferencedSegmentSchemaTest
     // this call should make the referenced schema used
     duty.run(mockDruidCoordinatorRuntimeParams);
 
-    Assert.assertEquals(Boolean.TRUE, getSchemaUsedStatus(fingerprintNewVersion));
+    Assertions.assertEquals(Boolean.TRUE, getSchemaUsedStatus(fingerprintNewVersion));
 
     // this call should kill the schema
     duty.run(mockDruidCoordinatorRuntimeParams);
-    Assert.assertNull(getSchemaUsedStatus(fingerprintOldVersion));
+    Assertions.assertNull(getSchemaUsedStatus(fingerprintOldVersion));
   }
 
   private static class TestKillUnreferencedSegmentSchemas extends KillUnreferencedSegmentSchema

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
@@ -61,10 +61,10 @@ import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -103,17 +103,17 @@ public class KillUnusedSegmentsTest
 
   private KillUnusedSegments killDuty;
 
-  @Rule
-  public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule
+  private final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule
       = new TestDerbyConnector.DerbyConnectorRule();
 
   private IndexerMetadataStorageCoordinator storageCoordinator;
   private SQLMetadataConnector connector;
   private MetadataStorageTablesConfig config;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
+    derbyConnectorRule.before();
     connector = derbyConnectorRule.getConnector();
     final SegmentMetadataTransactionFactory transactionFactory = new SqlSegmentMetadataReadOnlyTransactionFactory(
         TestHelper.JSON_MAPPER,
@@ -147,6 +147,12 @@ public class KillUnusedSegmentsTest
                                                  .withUsedSegments(Collections.emptySet());
   }
 
+  @AfterEach
+  public void tearDown()
+  {
+    derbyConnectorRule.after();
+  }
+
   @Test
   public void testKillWithDefaultCoordinatorConfig()
   {
@@ -166,10 +172,10 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(1, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, Intervals.ETERNITY);
   }
@@ -193,10 +199,10 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(1, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, Intervals.ETERNITY);
   }
@@ -207,9 +213,9 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
   }
 
   /**
@@ -234,33 +240,33 @@ public class KillUnusedSegmentsTest
     initDuty();
     CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
-    Assert.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, new Interval(YEAR_OLD.getStart(), MONTH_OLD.getEnd()));
     validateLastKillStateAndReset(DS2, new Interval(YEAR_OLD.getStart(), DAY_OLD.getEnd()));
 
     stats = runDutyAndGetStats();
 
-    Assert.assertEquals(20, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(4, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(20, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(4, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
-    Assert.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
+    Assertions.assertEquals(20, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(4, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(20, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(4, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, new Interval(DAY_OLD.getStart(), NEXT_DAY.getEnd()));
     validateLastKillStateAndReset(DS2, NEXT_DAY);
 
     stats = runDutyAndGetStats();
 
-    Assert.assertEquals(30, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(5, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(30, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(5, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
-    Assert.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
+    Assertions.assertEquals(30, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(5, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(30, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(5, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, NEXT_MONTH);
     validateLastKillStateAndReset(DS2, null);
@@ -294,35 +300,35 @@ public class KillUnusedSegmentsTest
     initDuty();
     CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(2, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
-    Assert.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
 
     stats = runDutyAndGetStats();
 
-    Assert.assertEquals(4, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(4, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(4, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS3_STAT_KEY));
-    Assert.assertEquals(4, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(4, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(4, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(4, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS3_STAT_KEY));
+    Assertions.assertEquals(4, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     stats = runDutyAndGetStats();
 
-    Assert.assertEquals(6, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(6, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(6, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
-    Assert.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS3_STAT_KEY));
+    Assertions.assertEquals(6, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(6, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(6, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS3_STAT_KEY));
 
     stats = runDutyAndGetStats();
 
-    Assert.assertEquals(8, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(7, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(8, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(5, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
-    Assert.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
+    Assertions.assertEquals(8, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(7, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(8, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(5, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
   }
 
   /**
@@ -343,10 +349,10 @@ public class KillUnusedSegmentsTest
     initDuty();
     CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(1, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, new Interval(YEAR_OLD.getStart(), MONTH_OLD.getEnd()));
 
@@ -356,24 +362,24 @@ public class KillUnusedSegmentsTest
 
     stats = runDutyAndGetStats();
 
-    Assert.assertEquals(2, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
 
     stats = runDutyAndGetStats();
 
-    Assert.assertEquals(3, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(3, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(3, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     stats = runDutyAndGetStats();
 
-    Assert.assertEquals(4, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(4, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(4, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
+    Assertions.assertEquals(4, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(4, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(4, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
   }
 
   @Test
@@ -390,24 +396,24 @@ public class KillUnusedSegmentsTest
     initDuty();
     CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(2, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     stats = runDutyAndGetStats();
 
-    Assert.assertEquals(4, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(4, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(4, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(4, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     stats = runDutyAndGetStats();
 
-    Assert.assertEquals(6, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(6, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(6, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(6, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
   }
 
@@ -434,10 +440,10 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(4, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(4, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, new Interval(YEAR_OLD.getStart(), NEXT_MONTH.getEnd()));
   }
@@ -460,10 +466,10 @@ public class KillUnusedSegmentsTest
     initDuty();
     CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, new Interval(DAY_OLD.getStart(), NEXT_DAY.getEnd()));
 
@@ -474,28 +480,28 @@ public class KillUnusedSegmentsTest
 
     stats = runDutyAndGetStats();
 
-    Assert.assertEquals(20, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(20, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(20, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(20, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, NEXT_MONTH);
 
     stats = runDutyAndGetStats();
 
-    Assert.assertEquals(30, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(30, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(30, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(30, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, null);
 
     stats = runDutyAndGetStats();
 
-    Assert.assertEquals(40, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(3, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(40, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(5, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(40, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(40, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(5, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, new Interval(YEAR_OLD.getStart(), MONTH_OLD.getEnd()));
   }
@@ -513,12 +519,12 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(0, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
-    Assert.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
-    Assert.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS3_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS3_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, null);
     validateLastKillStateAndReset(DS2, YEAR_OLD);
@@ -540,10 +546,10 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(5, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(5, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, new Interval(YEAR_OLD.getStart(), NEXT_DAY.getEnd())
     );
@@ -564,10 +570,10 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(6, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(6, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     // All past and future unused segments should be killed
     validateLastKillStateAndReset(DS1, new Interval(YEAR_OLD.getStart(), NEXT_MONTH.getEnd()));
@@ -585,10 +591,10 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, YEAR_OLD);
   }
@@ -605,10 +611,10 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, YEAR_OLD);
   }
@@ -625,7 +631,7 @@ public class KillUnusedSegmentsTest
     CoordinatorRunStats newDatasourceStats = runDutyAndGetStats();
 
     // For a new datasource, the duration to retain is used to determine kill interval
-    Assert.assertEquals(1, newDatasourceStats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(1, newDatasourceStats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
     validateLastKillStateAndReset(DS1, MONTH_OLD);
 
     // For a datasource where kill has already happened, maxIntervalToKill is used
@@ -634,7 +640,7 @@ public class KillUnusedSegmentsTest
     createAndAddUnusedSegment(DS1, DAY_OLD, VERSION, NOW.minusHours(2));
     CoordinatorRunStats oldDatasourceStats = runDutyAndGetStats();
 
-    Assert.assertEquals(2, oldDatasourceStats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(2, oldDatasourceStats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
     validateLastKillStateAndReset(DS1, FIFTEEN_DAY_OLD);
   }
 
@@ -649,7 +655,7 @@ public class KillUnusedSegmentsTest
     createAndAddUnusedSegment(DS1, YEAR_OLD, VERSION, NOW.minusDays(29));
     CoordinatorRunStats newDatasourceStats = runDutyAndGetStats();
 
-    Assert.assertEquals(1, newDatasourceStats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(1, newDatasourceStats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
     validateLastKillStateAndReset(DS1, YEAR_OLD);
 
     // For a datasource where (now - durationToRetain) < (lastKillTime(year old segment) + maxInterval)
@@ -658,7 +664,7 @@ public class KillUnusedSegmentsTest
     createAndAddUnusedSegment(DS1, FIFTEEN_DAY_OLD, VERSION, NOW.minusDays(14));
     CoordinatorRunStats oldDatasourceStats = runDutyAndGetStats();
 
-    Assert.assertEquals(2, oldDatasourceStats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(2, oldDatasourceStats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
     validateLastKillStateAndReset(DS1, MONTH_OLD);
   }
 
@@ -674,10 +680,10 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, JodaUtils.umbrellaInterval(Arrays.asList(YEAR_OLD, MONTH_OLD)));
   }
@@ -693,10 +699,10 @@ public class KillUnusedSegmentsTest
     initDuty();
     CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(0, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     createAndAddUnusedSegment(DS1, YEAR_OLD, VERSION, NOW.minusDays(10));
     createAndAddUnusedSegment(DS1, MONTH_OLD, VERSION, NOW.minusDays(10));
@@ -704,10 +710,10 @@ public class KillUnusedSegmentsTest
 
     stats = runDutyAndGetStats();
 
-    Assert.assertEquals(20, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(20, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(20, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(20, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, YEAR_OLD);
   }
@@ -730,19 +736,19 @@ public class KillUnusedSegmentsTest
     initDuty();
     CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, new Interval(YEAR_OLD.getStart(), MONTH_OLD.getEnd()));
 
     stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, null);
   }
@@ -771,11 +777,11 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(2, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
-    Assert.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS2_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, new Interval(YEAR_OLD.getStart(), MONTH_OLD.getEnd()));
     validateLastKillStateAndReset(DS2, YEAR_OLD);
@@ -796,9 +802,9 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(0, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(0, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.MAX_SLOTS));
   }
 
   @Test
@@ -815,9 +821,9 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(1, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(3, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.MAX_SLOTS));
   }
 
   @Test
@@ -829,9 +835,9 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(1, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.MAX_SLOTS));
   }
 
   @Test
@@ -844,9 +850,9 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
   }
 
   @Test
@@ -859,9 +865,9 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(0, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(0, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.MAX_SLOTS));
   }
 
   @Test
@@ -874,9 +880,9 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(0, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(0, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.MAX_SLOTS));
   }
 
   @Test
@@ -889,9 +895,9 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(1, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.MAX_SLOTS));
   }
 
   @Test
@@ -904,9 +910,9 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(2, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(0, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.MAX_SLOTS));
   }
 
   @Test
@@ -920,10 +926,10 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, firstHalfEternity);
   }
@@ -938,10 +944,10 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, Intervals.ETERNITY);
   }
@@ -957,10 +963,10 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, secondHalfEternity);
   }
@@ -977,10 +983,10 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(2, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, new Interval(largeTimeRange2.getStart(), largeTimeRange1.getEnd()));
   }
@@ -997,10 +1003,10 @@ public class KillUnusedSegmentsTest
     initDuty();
     final CoordinatorRunStats stats = runDutyAndGetStats();
 
-    Assert.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
-    Assert.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
-    Assert.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
-    Assert.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.AVAILABLE_SLOTS));
+    Assertions.assertEquals(1, stats.get(Stats.Kill.SUBMITTED_TASKS));
+    Assertions.assertEquals(10, stats.get(Stats.Kill.MAX_SLOTS));
+    Assertions.assertEquals(3, stats.get(Stats.Kill.ELIGIBLE_UNUSED_SEGMENTS, DS1_STAT_KEY));
 
     validateLastKillStateAndReset(DS1, YEAR_OLD);
   }
@@ -1008,7 +1014,7 @@ public class KillUnusedSegmentsTest
   @Test
   public void testLimitToPeriod_empty()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.emptyList(),
         KillUnusedSegments.limitToPeriod(Collections.emptyList(), Period.ZERO)
     );
@@ -1017,7 +1023,7 @@ public class KillUnusedSegmentsTest
   @Test
   public void testLimitToPeriod_zeroPeriod()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(DAY_OLD, YEAR_OLD, MONTH_OLD),
         KillUnusedSegments.limitToPeriod(ImmutableList.of(DAY_OLD, YEAR_OLD, MONTH_OLD), Period.ZERO)
     );
@@ -1026,7 +1032,7 @@ public class KillUnusedSegmentsTest
   @Test
   public void testLimitToPeriod_oneSecondPeriod()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(YEAR_OLD),
         KillUnusedSegments.limitToPeriod(ImmutableList.of(DAY_OLD, YEAR_OLD, MONTH_OLD), Period.seconds(1))
     );
@@ -1035,7 +1041,7 @@ public class KillUnusedSegmentsTest
   @Test
   public void testLimitToPeriod_360DayPeriod()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(YEAR_OLD, MONTH_OLD),
         KillUnusedSegments.limitToPeriod(ImmutableList.of(DAY_OLD, YEAR_OLD, MONTH_OLD), Period.days(360))
     );
@@ -1044,7 +1050,7 @@ public class KillUnusedSegmentsTest
   @Test
   public void testLimitToPeriod_1YearPeriod()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(DAY_OLD, YEAR_OLD, MONTH_OLD),
         KillUnusedSegments.limitToPeriod(ImmutableList.of(DAY_OLD, YEAR_OLD, MONTH_OLD), Period.years(1))
     );
@@ -1055,7 +1061,7 @@ public class KillUnusedSegmentsTest
     final Interval observedLastKillInterval = overlordClient.getLastKillInterval(dataSource);
     final String observedLastKillTaskId = overlordClient.getLastKillTaskId(dataSource);
 
-    Assert.assertEquals(expectedKillInterval, observedLastKillInterval);
+    Assertions.assertEquals(expectedKillInterval, observedLastKillInterval);
 
     String expectedKillTaskId = null;
     if (expectedKillInterval != null) {
@@ -1066,7 +1072,7 @@ public class KillUnusedSegmentsTest
       );
     }
 
-    Assert.assertEquals(expectedKillTaskId, observedLastKillTaskId);
+    Assertions.assertEquals(expectedKillTaskId, observedLastKillTaskId);
 
     // Clear the state after validation
     overlordClient.deleteLastKillTaskId(dataSource);
@@ -1095,7 +1101,7 @@ public class KillUnusedSegmentsTest
         TestHelper.JSON_MAPPER,
         lastUpdatedTime
     );
-    Assert.assertEquals(1, numUpdatedSegments);
+    Assertions.assertEquals(1, numUpdatedSegments);
   }
 
   private DataSegment createSegment(final String dataSource, final Interval interval, final String version)

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/MarkEternityTombstonesAsUnusedTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/MarkEternityTombstonesAsUnusedTest.java
@@ -42,9 +42,9 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
@@ -148,7 +148,7 @@ public class MarkEternityTombstonesAsUnusedTest
 
   private TestSegmentsMetadataManager segmentsMetadataManager;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     segmentsMetadataManager = new TestSegmentsMetadataManager();
@@ -174,10 +174,10 @@ public class MarkEternityTombstonesAsUnusedTest
                                                             .get(ds1);
 
     // Verify that the half-infinity tombstone is overshadowed and everything else is not
-    Assert.assertTrue(timeline.isOvershadowed(ds1NumberedSegmentMinToMaxV0));
-    Assert.assertFalse(timeline.isOvershadowed(ds1TombstoneSegmentMinTo2000V1));
-    Assert.assertFalse(timeline.isOvershadowed(ds1NumberedSegment2000To2001V1));
-    Assert.assertFalse(timeline.isOvershadowed(ds1TombstoneSegment2001ToMaxV1));
+    Assertions.assertTrue(timeline.isOvershadowed(ds1NumberedSegmentMinToMaxV0));
+    Assertions.assertFalse(timeline.isOvershadowed(ds1TombstoneSegmentMinTo2000V1));
+    Assertions.assertFalse(timeline.isOvershadowed(ds1NumberedSegment2000To2001V1));
+    Assertions.assertFalse(timeline.isOvershadowed(ds1TombstoneSegment2001ToMaxV1));
 
     runEternityTombstonesDutyAndVerify(params, allUsedSegments, expectedUsedSegments);
   }
@@ -199,8 +199,8 @@ public class MarkEternityTombstonesAsUnusedTest
                                                                .getUsedSegmentsTimelinesPerDataSource()
                                                                .get(ds1);
 
-    Assert.assertTrue(ds1Timeline.isOvershadowed(ds1NumberedSegmentMinToMaxV0));
-    Assert.assertFalse(ds1Timeline.isOvershadowed(ds1TombstoneSegmentMinToMaxV1));
+    Assertions.assertTrue(ds1Timeline.isOvershadowed(ds1NumberedSegmentMinToMaxV0));
+    Assertions.assertFalse(ds1Timeline.isOvershadowed(ds1TombstoneSegmentMinToMaxV1));
 
     runEternityTombstonesDutyAndVerify(params, allUsedSegments, expectedUsedSegments);
   }
@@ -225,9 +225,9 @@ public class MarkEternityTombstonesAsUnusedTest
                                                       .getUsedSegmentsTimelinesPerDataSource()
                                                       .get(ds1);
 
-    Assert.assertFalse(timeline.isOvershadowed(ds1TombstoneSegmentMinTo2000V1));
-    Assert.assertFalse(timeline.isOvershadowed(ds1NumberedSegment2000To2001V1));
-    Assert.assertFalse(timeline.isOvershadowed(ds1TombstoneSegmentMinTo2000V2));
+    Assertions.assertFalse(timeline.isOvershadowed(ds1TombstoneSegmentMinTo2000V1));
+    Assertions.assertFalse(timeline.isOvershadowed(ds1NumberedSegment2000To2001V1));
+    Assertions.assertFalse(timeline.isOvershadowed(ds1TombstoneSegmentMinTo2000V2));
 
     runEternityTombstonesDutyAndVerify(params, allUsedSegments, expectedUsedSegments);
   }
@@ -248,7 +248,7 @@ public class MarkEternityTombstonesAsUnusedTest
                                                                .getUsedSegmentsTimelinesPerDataSource()
                                                                .get(ds1);
 
-    Assert.assertFalse(ds1Timeline.isOvershadowed(ds1TombstoneSegmentMinToMaxV1));
+    Assertions.assertFalse(ds1Timeline.isOvershadowed(ds1TombstoneSegmentMinToMaxV1));
 
     runEternityTombstonesDutyAndVerify(params, allUsedSegments, expectedUsedSegments);
   }
@@ -274,11 +274,11 @@ public class MarkEternityTombstonesAsUnusedTest
                                                       .getUsedSegmentsTimelinesPerDataSource()
                                                       .get(ds1);
 
-    Assert.assertTrue(timeline.isOvershadowed(ds1TombstoneSegmentMinTo2000V1));
-    Assert.assertTrue(timeline.isOvershadowed(ds1TombstoneSegment2001ToMaxV1));
-    Assert.assertFalse(timeline.isOvershadowed(ds1NumberedSegment2000To2001V1));
-    Assert.assertFalse(timeline.isOvershadowed(ds1TombstoneSegmentMinTo2000V2));
-    Assert.assertFalse(timeline.isOvershadowed(ds1TombstoneSegment2001ToMaxV2));
+    Assertions.assertTrue(timeline.isOvershadowed(ds1TombstoneSegmentMinTo2000V1));
+    Assertions.assertTrue(timeline.isOvershadowed(ds1TombstoneSegment2001ToMaxV1));
+    Assertions.assertFalse(timeline.isOvershadowed(ds1NumberedSegment2000To2001V1));
+    Assertions.assertFalse(timeline.isOvershadowed(ds1TombstoneSegmentMinTo2000V2));
+    Assertions.assertFalse(timeline.isOvershadowed(ds1TombstoneSegment2001ToMaxV2));
 
     runEternityTombstonesDutyAndVerify(params, allUsedSegments, expectedUsedSegments);
   }
@@ -323,17 +323,17 @@ public class MarkEternityTombstonesAsUnusedTest
     SegmentTimeline ds1Timeline = segmentsMetadataManager.getRecentDataSourcesSnapshot()
                                                          .getUsedSegmentsTimelinesPerDataSource()
                                                          .get(ds1);
-    Assert.assertTrue(ds1Timeline.isOvershadowed(ds1TombstoneSegmentMinTo2000V1));
-    Assert.assertFalse(ds1Timeline.isOvershadowed(ds1NumberedSegment2000To2001V1));
-    Assert.assertFalse(ds1Timeline.isOvershadowed(ds1TombstoneSegment2001ToMaxV1));
-    Assert.assertFalse(ds1Timeline.isOvershadowed(ds1TombstoneSegmentMinTo2000V2));
+    Assertions.assertTrue(ds1Timeline.isOvershadowed(ds1TombstoneSegmentMinTo2000V1));
+    Assertions.assertFalse(ds1Timeline.isOvershadowed(ds1NumberedSegment2000To2001V1));
+    Assertions.assertFalse(ds1Timeline.isOvershadowed(ds1TombstoneSegment2001ToMaxV1));
+    Assertions.assertFalse(ds1Timeline.isOvershadowed(ds1TombstoneSegmentMinTo2000V2));
 
     SegmentTimeline ds2Timeline = segmentsMetadataManager.getRecentDataSourcesSnapshot()
                                                          .getUsedSegmentsTimelinesPerDataSource()
                                                          .get(ds2);
-    Assert.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegmentMinTo2000V1));
-    Assert.assertFalse(ds2Timeline.isOvershadowed(ds2NumberedSegment3000To4000V1));
-    Assert.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegment4000ToMaxV1));
+    Assertions.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegmentMinTo2000V1));
+    Assertions.assertFalse(ds2Timeline.isOvershadowed(ds2NumberedSegment3000To4000V1));
+    Assertions.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegment4000ToMaxV1));
 
     runEternityTombstonesDutyAndVerify(params, allUsedSegments, expectedUsedSegments);
   }
@@ -362,10 +362,10 @@ public class MarkEternityTombstonesAsUnusedTest
                                                                .getUsedSegmentsTimelinesPerDataSource()
                                                                .get(ds2);
 
-    Assert.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegment1995To2005V0));
-    Assert.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegmentMinTo2000V1));
-    Assert.assertFalse(ds2Timeline.isOvershadowed(ds2NumberedSegment3000To4000V1));
-    Assert.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegment4000ToMaxV1));
+    Assertions.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegment1995To2005V0));
+    Assertions.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegmentMinTo2000V1));
+    Assertions.assertFalse(ds2Timeline.isOvershadowed(ds2NumberedSegment3000To4000V1));
+    Assertions.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegment4000ToMaxV1));
 
     runEternityTombstonesDutyAndVerify(params, allUsedSegments, expectedUsedSegments);
   }
@@ -394,10 +394,10 @@ public class MarkEternityTombstonesAsUnusedTest
     final SegmentTimeline ds2Timeline = segmentsMetadataManager.getRecentDataSourcesSnapshot()
                                                                .getUsedSegmentsTimelinesPerDataSource()
                                                                .get(ds2);
-    Assert.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegmentMinTo2000V1));
-    Assert.assertFalse(ds2Timeline.isOvershadowed(ds2NumberedSegment3000To4000V1));
-    Assert.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegment4000ToMaxV1));
-    Assert.assertFalse(ds2Timeline.isOvershadowed(ds2NumberedSegment1999To2500V2));
+    Assertions.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegmentMinTo2000V1));
+    Assertions.assertFalse(ds2Timeline.isOvershadowed(ds2NumberedSegment3000To4000V1));
+    Assertions.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegment4000ToMaxV1));
+    Assertions.assertFalse(ds2Timeline.isOvershadowed(ds2NumberedSegment1999To2500V2));
 
     runEternityTombstonesDutyAndVerify(params, allUsedSegments, expectedUsedSegments);
   }
@@ -420,7 +420,7 @@ public class MarkEternityTombstonesAsUnusedTest
                                                                .getUsedSegmentsTimelinesPerDataSource()
                                                                .get(ds2);
 
-    Assert.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegment4000To4001V1));
+    Assertions.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegment4000To4001V1));
 
     runEternityTombstonesDutyAndVerify(params, allUsedSegments, expectedUsedSegments);
   }
@@ -444,7 +444,7 @@ public class MarkEternityTombstonesAsUnusedTest
                                                                .getUsedSegmentsTimelinesPerDataSource()
                                                                .get(ds2);
 
-    Assert.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegment4000ToMaxV1With1CorePartition));
+    Assertions.assertFalse(ds2Timeline.isOvershadowed(ds2TombstoneSegment4000ToMaxV1With1CorePartition));
 
     runEternityTombstonesDutyAndVerify(params, allUsedSegments, expectedUsedSegments);
   }
@@ -492,11 +492,11 @@ public class MarkEternityTombstonesAsUnusedTest
         segmentsMetadataManager.getRecentDataSourcesSnapshot().iterateAllUsedSegmentsInSnapshot()
     );
 
-    Assert.assertEquals(expectedUsedSegments.size(), actualUsedSegments.size());
-    Assert.assertTrue(actualUsedSegments.containsAll(expectedUsedSegments));
+    Assertions.assertEquals(expectedUsedSegments.size(), actualUsedSegments.size());
+    Assertions.assertTrue(actualUsedSegments.containsAll(expectedUsedSegments));
 
     final CoordinatorRunStats runStats = params.getCoordinatorStats();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         allUsedSegments.size() - expectedUsedSegments.size(),
         runStats.get(Stats.Segments.UNNEEDED_ETERNITY_TOMBSTONE, RowKey.of(Dimension.DATASOURCE, ds1)) +
         runStats.get(Stats.Segments.UNNEEDED_ETERNITY_TOMBSTONE, RowKey.of(Dimension.DATASOURCE, ds2))

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/MarkOvershadowedSegmentsAsUnusedTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/MarkOvershadowedSegmentsAsUnusedTest.java
@@ -20,8 +20,6 @@
 package org.apache.druid.server.coordinator.duty;
 
 import com.google.common.collect.Sets;
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.client.ImmutableDruidServer;
 import org.apache.druid.java.util.common.DateTimes;
@@ -42,14 +40,13 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentTimeline;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Set;
 
-@RunWith(JUnitParamsRunner.class)
 public class MarkOvershadowedSegmentsAsUnusedTest
 {
   private final DateTime start = DateTimes.of("2012-01-01");
@@ -64,14 +61,14 @@ public class MarkOvershadowedSegmentsAsUnusedTest
 
   private TestSegmentsMetadataManager segmentsMetadataManager;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     segmentsMetadataManager = new TestSegmentsMetadataManager();
   }
 
-  @Test
-  @Parameters({"historical", "broker"})
+  @ParameterizedTest
+  @ValueSource(strings = {"historical", "broker"})
   public void testRun(String serverType)
   {
     segmentsMetadataManager.addSegment(segmentV0);
@@ -107,8 +104,8 @@ public class MarkOvershadowedSegmentsAsUnusedTest
                                                       .get("test");
 
     // Verify that the segments V0 and V1 are overshadowed
-    Assert.assertTrue(timeline.isOvershadowed(segmentV0));
-    Assert.assertTrue(timeline.isOvershadowed(segmentV1));
+    Assertions.assertTrue(timeline.isOvershadowed(segmentV0));
+    Assertions.assertTrue(timeline.isOvershadowed(segmentV1));
 
     // Run the duty and verify that the overshadowed segments are marked unused
     params = new MarkOvershadowedSegmentsAsUnused(
@@ -118,11 +115,11 @@ public class MarkOvershadowedSegmentsAsUnusedTest
     Set<DataSegment> updatedUsedSegments = Sets.newHashSet(
         segmentsMetadataManager.getRecentDataSourcesSnapshot().iterateAllUsedSegmentsInSnapshot()
     );
-    Assert.assertEquals(1, updatedUsedSegments.size());
-    Assert.assertTrue(updatedUsedSegments.contains(segmentV2));
+    Assertions.assertEquals(1, updatedUsedSegments.size());
+    Assertions.assertTrue(updatedUsedSegments.contains(segmentV2));
 
     CoordinatorRunStats runStats = params.getCoordinatorStats();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2L,
         runStats.get(Stats.Segments.OVERSHADOWED, RowKey.of(Dimension.DATASOURCE, "test"))
     );

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/RunRulesPartialLoadPlacementTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/RunRulesPartialLoadPlacementTest.java
@@ -51,10 +51,10 @@ import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -75,7 +75,7 @@ public class RunRulesPartialLoadPlacementTest
   private BalancerStrategy balancerStrategy;
   private SegmentLoadQueueManager loadQueueManager;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     exec = MoreExecutors.listeningDecorator(Execs.multiThreaded(1, "RunRulesPartialLoadPlacementTest-%d"));
@@ -83,7 +83,7 @@ public class RunRulesPartialLoadPlacementTest
     loadQueueManager = new SegmentLoadQueueManager(null, null);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     exec.shutdown();
@@ -102,10 +102,10 @@ public class RunRulesPartialLoadPlacementTest
 
     final CoordinatorRunStats stats = runRules(matchNobodyForeverRule(), core0, core1);
 
-    Assert.assertEquals(
-        "both core partitions of a fully-unmatched group are empty loaded, not discarded",
+    Assertions.assertEquals(
         2L,
-        stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER, DATASOURCE)
+        stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER, DATASOURCE),
+        "both core partitions of a fully-unmatched group are empty loaded, not discarded"
     );
   }
 
@@ -120,14 +120,14 @@ public class RunRulesPartialLoadPlacementTest
 
     final CoordinatorRunStats stats = runRules(matchNobodyForeverRule(), appended);
 
-    Assert.assertEquals(
-        "appended unmatched segment is empty partial loaded",
+    Assertions.assertEquals(
         1L,
-        stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER, DATASOURCE)
+        stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER, DATASOURCE),
+        "appended unmatched segment is empty partial loaded"
     );
-    Assert.assertFalse(
-        "appended unmatched segment must not be fully downloaded",
-        stats.hasStat(Stats.Segments.ASSIGNED)
+    Assertions.assertFalse(
+        stats.hasStat(Stats.Segments.ASSIGNED),
+        "appended unmatched segment must not be fully downloaded"
     );
   }
 
@@ -151,7 +151,7 @@ public class RunRulesPartialLoadPlacementTest
     final CoordinatorRunStats stats = runRules(rule, matched, unmatched);
 
     // Both the positive match and the empty match are loaded
-    Assert.assertEquals(2L, stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER, DATASOURCE));
+    Assertions.assertEquals(2L, stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER, DATASOURCE));
   }
 
   /**
@@ -178,12 +178,12 @@ public class RunRulesPartialLoadPlacementTest
 
     final CoordinatorRunStats stats = runRules(rule, p0, p1, p2);
 
-    Assert.assertEquals(
-        "all 3 unmatched core partitions are partial loaded so the group stays queryable on demand",
+    Assertions.assertEquals(
         3L,
-        stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER, DATASOURCE)
+        stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER, DATASOURCE),
+        "all 3 unmatched core partitions are partial loaded so the group stays queryable on demand"
     );
-    Assert.assertFalse("no partition is fully downloaded", stats.hasStat(Stats.Segments.ASSIGNED));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.ASSIGNED), "no partition is fully downloaded");
   }
 
   private ForeverPartialLoadRule matchNobodyForeverRule()

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/RunRulesTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/RunRulesTest.java
@@ -57,10 +57,11 @@ import org.apache.druid.server.coordinator.stats.Stats;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.easymock.EasyMock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -68,6 +69,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  *
@@ -92,7 +94,7 @@ public class RunRulesTest
 
   private ListeningExecutorService balancerExecutor;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mockPeon = EasyMock.createMock(LoadQueuePeon.class);
@@ -104,7 +106,7 @@ public class RunRulesTest
     balancerExecutor = MoreExecutors.listeningDecorator(Execs.multiThreaded(1, "RunRulesTest-%d"));
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     balancerExecutor.shutdown();
@@ -162,7 +164,7 @@ public class RunRulesTest
     CoordinatorRunStats stats = runDutyAndGetStats(params);
 
     // There are 24 under-replicated segments, but only 10 replicas are assigned
-    Assert.assertEquals(10L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "normal", DATASOURCE));
+    Assertions.assertEquals(10L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "normal", DATASOURCE));
 
     EasyMock.verify(mockPeon);
   }
@@ -225,8 +227,8 @@ public class RunRulesTest
 
     CoordinatorRunStats stats = runDutyAndGetStats(params);
 
-    Assert.assertEquals(10L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "hot", DATASOURCE));
-    Assert.assertEquals(48L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "normal", DATASOURCE));
+    Assertions.assertEquals(10L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "hot", DATASOURCE));
+    Assertions.assertEquals(48L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "normal", DATASOURCE));
 
     EasyMock.verify(mockPeon);
   }
@@ -297,10 +299,10 @@ public class RunRulesTest
 
     CoordinatorRunStats stats = runDutyAndGetStats(params);
 
-    Assert.assertEquals(6L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "hot", DATASOURCE));
-    Assert.assertEquals(6L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "normal", DATASOURCE));
-    Assert.assertEquals(12L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "cold", DATASOURCE));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
+    Assertions.assertEquals(6L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "hot", DATASOURCE));
+    Assertions.assertEquals(6L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "normal", DATASOURCE));
+    Assertions.assertEquals(12L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "cold", DATASOURCE));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
 
     EasyMock.verify(mockPeon);
   }
@@ -380,9 +382,9 @@ public class RunRulesTest
         .build();
     CoordinatorRunStats stats = runDutyAndGetStats(params);
 
-    Assert.assertEquals(12L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "hot", DATASOURCE));
-    Assert.assertEquals(18L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "cold", DATASOURCE));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
+    Assertions.assertEquals(12L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "hot", DATASOURCE));
+    Assertions.assertEquals(18L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "cold", DATASOURCE));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
 
     EasyMock.verify(mockPeon);
   }
@@ -433,9 +435,9 @@ public class RunRulesTest
 
     CoordinatorRunStats stats = runDutyAndGetStats(params);
 
-    Assert.assertEquals(12L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "hot", DATASOURCE));
-    Assert.assertEquals(0L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "normal", DATASOURCE));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
+    Assertions.assertEquals(12L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "hot", DATASOURCE));
+    Assertions.assertEquals(0L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "normal", DATASOURCE));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
 
     EasyMock.verify(mockPeon);
   }
@@ -512,11 +514,11 @@ public class RunRulesTest
     runDutyAndGetStats(params);
 
     final List<AlertEvent> events = emitter.getAlerts();
-    Assert.assertEquals(1, events.size());
+    Assertions.assertEquals(1, events.size());
 
     AlertEvent alertEvent = events.get(0);
     EventMap eventMap = alertEvent.toMap();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "No matching retention rule for [24] segments in datasource[test]",
         eventMap.get("description")
     );
@@ -558,7 +560,7 @@ public class RunRulesTest
         .build();
 
     CoordinatorRunStats stats = runDutyAndGetStats(params);
-    Assert.assertEquals(12L, stats.get(Stats.Segments.DELETED, DATASOURCE_STAT_KEY));
+    Assertions.assertEquals(12L, stats.get(Stats.Segments.DELETED, DATASOURCE_STAT_KEY));
   }
 
   @Test
@@ -610,8 +612,8 @@ public class RunRulesTest
 
     CoordinatorRunStats stats = runDutyAndGetStats(params);
 
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, "normal", DATASOURCE));
-    Assert.assertEquals(12L, stats.get(Stats.Segments.DELETED, DATASOURCE_STAT_KEY));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, "normal", DATASOURCE));
+    Assertions.assertEquals(12L, stats.get(Stats.Segments.DELETED, DATASOURCE_STAT_KEY));
 
     EasyMock.verify(mockPeon);
   }
@@ -656,8 +658,8 @@ public class RunRulesTest
         .build();
 
     CoordinatorRunStats stats = runDutyAndGetStats(params);
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, "normal", DATASOURCE));
-    Assert.assertEquals(12L, stats.get(Stats.Segments.DELETED, DATASOURCE_STAT_KEY));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, "normal", DATASOURCE));
+    Assertions.assertEquals(12L, stats.get(Stats.Segments.DELETED, DATASOURCE_STAT_KEY));
 
     EasyMock.verify(mockPeon);
   }
@@ -699,8 +701,8 @@ public class RunRulesTest
         .build();
 
     CoordinatorRunStats stats = runDutyAndGetStats(params);
-    Assert.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
-    Assert.assertEquals(12L, stats.get(Stats.Segments.DELETED, DATASOURCE_STAT_KEY));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
+    Assertions.assertEquals(12L, stats.get(Stats.Segments.DELETED, DATASOURCE_STAT_KEY));
 
     EasyMock.verify(mockPeon);
   }
@@ -757,7 +759,7 @@ public class RunRulesTest
         .build();
 
     CoordinatorRunStats stats = runDutyAndGetStats(params);
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, "normal", DATASOURCE));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, "normal", DATASOURCE));
 
     EasyMock.verify(mockPeon);
     EasyMock.verify(anotherMockPeon);
@@ -811,8 +813,8 @@ public class RunRulesTest
             .build();
 
     CoordinatorRunStats stats = runDutyAndGetStats(params);
-    Assert.assertEquals(48L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "hot", DATASOURCE));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
+    Assertions.assertEquals(48L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "hot", DATASOURCE));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
 
     DataSegment overFlowSegment = new DataSegment(
         "test",
@@ -834,7 +836,7 @@ public class RunRulesTest
             .build()
     );
 
-    Assert.assertEquals(2L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "hot", DATASOURCE));
+    Assertions.assertEquals(2L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "hot", DATASOURCE));
 
     EasyMock.verify(mockPeon);
   }
@@ -890,9 +892,9 @@ public class RunRulesTest
         .build();
 
     CoordinatorRunStats stats = runDutyAndGetStats(params);
-    Assert.assertEquals(24L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "hot", DATASOURCE));
-    Assert.assertEquals(24L, stats.getSegmentStat(Stats.Segments.ASSIGNED, DruidServer.DEFAULT_TIER, DATASOURCE));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
+    Assertions.assertEquals(24L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "hot", DATASOURCE));
+    Assertions.assertEquals(24L, stats.getSegmentStat(Stats.Segments.ASSIGNED, DruidServer.DEFAULT_TIER, DATASOURCE));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
 
     EasyMock.verify(mockPeon);
   }
@@ -956,7 +958,7 @@ public class RunRulesTest
     CoordinatorRunStats stats = runDutyAndGetStats(params);
 
     // There is no throttling on drop
-    Assert.assertEquals(25L, stats.getSegmentStat(Stats.Segments.DROPPED, "normal", DATASOURCE));
+    Assertions.assertEquals(25L, stats.getSegmentStat(Stats.Segments.DROPPED, "normal", DATASOURCE));
     EasyMock.verify(mockPeon);
   }
 
@@ -1009,11 +1011,11 @@ public class RunRulesTest
         .build();
 
     CoordinatorRunStats stats = runDutyAndGetStats(params);
-    Assert.assertEquals(1, stats.getSegmentStat(Stats.Segments.ASSIGNED, DruidServer.DEFAULT_TIER, DATASOURCE));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
+    Assertions.assertEquals(1, stats.getSegmentStat(Stats.Segments.ASSIGNED, DruidServer.DEFAULT_TIER, DATASOURCE));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
 
-    Assert.assertEquals(2, usedSegments.size());
-    Assert.assertEquals(usedSegments, params.getUsedSegmentsNewestFirst());
+    Assertions.assertEquals(2, usedSegments.size());
+    Assertions.assertEquals(usedSegments, params.getUsedSegmentsNewestFirst());
 
     EasyMock.verify(mockPeon);
   }
@@ -1024,7 +1026,8 @@ public class RunRulesTest
    * Replicants - 3
    * Random balancer strategy should not assign anything and not get into loop as there are not enough nodes for replication
    */
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
   public void testTwoNodesOneTierThreeReplicantsRandomStrategyNotEnoughNodes()
   {
     mockEmptyPeon();
@@ -1071,8 +1074,8 @@ public class RunRulesTest
             .build();
 
     CoordinatorRunStats stats = runDutyAndGetStats(params);
-    Assert.assertEquals(0L, stats.getSegmentStat(Stats.Segments.ASSIGNED, DruidServer.DEFAULT_TIER, DATASOURCE));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
+    Assertions.assertEquals(0L, stats.getSegmentStat(Stats.Segments.ASSIGNED, DruidServer.DEFAULT_TIER, DATASOURCE));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
 
     EasyMock.verify(mockPeon);
   }
@@ -1084,7 +1087,8 @@ public class RunRulesTest
    * Replicants - 1
    * Random balancer strategy should select the only node
    */
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
   public void testOneNodesOneTierOneReplicantRandomStrategyEnoughSpace()
   {
     mockPeon.loadSegment(EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject());
@@ -1125,8 +1129,8 @@ public class RunRulesTest
             .build();
 
     CoordinatorRunStats stats = runDutyAndGetStats(params);
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, DruidServer.DEFAULT_TIER, DATASOURCE));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, DruidServer.DEFAULT_TIER, DATASOURCE));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
 
     EasyMock.verify(mockPeon);
   }
@@ -1137,7 +1141,8 @@ public class RunRulesTest
    * Replicants - 1
    * Random balancer strategy should not assign anything as there is not enough space
    */
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
   public void testOneNodesOneTierOneReplicantRandomStrategyNotEnoughSpace()
   {
     mockEmptyPeon();
@@ -1181,14 +1186,14 @@ public class RunRulesTest
 
     CoordinatorRunStats stats = runDutyAndGetStats(params);
     final RowKey tierRowKey = RowKey.of(Dimension.TIER, DruidServer.DEFAULT_TIER);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         dataSegment.getSize() * numReplicants,
         stats.get(Stats.Tier.REQUIRED_CAPACITY, tierRowKey)
     );
 
     // Verify that primary assignment failed
-    Assert.assertEquals(0L, stats.getSegmentStat(Stats.Segments.ASSIGNED, DruidServer.DEFAULT_TIER, DATASOURCE));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
+    Assertions.assertEquals(0L, stats.getSegmentStat(Stats.Segments.ASSIGNED, DruidServer.DEFAULT_TIER, DATASOURCE));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
 
     EasyMock.verify(mockPeon);
   }
@@ -1243,12 +1248,12 @@ public class RunRulesTest
 
     CoordinatorRunStats stats = runDutyAndGetStats(params);
     final RowKey tierRowKey = RowKey.of(Dimension.TIER, DruidServer.DEFAULT_TIER);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         dataSegment.getSize() * numReplicants,
         stats.get(Stats.Tier.REQUIRED_CAPACITY, tierRowKey)
     );
-    Assert.assertEquals(0L, stats.getSegmentStat(Stats.Segments.ASSIGNED, DruidServer.DEFAULT_TIER, DATASOURCE));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
+    Assertions.assertEquals(0L, stats.getSegmentStat(Stats.Segments.ASSIGNED, DruidServer.DEFAULT_TIER, DATASOURCE));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
 
     EasyMock.verify(mockPeon);
   }
@@ -1275,15 +1280,15 @@ public class RunRulesTest
         .build();
     params = ruleRunner.run(params);
 
-    Assert.assertNotNull(params);
+    Assertions.assertNotNull(params);
     SegmentReplicationStatus replicationStatus = params.getSegmentReplicationStatus();
-    Assert.assertNotNull(replicationStatus);
+    Assertions.assertNotNull(replicationStatus);
 
     SegmentReplicaCount replicaCounts = replicationStatus.getReplicaCountsInCluster(segment.getId());
-    Assert.assertNotNull(replicaCounts);
-    Assert.assertEquals(0, replicaCounts.required());
-    Assert.assertEquals(0, replicaCounts.totalLoaded());
-    Assert.assertEquals(0, replicaCounts.requiredAndLoadable());
+    Assertions.assertNotNull(replicaCounts);
+    Assertions.assertEquals(0, replicaCounts.required());
+    Assertions.assertEquals(0, replicaCounts.totalLoaded());
+    Assertions.assertEquals(0, replicaCounts.requiredAndLoadable());
   }
 
   private CoordinatorRunStats runDutyAndGetStats(DruidCoordinatorRuntimeParams params)

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/RunRulesTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/RunRulesTest.java
@@ -62,6 +62,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -1027,7 +1028,7 @@ public class RunRulesTest
    * Random balancer strategy should not assign anything and not get into loop as there are not enough nodes for replication
    */
   @Test
-  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testTwoNodesOneTierThreeReplicantsRandomStrategyNotEnoughNodes()
   {
     mockEmptyPeon();
@@ -1088,7 +1089,7 @@ public class RunRulesTest
    * Random balancer strategy should select the only node
    */
   @Test
-  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testOneNodesOneTierOneReplicantRandomStrategyEnoughSpace()
   {
     mockPeon.loadSegment(EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject());
@@ -1142,7 +1143,7 @@ public class RunRulesTest
    * Random balancer strategy should not assign anything as there is not enough space
    */
   @Test
-  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testOneNodesOneTierOneReplicantRandomStrategyNotEnoughSpace()
   {
     mockEmptyPeon();

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/UnloadUnusedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/UnloadUnusedSegmentsTest.java
@@ -44,10 +44,10 @@ import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -75,7 +75,7 @@ public class UnloadUnusedSegmentsTest
   private MetadataRuleManager databaseRuleManager;
   private SegmentLoadQueueManager loadQueueManager;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     coordinator = EasyMock.createMock(DruidCoordinator.class);
@@ -177,7 +177,7 @@ public class UnloadUnusedSegmentsTest
     dataSourcesForRealtime = ImmutableList.of(dataSource2ForRealtime, broadcastDatasource);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     EasyMock.verify(coordinator);
@@ -267,11 +267,11 @@ public class UnloadUnusedSegmentsTest
     CoordinatorRunStats stats = params.getCoordinatorStats();
 
     // We drop segment1 and broadcast1 from all servers, realtimeSegment is not dropped by the indexer
-    Assert.assertEquals(2L, stats.getSegmentStat(Stats.Segments.UNNEEDED, DruidServer.DEFAULT_TIER, segment1.getDataSource()));
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.UNNEEDED, "tier2", segment1.getDataSource()));
+    Assertions.assertEquals(2L, stats.getSegmentStat(Stats.Segments.UNNEEDED, DruidServer.DEFAULT_TIER, segment1.getDataSource()));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.UNNEEDED, "tier2", segment1.getDataSource()));
 
-    Assert.assertEquals(3L, stats.getSegmentStat(Stats.Segments.UNNEEDED, DruidServer.DEFAULT_TIER, broadcastDatasource));
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.UNNEEDED, "tier2", broadcastDatasource));
+    Assertions.assertEquals(3L, stats.getSegmentStat(Stats.Segments.UNNEEDED, DruidServer.DEFAULT_TIER, broadcastDatasource));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.UNNEEDED, "tier2", broadcastDatasource));
   }
 
   private static void mockDruidServer(

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeonTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeonTest.java
@@ -46,10 +46,10 @@ import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.joda.time.Duration;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
@@ -75,7 +75,7 @@ public class HttpLoadQueuePeonTest
   private HttpLoadQueuePeon httpLoadQueuePeon;
   private SegmentLoadingCapabilities segmentLoadingCapabilities;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     segmentLoadingCapabilities = new SegmentLoadingCapabilities(1, 3);
@@ -96,7 +96,7 @@ public class HttpLoadQueuePeonTest
     httpLoadQueuePeon.start();
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     httpLoadQueuePeon.stop();
@@ -115,11 +115,11 @@ public class HttpLoadQueuePeonTest
         .loadSegment(segments.get(3), SegmentAction.MOVE_TO, markSegmentProcessed(segments.get(3)));
 
     httpClient.sendRequestToServerAndHandleResponse();
-    Assert.assertEquals(segments, httpClient.segmentsSentToServer);
+    Assertions.assertEquals(segments, httpClient.segmentsSentToServer);
 
     // Verify that all callbacks are executed
     httpClient.executeCallbacks();
-    Assert.assertEquals(segments, httpClient.processedSegments);
+    Assertions.assertEquals(segments, httpClient.processedSegments);
   }
 
   @Test
@@ -142,8 +142,8 @@ public class HttpLoadQueuePeonTest
       }
     });
 
-    Assert.assertTrue(failedSegments.contains(segment1));
-    Assert.assertTrue(failedSegments.contains(segment2));
+    Assertions.assertTrue(failedSegments.contains(segment1));
+    Assertions.assertTrue(failedSegments.contains(segment2));
   }
 
   @Test
@@ -169,7 +169,7 @@ public class HttpLoadQueuePeonTest
     httpClient.sendRequestToServerAndHandleResponse();
 
     // Verify that all segments are sent to the server in the expected order
-    Assert.assertEquals(segmentsDay1, httpClient.segmentsSentToServer);
+    Assertions.assertEquals(segmentsDay1, httpClient.segmentsSentToServer);
   }
 
   @Test
@@ -210,7 +210,7 @@ public class HttpLoadQueuePeonTest
     httpClient.sendRequestToServerAndHandleResponse();
 
     // Verify that all segments are sent to the server in the expected order
-    Assert.assertEquals(expectedSegmentOrder, httpClient.segmentsSentToServer);
+    Assertions.assertEquals(expectedSegmentOrder, httpClient.segmentsSentToServer);
   }
 
   @Test
@@ -218,13 +218,13 @@ public class HttpLoadQueuePeonTest
   {
     final DataSegment segment = segments.get(0);
     httpLoadQueuePeon.loadSegment(segment, SegmentAction.REPLICATE, markSegmentProcessed(segment));
-    Assert.assertEquals(1, httpLoadQueuePeon.getSegmentsToLoad().size());
+    Assertions.assertEquals(1, httpLoadQueuePeon.getSegmentsToLoad().size());
 
     boolean cancelled = httpLoadQueuePeon.cancelOperation(segment);
-    Assert.assertTrue(cancelled);
-    Assert.assertEquals(0, httpLoadQueuePeon.getSegmentsToLoad().size());
+    Assertions.assertTrue(cancelled);
+    Assertions.assertEquals(0, httpLoadQueuePeon.getSegmentsToLoad().size());
 
-    Assert.assertTrue(httpClient.processedSegments.isEmpty());
+    Assertions.assertTrue(httpClient.processedSegments.isEmpty());
   }
 
   @Test
@@ -232,13 +232,13 @@ public class HttpLoadQueuePeonTest
   {
     final DataSegment segment = segments.get(0);
     httpLoadQueuePeon.dropSegment(segment, markSegmentProcessed(segment));
-    Assert.assertEquals(1, httpLoadQueuePeon.getSegmentsToDrop().size());
+    Assertions.assertEquals(1, httpLoadQueuePeon.getSegmentsToDrop().size());
 
     boolean cancelled = httpLoadQueuePeon.cancelOperation(segment);
-    Assert.assertTrue(cancelled);
-    Assert.assertTrue(httpLoadQueuePeon.getSegmentsToDrop().isEmpty());
+    Assertions.assertTrue(cancelled);
+    Assertions.assertTrue(httpLoadQueuePeon.getSegmentsToDrop().isEmpty());
 
-    Assert.assertTrue(httpClient.processedSegments.isEmpty());
+    Assertions.assertTrue(httpClient.processedSegments.isEmpty());
   }
 
   @Test
@@ -246,26 +246,26 @@ public class HttpLoadQueuePeonTest
   {
     final DataSegment segment = segments.get(0);
     httpLoadQueuePeon.loadSegment(segment, SegmentAction.REPLICATE, markSegmentProcessed(segment));
-    Assert.assertTrue(httpLoadQueuePeon.getSegmentsToLoad().contains(segment));
+    Assertions.assertTrue(httpLoadQueuePeon.getSegmentsToLoad().contains(segment));
 
     httpClient.sendRequestToServer();
-    Assert.assertTrue(httpClient.segmentsSentToServer.contains(segment));
+    Assertions.assertTrue(httpClient.segmentsSentToServer.contains(segment));
 
     // Segment is still in queue but operation cannot be cancelled
-    Assert.assertTrue(httpLoadQueuePeon.getSegmentsToLoad().contains(segment));
+    Assertions.assertTrue(httpLoadQueuePeon.getSegmentsToLoad().contains(segment));
     boolean cancelled = httpLoadQueuePeon.cancelOperation(segment);
-    Assert.assertFalse(cancelled);
+    Assertions.assertFalse(cancelled);
 
     httpClient.handleResponseFromServer();
 
     // Segment has been removed from queue
-    Assert.assertTrue(httpLoadQueuePeon.getSegmentsToLoad().isEmpty());
+    Assertions.assertTrue(httpLoadQueuePeon.getSegmentsToLoad().isEmpty());
     cancelled = httpLoadQueuePeon.cancelOperation(segment);
-    Assert.assertFalse(cancelled);
+    Assertions.assertFalse(cancelled);
 
     // Execute callbacks and verify segment is fully processed
     httpClient.executeCallbacks();
-    Assert.assertTrue(httpClient.processedSegments.contains(segment));
+    Assertions.assertTrue(httpClient.processedSegments.contains(segment));
   }
 
   @Test
@@ -273,10 +273,10 @@ public class HttpLoadQueuePeonTest
   {
     final DataSegment segment = segments.get(0);
     httpLoadQueuePeon.loadSegment(segment, SegmentAction.REPLICATE, markSegmentProcessed(segment));
-    Assert.assertTrue(httpLoadQueuePeon.getSegmentsToLoad().contains(segment));
+    Assertions.assertTrue(httpLoadQueuePeon.getSegmentsToLoad().contains(segment));
 
-    Assert.assertTrue(httpLoadQueuePeon.cancelOperation(segment));
-    Assert.assertFalse(httpLoadQueuePeon.cancelOperation(segment));
+    Assertions.assertTrue(httpLoadQueuePeon.cancelOperation(segment));
+    Assertions.assertFalse(httpLoadQueuePeon.cancelOperation(segment));
   }
 
   @Test
@@ -284,8 +284,8 @@ public class HttpLoadQueuePeonTest
   {
     httpLoadQueuePeon.loadSegment(segments.get(0), SegmentAction.LOAD, null);
     httpClient.sendRequestToServer();
-    Assert.assertEquals(1, httpLoadQueuePeon.getSegmentsToLoad().size());
-    Assert.assertEquals(0, httpLoadQueuePeon.getLoadRateKbps());
+    Assertions.assertEquals(1, httpLoadQueuePeon.getSegmentsToLoad().size());
+    Assertions.assertEquals(0, httpLoadQueuePeon.getLoadRateKbps());
   }
 
   @Test
@@ -299,7 +299,7 @@ public class HttpLoadQueuePeonTest
     httpClient.handleResponseFromServer();
 
     // Verify that load rate is still zero
-    Assert.assertEquals(0, httpLoadQueuePeon.getLoadRateKbps());
+    Assertions.assertEquals(0, httpLoadQueuePeon.getLoadRateKbps());
   }
 
   @Test
@@ -315,7 +315,7 @@ public class HttpLoadQueuePeonTest
     // Verify that load rate has been updated
     long expectedRateKbps = (8 * segments.get(0).getSize()) / millisTakenToLoadSegment;
     long observedRateKbps = httpLoadQueuePeon.getLoadRateKbps();
-    Assert.assertTrue(
+    Assertions.assertTrue(
         observedRateKbps > expectedRateKbps / 2
         && observedRateKbps <= expectedRateKbps
     );
@@ -324,7 +324,7 @@ public class HttpLoadQueuePeonTest
   @Test
   public void testBatchSize()
   {
-    Assert.assertEquals(10, httpLoadQueuePeon.calculateBatchSize(SegmentLoadingMode.NORMAL));
+    Assertions.assertEquals(10, httpLoadQueuePeon.calculateBatchSize(SegmentLoadingMode.NORMAL));
 
     // Without a batch size runtime parameter
     httpLoadQueuePeon = new HttpLoadQueuePeon(
@@ -341,8 +341,8 @@ public class HttpLoadQueuePeonTest
         httpClient.callbackExecutor
     );
 
-    Assert.assertEquals(1, httpLoadQueuePeon.calculateBatchSize(SegmentLoadingMode.NORMAL));
-    Assert.assertEquals(3, httpLoadQueuePeon.calculateBatchSize(SegmentLoadingMode.TURBO));
+    Assertions.assertEquals(1, httpLoadQueuePeon.calculateBatchSize(SegmentLoadingMode.NORMAL));
+    Assertions.assertEquals(3, httpLoadQueuePeon.calculateBatchSize(SegmentLoadingMode.TURBO));
   }
 
   private LoadPeonCallback markSegmentProcessed(DataSegment segment)

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/LoadingRateTrackerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/LoadingRateTrackerTest.java
@@ -20,9 +20,9 @@
 package org.apache.druid.server.coordinator.loading;
 
 import org.apache.druid.error.DruidException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
@@ -30,7 +30,7 @@ public class LoadingRateTrackerTest
 {
   private LoadingRateTracker tracker;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     tracker = new LoadingRateTracker();
@@ -39,11 +39,11 @@ public class LoadingRateTrackerTest
   @Test
   public void testUpdateThrowsExceptionIfBatchNotStarted()
   {
-    DruidException e = Assert.assertThrows(
+    DruidException e = Assertions.assertThrows(
         DruidException.class,
         () -> tracker.incrementBytesLoadedInBatch(1000, 10)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "markBatchLoadingStarted() must be called before tracking load progress.",
         e.getMessage()
     );
@@ -52,7 +52,7 @@ public class LoadingRateTrackerTest
   @Test
   public void testRateIsZeroWhenEmpty()
   {
-    Assert.assertEquals(0, tracker.getMovingAverageLoadRateKbps());
+    Assertions.assertEquals(0, tracker.getMovingAverageLoadRateKbps());
   }
 
   @Test
@@ -60,10 +60,10 @@ public class LoadingRateTrackerTest
   {
     tracker.markBatchLoadingStarted();
     tracker.incrementBytesLoadedInBatch(1000, 10);
-    Assert.assertEquals(8 * 1000 / 10, tracker.getMovingAverageLoadRateKbps());
+    Assertions.assertEquals(8 * 1000 / 10, tracker.getMovingAverageLoadRateKbps());
 
     tracker.stop();
-    Assert.assertEquals(0, tracker.getMovingAverageLoadRateKbps());
+    Assertions.assertEquals(0, tracker.getMovingAverageLoadRateKbps());
   }
 
   @Test
@@ -71,10 +71,10 @@ public class LoadingRateTrackerTest
   {
     tracker.markBatchLoadingStarted();
     tracker.incrementBytesLoadedInBatch(1000, 10);
-    Assert.assertEquals(8 * 1000 / 10, tracker.getMovingAverageLoadRateKbps());
+    Assertions.assertEquals(8 * 1000 / 10, tracker.getMovingAverageLoadRateKbps());
 
     tracker.incrementBytesLoadedInBatch(1000, 15);
-    Assert.assertEquals(8 * 2000 / 15, tracker.getMovingAverageLoadRateKbps());
+    Assertions.assertEquals(8 * 2000 / 15, tracker.getMovingAverageLoadRateKbps());
   }
 
   @Test
@@ -82,12 +82,12 @@ public class LoadingRateTrackerTest
   {
     tracker.markBatchLoadingStarted();
     tracker.incrementBytesLoadedInBatch(1000, 10);
-    Assert.assertEquals(8 * 1000 / 10, tracker.getMovingAverageLoadRateKbps());
+    Assertions.assertEquals(8 * 1000 / 10, tracker.getMovingAverageLoadRateKbps());
     tracker.markBatchLoadingFinished();
 
     tracker.markBatchLoadingStarted();
     tracker.incrementBytesLoadedInBatch(1000, 5);
-    Assert.assertEquals(8 * 2000 / 15, tracker.getMovingAverageLoadRateKbps());
+    Assertions.assertEquals(8 * 2000 / 15, tracker.getMovingAverageLoadRateKbps());
     tracker.markBatchLoadingFinished();
   }
 
@@ -107,11 +107,11 @@ public class LoadingRateTrackerTest
       tracker.incrementBytesLoadedInBatch(updateBytes, monoticBatchDuration);
 
       totalUpdateBytes += updateBytes;
-      Assert.assertEquals(8 * totalUpdateBytes / monoticBatchDuration, tracker.getMovingAverageLoadRateKbps());
+      Assertions.assertEquals(8 * totalUpdateBytes / monoticBatchDuration, tracker.getMovingAverageLoadRateKbps());
     }
 
     tracker.markBatchLoadingFinished();
-    Assert.assertEquals(8 * totalUpdateBytes / monoticBatchDuration, tracker.getMovingAverageLoadRateKbps());
+    Assertions.assertEquals(8 * totalUpdateBytes / monoticBatchDuration, tracker.getMovingAverageLoadRateKbps());
   }
 
   @Test
@@ -136,7 +136,7 @@ public class LoadingRateTrackerTest
 
       tracker.markBatchLoadingStarted();
       tracker.incrementBytesLoadedInBatch(updateBytes[i], updateMillis[i]);
-      Assert.assertEquals(
+      Assertions.assertEquals(
           8 * totalBytes / totalMillis,
           tracker.getMovingAverageLoadRateKbps()
       );
@@ -153,7 +153,7 @@ public class LoadingRateTrackerTest
     // Verify that the average window has moved
     totalBytes = totalBytes - updateBytes[0] + latestUpdateBytes;
     totalMillis = totalMillis - updateMillis[0] + latestUpdateMillis;
-    Assert.assertEquals(
+    Assertions.assertEquals(
         8 * totalBytes / totalMillis,
         tracker.getMovingAverageLoadRateKbps()
     );
@@ -182,7 +182,7 @@ public class LoadingRateTrackerTest
       tracker.markBatchLoadingFinished();
 
       // Verify that the average window doesn't move
-      Assert.assertEquals(
+      Assertions.assertEquals(
           8 * totalBytes / totalMillis,
           tracker.getMovingAverageLoadRateKbps()
       );

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/ReplicationThrottlerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/ReplicationThrottlerTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.server.coordinator.loading;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ReplicationThrottlerTest
 {
@@ -39,10 +39,10 @@ public class ReplicationThrottlerTest
 
     // Verify that both the tiers can be assigned replicas upto the limit
     for (int i = 0; i < replicationThrottleLimit; ++i) {
-      Assert.assertFalse(throttler.isReplicationThrottledForTier(TIER_1));
+      Assertions.assertFalse(throttler.isReplicationThrottledForTier(TIER_1));
       throttler.incrementAssignedReplicas(TIER_1);
 
-      Assert.assertFalse(throttler.isReplicationThrottledForTier(TIER_2));
+      Assertions.assertFalse(throttler.isReplicationThrottledForTier(TIER_2));
       throttler.incrementAssignedReplicas(TIER_2);
     }
   }
@@ -57,14 +57,14 @@ public class ReplicationThrottlerTest
     );
 
     // T1 cannot be assigned any more replicas
-    Assert.assertTrue(throttler.isReplicationThrottledForTier(TIER_1));
+    Assertions.assertTrue(throttler.isReplicationThrottledForTier(TIER_1));
 
     // T2 can be assigned replicas until it hits the limit
     for (int i = 0; i < 3; ++i) {
-      Assert.assertFalse(throttler.isReplicationThrottledForTier(TIER_2));
+      Assertions.assertFalse(throttler.isReplicationThrottledForTier(TIER_2));
       throttler.incrementAssignedReplicas(TIER_2);
     }
-    Assert.assertTrue(throttler.isReplicationThrottledForTier(TIER_2));
+    Assertions.assertTrue(throttler.isReplicationThrottledForTier(TIER_2));
   }
 
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/RoundRobinServerSelectorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/RoundRobinServerSelectorTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.server.coordinator.DruidCluster;
 import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Iterator;
@@ -69,12 +69,12 @@ public class RoundRobinServerSelectorTest
     // Verify that only eligible servers are returned in order of available size
     Iterator<ServerHolder> pickedServers = selector.getServersInTierToLoadSegment(TIER, segment);
 
-    Assert.assertTrue(pickedServers.hasNext());
-    Assert.assertEquals(serverXL, pickedServers.next());
-    Assert.assertEquals(serverL, pickedServers.next());
-    Assert.assertEquals(serverM, pickedServers.next());
+    Assertions.assertTrue(pickedServers.hasNext());
+    Assertions.assertEquals(serverXL, pickedServers.next());
+    Assertions.assertEquals(serverL, pickedServers.next());
+    Assertions.assertEquals(serverM, pickedServers.next());
 
-    Assert.assertFalse(pickedServers.hasNext());
+    Assertions.assertFalse(pickedServers.hasNext());
   }
 
   @Test
@@ -95,18 +95,18 @@ public class RoundRobinServerSelectorTest
 
     // Verify that only eligible servers are returned in order of available size
     Iterator<ServerHolder> pickedServers = selector.getServersInTierToLoadSegment(TIER, segment);
-    Assert.assertTrue(pickedServers.hasNext());
-    Assert.assertEquals(serverXL, pickedServers.next());
+    Assertions.assertTrue(pickedServers.hasNext());
+    Assertions.assertEquals(serverXL, pickedServers.next());
 
     // Second iterator starts from previous position but resets allowed number of iterations
     pickedServers = selector.getServersInTierToLoadSegment(TIER, segment);
-    Assert.assertTrue(pickedServers.hasNext());
+    Assertions.assertTrue(pickedServers.hasNext());
 
-    Assert.assertEquals(serverL, pickedServers.next());
-    Assert.assertEquals(serverM, pickedServers.next());
-    Assert.assertEquals(serverXL, pickedServers.next());
+    Assertions.assertEquals(serverL, pickedServers.next());
+    Assertions.assertEquals(serverM, pickedServers.next());
+    Assertions.assertEquals(serverXL, pickedServers.next());
 
-    Assert.assertFalse(pickedServers.hasNext());
+    Assertions.assertFalse(pickedServers.hasNext());
   }
 
   @Test
@@ -116,7 +116,7 @@ public class RoundRobinServerSelectorTest
     final RoundRobinServerSelector selector = new RoundRobinServerSelector(cluster);
 
     Iterator<ServerHolder> eligibleServers = selector.getServersInTierToLoadSegment(TIER, segment);
-    Assert.assertFalse(eligibleServers.hasNext());
+    Assertions.assertFalse(eligibleServers.hasNext());
   }
 
   @Test
@@ -133,7 +133,7 @@ public class RoundRobinServerSelectorTest
 
     // Verify that only eligible servers are returned in order of available size
     Iterator<ServerHolder> eligibleServers = selector.getServersInTierToLoadSegment(TIER, segment);
-    Assert.assertFalse(eligibleServers.hasNext());
+    Assertions.assertFalse(eligibleServers.hasNext());
   }
 
   private ServerHolder createHistorical(String name, long size)

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/SegmentReplicationStatusTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/SegmentReplicationStatusTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.server.coordinator.CreateDataSegments;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
@@ -83,9 +83,9 @@ public class SegmentReplicationStatusTest
       final Map<String, Object2LongMap<String>> expectedUnderReplicated =
           status.getTierToDatasourceToUnderReplicated(segments, ignoreMissingServers);
 
-      Assert.assertEquals(expectedUnavailable, snapshot.getDatasourceToUnavailableCount());
-      Assert.assertEquals(expectedDeepStorageOnly, snapshot.getDatasourceToDeepStorageOnlyCount());
-      Assert.assertEquals(expectedUnderReplicated, snapshot.getTierToDatasourceToUnderReplicatedCount());
+      Assertions.assertEquals(expectedUnavailable, snapshot.getDatasourceToUnavailableCount());
+      Assertions.assertEquals(expectedDeepStorageOnly, snapshot.getDatasourceToDeepStorageOnlyCount());
+      Assertions.assertEquals(expectedUnderReplicated, snapshot.getTierToDatasourceToUnderReplicatedCount());
     }
   }
 
@@ -105,14 +105,14 @@ public class SegmentReplicationStatusTest
 
     final SegmentStatsSnapshot ignoreMissing =
         status.computeSegmentStats(singleSegment, true);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         3L,
         ignoreMissing.getTierToDatasourceToUnderReplicatedCount().get(TIER_1).getLong("wiki")
     );
 
     final SegmentStatsSnapshot respectMissing =
         status.computeSegmentStats(singleSegment, false);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1L,
         respectMissing.getTierToDatasourceToUnderReplicatedCount().get(TIER_1).getLong("wiki")
     );
@@ -129,7 +129,7 @@ public class SegmentReplicationStatusTest
 
     final SegmentReplicationStatus status = new SegmentReplicationStatus(replicaCountsInTier);
     final SegmentReplicaCount totalBefore = status.getReplicaCountsInCluster(segments.get(0).getId());
-    Assert.assertEquals(1, totalBefore.totalLoaded());
+    Assertions.assertEquals(1, totalBefore.totalLoaded());
 
     // Mutate the caller's inputs after construction, as BalanceSegments does later in the same
     // coordinator cycle: add a brand new segment key and mutate an already-tracked count in place.
@@ -137,8 +137,8 @@ public class SegmentReplicationStatusTest
     tierMap.put(TIER_2, countOf(1, 1, 1));
     replicaCountsInTier.put(segments.get(1).getId(), Map.of(TIER_1, countOf(1, 1, 1)));
 
-    Assert.assertEquals(1, status.getReplicaCountsInCluster(segments.get(0).getId()).totalLoaded());
-    Assert.assertNull(status.getReplicaCountsInCluster(segments.get(1).getId()));
+    Assertions.assertEquals(1, status.getReplicaCountsInCluster(segments.get(0).getId()).totalLoaded());
+    Assertions.assertNull(status.getReplicaCountsInCluster(segments.get(1).getId()));
   }
 
   private static SegmentReplicaCount countOf(int required, int requiredAndLoadable, int loaded)

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssignerPartialTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssignerPartialTest.java
@@ -46,10 +46,10 @@ import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -83,7 +83,7 @@ public class StrategicSegmentAssignerPartialTest
 
   private final AtomicInteger serverId = new AtomicInteger();
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     exec = MoreExecutors.listeningDecorator(Execs.multiThreaded(1, "StrategicSegmentAssignerPartialTest-%d"));
@@ -91,7 +91,7 @@ public class StrategicSegmentAssignerPartialTest
     loadQueueManager = new SegmentLoadQueueManager(null, null);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     exec.shutdown();
@@ -109,12 +109,12 @@ public class StrategicSegmentAssignerPartialTest
     final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
     params.getSegmentAssigner().replicateSegmentPartially(segment, profile, ImmutableMap.of(TIER1, 1));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1L,
         params.getCoordinatorStats().getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource())
     );
-    Assert.assertTrue(server.getLoadingSegments().contains(segment));
-    Assert.assertEquals(profile, ((TestLoadQueuePeon) server.getPeon()).getProfileFor(segment));
+    Assertions.assertTrue(server.getLoadingSegments().contains(segment));
+    Assertions.assertEquals(profile, ((TestLoadQueuePeon) server.getPeon()).getProfileFor(segment));
   }
 
   @Test
@@ -132,10 +132,10 @@ public class StrategicSegmentAssignerPartialTest
           .replicateSegmentPartially(segment, profile, ImmutableMap.of(TIER1, 1, TIER2, 1));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource()));
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER2, segment.getDataSource()));
-    Assert.assertEquals(profile, ((TestLoadQueuePeon) s1.getPeon()).getProfileFor(segment));
-    Assert.assertEquals(profile, ((TestLoadQueuePeon) s2.getPeon()).getProfileFor(segment));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource()));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER2, segment.getDataSource()));
+    Assertions.assertEquals(profile, ((TestLoadQueuePeon) s1.getPeon()).getProfileFor(segment));
+    Assertions.assertEquals(profile, ((TestLoadQueuePeon) s2.getPeon()).getProfileFor(segment));
   }
 
   @Test
@@ -153,11 +153,11 @@ public class StrategicSegmentAssignerPartialTest
           .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 1));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_ASSIGNED));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_STALE_DROPPED));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
-    Assert.assertTrue(s2.getLoadingSegments().isEmpty());
-    Assert.assertTrue(s1.getPeon().getSegmentsToDrop().isEmpty());
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_ASSIGNED));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_STALE_DROPPED));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
+    Assertions.assertTrue(s2.getLoadingSegments().isEmpty());
+    Assertions.assertTrue(s1.getPeon().getSegmentsToDrop().isEmpty());
   }
 
   @Test
@@ -175,16 +175,22 @@ public class StrategicSegmentAssignerPartialTest
     params.getSegmentAssigner().replicateSegment(segment, ImmutableMap.of(TIER1, 1));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1L,
         stats.getSegmentStat(Stats.Segments.PARTIAL_RULE_REVERTED, TIER1, segment.getDataSource())
     );
-    Assert.assertTrue("in-place reload must be queued on the pinned server", s1.getLoadingSegments().contains(segment));
-    Assert.assertNull(
-        "revert must carry no profile so the historical receives the plain unwrapped load spec",
-        ((TestLoadQueuePeon) s1.getPeon()).getProfileFor(segment)
+    Assertions.assertTrue(
+        s1.getLoadingSegments().contains(segment),
+        "in-place reload must be queued on the pinned server"
     );
-    Assert.assertTrue("the replica is still serving and must not be dropped", s1.getPeon().getSegmentsToDrop().isEmpty());
+    Assertions.assertNull(
+        ((TestLoadQueuePeon) s1.getPeon()).getProfileFor(segment),
+        "revert must carry no profile so the historical receives the plain unwrapped load spec"
+    );
+    Assertions.assertTrue(
+        s1.getPeon().getSegmentsToDrop().isEmpty(),
+        "the replica is still serving and must not be dropped"
+    );
   }
 
   @Test
@@ -199,10 +205,10 @@ public class StrategicSegmentAssignerPartialTest
     params.getSegmentAssigner().replicateSegment(segment, ImmutableMap.of(TIER1, 1));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_RULE_REVERTED));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.ASSIGNED));
-    Assert.assertTrue(s1.getLoadingSegments().isEmpty());
-    Assert.assertTrue(s1.getPeon().getSegmentsToDrop().isEmpty());
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_RULE_REVERTED));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.ASSIGNED));
+    Assertions.assertTrue(s1.getLoadingSegments().isEmpty());
+    Assertions.assertTrue(s1.getPeon().getSegmentsToDrop().isEmpty());
   }
 
   @Test
@@ -218,9 +224,9 @@ public class StrategicSegmentAssignerPartialTest
     params.getSegmentAssigner().replicateSegment(segment, ImmutableMap.of(TIER1, 0));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_RULE_REVERTED));
-    Assert.assertTrue(s1.getLoadingSegments().isEmpty());
-    Assert.assertTrue(s1.getPeon().getSegmentsToDrop().contains(segment));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_RULE_REVERTED));
+    Assertions.assertTrue(s1.getLoadingSegments().isEmpty());
+    Assertions.assertTrue(s1.getPeon().getSegmentsToDrop().contains(segment));
   }
 
   @Test
@@ -238,17 +244,20 @@ public class StrategicSegmentAssignerPartialTest
     params.getSegmentAssigner().replicateSegment(segment, ImmutableMap.of(TIER1, 1));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, TIER1, segment.getDataSource()));
-    Assert.assertEquals(
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, TIER1, segment.getDataSource()));
+    Assertions.assertEquals(
         1L,
         stats.getSegmentStat(Stats.Segments.PARTIAL_RULE_REVERTED, TIER1, segment.getDataSource())
     );
 
     final ServerHolder dropped = s1.getPeon().getSegmentsToDrop().contains(segment) ? s1 : s2;
     final ServerHolder survivor = dropped == s1 ? s2 : s1;
-    Assert.assertTrue(dropped.getPeon().getSegmentsToDrop().contains(segment));
-    Assert.assertTrue("a server queued for drop must not also be reloaded", dropped.getLoadingSegments().isEmpty());
-    Assert.assertTrue(survivor.getLoadingSegments().contains(segment));
+    Assertions.assertTrue(dropped.getPeon().getSegmentsToDrop().contains(segment));
+    Assertions.assertTrue(
+        dropped.getLoadingSegments().isEmpty(),
+        "a server queued for drop must not also be reloaded"
+    );
+    Assertions.assertTrue(survivor.getLoadingSegments().contains(segment));
   }
 
   @Test
@@ -266,15 +275,21 @@ public class StrategicSegmentAssignerPartialTest
     params.getSegmentAssigner().replicateSegment(segment, ImmutableMap.of(TIER1, 2));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER1, segment.getDataSource()));
-    Assert.assertEquals(
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER1, segment.getDataSource()));
+    Assertions.assertEquals(
         1L,
         stats.getSegmentStat(Stats.Segments.PARTIAL_RULE_REVERTED, TIER1, segment.getDataSource())
     );
-    Assert.assertTrue("deficit must be filled on the empty server", s2.getLoadingSegments().contains(segment));
-    Assert.assertTrue("pinned replica must still be reverted", s1.getLoadingSegments().contains(segment));
-    Assert.assertNull(((TestLoadQueuePeon) s1.getPeon()).getProfileFor(segment));
-    Assert.assertNull(((TestLoadQueuePeon) s2.getPeon()).getProfileFor(segment));
+    Assertions.assertTrue(
+        s2.getLoadingSegments().contains(segment),
+        "deficit must be filled on the empty server"
+    );
+    Assertions.assertTrue(
+        s1.getLoadingSegments().contains(segment),
+        "pinned replica must still be reverted"
+    );
+    Assertions.assertNull(((TestLoadQueuePeon) s1.getPeon()).getProfileFor(segment));
+    Assertions.assertNull(((TestLoadQueuePeon) s2.getPeon()).getProfileFor(segment));
   }
 
   @Test
@@ -294,12 +309,12 @@ public class StrategicSegmentAssignerPartialTest
     params.getSegmentAssigner().replicateSegment(segment2, ImmutableMap.of(TIER1, 1));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertEquals(
-        "only one revert fits in this run's queue budget; the rest wait for a later run",
+    Assertions.assertEquals(
         1L,
-        stats.getSegmentStat(Stats.Segments.PARTIAL_RULE_REVERTED, TIER1, segment1.getDataSource())
+        stats.getSegmentStat(Stats.Segments.PARTIAL_RULE_REVERTED, TIER1, segment1.getDataSource()),
+        "only one revert fits in this run's queue budget; the rest wait for a later run"
     );
-    Assert.assertEquals(1, s1.getLoadingSegments().size());
+    Assertions.assertEquals(1, s1.getLoadingSegments().size());
   }
 
   @Test
@@ -330,15 +345,18 @@ public class StrategicSegmentAssignerPartialTest
     params.getSegmentAssigner().replicateSegment(segment, ImmutableMap.of(TIER1, 1));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertTrue(
-        "the in-flight revert must still be queued, not cancelled as surplus",
-        s1.getLoadingSegments().contains(segment)
+    Assertions.assertTrue(
+        s1.getLoadingSegments().contains(segment),
+        "the in-flight revert must still be queued, not cancelled as surplus"
     );
-    Assert.assertFalse("a pending revert must not be mistaken for a surplus replica", stats.hasStat(Stats.Segments.DROPPED));
-    Assert.assertTrue(s1.getPeon().getSegmentsToDrop().isEmpty());
-    Assert.assertFalse(
-        "the revert is already in flight, so this run has nothing more to queue",
-        stats.hasStat(Stats.Segments.PARTIAL_RULE_REVERTED)
+    Assertions.assertFalse(
+        stats.hasStat(Stats.Segments.DROPPED),
+        "a pending revert must not be mistaken for a surplus replica"
+    );
+    Assertions.assertTrue(s1.getPeon().getSegmentsToDrop().isEmpty());
+    Assertions.assertFalse(
+        stats.hasStat(Stats.Segments.PARTIAL_RULE_REVERTED),
+        "the revert is already in flight, so this run has nothing more to queue"
     );
   }
 
@@ -365,8 +383,8 @@ public class StrategicSegmentAssignerPartialTest
     final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
     params.getSegmentAssigner().replicateSegment(segment, ImmutableMap.of(TIER1, 1));
 
-    Assert.assertFalse(params.getCoordinatorStats().hasStat(Stats.Segments.PARTIAL_RULE_REVERTED));
-    Assert.assertFalse(s1.getLoadingSegments().contains(segment));
+    Assertions.assertFalse(params.getCoordinatorStats().hasStat(Stats.Segments.PARTIAL_RULE_REVERTED));
+    Assertions.assertFalse(s1.getLoadingSegments().contains(segment));
   }
 
   @Test
@@ -383,18 +401,18 @@ public class StrategicSegmentAssignerPartialTest
     params.getSegmentAssigner().broadcastSegment(segment);
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1L,
         stats.getSegmentStat(Stats.Segments.PARTIAL_RULE_REVERTED, TIER1, segment.getDataSource())
     );
-    Assert.assertTrue(s1.getLoadingSegments().contains(segment));
-    Assert.assertNull(
-        "the broadcast revert must carry no profile, same as on the replication path",
-        ((TestLoadQueuePeon) s1.getPeon()).getProfileFor(segment)
+    Assertions.assertTrue(s1.getLoadingSegments().contains(segment));
+    Assertions.assertNull(
+        ((TestLoadQueuePeon) s1.getPeon()).getProfileFor(segment),
+        "the broadcast revert must carry no profile, same as on the replication path"
     );
-    Assert.assertFalse(
-        "an in-place revert is not a new assignment",
-        stats.hasStat(Stats.Segments.ASSIGNED)
+    Assertions.assertFalse(
+        stats.hasStat(Stats.Segments.ASSIGNED),
+        "an in-place revert is not a new assignment"
     );
   }
 
@@ -410,9 +428,9 @@ public class StrategicSegmentAssignerPartialTest
     params.getSegmentAssigner().broadcastSegment(segment);
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_RULE_REVERTED));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.ASSIGNED));
-    Assert.assertTrue(s1.getLoadingSegments().isEmpty());
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_RULE_REVERTED));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.ASSIGNED));
+    Assertions.assertTrue(s1.getLoadingSegments().isEmpty());
   }
 
   @Test
@@ -429,9 +447,9 @@ public class StrategicSegmentAssignerPartialTest
     params.getSegmentAssigner().broadcastSegment(segment);
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER1, segment.getDataSource()));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_RULE_REVERTED));
-    Assert.assertTrue(s1.getLoadingSegments().contains(segment));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER1, segment.getDataSource()));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_RULE_REVERTED));
+    Assertions.assertTrue(s1.getLoadingSegments().contains(segment));
   }
 
   @Test
@@ -446,8 +464,8 @@ public class StrategicSegmentAssignerPartialTest
     final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
     params.getSegmentAssigner().replicateSegment(segment, ImmutableMap.of(TIER1, 1));
 
-    Assert.assertFalse(params.getCoordinatorStats().hasStat(Stats.Segments.PARTIAL_RULE_REVERTED));
-    Assert.assertTrue(s1.getLoadingSegments().isEmpty());
+    Assertions.assertFalse(params.getCoordinatorStats().hasStat(Stats.Segments.PARTIAL_RULE_REVERTED));
+    Assertions.assertTrue(s1.getLoadingSegments().isEmpty());
   }
 
   @Test
@@ -470,8 +488,8 @@ public class StrategicSegmentAssignerPartialTest
     params.getSegmentAssigner()
           .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 1));
 
-    Assert.assertFalse(params.getCoordinatorStats().hasStat(Stats.Segments.PARTIAL_ASSIGNED));
-    Assert.assertTrue(s2.getLoadingSegments().isEmpty());
+    Assertions.assertFalse(params.getCoordinatorStats().hasStat(Stats.Segments.PARTIAL_ASSIGNED));
+    Assertions.assertTrue(s2.getLoadingSegments().isEmpty());
   }
 
   @Test
@@ -490,14 +508,14 @@ public class StrategicSegmentAssignerPartialTest
           .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 1));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource()));
-    Assert.assertFalse(
-        "Stale must not be dropped before matching has actually loaded",
-        stats.hasStat(Stats.Segments.PARTIAL_STALE_DROPPED)
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource()));
+    Assertions.assertFalse(
+        stats.hasStat(Stats.Segments.PARTIAL_STALE_DROPPED),
+        "Stale must not be dropped before matching has actually loaded"
     );
-    Assert.assertTrue(s2.getLoadingSegments().contains(segment));
-    Assert.assertEquals(profileForRevenue(), ((TestLoadQueuePeon) s2.getPeon()).getProfileFor(segment));
-    Assert.assertTrue(s1.getPeon().getSegmentsToDrop().isEmpty());
+    Assertions.assertTrue(s2.getLoadingSegments().contains(segment));
+    Assertions.assertEquals(profileForRevenue(), ((TestLoadQueuePeon) s2.getPeon()).getProfileFor(segment));
+    Assertions.assertTrue(s1.getPeon().getSegmentsToDrop().isEmpty());
   }
 
   @Test
@@ -516,10 +534,10 @@ public class StrategicSegmentAssignerPartialTest
           .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 1));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.PARTIAL_STALE_DROPPED, TIER1, segment.getDataSource()));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_ASSIGNED));
-    Assert.assertTrue(s2.getPeon().getSegmentsToDrop().contains(segment));
-    Assert.assertTrue(s1.getPeon().getSegmentsToDrop().isEmpty());
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.PARTIAL_STALE_DROPPED, TIER1, segment.getDataSource()));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_ASSIGNED));
+    Assertions.assertTrue(s2.getPeon().getSegmentsToDrop().contains(segment));
+    Assertions.assertTrue(s1.getPeon().getSegmentsToDrop().isEmpty());
   }
 
   @Test
@@ -544,11 +562,11 @@ public class StrategicSegmentAssignerPartialTest
           .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 2));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertEquals(2L, stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource()));
-    Assert.assertEquals(profileForRevenue(), ((TestLoadQueuePeon) s1.getPeon()).getProfileFor(segment));
-    Assert.assertEquals(profileForRevenue(), ((TestLoadQueuePeon) s2.getPeon()).getProfileFor(segment));
+    Assertions.assertEquals(2L, stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource()));
+    Assertions.assertEquals(profileForRevenue(), ((TestLoadQueuePeon) s1.getPeon()).getProfileFor(segment));
+    Assertions.assertEquals(profileForRevenue(), ((TestLoadQueuePeon) s2.getPeon()).getProfileFor(segment));
     // Stale must NOT be dropped; matching hasn't loaded yet.
-    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_STALE_DROPPED));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_STALE_DROPPED));
   }
 
   @Test
@@ -566,8 +584,8 @@ public class StrategicSegmentAssignerPartialTest
           .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 1));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, TIER1, segment.getDataSource()));
-    Assert.assertEquals(
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, TIER1, segment.getDataSource()));
+    Assertions.assertEquals(
         1,
         s1.getPeon().getSegmentsToDrop().size() + s2.getPeon().getSegmentsToDrop().size()
     );
@@ -587,14 +605,14 @@ public class StrategicSegmentAssignerPartialTest
     final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
     params.getSegmentAssigner().replicateSegmentPartially(segment, profile, ImmutableMap.of(TIER1, 1));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1L,
         params.getCoordinatorStats().getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource())
     );
-    Assert.assertTrue(decommServer.getLoadingSegments().isEmpty());
-    Assert.assertTrue(activeServer.getLoadingSegments().contains(segment));
-    Assert.assertEquals(profile, ((TestLoadQueuePeon) activeServer.getPeon()).getProfileFor(segment));
-    Assert.assertNull(((TestLoadQueuePeon) decommServer.getPeon()).getProfileFor(segment));
+    Assertions.assertTrue(decommServer.getLoadingSegments().isEmpty());
+    Assertions.assertTrue(activeServer.getLoadingSegments().contains(segment));
+    Assertions.assertEquals(profile, ((TestLoadQueuePeon) activeServer.getPeon()).getProfileFor(segment));
+    Assertions.assertNull(((TestLoadQueuePeon) decommServer.getPeon()).getProfileFor(segment));
   }
 
   @Test
@@ -631,15 +649,15 @@ public class StrategicSegmentAssignerPartialTest
           .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 1));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1L,
         stats.getSegmentStat(Stats.Segments.PARTIAL_STALE_CANCELLED, TIER1, segment.getDataSource())
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1L,
         stats.getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource())
     );
-    Assert.assertEquals(profileForRevenue(), peon.getProfileFor(segment));
+    Assertions.assertEquals(profileForRevenue(), peon.getProfileFor(segment));
   }
 
   @Test
@@ -661,16 +679,16 @@ public class StrategicSegmentAssignerPartialTest
     final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
     rule.run(segment, params.getSegmentAssigner());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1L,
         params.getCoordinatorStats().getSegmentStat(Stats.Segments.PARTIAL_ASSIGNED, TIER1, segment.getDataSource())
     );
     final PartialLoadProfile profile = ((TestLoadQueuePeon) server.getPeon()).getProfileFor(segment);
-    Assert.assertNotNull("Matcher matched, profile should be threaded", profile);
-    Assert.assertEquals("partialProjection", profile.wrappedLoadSpec().get("type"));
-    Assert.assertEquals(List.of("revenue"), profile.wrappedLoadSpec().get("projections"));
-    Assert.assertTrue(profile.fingerprint().startsWith("v1:"));
-    Assert.assertNull("Outbound request profile should not carry loadedBytes", profile.loadedBytes());
+    Assertions.assertNotNull(profile, "Matcher matched, profile should be threaded");
+    Assertions.assertEquals("partialProjection", profile.wrappedLoadSpec().get("type"));
+    Assertions.assertEquals(List.of("revenue"), profile.wrappedLoadSpec().get("projections"));
+    Assertions.assertTrue(profile.fingerprint().startsWith("v1:"));
+    Assertions.assertNull(profile.loadedBytes(), "Outbound request profile should not carry loadedBytes");
   }
 
   @Test
@@ -693,14 +711,14 @@ public class StrategicSegmentAssignerPartialTest
     final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
     rule.run(segment, params.getSegmentAssigner());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1L,
         params.getCoordinatorStats().getSegmentStat(Stats.Segments.ASSIGNED, TIER1, segment.getDataSource())
     );
-    Assert.assertTrue(server.getLoadingSegments().contains(segment));
-    Assert.assertNull(
-        "Full-load fallback must not thread a profile to the peon",
-        ((TestLoadQueuePeon) server.getPeon()).getProfileFor(segment)
+    Assertions.assertTrue(server.getLoadingSegments().contains(segment));
+    Assertions.assertNull(
+        ((TestLoadQueuePeon) server.getPeon()).getProfileFor(segment),
+        "Full-load fallback must not thread a profile to the peon"
     );
   }
 
@@ -717,11 +735,11 @@ public class StrategicSegmentAssignerPartialTest
     final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
     final boolean moved = params.getSegmentAssigner().moveSegment(segment, source, List.of(destination));
 
-    Assert.assertTrue(moved);
-    Assert.assertEquals(SegmentAction.MOVE_TO, destination.getActionOnSegment(segment));
+    Assertions.assertTrue(moved);
+    Assertions.assertEquals(SegmentAction.MOVE_TO, destination.getActionOnSegment(segment));
     final PartialLoadProfile queued = ((TestLoadQueuePeon) destination.getPeon()).getProfileFor(segment);
-    Assert.assertNotNull("Move destination should be asked for the same parts the source holds", queued);
-    Assert.assertEquals(FP_REVENUE, queued.fingerprint());
+    Assertions.assertNotNull(queued, "Move destination should be asked for the same parts the source holds");
+    Assertions.assertEquals(FP_REVENUE, queued.fingerprint());
   }
 
   @Test
@@ -746,10 +764,10 @@ public class StrategicSegmentAssignerPartialTest
     final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
     final boolean moved = params.getSegmentAssigner().moveSegment(segment, source, List.of(destination));
 
-    Assert.assertTrue(moved);
+    Assertions.assertTrue(moved);
     final PartialLoadProfile queued = ((TestLoadQueuePeon) destination.getPeon()).getProfileFor(segment);
-    Assert.assertNotNull("Cancelled in-flight partial load should be reissued to the destination", queued);
-    Assert.assertEquals(FP_REVENUE, queued.fingerprint());
+    Assertions.assertNotNull(queued, "Cancelled in-flight partial load should be reissued to the destination");
+    Assertions.assertEquals(FP_REVENUE, queued.fingerprint());
   }
 
   @Test
@@ -763,11 +781,11 @@ public class StrategicSegmentAssignerPartialTest
     final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster, segment);
     final boolean moved = params.getSegmentAssigner().moveSegment(segment, source, List.of(destination));
 
-    Assert.assertTrue(moved);
-    Assert.assertEquals(SegmentAction.MOVE_TO, destination.getActionOnSegment(segment));
-    Assert.assertNull(
-        "Moving a regular full-load replica must not thread a profile",
-        ((TestLoadQueuePeon) destination.getPeon()).getProfileFor(segment)
+    Assertions.assertTrue(moved);
+    Assertions.assertEquals(SegmentAction.MOVE_TO, destination.getActionOnSegment(segment));
+    Assertions.assertNull(
+        ((TestLoadQueuePeon) destination.getPeon()).getProfileFor(segment),
+        "Moving a regular full-load replica must not thread a profile"
     );
   }
 
@@ -789,10 +807,10 @@ public class StrategicSegmentAssignerPartialTest
           .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 1));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_ASSIGNED));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_STALE_DROPPED));
-    Assert.assertTrue(spare.getLoadingSegments().isEmpty());
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_ASSIGNED));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_STALE_DROPPED));
+    Assertions.assertTrue(spare.getLoadingSegments().isEmpty());
   }
 
   @Test
@@ -812,10 +830,10 @@ public class StrategicSegmentAssignerPartialTest
           .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 1));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_ASSIGNED));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_STALE_DROPPED));
-    Assert.assertTrue(spare.getLoadingSegments().isEmpty());
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_ASSIGNED));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_STALE_DROPPED));
+    Assertions.assertTrue(spare.getLoadingSegments().isEmpty());
   }
 
   @Test
@@ -841,11 +859,11 @@ public class StrategicSegmentAssignerPartialTest
           .replicateSegmentPartially(segment, profileForRevenue(), ImmutableMap.of(TIER1, 1));
 
     final CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_ASSIGNED));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
-    Assert.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_STALE_DROPPED));
-    Assert.assertTrue(spare.getLoadingSegments().isEmpty());
-    Assert.assertTrue(matching.getPeon().getSegmentsToDrop().isEmpty());
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_ASSIGNED));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.DROPPED));
+    Assertions.assertFalse(stats.hasStat(Stats.Segments.PARTIAL_STALE_DROPPED));
+    Assertions.assertTrue(spare.getLoadingSegments().isEmpty());
+    Assertions.assertTrue(matching.getPeon().getSegmentsToDrop().isEmpty());
   }
 
   private DruidCoordinatorRuntimeParams makeRuntimeParams(DruidCluster cluster, DataSegment... segments)

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/BroadcastDistributionRuleSerdeTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/BroadcastDistributionRuleSerdeTest.java
@@ -25,21 +25,21 @@ import com.google.common.collect.Lists;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class BroadcastDistributionRuleSerdeTest
 {
   private static final ObjectMapper MAPPER = new DefaultObjectMapper();
 
-  @Parameterized.Parameters
   public static List<Object[]> constructorFeeder()
   {
     return Lists.newArrayList(
@@ -62,6 +62,6 @@ public class BroadcastDistributionRuleSerdeTest
     final List<Rule> rules = Collections.singletonList(testRule);
     final String json = MAPPER.writeValueAsString(rules);
     final List<Rule> fromJson = MAPPER.readValue(json, new TypeReference<>() {});
-    Assert.assertEquals(rules, fromJson);
+    Assertions.assertEquals(rules, fromJson);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/BroadcastDistributionRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/BroadcastDistributionRuleTest.java
@@ -37,9 +37,9 @@ import org.apache.druid.server.coordinator.stats.Dimension;
 import org.apache.druid.server.coordinator.stats.RowKey;
 import org.apache.druid.server.coordinator.stats.Stats;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -53,7 +53,7 @@ public class BroadcastDistributionRuleTest
   private final DataSegment wikiSegment
       = CreateDataSegments.ofDatasource(TestDataSource.WIKI).eachOfSizeInMb(100).get(0);
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     serverId = 0;
@@ -72,11 +72,11 @@ public class BroadcastDistributionRuleTest
     CoordinatorRunStats stats = runRuleOnSegment(rule, wikiSegment, params);
 
     // Verify that segment is assigned to servers of all tiers
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER_1, TestDataSource.WIKI));
-    Assert.assertTrue(serverT11.isLoadingSegment(wikiSegment));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER_1, TestDataSource.WIKI));
+    Assertions.assertTrue(serverT11.isLoadingSegment(wikiSegment));
 
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER_2, TestDataSource.WIKI));
-    Assert.assertTrue(serverT21.isLoadingSegment(wikiSegment));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER_2, TestDataSource.WIKI));
+    Assertions.assertTrue(serverT21.isLoadingSegment(wikiSegment));
   }
 
   @Test
@@ -92,10 +92,10 @@ public class BroadcastDistributionRuleTest
     CoordinatorRunStats stats = runRuleOnSegment(rule, wikiSegment, params);
 
     // Verify that serverT11 is already serving and serverT12 is loading segment
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER_1, TestDataSource.WIKI));
-    Assert.assertFalse(serverT11.isLoadingSegment(wikiSegment));
-    Assert.assertTrue(serverT11.isServingSegment(wikiSegment));
-    Assert.assertTrue(serverT12.isLoadingSegment(wikiSegment));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER_1, TestDataSource.WIKI));
+    Assertions.assertFalse(serverT11.isLoadingSegment(wikiSegment));
+    Assertions.assertTrue(serverT11.isServingSegment(wikiSegment));
+    Assertions.assertTrue(serverT12.isLoadingSegment(wikiSegment));
   }
 
   @Test
@@ -111,9 +111,9 @@ public class BroadcastDistributionRuleTest
     ForeverBroadcastDistributionRule rule = new ForeverBroadcastDistributionRule();
     CoordinatorRunStats stats = runRuleOnSegment(rule, wikiSegment, params);
 
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER_1, TestDataSource.WIKI));
-    Assert.assertTrue(activeServer.isLoadingSegment(wikiSegment));
-    Assert.assertTrue(decommissioningServer.getLoadingSegments().isEmpty());
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER_1, TestDataSource.WIKI));
+    Assertions.assertTrue(activeServer.isLoadingSegment(wikiSegment));
+    Assertions.assertTrue(decommissioningServer.getLoadingSegments().isEmpty());
   }
 
   @Test
@@ -132,9 +132,9 @@ public class BroadcastDistributionRuleTest
     CoordinatorRunStats stats = runRuleOnSegment(rule, wikiSegment, params);
 
     // Verify that segment is dropped only from the decommissioning server
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, TIER_1, TestDataSource.WIKI));
-    Assert.assertTrue(activeServer.getPeon().getSegmentsToDrop().isEmpty());
-    Assert.assertTrue(decommissioningServer.getPeon().getSegmentsToDrop().contains(wikiSegment));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, TIER_1, TestDataSource.WIKI));
+    Assertions.assertTrue(activeServer.getPeon().getSegmentsToDrop().isEmpty());
+    Assertions.assertTrue(decommissioningServer.getPeon().getSegmentsToDrop().contains(wikiSegment));
   }
 
   @Test
@@ -159,13 +159,13 @@ public class BroadcastDistributionRuleTest
     final CoordinatorRunStats stats = runRuleOnSegment(rule, wikiSegment, params);
 
     // Verify that segment is assigned to historical, broker as well as indexer
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER_1, TestDataSource.WIKI));
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER_2, TestDataSource.WIKI));
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, broker.getServer().getTier(), TestDataSource.WIKI));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER_1, TestDataSource.WIKI));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER_2, TestDataSource.WIKI));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, broker.getServer().getTier(), TestDataSource.WIKI));
 
-    Assert.assertTrue(historical.isLoadingSegment(wikiSegment));
-    Assert.assertTrue(indexer.isLoadingSegment(wikiSegment));
-    Assert.assertTrue(broker.isLoadingSegment(wikiSegment));
+    Assertions.assertTrue(historical.isLoadingSegment(wikiSegment));
+    Assertions.assertTrue(indexer.isLoadingSegment(wikiSegment));
+    Assertions.assertTrue(broker.isLoadingSegment(wikiSegment));
   }
 
   @Test
@@ -191,7 +191,7 @@ public class BroadcastDistributionRuleTest
                             .withNumPartitions(1)
                             .eachOfSizeInMb(10);
     segmentsInQueue.forEach(s -> serverWithFullQueue.startOperation(SegmentAction.LOAD, s));
-    Assert.assertTrue(serverWithFullQueue.isLoadQueueFull());
+    Assertions.assertTrue(serverWithFullQueue.isLoadQueueFull());
 
     DruidCluster cluster = DruidCluster.builder()
                                        .add(eligibleServer)
@@ -204,18 +204,18 @@ public class BroadcastDistributionRuleTest
     final CoordinatorRunStats stats = runRuleOnSegment(rule, wikiSegment, params);
 
     // Verify that the segment is broadcast only to the eligible server
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER_1, TestDataSource.WIKI));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER_1, TestDataSource.WIKI));
     RowKey metricKey = RowKey.with(Dimension.DATASOURCE, TestDataSource.WIKI)
                              .with(Dimension.TIER, TIER_1)
                              .with(Dimension.SERVER, serverWithNoDiskSpace.getServer().getName())
                              .and(Dimension.DESCRIPTION, "Not enough disk space");
-    Assert.assertEquals(1L, stats.get(Stats.Segments.ASSIGN_SKIPPED, metricKey));
+    Assertions.assertEquals(1L, stats.get(Stats.Segments.ASSIGN_SKIPPED, metricKey));
 
     metricKey = RowKey.with(Dimension.DATASOURCE, TestDataSource.WIKI)
                       .with(Dimension.TIER, TIER_1)
                       .with(Dimension.SERVER, serverWithFullQueue.getServer().getName())
                       .and(Dimension.DESCRIPTION, "Load queue is full");
-    Assert.assertEquals(1L, stats.get(Stats.Segments.ASSIGN_SKIPPED, metricKey));
+    Assertions.assertEquals(1L, stats.get(Stats.Segments.ASSIGN_SKIPPED, metricKey));
   }
 
   private CoordinatorRunStats runRuleOnSegment(

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/ForeverLoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/ForeverLoadRuleTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.client.DruidServer;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -43,15 +43,15 @@ public class ForeverLoadRuleTest
     ObjectMapper jsonMapper = new DefaultObjectMapper();
     Rule reread = jsonMapper.readValue(jsonMapper.writeValueAsString(rule), Rule.class);
 
-    Assert.assertEquals(rule.getTieredReplicants(), ((ForeverLoadRule) reread).getTieredReplicants());
-    Assert.assertEquals(ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS), rule.getTieredReplicants());
+    Assertions.assertEquals(rule.getTieredReplicants(), ((ForeverLoadRule) reread).getTieredReplicants());
+    Assertions.assertEquals(ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS), rule.getTieredReplicants());
   }
 
   @Test
   public void testCreatingNegativeTieredReplicants()
   {
     DruidExceptionMatcher.assertThat(
-        Assert.assertThrows(DruidException.class, () ->
+        Assertions.assertThrows(DruidException.class, () ->
             new ForeverLoadRule(
                 ImmutableMap.of(DruidServer.DEFAULT_TIER, -1),
                 null
@@ -69,7 +69,7 @@ public class ForeverLoadRuleTest
     ForeverLoadRule rule = new ForeverLoadRule(ImmutableMap.of(), false);
 
     LoadRule reread = (LoadRule) OBJECT_MAPPER.readValue(OBJECT_MAPPER.writeValueAsString(rule), Rule.class);
-    Assert.assertEquals(ImmutableMap.of(), reread.getTieredReplicants());
+    Assertions.assertEquals(ImmutableMap.of(), reread.getTieredReplicants());
   }
 
   @Test
@@ -80,7 +80,7 @@ public class ForeverLoadRuleTest
     tieredReplicants.put("tier", null);
 
     DruidExceptionMatcher.assertThat(
-        Assert.assertThrows(DruidException.class, () ->
+        Assertions.assertThrows(DruidException.class, () ->
             new ForeverLoadRule(
                 tieredReplicants,
                 true
@@ -99,7 +99,7 @@ public class ForeverLoadRuleTest
                        + "     \"type\": \"loadForever\"\n"
                        + "  }";
     ForeverLoadRule inputForeverLoadRule = OBJECT_MAPPER.readValue(inputJson, ForeverLoadRule.class);
-    Assert.assertEquals(ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS), inputForeverLoadRule.getTieredReplicants());
+    Assertions.assertEquals(ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS), inputForeverLoadRule.getTieredReplicants());
   }
 
   @Test
@@ -110,7 +110,7 @@ public class ForeverLoadRuleTest
                        + "     \"useDefaultTierForNull\": \"true\"\n"
                        + "  }";
     ForeverLoadRule inputForeverLoadRule = OBJECT_MAPPER.readValue(inputJson, ForeverLoadRule.class);
-    Assert.assertEquals(ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS), inputForeverLoadRule.getTieredReplicants());
+    Assertions.assertEquals(ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS), inputForeverLoadRule.getTieredReplicants());
   }
 
   @Test
@@ -121,6 +121,6 @@ public class ForeverLoadRuleTest
                        + "     \"useDefaultTierForNull\": \"false\"\n"
                        + "  }";
     ForeverLoadRule inputForeverLoadRule = OBJECT_MAPPER.readValue(inputJson, ForeverLoadRule.class);
-    Assert.assertEquals(ImmutableMap.of(), inputForeverLoadRule.getTieredReplicants());
+    Assertions.assertEquals(ImmutableMap.of(), inputForeverLoadRule.getTieredReplicants());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/IntervalLoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/IntervalLoadRuleTest.java
@@ -26,8 +26,8 @@ import org.apache.druid.error.DruidException;
 import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -50,7 +50,7 @@ public class IntervalLoadRuleTest
 
     Rule reread = OBJECT_MAPPER.readValue(OBJECT_MAPPER.writeValueAsString(rule), Rule.class);
 
-    Assert.assertEquals(rule, reread);
+    Assertions.assertEquals(rule, reread);
   }
 
   @Test
@@ -62,15 +62,15 @@ public class IntervalLoadRuleTest
 
     Rule reread = OBJECT_MAPPER.readValue(OBJECT_MAPPER.writeValueAsString(rule), Rule.class);
 
-    Assert.assertEquals(rule, reread);
-    Assert.assertEquals(ImmutableMap.of(), rule.getTieredReplicants());
+    Assertions.assertEquals(rule, reread);
+    Assertions.assertEquals(ImmutableMap.of(), rule.getTieredReplicants());
   }
 
   @Test
   public void testCreatingNegativeTieredReplicants()
   {
     DruidExceptionMatcher.assertThat(
-        Assert.assertThrows(DruidException.class, () ->
+        Assertions.assertThrows(DruidException.class, () ->
             new IntervalLoadRule(
                 Intervals.of("0/3000"),
                 ImmutableMap.of(DruidServer.DEFAULT_TIER, -1),
@@ -91,7 +91,7 @@ public class IntervalLoadRuleTest
     tieredReplicants.put("tier", null);
 
     DruidExceptionMatcher.assertThat(
-        Assert.assertThrows(DruidException.class, () ->
+        Assertions.assertThrows(DruidException.class, () ->
             new IntervalLoadRule(
                 Intervals.of("0/3000"),
                 tieredReplicants,
@@ -112,7 +112,7 @@ public class IntervalLoadRuleTest
                        + "      \"type\": \"loadByInterval\"\n"
                        + "   }";
     IntervalLoadRule inputIntervalLoadRule = OBJECT_MAPPER.readValue(inputJson, IntervalLoadRule.class);
-    Assert.assertEquals(ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS), inputIntervalLoadRule.getTieredReplicants());
+    Assertions.assertEquals(ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS), inputIntervalLoadRule.getTieredReplicants());
   }
 
   @Test
@@ -124,7 +124,7 @@ public class IntervalLoadRuleTest
                        + "      \"useDefaultTierForNull\": \"true\"\n"
                        + "   }";
     IntervalLoadRule inputIntervalLoadRule = OBJECT_MAPPER.readValue(inputJson, IntervalLoadRule.class);
-    Assert.assertEquals(ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS), inputIntervalLoadRule.getTieredReplicants());
+    Assertions.assertEquals(ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS), inputIntervalLoadRule.getTieredReplicants());
   }
 
   @Test
@@ -136,6 +136,6 @@ public class IntervalLoadRuleTest
                        + "      \"useDefaultTierForNull\": \"false\"\n"
                        + "   }";
     IntervalLoadRule inputIntervalLoadRule = OBJECT_MAPPER.readValue(inputJson, IntervalLoadRule.class);
-    Assert.assertEquals(ImmutableMap.of(), inputIntervalLoadRule.getTieredReplicants());
+    Assertions.assertEquals(ImmutableMap.of(), inputIntervalLoadRule.getTieredReplicants());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/LoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/LoadRuleTest.java
@@ -48,13 +48,13 @@ import org.apache.druid.server.coordinator.stats.RowKey;
 import org.apache.druid.server.coordinator.stats.Stats;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -66,7 +66,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  *
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "useRoundRobin = {0}")
+@MethodSource("getTestParams")
 public class LoadRuleTest
 {
   private ListeningExecutorService exec;
@@ -77,7 +78,6 @@ public class LoadRuleTest
 
   private final AtomicInteger serverId = new AtomicInteger();
 
-  @Parameterized.Parameters(name = "useRoundRobin = {0}")
   public static List<Boolean> getTestParams()
   {
     return Arrays.asList(true, false);
@@ -88,7 +88,7 @@ public class LoadRuleTest
     this.useRoundRobinAssignment = useRoundRobinAssignment;
   }
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     exec = MoreExecutors.listeningDecorator(Execs.multiThreaded(1, "LoadRuleTest-%d"));
@@ -96,7 +96,7 @@ public class LoadRuleTest
     loadQueueManager = new SegmentLoadQueueManager(null, null);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     exec.shutdown();
@@ -116,11 +116,11 @@ public class LoadRuleTest
 
     final DataSegment segment = createDataSegment(TestDataSource.WIKI);
     LoadRule rule = loadForever(ImmutableMap.of(Tier.T1, 1, Tier.T2, 2));
-    Assert.assertTrue(rule.shouldMatchingSegmentBeLoaded());
+    Assertions.assertTrue(rule.shouldMatchingSegmentBeLoaded());
     CoordinatorRunStats stats = runRuleAndGetStats(rule, segment, druidCluster);
 
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, TestDataSource.WIKI));
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T2, TestDataSource.WIKI));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, TestDataSource.WIKI));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T2, TestDataSource.WIKI));
   }
 
   private CoordinatorRunStats runRuleAndGetStats(LoadRule rule, DataSegment segment, DruidCluster cluster)
@@ -172,17 +172,17 @@ public class LoadRuleTest
     final LoadRule rule = loadForever(ImmutableMap.of(Tier.T1, 1));
     final DataSegment segment = createDataSegment(TestDataSource.WIKI);
     CoordinatorRunStats firstRunStats = runRuleAndGetStats(rule, segment, druidCluster);
-    Assert.assertEquals(1L, firstRunStats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, segment.getDataSource()));
-    Assert.assertEquals(1, server1.getLoadingSegments().size() + server2.getLoadingSegments().size());
+    Assertions.assertEquals(1L, firstRunStats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, segment.getDataSource()));
+    Assertions.assertEquals(1, server1.getLoadingSegments().size() + server2.getLoadingSegments().size());
 
     // Verify that multiple runs don't assign primary segment again if at replication count
     CoordinatorRunStats secondRunStats = runRuleAndGetStats(rule, segment, druidCluster);
-    Assert.assertFalse(secondRunStats.hasStat(Stats.Segments.ASSIGNED));
-    Assert.assertEquals(1, server1.getLoadingSegments().size() + server2.getLoadingSegments().size());
+    Assertions.assertFalse(secondRunStats.hasStat(Stats.Segments.ASSIGNED));
+    Assertions.assertEquals(1, server1.getLoadingSegments().size() + server2.getLoadingSegments().size());
   }
 
   @Test
-  @Ignore("Enable this test when timeout behaviour is fixed")
+  @Disabled("Enable this test when timeout behaviour is fixed")
   public void testOverAssignForTimedOutSegments()
   {
     ServerHolder server1 = createServer(Tier.T1);
@@ -197,11 +197,11 @@ public class LoadRuleTest
     CoordinatorRunStats stats = runRuleAndGetStats(rule, segment, druidCluster);
 
     // Ensure that the segment is assigned to one of the historicals
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, segment.getDataSource()));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, segment.getDataSource()));
 
     // Ensure that the primary segment is assigned again in case the peon timed out on loading the segment
     CoordinatorRunStats statsAfterLoadPrimary = runRuleAndGetStats(rule, segment, druidCluster);
-    Assert.assertEquals(1L, statsAfterLoadPrimary.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, TestDataSource.WIKI));
+    Assertions.assertEquals(1L, statsAfterLoadPrimary.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, TestDataSource.WIKI));
   }
 
   @Test
@@ -219,13 +219,13 @@ public class LoadRuleTest
     CoordinatorRunStats stats = runRuleAndGetStats(rule, segment, druidCluster);
 
     // Ensure that the segment is assigned to one of the historicals
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, segment.getDataSource()));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, segment.getDataSource()));
 
     // Add the segment to the timed out list to simulate peon timeout on loading the segment
     // Default behavior is to not replicate the timed out segments on other servers
     CoordinatorRunStats statsAfterLoadPrimary = runRuleAndGetStats(rule, segment, druidCluster);
 
-    Assert.assertFalse(statsAfterLoadPrimary.hasStat(Stats.Segments.ASSIGNED));
+    Assertions.assertFalse(statsAfterLoadPrimary.hasStat(Stats.Segments.ASSIGNED));
   }
 
   @Test
@@ -251,7 +251,7 @@ public class LoadRuleTest
         segments.get(1),
         makeCoordinatorRuntimeParams(druidCluster, segments.toArray(new DataSegment[0]))
     );
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, TestDataSource.WIKI));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, TestDataSource.WIKI));
   }
 
   @Test
@@ -270,11 +270,11 @@ public class LoadRuleTest
         .build();
 
     LoadRule rule = loadForever(ImmutableMap.of(Tier.T1, 0, Tier.T2, 0));
-    Assert.assertFalse(rule.shouldMatchingSegmentBeLoaded());
+    Assertions.assertFalse(rule.shouldMatchingSegmentBeLoaded());
     CoordinatorRunStats stats = runRuleAndGetStats(rule, segment, druidCluster);
 
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, Tier.T1, TestDataSource.WIKI));
-    Assert.assertEquals(2L, stats.getSegmentStat(Stats.Segments.DROPPED, Tier.T2, TestDataSource.WIKI));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, Tier.T1, TestDataSource.WIKI));
+    Assertions.assertEquals(2L, stats.getSegmentStat(Stats.Segments.DROPPED, Tier.T2, TestDataSource.WIKI));
   }
 
   @Test
@@ -288,10 +288,10 @@ public class LoadRuleTest
 
     final DataSegment segment = createDataSegment(TestDataSource.WIKI);
     LoadRule rule = loadForever(ImmutableMap.of("invalidTier", 1, Tier.T1, 1));
-    Assert.assertTrue(rule.shouldMatchingSegmentBeLoaded());
+    Assertions.assertTrue(rule.shouldMatchingSegmentBeLoaded());
     CoordinatorRunStats stats = runRuleAndGetStats(rule, segment, druidCluster);
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, TestDataSource.WIKI));
-    Assert.assertEquals(0L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "invalidTier", TestDataSource.WIKI));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, TestDataSource.WIKI));
+    Assertions.assertEquals(0L, stats.getSegmentStat(Stats.Segments.ASSIGNED, "invalidTier", TestDataSource.WIKI));
   }
 
   @Test
@@ -310,8 +310,8 @@ public class LoadRuleTest
     LoadRule rule = loadForever(ImmutableMap.of("invalidTier", 1, Tier.T1, 1));
     CoordinatorRunStats stats = runRuleAndGetStats(rule, segment, druidCluster);
 
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, Tier.T1, TestDataSource.WIKI));
-    Assert.assertEquals(0L, stats.getSegmentStat(Stats.Segments.DROPPED, "invalidTier", TestDataSource.WIKI));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, Tier.T1, TestDataSource.WIKI));
+    Assertions.assertEquals(0L, stats.getSegmentStat(Stats.Segments.DROPPED, "invalidTier", TestDataSource.WIKI));
   }
 
   @Test
@@ -351,14 +351,14 @@ public class LoadRuleTest
         .build();
 
     final LoadRule rule = loadForever(ImmutableMap.of(Tier.T1, 1));
-    Assert.assertTrue(rule.shouldMatchingSegmentBeLoaded());
+    Assertions.assertTrue(rule.shouldMatchingSegmentBeLoaded());
     CoordinatorRunStats stats1 = runRuleAndGetStats(rule, dataSegment1, params);
     CoordinatorRunStats stats2 = runRuleAndGetStats(rule, dataSegment2, params);
     CoordinatorRunStats stats3 = runRuleAndGetStats(rule, dataSegment3, params);
 
-    Assert.assertEquals(1L, stats1.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, dataSegment1.getDataSource()));
-    Assert.assertEquals(1L, stats2.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, dataSegment2.getDataSource()));
-    Assert.assertEquals(0L, stats3.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, dataSegment3.getDataSource()));
+    Assertions.assertEquals(1L, stats1.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, dataSegment1.getDataSource()));
+    Assertions.assertEquals(1L, stats2.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, dataSegment2.getDataSource()));
+    Assertions.assertEquals(0L, stats3.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, dataSegment3.getDataSource()));
   }
 
   @Test
@@ -375,14 +375,14 @@ public class LoadRuleTest
 
     // Load rule requires 1 replica on each tier
     LoadRule rule = loadForever(ImmutableMap.of(Tier.T1, 1, Tier.T2, 1));
-    Assert.assertTrue(rule.shouldMatchingSegmentBeLoaded());
+    Assertions.assertTrue(rule.shouldMatchingSegmentBeLoaded());
     DataSegment segment = createDataSegment(TestDataSource.WIKI);
     CoordinatorRunStats stats = runRuleAndGetStats(rule, segment, druidCluster);
 
     // Verify that segment is not loaded on decommissioning server
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T2, TestDataSource.WIKI));
-    Assert.assertEquals(0, decommServerT1.getLoadingSegments().size());
-    Assert.assertTrue(serverT2.getLoadingSegments().contains(segment));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T2, TestDataSource.WIKI));
+    Assertions.assertEquals(0, decommServerT1.getLoadingSegments().size());
+    Assertions.assertTrue(serverT2.getLoadingSegments().contains(segment));
   }
 
   @Test
@@ -406,11 +406,11 @@ public class LoadRuleTest
     CoordinatorRunStats stats = runRuleAndGetStats(rule, segment, druidCluster);
 
     // Verify that no replica is assigned to decommissioning server
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, TestDataSource.WIKI));
-    Assert.assertTrue(decommServerT11.getLoadingSegments().isEmpty());
-    Assert.assertEquals(0, decommServerT11.getLoadingSegments().size());
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, TestDataSource.WIKI));
+    Assertions.assertTrue(decommServerT11.getLoadingSegments().isEmpty());
+    Assertions.assertEquals(0, decommServerT11.getLoadingSegments().size());
 
-    Assert.assertEquals(2L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T2, TestDataSource.WIKI));
+    Assertions.assertEquals(2L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T2, TestDataSource.WIKI));
   }
 
   /**
@@ -433,14 +433,14 @@ public class LoadRuleTest
 
     DruidCoordinatorRuntimeParams params = makeCoordinatorRuntimeParams(druidCluster, segment1, segment2);
     final LoadRule rule = loadForever(ImmutableMap.of(Tier.T1, 0));
-    Assert.assertFalse(rule.shouldMatchingSegmentBeLoaded());
+    Assertions.assertFalse(rule.shouldMatchingSegmentBeLoaded());
     CoordinatorRunStats stats = runRuleAndGetStats(rule, segment1, params);
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, Tier.T1, segment1.getDataSource()));
-    Assert.assertTrue(server1.getPeon().getSegmentsToDrop().contains(segment1));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, Tier.T1, segment1.getDataSource()));
+    Assertions.assertTrue(server1.getPeon().getSegmentsToDrop().contains(segment1));
 
     stats = runRuleAndGetStats(rule, segment2, params);
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, Tier.T1, segment2.getDataSource()));
-    Assert.assertTrue(server2.getPeon().getSegmentsToDrop().contains(segment2));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, Tier.T1, segment2.getDataSource()));
+    Assertions.assertTrue(server2.getPeon().getSegmentsToDrop().contains(segment2));
   }
 
   @Test
@@ -467,10 +467,10 @@ public class LoadRuleTest
     );
 
     // Verify that the extra replica is dropped from the decommissioning server
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, Tier.T1, TestDataSource.WIKI));
-    Assert.assertEquals(0, server1.getPeon().getSegmentsToDrop().size());
-    Assert.assertEquals(1, server2.getPeon().getSegmentsToDrop().size());
-    Assert.assertEquals(0, server3.getPeon().getSegmentsToDrop().size());
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.DROPPED, Tier.T1, TestDataSource.WIKI));
+    Assertions.assertEquals(0, server1.getPeon().getSegmentsToDrop().size());
+    Assertions.assertEquals(1, server2.getPeon().getSegmentsToDrop().size());
+    Assertions.assertEquals(0, server3.getPeon().getSegmentsToDrop().size());
   }
 
   private DataSegment createDataSegment(String dataSource)
@@ -554,9 +554,9 @@ public class LoadRuleTest
         )
     );
 
-    Assert.assertEquals(0L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, TestDataSource.WIKI));
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T2, TestDataSource.WIKI));
-    Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T3, TestDataSource.WIKI));
+    Assertions.assertEquals(0L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, TestDataSource.WIKI));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T2, TestDataSource.WIKI));
+    Assertions.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T3, TestDataSource.WIKI));
   }
 
   /**
@@ -591,12 +591,12 @@ public class LoadRuleTest
     // Required capacity is reported against the physical tier AND tagged with the alias
     final RowKey t2WithAlias = RowKey.with(Dimension.TIER, Tier.T2).and(Dimension.TIER_ALIAS, Tier.T1);
     final RowKey t3WithAlias = RowKey.with(Dimension.TIER, Tier.T3).and(Dimension.TIER_ALIAS, Tier.T1);
-    Assert.assertEquals(segment.getSize(), stats.get(Stats.Tier.REQUIRED_CAPACITY, t2WithAlias));
-    Assert.assertEquals(segment.getSize(), stats.get(Stats.Tier.REQUIRED_CAPACITY, t3WithAlias));
+    Assertions.assertEquals(segment.getSize(), stats.get(Stats.Tier.REQUIRED_CAPACITY, t2WithAlias));
+    Assertions.assertEquals(segment.getSize(), stats.get(Stats.Tier.REQUIRED_CAPACITY, t3WithAlias));
 
     // The same stat without the alias dimension is a different row and must be absent
-    Assert.assertEquals(0L, stats.get(Stats.Tier.REQUIRED_CAPACITY, RowKey.of(Dimension.TIER, Tier.T2)));
-    Assert.assertEquals(0L, stats.get(Stats.Tier.REQUIRED_CAPACITY, RowKey.of(Dimension.TIER, Tier.T3)));
+    Assertions.assertEquals(0L, stats.get(Stats.Tier.REQUIRED_CAPACITY, RowKey.of(Dimension.TIER, Tier.T2)));
+    Assertions.assertEquals(0L, stats.get(Stats.Tier.REQUIRED_CAPACITY, RowKey.of(Dimension.TIER, Tier.T3)));
   }
 
   /**
@@ -626,13 +626,13 @@ public class LoadRuleTest
     rule.run(segment, params.getSegmentAssigner());
     Map<String, Set<String>> invalidTiers = params.getSegmentAssigner().getDatasourceToInvalidLoadTiers();
 
-    Assert.assertFalse(
-        "Alias key tier should not trigger an invalid-tier alert",
-        invalidTiers.getOrDefault(TestDataSource.WIKI, Collections.emptySet()).contains(Tier.T1)
+    Assertions.assertFalse(
+        invalidTiers.getOrDefault(TestDataSource.WIKI, Collections.emptySet()).contains(Tier.T1),
+        "Alias key tier should not trigger an invalid-tier alert"
     );
-    Assert.assertTrue(
-        "Alias value tier with no servers should trigger an invalid-tier alert",
-        invalidTiers.getOrDefault(TestDataSource.WIKI, Collections.emptySet()).contains(Tier.T3)
+    Assertions.assertTrue(
+        invalidTiers.getOrDefault(TestDataSource.WIKI, Collections.emptySet()).contains(Tier.T3),
+        "Alias value tier with no servers should trigger an invalid-tier alert"
     );
   }
 
@@ -665,8 +665,8 @@ public class LoadRuleTest
         )
     );
 
-    Assert.assertEquals(0L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, TestDataSource.WIKI));
-    Assert.assertEquals(2L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T2, TestDataSource.WIKI));
+    Assertions.assertEquals(0L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T1, TestDataSource.WIKI));
+    Assertions.assertEquals(2L, stats.getSegmentStat(Stats.Segments.ASSIGNED, Tier.T2, TestDataSource.WIKI));
   }
 
   private DruidCoordinatorRuntimeParams makeCoordinatorRuntimeParams(

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodDropBeforeRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodDropBeforeRuleTest.java
@@ -27,8 +27,8 @@ import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PeriodDropBeforeRuleTest
 {
@@ -49,7 +49,7 @@ public class PeriodDropBeforeRuleTest
     ObjectMapper jsonMapper = new DefaultObjectMapper();
     Rule reread = jsonMapper.readValue(jsonMapper.writeValueAsString(rule), Rule.class);
 
-    Assert.assertEquals(rule.getPeriod(), ((PeriodDropBeforeRule) reread).getPeriod());
+    Assertions.assertEquals(rule.getPeriod(), ((PeriodDropBeforeRule) reread).getPeriod());
   }
 
   @Test
@@ -60,25 +60,25 @@ public class PeriodDropBeforeRuleTest
         new Period("P1D")
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         rule.appliesTo(
             BUILDER.interval(new Interval(now.minusDays(3), now.minusDays(2))).build(),
             now
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         rule.appliesTo(
             BUILDER.interval(new Interval(now.minusDays(2), now.minusDays(1))).build(),
             now
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         rule.appliesTo(
             BUILDER.interval(new Interval(now.minusDays(1), now)).build(),
             now
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         rule.appliesTo(
             BUILDER.interval(new Interval(now, now.plusDays(1))).build(),
             now

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodDropRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodDropRuleTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  */
@@ -48,7 +48,7 @@ public class PeriodDropRuleTest
         false
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         rule.appliesTo(
             BUILDER.interval(
                 new Interval(
@@ -59,7 +59,7 @@ public class PeriodDropRuleTest
             now
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         rule.appliesTo(
             BUILDER.interval(new Interval(now.minusYears(100), now.minusDays(1)))
                        .build(),
@@ -77,28 +77,28 @@ public class PeriodDropRuleTest
         false
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         rule.appliesTo(
             BUILDER.interval(new Interval(now.minusWeeks(1), now.minusDays(1)))
                        .build(),
             now
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         rule.appliesTo(
             BUILDER.interval(new Interval(now.minusDays(1), now))
                    .build(),
             now
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         rule.appliesTo(
             BUILDER.interval(new Interval(now.minusYears(1), now.minusDays(1)))
                        .build(),
             now
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         rule.appliesTo(
             BUILDER.interval(new Interval(now.minusMonths(2), now.minusDays(1)))
                        .build(),
@@ -120,13 +120,13 @@ public class PeriodDropRuleTest
         false
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         includeFutureRule.appliesTo(
             BUILDER.interval(new Interval(now.plusDays(1), now.plusDays(2))).build(),
             now
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         notIncludeFutureRule.appliesTo(
             BUILDER.interval(new Interval(now.plusDays(1), now.plusDays(2))).build(),
             now

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodLoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/PeriodLoadRuleTest.java
@@ -33,8 +33,8 @@ import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -63,9 +63,9 @@ public class PeriodLoadRuleTest
         null
     );
 
-    Assert.assertTrue(rule.appliesTo(BUILDER.interval(Intervals.of("2012-01-01/2012-12-31")).build(), now));
-    Assert.assertTrue(rule.appliesTo(BUILDER.interval(Intervals.of("1000-01-01/2012-12-31")).build(), now));
-    Assert.assertTrue(rule.appliesTo(BUILDER.interval(Intervals.of("0500-01-01/2100-12-31")).build(), now));
+    Assertions.assertTrue(rule.appliesTo(BUILDER.interval(Intervals.of("2012-01-01/2012-12-31")).build(), now));
+    Assertions.assertTrue(rule.appliesTo(BUILDER.interval(Intervals.of("1000-01-01/2012-12-31")).build(), now));
+    Assertions.assertTrue(rule.appliesTo(BUILDER.interval(Intervals.of("0500-01-01/2100-12-31")).build(), now));
   }
 
   @Test
@@ -79,15 +79,15 @@ public class PeriodLoadRuleTest
         null
     );
 
-    Assert.assertTrue(rule.appliesTo(BUILDER.interval(new Interval(now.minusWeeks(1), now)).build(), now));
-    Assert.assertTrue(
+    Assertions.assertTrue(rule.appliesTo(BUILDER.interval(new Interval(now.minusWeeks(1), now)).build(), now));
+    Assertions.assertTrue(
         rule.appliesTo(
             BUILDER.interval(new Interval(now.minusDays(1), now.plusDays(1)))
                    .build(),
             now
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         rule.appliesTo(
             BUILDER.interval(new Interval(now.plusDays(1), now.plusDays(2)))
                    .build(),
@@ -107,13 +107,13 @@ public class PeriodLoadRuleTest
         null
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         rule.appliesTo(
             BUILDER.interval(new Interval(now.minusWeeks(1), now.plusWeeks(1))).build(),
             now
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         rule.appliesTo(
             BUILDER.interval(
                 new Interval(now.minusMonths(1).minusWeeks(1), now.minusMonths(1).plusWeeks(1))
@@ -140,13 +140,13 @@ public class PeriodLoadRuleTest
         null
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         includeFutureRule.appliesTo(
             BUILDER.interval(new Interval(now.plusDays(1), now.plusDays(2))).build(),
             now
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         notIncludeFutureRule.appliesTo(
             BUILDER.interval(new Interval(now.plusDays(1), now.plusDays(2))).build(),
             now
@@ -166,11 +166,11 @@ public class PeriodLoadRuleTest
 
     Rule reread = OBJECT_MAPPER.readValue(OBJECT_MAPPER.writeValueAsString(rule), Rule.class);
 
-    Assert.assertEquals(rule.getPeriod(), ((PeriodLoadRule) reread).getPeriod());
-    Assert.assertEquals(rule.isIncludeFuture(), ((PeriodLoadRule) reread).isIncludeFuture());
-    Assert.assertEquals(PeriodLoadRule.DEFAULT_INCLUDE_FUTURE, rule.isIncludeFuture());
-    Assert.assertEquals(rule.getTieredReplicants(), ((PeriodLoadRule) reread).getTieredReplicants());
-    Assert.assertEquals(ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS), rule.getTieredReplicants());
+    Assertions.assertEquals(rule.getPeriod(), ((PeriodLoadRule) reread).getPeriod());
+    Assertions.assertEquals(rule.isIncludeFuture(), ((PeriodLoadRule) reread).isIncludeFuture());
+    Assertions.assertEquals(PeriodLoadRule.DEFAULT_INCLUDE_FUTURE, rule.isIncludeFuture());
+    Assertions.assertEquals(rule.getTieredReplicants(), ((PeriodLoadRule) reread).getTieredReplicants());
+    Assertions.assertEquals(ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS), rule.getTieredReplicants());
   }
 
   /**
@@ -190,16 +190,16 @@ public class PeriodLoadRuleTest
                           + "    }";
     PeriodLoadRule inputPeriodLoadRule = OBJECT_MAPPER.readValue(inputJson, PeriodLoadRule.class);
     PeriodLoadRule expectedPeriodLoadRule = OBJECT_MAPPER.readValue(expectedJson, PeriodLoadRule.class);
-    Assert.assertEquals(expectedPeriodLoadRule.getTieredReplicants(), inputPeriodLoadRule.getTieredReplicants());
-    Assert.assertEquals(expectedPeriodLoadRule.getPeriod(), inputPeriodLoadRule.getPeriod());
-    Assert.assertEquals(expectedPeriodLoadRule.isIncludeFuture(), inputPeriodLoadRule.isIncludeFuture());
+    Assertions.assertEquals(expectedPeriodLoadRule.getTieredReplicants(), inputPeriodLoadRule.getTieredReplicants());
+    Assertions.assertEquals(expectedPeriodLoadRule.getPeriod(), inputPeriodLoadRule.getPeriod());
+    Assertions.assertEquals(expectedPeriodLoadRule.isIncludeFuture(), inputPeriodLoadRule.isIncludeFuture());
   }
 
   @Test
   public void testCreatingNegativeTieredReplicants()
   {
     DruidExceptionMatcher.assertThat(
-        Assert.assertThrows(DruidException.class, () ->
+        Assertions.assertThrows(DruidException.class, () ->
             new PeriodLoadRule(
                 Period.days(1),
                 true,
@@ -221,7 +221,7 @@ public class PeriodLoadRuleTest
     tieredReplicants.put("tier", null);
 
     DruidExceptionMatcher.assertThat(
-        Assert.assertThrows(DruidException.class, () ->
+        Assertions.assertThrows(DruidException.class, () ->
             new PeriodLoadRule(
                 Period.days(1),
                 true,
@@ -245,7 +245,7 @@ public class PeriodLoadRuleTest
                        + "      \"type\": \"loadByPeriod\"\n"
                        + "    }";
     PeriodLoadRule inputPeriodLoadRule = OBJECT_MAPPER.readValue(inputJson, PeriodLoadRule.class);
-    Assert.assertEquals(ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS), inputPeriodLoadRule.getTieredReplicants());
+    Assertions.assertEquals(ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS), inputPeriodLoadRule.getTieredReplicants());
   }
 
   @Test
@@ -258,7 +258,7 @@ public class PeriodLoadRuleTest
                        + "      \"type\": \"loadByPeriod\"\n"
                        + "    }";
     PeriodLoadRule inputPeriodLoadRule = OBJECT_MAPPER.readValue(inputJson, PeriodLoadRule.class);
-    Assert.assertEquals(ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS), inputPeriodLoadRule.getTieredReplicants());
+    Assertions.assertEquals(ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS), inputPeriodLoadRule.getTieredReplicants());
   }
 
   @Test
@@ -271,7 +271,7 @@ public class PeriodLoadRuleTest
                        + "     \"type\": \"loadByPeriod\"\n"
                        + "  }";
     PeriodLoadRule inputPeriodLoadRule = OBJECT_MAPPER.readValue(inputJson, PeriodLoadRule.class);
-    Assert.assertEquals(ImmutableMap.of(), inputPeriodLoadRule.getTieredReplicants());
+    Assertions.assertEquals(ImmutableMap.of(), inputPeriodLoadRule.getTieredReplicants());
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/BalancingStrategiesTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/BalancingStrategiesTest.java
@@ -22,15 +22,17 @@ package org.apache.druid.server.coordinator.simulate;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.segment.TestDataSource;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "{0}")
+@MethodSource("getTestParameters")
 public class BalancingStrategiesTest extends CoordinatorSimulationBaseTest
 {
   private static final long SIZE_1TB = 1_000_000;
@@ -38,7 +40,6 @@ public class BalancingStrategiesTest extends CoordinatorSimulationBaseTest
   private final String strategy;
   private final List<DataSegment> segments = Segments.WIKI_10X100D;
 
-  @Parameterized.Parameters(name = "{0}")
   public static String[] getTestParameters()
   {
     return new String[]{"cost", "cachingCost"};
@@ -50,6 +51,7 @@ public class BalancingStrategiesTest extends CoordinatorSimulationBaseTest
   }
 
   @Override
+  @BeforeEach
   public void setUp()
   {
 
@@ -79,7 +81,7 @@ public class BalancingStrategiesTest extends CoordinatorSimulationBaseTest
     verifyNotEmitted(Metric.MOVED_COUNT);
 
     for (DruidServer historical : historicals) {
-      Assert.assertEquals(200, historical.getTotalSegments());
+      Assertions.assertEquals(200, historical.getTotalSegments());
     }
 
     // Run 2: nothing is assigned, nothing is moved as servers are already balanced
@@ -114,7 +116,7 @@ public class BalancingStrategiesTest extends CoordinatorSimulationBaseTest
 
     // Verify that each server is equally loaded
     for (DruidServer historical : historicals) {
-      Assert.assertEquals(250, historical.getTotalSegments());
+      Assertions.assertEquals(250, historical.getTotalSegments());
     }
 
     // Add another historical
@@ -131,7 +133,7 @@ public class BalancingStrategiesTest extends CoordinatorSimulationBaseTest
     // Verify that the segments have been balanced
     for (DruidServer historical : historicals) {
       long loadedSegments = historical.getTotalSegments();
-      Assert.assertTrue(loadedSegments >= 195 && loadedSegments <= 205);
+      Assertions.assertTrue(loadedSegments >= 195 && loadedSegments <= 205);
     }
   }
 
@@ -160,7 +162,7 @@ public class BalancingStrategiesTest extends CoordinatorSimulationBaseTest
 
     // Verify that each server is equally loaded
     for (DruidServer historical : historicals) {
-      Assert.assertEquals(200, historical.getTotalSegments());
+      Assertions.assertEquals(200, historical.getTotalSegments());
     }
 
     // Remove a historical
@@ -171,10 +173,10 @@ public class BalancingStrategiesTest extends CoordinatorSimulationBaseTest
     runCoordinatorCycle();
     loadQueuedSegments();
     int assignedCount = getValue(Metric.ASSIGNED_COUNT, null).intValue();
-    Assert.assertTrue(assignedCount >= 200);
+    Assertions.assertTrue(assignedCount >= 200);
 
     for (DruidServer historical : historicals) {
-      Assert.assertEquals(250, historical.getTotalSegments());
+      Assertions.assertEquals(250, historical.getTotalSegments());
     }
   }
 

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBaseTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBaseTest.java
@@ -32,9 +32,9 @@ import org.apache.druid.server.coordinator.rules.ForeverLoadRule;
 import org.apache.druid.server.coordinator.rules.Rule;
 import org.apache.druid.server.coordinator.stats.Dimension;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -62,10 +62,10 @@ public abstract class CoordinatorSimulationBaseTest implements
   private CoordinatorSimulation sim;
   private MetricsVerifier metricsVerifier;
 
-  @Before
+  @BeforeEach
   public abstract void setUp();
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     if (sim != null) {
@@ -165,7 +165,7 @@ public abstract class CoordinatorSimulationBaseTest implements
   // Verification methods
   void verifyDatasourceIsFullyLoaded(String datasource)
   {
-    Assert.assertEquals(100.0, getLoadPercentage(datasource), DOUBLE_DELTA);
+    Assertions.assertEquals(100.0, getLoadPercentage(datasource), DOUBLE_DELTA);
   }
 
   @Override

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/HistoricalCloningTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/HistoricalCloningTest.java
@@ -23,8 +23,9 @@ import org.apache.druid.client.DruidServer;
 import org.apache.druid.segment.TestDataSource;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.apache.druid.server.coordinator.stats.Stats;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -39,6 +40,7 @@ public class HistoricalCloningTest extends CoordinatorSimulationBaseTest
   private final String datasource = TestDataSource.WIKI;
 
   @Override
+  @BeforeEach
   public void setUp()
   {
     // Setup historicals for 1 tier, size 1 TB each
@@ -84,11 +86,11 @@ public class HistoricalCloningTest extends CoordinatorSimulationBaseTest
         10L
     );
 
-    Assert.assertEquals(Segments.WIKI_10X1D.size(), historicalT11.getTotalSegments());
-    Assert.assertEquals(Segments.WIKI_10X1D.size(), historicalT12.getTotalSegments());
+    Assertions.assertEquals(Segments.WIKI_10X1D.size(), historicalT11.getTotalSegments());
+    Assertions.assertEquals(Segments.WIKI_10X1D.size(), historicalT12.getTotalSegments());
     Segments.WIKI_10X1D.forEach(segment -> {
-      Assert.assertEquals(segment, historicalT11.getSegment(segment.getId()));
-      Assert.assertEquals(segment, historicalT12.getSegment(segment.getId()));
+      Assertions.assertEquals(segment, historicalT11.getSegment(segment.getId()));
+      Assertions.assertEquals(segment, historicalT12.getSegment(segment.getId()));
     });
   }
 
@@ -120,8 +122,8 @@ public class HistoricalCloningTest extends CoordinatorSimulationBaseTest
     runCoordinatorCycle();
 
     // Confirm number of segments.
-    Assert.assertEquals(10, historicalT11.getTotalSegments());
-    Assert.assertEquals(10, historicalT12.getTotalSegments());
+    Assertions.assertEquals(10, historicalT11.getTotalSegments());
+    Assertions.assertEquals(10, historicalT12.getTotalSegments());
 
     // Add a new historical.
     final DruidServer newHistorical = createHistorical(3, Tier.T1, 10_000);
@@ -131,9 +133,9 @@ public class HistoricalCloningTest extends CoordinatorSimulationBaseTest
     runCoordinatorCycle();
 
     // Check that segments have been distributed to the new historical and have also been dropped by the clone
-    Assert.assertEquals(5, historicalT11.getTotalSegments());
-    Assert.assertEquals(5, historicalT12.getTotalSegments());
-    Assert.assertEquals(5, newHistorical.getTotalSegments());
+    Assertions.assertEquals(5, historicalT11.getTotalSegments());
+    Assertions.assertEquals(5, historicalT12.getTotalSegments());
+    Assertions.assertEquals(5, newHistorical.getTotalSegments());
     verifyValue(
         Stats.Segments.DROPPED_FROM_CLONE.getMetricName(),
         Map.of("server", historicalT12.getName()),
@@ -162,8 +164,8 @@ public class HistoricalCloningTest extends CoordinatorSimulationBaseTest
 
     // Run 1: All segments are loaded.
     runCoordinatorCycle();
-    Assert.assertEquals(10, historicalT11.getTotalSegments());
-    Assert.assertEquals(10, historicalT12.getTotalSegments());
+    Assertions.assertEquals(10, historicalT11.getTotalSegments());
+    Assertions.assertEquals(10, historicalT12.getTotalSegments());
 
     // Target server disappears, loses loaded segments.
     removeServer(historicalT12);
@@ -172,8 +174,8 @@ public class HistoricalCloningTest extends CoordinatorSimulationBaseTest
     // Run 2: No change in source historical.
     runCoordinatorCycle();
 
-    Assert.assertEquals(10, historicalT11.getTotalSegments());
-    Assert.assertEquals(0, historicalT12.getTotalSegments());
+    Assertions.assertEquals(10, historicalT11.getTotalSegments());
+    Assertions.assertEquals(0, historicalT12.getTotalSegments());
 
     // Server readded
     addServer(historicalT12);
@@ -181,8 +183,8 @@ public class HistoricalCloningTest extends CoordinatorSimulationBaseTest
     // Run 3: Segments recloned.
     runCoordinatorCycle();
 
-    Assert.assertEquals(10, historicalT11.getTotalSegments());
-    Assert.assertEquals(10, historicalT12.getTotalSegments());
+    Assertions.assertEquals(10, historicalT11.getTotalSegments());
+    Assertions.assertEquals(10, historicalT12.getTotalSegments());
     verifyValue(
         Stats.Segments.ASSIGNED_TO_CLONE.getMetricName(),
         Map.of("server", historicalT12.getName()),
@@ -194,11 +196,11 @@ public class HistoricalCloningTest extends CoordinatorSimulationBaseTest
         10L
     );
 
-    Assert.assertEquals(Segments.WIKI_10X1D.size(), historicalT11.getTotalSegments());
-    Assert.assertEquals(Segments.WIKI_10X1D.size(), historicalT12.getTotalSegments());
+    Assertions.assertEquals(Segments.WIKI_10X1D.size(), historicalT11.getTotalSegments());
+    Assertions.assertEquals(Segments.WIKI_10X1D.size(), historicalT12.getTotalSegments());
     Segments.WIKI_10X1D.forEach(segment -> {
-      Assert.assertEquals(segment, historicalT11.getSegment(segment.getId()));
-      Assert.assertEquals(segment, historicalT12.getSegment(segment.getId()));
+      Assertions.assertEquals(segment, historicalT11.getSegment(segment.getId()));
+      Assertions.assertEquals(segment, historicalT12.getSegment(segment.getId()));
     });
   }
 
@@ -225,8 +227,8 @@ public class HistoricalCloningTest extends CoordinatorSimulationBaseTest
 
     // Run 1: All segments are loaded on the source historical
     runCoordinatorCycle();
-    Assert.assertEquals(1000, historicalT11.getTotalSegments());
-    Assert.assertEquals(0, historicalT12.getTotalSegments());
+    Assertions.assertEquals(1000, historicalT11.getTotalSegments());
+    Assertions.assertEquals(0, historicalT12.getTotalSegments());
 
     // Clone server now added.
     addServer(historicalT12);
@@ -234,8 +236,8 @@ public class HistoricalCloningTest extends CoordinatorSimulationBaseTest
     // Run 2: Assigns all segments to the cloned historical
     runCoordinatorCycle();
 
-    Assert.assertEquals(1000, historicalT11.getTotalSegments());
-    Assert.assertEquals(1000, historicalT12.getTotalSegments());
+    Assertions.assertEquals(1000, historicalT11.getTotalSegments());
+    Assertions.assertEquals(1000, historicalT12.getTotalSegments());
 
     verifyValue(
         Stats.Segments.ASSIGNED_TO_CLONE.getMetricName(),
@@ -277,7 +279,7 @@ public class HistoricalCloningTest extends CoordinatorSimulationBaseTest
       runCoordinatorCycle();
 
       // Check that all segments are cloned.
-      Assert.assertEquals(historicalT11.getTotalSegments(), historicalT12.getTotalSegments());
+      Assertions.assertEquals(historicalT11.getTotalSegments(), historicalT12.getTotalSegments());
 
       // Check that the replication throttling is respected.
       verifyValue(Metric.ASSIGNED_COUNT, 2L);
@@ -288,13 +290,13 @@ public class HistoricalCloningTest extends CoordinatorSimulationBaseTest
       );
     }
 
-    Assert.assertEquals(Segments.WIKI_10X1D.size(), historicalT11.getTotalSegments());
-    Assert.assertEquals(Segments.WIKI_10X1D.size(), historicalT12.getTotalSegments());
-    Assert.assertEquals(Segments.WIKI_10X1D.size(), historicalT13.getTotalSegments());
+    Assertions.assertEquals(Segments.WIKI_10X1D.size(), historicalT11.getTotalSegments());
+    Assertions.assertEquals(Segments.WIKI_10X1D.size(), historicalT12.getTotalSegments());
+    Assertions.assertEquals(Segments.WIKI_10X1D.size(), historicalT13.getTotalSegments());
     Segments.WIKI_10X1D.forEach(segment -> {
-      Assert.assertEquals(segment, historicalT11.getSegment(segment.getId()));
-      Assert.assertEquals(segment, historicalT12.getSegment(segment.getId()));
-      Assert.assertEquals(segment, historicalT13.getSegment(segment.getId()));
+      Assertions.assertEquals(segment, historicalT11.getSegment(segment.getId()));
+      Assertions.assertEquals(segment, historicalT12.getSegment(segment.getId()));
+      Assertions.assertEquals(segment, historicalT13.getSegment(segment.getId()));
     });
   }
 
@@ -339,7 +341,7 @@ public class HistoricalCloningTest extends CoordinatorSimulationBaseTest
     );
 
     loadQueuedSegments();
-    Assert.assertEquals(5, historicalT11.getTotalSegments());
-    Assert.assertEquals(5, historicalT12.getTotalSegments());
+    Assertions.assertEquals(5, historicalT11.getTotalSegments());
+    Assertions.assertEquals(5, historicalT12.getTotalSegments());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/HistoricalTierAliasTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/HistoricalTierAliasTest.java
@@ -24,7 +24,8 @@ import org.apache.druid.segment.TestDataSource;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.apache.druid.server.coordinator.stats.Dimension;
 import org.apache.druid.server.coordinator.stats.Stats;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Set;
@@ -45,6 +46,7 @@ public class HistoricalTierAliasTest extends CoordinatorSimulationBaseTest
   private final String datasource = TestDataSource.WIKI;
 
   @Override
+  @BeforeEach
   public void setUp()
   {
     // T1 and T2 are interchangeable physical tiers grouped under the alias "hot"

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/MarkSegmentsAsUnusedTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/MarkSegmentsAsUnusedTest.java
@@ -23,7 +23,8 @@ import org.apache.druid.client.DruidServer;
 import org.apache.druid.segment.TestDataSource;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +33,7 @@ import java.util.stream.Collectors;
 public class MarkSegmentsAsUnusedTest extends CoordinatorSimulationBaseTest
 {
   @Override
+  @BeforeEach
   public void setUp()
   {
 

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/RoundRobinAssignmentTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/RoundRobinAssignmentTest.java
@@ -23,8 +23,9 @@ import org.apache.druid.client.DruidServer;
 import org.apache.druid.segment.TestDataSource;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,6 +37,7 @@ public class RoundRobinAssignmentTest extends CoordinatorSimulationBaseTest
   private List<DruidServer> historicals;
 
   @Override
+  @BeforeEach
   public void setUp()
   {
     historicals = new ArrayList<>();
@@ -71,7 +73,7 @@ public class RoundRobinAssignmentTest extends CoordinatorSimulationBaseTest
     verifyValue(Metric.ASSIGNED_COUNT, 2000L);
 
     for (DruidServer historical : historicals) {
-      Assert.assertEquals(200, historical.getTotalSegments());
+      Assertions.assertEquals(200, historical.getTotalSegments());
     }
   }
 
@@ -107,7 +109,7 @@ public class RoundRobinAssignmentTest extends CoordinatorSimulationBaseTest
     verifyValue(Metric.ASSIGNED_COUNT, filterByDatasource(TestDataSource.WIKI), 3000L);
 
     for (DruidServer historical : historicals) {
-      Assert.assertEquals(1300, historical.getTotalSegments());
+      Assertions.assertEquals(1300, historical.getTotalSegments());
     }
   }
 

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentBalancingTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentBalancingTest.java
@@ -23,10 +23,13 @@ import org.apache.druid.client.DruidServer;
 import org.apache.druid.segment.TestDataSource;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -42,6 +45,7 @@ public class SegmentBalancingTest extends CoordinatorSimulationBaseTest
   private final List<DataSegment> segments = Segments.WIKI_10X1D;
 
   @Override
+  @BeforeEach
   public void setUp()
   {
     // Setup historicals for 2 tiers, size 10 GB each
@@ -87,8 +91,8 @@ public class SegmentBalancingTest extends CoordinatorSimulationBaseTest
     loadQueuedSegments();
 
     // Verify that segments have now been balanced out
-    Assert.assertEquals(5, historicalT11.getTotalSegments());
-    Assert.assertEquals(5, historicalT12.getTotalSegments());
+    Assertions.assertEquals(5, historicalT11.getTotalSegments());
+    Assertions.assertEquals(5, historicalT12.getTotalSegments());
     verifyDatasourceIsFullyLoaded(datasource);
   }
 
@@ -113,8 +117,8 @@ public class SegmentBalancingTest extends CoordinatorSimulationBaseTest
 
     // Load segments, skip callbacks and verify that some segments are now loaded on histT12
     loadQueuedSegmentsSkipCallbacks();
-    Assert.assertEquals(10, historicalT11.getTotalSegments());
-    Assert.assertEquals(5, historicalT12.getTotalSegments());
+    Assertions.assertEquals(10, historicalT11.getTotalSegments());
+    Assertions.assertEquals(5, historicalT12.getTotalSegments());
 
     // Run another coordinator cycle
     runCoordinatorCycle();
@@ -122,15 +126,15 @@ public class SegmentBalancingTest extends CoordinatorSimulationBaseTest
 
     // Verify that segments have not been dropped from either server since
     // MOVE_FROM operation is still not complete
-    Assert.assertEquals(10, historicalT11.getTotalSegments());
-    Assert.assertEquals(5, historicalT12.getTotalSegments());
+    Assertions.assertEquals(10, historicalT11.getTotalSegments());
+    Assertions.assertEquals(5, historicalT12.getTotalSegments());
     verifyNotEmitted(Metric.DROPPED_COUNT);
     verifyNotEmitted(Metric.MOVED_COUNT);
 
     // Finish the move operations
     loadQueuedSegments();
-    Assert.assertEquals(5, historicalT11.getTotalSegments());
-    Assert.assertEquals(5, historicalT12.getTotalSegments());
+    Assertions.assertEquals(5, historicalT11.getTotalSegments());
+    Assertions.assertEquals(5, historicalT12.getTotalSegments());
   }
 
   @Test
@@ -156,8 +160,8 @@ public class SegmentBalancingTest extends CoordinatorSimulationBaseTest
     loadQueuedSegments();
 
     // Verify that no segment has been loaded or dropped
-    Assert.assertEquals(10, historicalT11.getTotalSegments());
-    Assert.assertEquals(0, historicalT12.getTotalSegments());
+    Assertions.assertEquals(10, historicalT11.getTotalSegments());
+    Assertions.assertEquals(0, historicalT12.getTotalSegments());
     verifyDatasourceIsFullyLoaded(datasource);
   }
 
@@ -190,8 +194,8 @@ public class SegmentBalancingTest extends CoordinatorSimulationBaseTest
 
     // Finish and verify balancing
     loadQueuedSegments();
-    Assert.assertEquals(5, historicalT11.getTotalSegments());
-    Assert.assertEquals(5, historicalT12.getTotalSegments());
+    Assertions.assertEquals(5, historicalT11.getTotalSegments());
+    Assertions.assertEquals(5, historicalT12.getTotalSegments());
     verifyDatasourceIsFullyLoaded(datasource);
   }
 
@@ -224,8 +228,8 @@ public class SegmentBalancingTest extends CoordinatorSimulationBaseTest
 
     // Complete loading the segments
     loadQueuedSegments();
-    Assert.assertEquals(5, historicalT11.getTotalSegments());
-    Assert.assertEquals(5, historicalT12.getTotalSegments());
+    Assertions.assertEquals(5, historicalT11.getTotalSegments());
+    Assertions.assertEquals(5, historicalT12.getTotalSegments());
   }
 
   @Test
@@ -270,10 +274,11 @@ public class SegmentBalancingTest extends CoordinatorSimulationBaseTest
     // Run 4: Load pending segments, more are moved
     loadQueuedSegments();
     runCoordinatorCycle();
-    Assert.assertTrue(getValue(Metric.MOVED_COUNT, null).intValue() > 0);
+    Assertions.assertTrue(getValue(Metric.MOVED_COUNT, null).intValue() > 0);
   }
 
-  @Test(timeout = 60000L)
+  @Test
+  @Timeout(value = 60000L, unit = TimeUnit.MILLISECONDS)
   public void testMaxSegmentsAreMovedWhenClusterIsSkewed()
   {
     // Add 10 historicals of size 1 TB each

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentBalancingTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentBalancingTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -278,7 +279,7 @@ public class SegmentBalancingTest extends CoordinatorSimulationBaseTest
   }
 
   @Test
-  @Timeout(value = 60000L, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60000L, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testMaxSegmentsAreMovedWhenClusterIsSkewed()
   {
     // Add 10 historicals of size 1 TB each

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentLoadingTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentLoadingTest.java
@@ -23,8 +23,9 @@ import org.apache.druid.client.DruidServer;
 import org.apache.druid.segment.TestDataSource;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -46,6 +47,7 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
   private final List<DataSegment> segments = Segments.WIKI_10X1D;
 
   @Override
+  @BeforeEach
   public void setUp()
   {
     // Setup historicals for 2 tiers, size 10 GB each
@@ -80,8 +82,8 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
     verifyValue(Metric.ASSIGNED_COUNT, 2L);
 
     loadQueuedSegments();
-    Assert.assertEquals(10, historicalT11.getTotalSegments());
-    Assert.assertEquals(2, historicalT12.getTotalSegments());
+    Assertions.assertEquals(10, historicalT11.getTotalSegments());
+    Assertions.assertEquals(2, historicalT12.getTotalSegments());
   }
 
   @Test
@@ -107,7 +109,7 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
     // Verify that the number of segments assigned is within the historical capacity
     verifyValue(Metric.ASSIGNED_COUNT, 2L);
     loadQueuedSegments();
-    Assert.assertEquals(2, historicalT11.getTotalSegments());
+    Assertions.assertEquals(2, historicalT11.getTotalSegments());
   }
 
   @Test
@@ -143,8 +145,8 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
     verifyValue(Metric.ASSIGNED_COUNT, filterByTier(Tier.T2), 0L);
 
     loadQueuedSegments();
-    Assert.assertEquals(2, getNumLoadedSegments(historicalT21, historicalT22));
-    Assert.assertEquals(2, getNumLoadedSegments(historicalT11, historicalT12));
+    Assertions.assertEquals(2, getNumLoadedSegments(historicalT21, historicalT22));
+    Assertions.assertEquals(2, getNumLoadedSegments(historicalT11, historicalT12));
 
     // Run 3: total loaded replicas (4) > total required replicas (3) > total loadable replicas (2)
     // no server to assign third replica in T2, but all replicas are dropped from T1
@@ -154,8 +156,8 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
     verifyValue(Metric.ASSIGNED_COUNT, filterByTier(Tier.T2), 0L);
 
     loadQueuedSegments();
-    Assert.assertEquals(2, getNumLoadedSegments(historicalT21, historicalT22));
-    Assert.assertEquals(0, getNumLoadedSegments(historicalT11, historicalT12));
+    Assertions.assertEquals(2, getNumLoadedSegments(historicalT21, historicalT22));
+    Assertions.assertEquals(0, getNumLoadedSegments(historicalT11, historicalT12));
 
     // Run 4: Add 3rd server to T2, third replica can now be assigned
     // Add 3rd server to T1 with replica loaded, but it will not be dropped
@@ -169,8 +171,8 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
     verifyValue(Metric.ASSIGNED_COUNT, filterByTier(Tier.T2), 1L);
 
     loadQueuedSegments();
-    Assert.assertEquals(3, getNumLoadedSegments(historicalT21, historicalT22, historicalT23));
-    Assert.assertEquals(1, historicalT13.getTotalSegments());
+    Assertions.assertEquals(3, getNumLoadedSegments(historicalT21, historicalT22, historicalT23));
+    Assertions.assertEquals(1, historicalT13.getTotalSegments());
 
     // Run 5: segment is fully replicated on T2, remaining replica will now be dropped from T1
     runCoordinatorCycle();
@@ -179,8 +181,8 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
     verifyNotEmitted(Metric.ASSIGNED_COUNT);
 
     loadQueuedSegments();
-    Assert.assertEquals(3, getNumLoadedSegments(historicalT21, historicalT22, historicalT23));
-    Assert.assertEquals(0, getNumLoadedSegments(historicalT11, historicalT12, historicalT13));
+    Assertions.assertEquals(3, getNumLoadedSegments(historicalT21, historicalT22, historicalT23));
+    Assertions.assertEquals(0, getNumLoadedSegments(historicalT11, historicalT12, historicalT13));
     verifyDatasourceIsFullyLoaded(datasource);
   }
 
@@ -218,8 +220,8 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
     verifyNotEmitted(Metric.ASSIGNED_COUNT);
 
     loadQueuedSegments();
-    Assert.assertEquals(1, getNumLoadedSegments(historicalT21));
-    Assert.assertEquals(2, getNumLoadedSegments(historicalT11, historicalT12));
+    Assertions.assertEquals(1, getNumLoadedSegments(historicalT21));
+    Assertions.assertEquals(2, getNumLoadedSegments(historicalT11, historicalT12));
 
     // Run 3: total loaded replicas (3) > total required replicas (2)
     // one replica is dropped from T1
@@ -228,8 +230,8 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
     verifyValue(Metric.DROPPED_COUNT, filterByTier(Tier.T1), 1L);
 
     loadQueuedSegments();
-    Assert.assertEquals(1, getNumLoadedSegments(historicalT21));
-    Assert.assertEquals(1, getNumLoadedSegments(historicalT11, historicalT12));
+    Assertions.assertEquals(1, getNumLoadedSegments(historicalT21));
+    Assertions.assertEquals(1, getNumLoadedSegments(historicalT11, historicalT12));
   }
 
   @Test
@@ -254,7 +256,7 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
 
     // The historical is only assigned segments that it can load
     verifyValue(Metric.ASSIGNED_COUNT, 2L);
-    Assert.assertEquals(2, historicalT11.getTotalSegments());
+    Assertions.assertEquals(2, historicalT11.getTotalSegments());
   }
 
   @Test
@@ -327,8 +329,8 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
     loadQueuedSegments();
 
     verifyDatasourceIsFullyLoaded(datasource);
-    Assert.assertEquals(10, historicalT11.getTotalSegments());
-    Assert.assertEquals(10, historicalT21.getTotalSegments());
+    Assertions.assertEquals(10, historicalT11.getTotalSegments());
+    Assertions.assertEquals(10, historicalT21.getTotalSegments());
   }
 
   @Test
@@ -354,8 +356,8 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
     // Verify that number of replicas does not exceed the replicationThrottleLimit
     verifyValue(Metric.ASSIGNED_COUNT, 2L);
 
-    Assert.assertEquals(10, historicalT11.getTotalSegments());
-    Assert.assertEquals(2, historicalT12.getTotalSegments());
+    Assertions.assertEquals(10, historicalT11.getTotalSegments());
+    Assertions.assertEquals(2, historicalT12.getTotalSegments());
   }
 
   @Test
@@ -445,8 +447,8 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
     runCoordinatorCycle();
     verifyValue(Metric.ASSIGNED_COUNT, 5L);
 
-    Assert.assertEquals(10, historicalT11.getTotalSegments());
-    Assert.assertEquals(5, historicalT12.getTotalSegments());
+    Assertions.assertEquals(10, historicalT11.getTotalSegments());
+    Assertions.assertEquals(5, historicalT12.getTotalSegments());
   }
 
   @Test
@@ -481,8 +483,8 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
     verifyValue(Metric.CANCELLED_ACTIONS, 10L);
 
     loadQueuedSegments();
-    Assert.assertEquals(10, historicalT11.getTotalSegments());
-    Assert.assertEquals(0, historicalT12.getTotalSegments());
+    Assertions.assertEquals(10, historicalT11.getTotalSegments());
+    Assertions.assertEquals(0, historicalT12.getTotalSegments());
   }
 
   @Test
@@ -541,7 +543,7 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
     verifyValue(Metric.DROP_QUEUE_COUNT, filterByServer(historicalT12), 4L);
 
     loadQueuedSegments();
-    Assert.assertEquals(historicalT11.getCurrSize(), historicalT12.getCurrSize());
+    Assertions.assertEquals(historicalT11.getCurrSize(), historicalT12.getCurrSize());
   }
 
   @Test
@@ -566,8 +568,8 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
     runCoordinatorCycle();
     loadQueuedSegments();
     verifyValue(Metric.ASSIGNED_COUNT, 10L);
-    Assert.assertEquals(5, historicalT11.getTotalSegments());
-    Assert.assertEquals(5, historicalT12.getTotalSegments());
+    Assertions.assertEquals(5, historicalT11.getTotalSegments());
+    Assertions.assertEquals(5, historicalT12.getTotalSegments());
 
     // Run 2: Emit success metrics
     runCoordinatorCycle();


### PR DESCRIPTION
## Summary

- Migrate 71 owned server coordinator and compaction tests from JUnit 4 to JUnit 5.
- Preserve class-wide parameterization, lifecycle behavior, timeouts, assumptions, execution counts, and assertion semantics.
- Keep shared POMs and helpers unchanged; no JUnit 4/Vintage dependencies were removed.

## Validation

- `mvn -pl server -am -DskipTests test-compile -Pskip-static-checks -Dweb.console.skip=true -T1C -ntp` — PASS (`BUILD SUCCESS`).
- `mvn -pl server -am -DskipTests -Dweb.console.skip=true -T1C -ntp checkstyle:check spotbugs:check` — PASS; Checkstyle reported 0 violations and SpotBugs reported 0 bugs/errors. SpotBugs emitted the existing processing analysis warning for missing `org.apache.logging.log4j.MarkerManager`.
- `mvn test -pl server -am -Dtest="org.apache.druid.server.coordinator.**,org.apache.druid.server.compaction.**" -Dsurefire.failIfNoSpecifiedTests=false -DforkCount=0 -Pskip-static-checks -Dweb.console.skip=true -ntp` — 823 tests executed, 0 failures, 24 errors, 1 skipped. The errors are Mockito inline Byte Buddy self-attach failures under local OpenJDK 25 (`AttachNotSupportedException`), not migration assertion failures.

The forked focused-test mode could not start in the local sandbox because Surefire's fork channel failed with `SocketException: Operation not permitted` while binding its socket.

Part of #13948
