### PR TITLE
test: migrate scoped server tests to JUnit 5

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/azure/AbstractAzureInputSourceParallelIndexTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/azure/AbstractAzureInputSourceParallelIndexTest.java
@@ -24,7 +24,6 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.storage.azure.output.AzureStorageConnectorModule;
 import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
 import org.apache.druid.testing.embedded.indexer.AbstractCloudInputSourceParallelIndexTest;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 
@@ -79,10 +78,10 @@ public abstract class AbstractAzureInputSourceParallelIndexTest extends Abstract
       LOG.warn(e, "Failed to validate that azure segment files were deleted.");
     }
     finally {
-      Assert.assertEquals(
-            "Some segment files were not deleted: " + segmentFiles,
+      Assertions.assertEquals(
             segmentFiles.size(),
-            0
+            0,
+            "Some segment files were not deleted: " + segmentFiles
       );
     }
   }

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexer/AbstractITBatchIndexTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexer/AbstractITBatchIndexTest.java
@@ -49,7 +49,7 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.TimelineObjectHolder;
 import org.jboss.netty.handler.codec.http.HttpMethod;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -349,7 +349,7 @@ public abstract class AbstractITBatchIndexTest extends AbstractIndexerTest
           mapper -> new RequestBuilder(HttpMethod.GET, url),
           new TypeReference<>(){}
       );
-      Assert.assertFalse("dimensions : " + dimensions, dimensions.contains("robot"));
+      Assertions.assertFalse(dimensions.contains("robot"), "dimensions : " + dimensions);
     }
     catch (Exception e) {
       LOG.error(e, "Error while testing");
@@ -413,12 +413,12 @@ public abstract class AbstractITBatchIndexTest extends AbstractIndexerTest
     if (assertRunsSubTasks) {
       final boolean perfectRollup = !taskSpec.contains("dynamic");
       final long newSubTasks = countCompleteSubTasks(dataSourceName, perfectRollup) - startSubTaskCount;
-      Assert.assertTrue(
+      Assertions.assertTrue(
+          newSubTasks > 0,
           StringUtils.format(
               "The supervisor task [%s] didn't create any sub tasks. Was it executed in the parallel mode?",
               taskID
-          ),
-          newSubTasks > 0
+          )
       );
     }
 
@@ -428,11 +428,11 @@ public abstract class AbstractITBatchIndexTest extends AbstractIndexerTest
       IngestionStatsAndErrors reportData = report.getPayload();
 
       // Confirm that the task waited longer than 0ms for the task to complete.
-      Assert.assertTrue(reportData.getSegmentAvailabilityWaitTimeMs() > 0);
+      Assertions.assertTrue(reportData.getSegmentAvailabilityWaitTimeMs() > 0);
 
       // Make sure that the result of waiting for segments to load matches the expected result
       if (segmentAvailabilityConfirmationPair.rhs != null) {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             reportData.isSegmentAvailabilityConfirmed(),
             segmentAvailabilityConfirmationPair.rhs
         );
@@ -443,7 +443,7 @@ public abstract class AbstractITBatchIndexTest extends AbstractIndexerTest
                                      .onLeaderOverlord(o -> o.taskReportAsMap(taskID))
                                      .get(TaskContextReport.REPORT_KEY);
 
-      Assert.assertFalse(taskContextReport.getPayload().isEmpty());
+      Assertions.assertFalse(taskContextReport.getPayload().isEmpty());
     }
 
     // IT*ParallelIndexTest do a second round of ingestion to replace segments in an existing

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedDartReportApiTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedDartReportApiTest.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.common.utils.IdUtils;
 import org.apache.druid.data.input.impl.CsvInputFormat;
 import org.apache.druid.error.DruidException;
+import org.apache.druid.error.ThrowableMatcher;
 import org.apache.druid.guice.SleepModule;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.report.TaskReport;
@@ -485,12 +486,9 @@ public class EmbeddedDartReportApiTest extends EmbeddedClusterTestBase
     Assertions.assertTrue(regularUserVisibleSqlQueryIds.contains(regularUserQueryId));
 
     // Regular user can get only their own query report
-    final RuntimeException e = Assertions.assertThrows(
-        RuntimeException.class,
-        () -> getReportWithClient(adminQueryId, regularUserClient)
-    );
-    Assertions.assertNotNull(e.getMessage());
-    Assertions.assertTrue(e.getMessage().contains("404 Not Found"));
+    ThrowableMatcher.of(RuntimeException.class)
+                    .expectMessageContains("404 Not Found")
+                    .assertThrowsAndMatches(() -> getReportWithClient(adminQueryId, regularUserClient));
     Assertions.assertNotNull(getReportWithClient(regularUserQueryId, regularUserClient));
   }
 

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedDartReportApiTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedDartReportApiTest.java
@@ -62,11 +62,8 @@ import org.apache.druid.testing.embedded.auth.EmbeddedBasicAuthResource;
 import org.apache.druid.testing.embedded.auth.HttpUtil;
 import org.apache.druid.testing.embedded.indexing.MoreResources;
 import org.apache.druid.testing.embedded.junit5.EmbeddedClusterTestBase;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -492,7 +489,8 @@ public class EmbeddedDartReportApiTest extends EmbeddedClusterTestBase
         RuntimeException.class,
         () -> getReportWithClient(adminQueryId, regularUserClient)
     );
-    MatcherAssert.assertThat(e, ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("404 Not Found")));
+    Assertions.assertNotNull(e.getMessage());
+    Assertions.assertTrue(e.getMessage().contains("404 Not Found"));
     Assertions.assertNotNull(getReportWithClient(regularUserQueryId, regularUserClient));
   }
 

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedMSQRealtimeQueryTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedMSQRealtimeQueryTest.java
@@ -36,9 +36,6 @@ import org.apache.druid.testing.embedded.EmbeddedHistorical;
 import org.apache.druid.testing.embedded.EmbeddedIndexer;
 import org.apache.druid.testing.embedded.EmbeddedOverlord;
 import org.apache.druid.testing.embedded.EmbeddedRouter;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -241,16 +238,15 @@ public class EmbeddedMSQRealtimeQueryTest extends BaseRealtimeQueryTest
                        + "  LIMIT 1\n"
                        + ")";
 
-    MatcherAssert.assertThat(
-        Assertions.assertThrows(
-            RuntimeException.class,
-            () -> msqApis.runDartSql(sql, dataSource, dataSource)
-        ),
-        ThrowableMessageMatcher.hasMessage(
-            CoreMatchers.containsString(
-                "Cannot handle stage with multiple sources while querying realtime data. If using broadcast "
-                + "joins, try setting[sqlJoinAlgorithm] to[sortMerge] in your query context."
-            )
+    final RuntimeException exception = Assertions.assertThrows(
+        RuntimeException.class,
+        () -> msqApis.runDartSql(sql, dataSource, dataSource)
+    );
+    Assertions.assertNotNull(exception.getMessage());
+    Assertions.assertTrue(
+        exception.getMessage().contains(
+            "Cannot handle stage with multiple sources while querying realtime data. If using broadcast "
+            + "joins, try setting[sqlJoinAlgorithm] to[sortMerge] in your query context."
         )
     );
   }
@@ -289,11 +285,12 @@ public class EmbeddedMSQRealtimeQueryTest extends BaseRealtimeQueryTest
         StringUtils.format("Task[%s] has unexpected status", taskId)
     );
 
+    Assertions.assertNotNull(currentStatus.getStatus().getErrorMsg());
     Assertions.assertTrue(
-        CoreMatchers.containsString(
+        currentStatus.getStatus().getErrorMsg().contains(
             "Cannot handle stage with multiple sources while querying realtime data. If using broadcast "
             + "joins, try setting[sqlJoinAlgorithm] to[sortMerge] in your query context."
-        ).matches(currentStatus.getStatus().getErrorMsg())
+        )
     );
   }
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -359,6 +359,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>

--- a/server/src/test/java/org/apache/druid/server/JettyUtilsTest.java
+++ b/server/src/test/java/org/apache/druid/server/JettyUtilsTest.java
@@ -19,15 +19,15 @@
 
 package org.apache.druid.server;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JettyUtilsTest
 {
   @Test
   public void testConcatenateForRewrite()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "http://example.com/foo%20bar?q=baz%20qux",
         JettyUtils.concatenateForRewrite(
             "http://example.com",
@@ -40,7 +40,7 @@ public class JettyUtilsTest
   @Test
   public void testConcatenateForRewriteEmptyPath()
   {
-    Assert.assertNull(
+    Assertions.assertNull(
         JettyUtils.concatenateForRewrite(
             "http://example.com",
             "",
@@ -52,7 +52,7 @@ public class JettyUtilsTest
   @Test
   public void testConcatenateForRewriteInvalidPath()
   {
-    Assert.assertNull(
+    Assertions.assertNull(
         JettyUtils.concatenateForRewrite(
             "http://example.com",
             "foo%20bar", // path must start with '/'

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorBrokerConfigsResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorBrokerConfigsResourceTest.java
@@ -26,9 +26,9 @@ import org.apache.druid.common.config.ConfigManager.SetResult;
 import org.apache.druid.common.config.JacksonConfigManager;
 import org.apache.druid.server.broker.BrokerDynamicConfig;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
@@ -40,7 +40,7 @@ public class CoordinatorBrokerConfigsResourceTest
   private AuditManager auditManager;
   private BrokerDynamicConfigSyncer brokerDynamicConfigSyncer;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     configManager = EasyMock.createStrictMock(JacksonConfigManager.class);
@@ -70,8 +70,8 @@ public class CoordinatorBrokerConfigsResourceTest
         brokerDynamicConfigSyncer
     ).getBrokerDynamicConfig();
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(config, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(config, response.getEntity());
 
     EasyMock.verify(configManager, auditManager, brokerDynamicConfigSyncer);
   }
@@ -107,7 +107,7 @@ public class CoordinatorBrokerConfigsResourceTest
     );
 
     Response response = resource.getBrokerDynamicConfigHistory(null, 10);
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
 
     EasyMock.verify(configManager, auditManager, brokerDynamicConfigSyncer);
   }
@@ -143,7 +143,7 @@ public class CoordinatorBrokerConfigsResourceTest
     );
 
     Response response = resource.getBrokerDynamicConfigHistory(null, null);
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
 
     EasyMock.verify(configManager, auditManager, brokerDynamicConfigSyncer);
   }
@@ -183,7 +183,7 @@ public class CoordinatorBrokerConfigsResourceTest
     );
 
     Response response = resource.setBrokerDynamicConfig(BrokerDynamicConfig.builder(), request);
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
 
     EasyMock.verify(configManager, auditManager, brokerDynamicConfigSyncer);
   }

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResourceTest.java
@@ -46,14 +46,11 @@ import org.apache.druid.server.coordinator.InlineSchemaDataSourceCompactionConfi
 import org.apache.druid.server.coordinator.UserCompactionTaskGranularityConfig;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.skife.jdbi.v2.Handle;
 
 import javax.annotation.Nullable;
@@ -67,21 +64,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 
-@RunWith(MockitoJUnitRunner.class)
 public class CoordinatorCompactionConfigsResourceTest
 {
   private static final double DELTA = 1e-9;
   private static final ObjectMapper OBJECT_MAPPER = new DefaultObjectMapper();
 
-  @Mock
   private HttpServletRequest mockHttpServletRequest;
 
   private TestCoordinatorConfigManager configManager;
   private CoordinatorCompactionConfigsResource resource;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
+    mockHttpServletRequest = Mockito.mock(HttpServletRequest.class);
     Mockito.when(mockHttpServletRequest.getRemoteAddr()).thenReturn("123");
     final AuditManager auditManager = new TestAuditManager();
     configManager = TestCoordinatorConfigManager.create(auditManager);
@@ -89,7 +85,7 @@ public class CoordinatorCompactionConfigsResourceTest
     configManager.delegate.start();
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     configManager.delegate.stop();
@@ -102,11 +98,11 @@ public class CoordinatorCompactionConfigsResourceTest
     final DruidCompactionConfig defaultConfig
         = verifyAndGetPayload(response, DruidCompactionConfig.class);
 
-    Assert.assertEquals(0.1, defaultConfig.getCompactionTaskSlotRatio(), DELTA);
-    Assert.assertEquals(Integer.MAX_VALUE, defaultConfig.getMaxCompactionTaskSlots());
-    Assert.assertTrue(defaultConfig.getCompactionConfigs().isEmpty());
-    Assert.assertTrue(defaultConfig.isUseSupervisors());
-    Assert.assertEquals(CompactionEngine.NATIVE, defaultConfig.getEngine());
+    Assertions.assertEquals(0.1, defaultConfig.getCompactionTaskSlotRatio(), DELTA);
+    Assertions.assertEquals(Integer.MAX_VALUE, defaultConfig.getMaxCompactionTaskSlots());
+    Assertions.assertTrue(defaultConfig.getCompactionConfigs().isEmpty());
+    Assertions.assertTrue(defaultConfig.isUseSupervisors());
+    Assertions.assertEquals(CompactionEngine.NATIVE, defaultConfig.getEngine());
   }
 
   @Test
@@ -116,8 +112,8 @@ public class CoordinatorCompactionConfigsResourceTest
 
     final DruidCompactionConfig oldConfig
         = verifyAndGetPayload(resource.getCompactionConfig(), DruidCompactionConfig.class);
-    Assert.assertEquals(100, oldConfig.getMaxCompactionTaskSlots());
-    Assert.assertEquals(0.1, oldConfig.getCompactionTaskSlotRatio(), 1e-9);
+    Assertions.assertEquals(100, oldConfig.getMaxCompactionTaskSlots());
+    Assertions.assertEquals(0.1, oldConfig.getCompactionTaskSlotRatio(), 1e-9);
 
     Response response = resource.setCompactionTaskLimit(0.5, 9, mockHttpServletRequest);
     verifyStatus(Response.Status.OK, response);
@@ -126,16 +122,16 @@ public class CoordinatorCompactionConfigsResourceTest
         = verifyAndGetPayload(resource.getCompactionConfig(), DruidCompactionConfig.class);
 
     // Verify that the task slot fields have been updated
-    Assert.assertEquals(0.5, updatedConfig.getCompactionTaskSlotRatio(), DELTA);
-    Assert.assertEquals(9, updatedConfig.getMaxCompactionTaskSlots());
+    Assertions.assertEquals(0.5, updatedConfig.getCompactionTaskSlotRatio(), DELTA);
+    Assertions.assertEquals(9, updatedConfig.getMaxCompactionTaskSlots());
 
     // Verify that other cluster config fields are unchanged
-    Assert.assertEquals(oldConfig.isUseSupervisors(), updatedConfig.isUseSupervisors());
-    Assert.assertEquals(oldConfig.getCompactionPolicy(), updatedConfig.getCompactionPolicy());
-    Assert.assertEquals(oldConfig.getEngine(), updatedConfig.getEngine());
+    Assertions.assertEquals(oldConfig.isUseSupervisors(), updatedConfig.isUseSupervisors());
+    Assertions.assertEquals(oldConfig.getCompactionPolicy(), updatedConfig.getCompactionPolicy());
+    Assertions.assertEquals(oldConfig.getEngine(), updatedConfig.getEngine());
 
     // Verify that the other fields are unchanged
-    Assert.assertEquals(oldConfig.getCompactionConfigs(), updatedConfig.getCompactionConfigs());
+    Assertions.assertEquals(oldConfig.getCompactionConfigs(), updatedConfig.getCompactionConfigs());
   }
 
   @Test
@@ -155,12 +151,12 @@ public class CoordinatorCompactionConfigsResourceTest
 
     final DataSourceCompactionConfig fetchedDatasourceConfig
         = verifyAndGetPayload(resource.getDatasourceCompactionConfig(TestDataSource.WIKI), InlineSchemaDataSourceCompactionConfig.class);
-    Assert.assertEquals(newDatasourceConfig, fetchedDatasourceConfig);
+    Assertions.assertEquals(newDatasourceConfig, fetchedDatasourceConfig);
 
     final DruidCompactionConfig fullCompactionConfig
         = verifyAndGetPayload(resource.getCompactionConfig(), DruidCompactionConfig.class);
-    Assert.assertEquals(1, fullCompactionConfig.getCompactionConfigs().size());
-    Assert.assertEquals(newDatasourceConfig, fullCompactionConfig.getCompactionConfigs().get(0));
+    Assertions.assertEquals(1, fullCompactionConfig.getCompactionConfigs().size());
+    Assertions.assertEquals(newDatasourceConfig, fullCompactionConfig.getCompactionConfigs().get(0));
   }
 
   @Test
@@ -173,8 +169,8 @@ public class CoordinatorCompactionConfigsResourceTest
                                                 .build();
     Response response = resource.addOrUpdateDatasourceCompactionConfig(newDatasourceConfig, mockHttpServletRequest);
     verifyStatus(Response.Status.BAD_REQUEST, response);
-    Assert.assertTrue(response.getEntity() instanceof ErrorResponse);
-    Assert.assertEquals(
+    Assertions.assertTrue(response.getEntity() instanceof ErrorResponse);
+    Assertions.assertEquals(
         "MSQ engine is supported only with supervisor-based compaction on the Overlord.",
         ((ErrorResponse) response.getEntity()).getUnderlyingException().getMessage()
     );
@@ -216,12 +212,12 @@ public class CoordinatorCompactionConfigsResourceTest
 
     final DataSourceCompactionConfig latestDatasourceConfig
         = verifyAndGetPayload(resource.getDatasourceCompactionConfig(TestDataSource.WIKI), InlineSchemaDataSourceCompactionConfig.class);
-    Assert.assertEquals(originalDatasourceConfig, latestDatasourceConfig);
+    Assertions.assertEquals(originalDatasourceConfig, latestDatasourceConfig);
 
     final DruidCompactionConfig fullCompactionConfig
         = verifyAndGetPayload(resource.getCompactionConfig(), DruidCompactionConfig.class);
-    Assert.assertEquals(1, fullCompactionConfig.getCompactionConfigs().size());
-    Assert.assertEquals(originalDatasourceConfig, fullCompactionConfig.getCompactionConfigs().get(0));
+    Assertions.assertEquals(1, fullCompactionConfig.getCompactionConfigs().size());
+    Assertions.assertEquals(originalDatasourceConfig, fullCompactionConfig.getCompactionConfigs().get(0));
   }
 
   @Test
@@ -256,7 +252,7 @@ public class CoordinatorCompactionConfigsResourceTest
         mockHttpServletRequest
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         5,
         configManager.numUpdateAttempts
     );
@@ -272,7 +268,7 @@ public class CoordinatorCompactionConfigsResourceTest
         mockHttpServletRequest
     );
 
-    Assert.assertEquals(1, configManager.numUpdateAttempts);
+    Assertions.assertEquals(1, configManager.numUpdateAttempts);
   }
 
   @Test
@@ -298,10 +294,10 @@ public class CoordinatorCompactionConfigsResourceTest
 
     final List<DataSourceCompactionConfigAuditEntry> history
         = (List<DataSourceCompactionConfigAuditEntry>) response.getEntity();
-    Assert.assertEquals(3, history.size());
-    Assert.assertEquals(configV1, history.get(0).getCompactionConfig());
-    Assert.assertEquals(configV2, history.get(1).getCompactionConfig());
-    Assert.assertEquals(configV3, history.get(2).getCompactionConfig());
+    Assertions.assertEquals(3, history.size());
+    Assertions.assertEquals(configV1, history.get(0).getCompactionConfig());
+    Assertions.assertEquals(configV2, history.get(1).getCompactionConfig());
+    Assertions.assertEquals(configV3, history.get(2).getCompactionConfig());
   }
 
   @Test
@@ -309,7 +305,7 @@ public class CoordinatorCompactionConfigsResourceTest
   {
     Response response = resource.getCompactionConfigHistory(TestDataSource.WIKI, null, null);
     verifyStatus(Response.Status.OK, response);
-    Assert.assertTrue(((List<?>) response.getEntity()).isEmpty());
+    Assertions.assertTrue(((List<?>) response.getEntity()).isEmpty());
   }
 
   @Test
@@ -324,8 +320,8 @@ public class CoordinatorCompactionConfigsResourceTest
 
     final Response response = resource.addOrUpdateDatasourceCompactionConfig(datasourceConfig, mockHttpServletRequest);
     verifyStatus(Response.Status.BAD_REQUEST, response);
-    Assert.assertTrue(response.getEntity() instanceof ErrorResponse);
-    Assert.assertEquals(
+    Assertions.assertTrue(response.getEntity() instanceof ErrorResponse);
+    Assertions.assertEquals(
         "MSQ engine is supported only with supervisor-based compaction on the Overlord.",
         ((ErrorResponse) response.getEntity()).getUnderlyingException().getMessage()
     );
@@ -333,15 +329,15 @@ public class CoordinatorCompactionConfigsResourceTest
   @SuppressWarnings("unchecked")
   private <T> T verifyAndGetPayload(Response response, Class<T> type)
   {
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
-    Assert.assertTrue(type.isInstance(response.getEntity()));
+    Assertions.assertTrue(type.isInstance(response.getEntity()));
     return (T) response.getEntity();
   }
 
   private void verifyStatus(Response.Status expectedStatus, Response response)
   {
-    Assert.assertEquals(expectedStatus.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(expectedStatus.getStatusCode(), response.getStatus());
   }
 
   /**

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResourceTest.java
@@ -54,6 +54,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.skife.jdbi.v2.Handle;
 
 import javax.annotation.Nullable;
@@ -68,6 +70,7 @@ import java.util.Map;
 import java.util.function.UnaryOperator;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class CoordinatorCompactionConfigsResourceTest
 {
   private static final double DELTA = 1e-9;

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResourceTest.java
@@ -50,7 +50,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.skife.jdbi.v2.Handle;
 
 import javax.annotation.Nullable;
@@ -64,11 +67,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 
+@ExtendWith(MockitoExtension.class)
 public class CoordinatorCompactionConfigsResourceTest
 {
   private static final double DELTA = 1e-9;
   private static final ObjectMapper OBJECT_MAPPER = new DefaultObjectMapper();
 
+  @Mock
   private HttpServletRequest mockHttpServletRequest;
 
   private TestCoordinatorConfigManager configManager;
@@ -77,8 +82,7 @@ public class CoordinatorCompactionConfigsResourceTest
   @BeforeEach
   public void setup()
   {
-    mockHttpServletRequest = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(mockHttpServletRequest.getRemoteAddr()).thenReturn("123");
+    Mockito.lenient().when(mockHttpServletRequest.getRemoteAddr()).thenReturn("123");
     final AuditManager auditManager = new TestAuditManager();
     configManager = TestCoordinatorConfigManager.create(auditManager);
     resource = new CoordinatorCompactionConfigsResource(configManager);

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionResourceTest.java
@@ -26,10 +26,10 @@ import org.apache.druid.server.compaction.CompactionStatusResponse;
 import org.apache.druid.server.coordinator.AutoCompactionSnapshot;
 import org.apache.druid.server.coordinator.DruidCoordinator;
 import org.easymock.EasyMock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 import java.util.Collections;
@@ -55,13 +55,13 @@ public class CoordinatorCompactionResourceTest
       1
   );
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mock = EasyMock.createStrictMock(DruidCoordinator.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     EasyMock.verify(mock);
@@ -80,8 +80,8 @@ public class CoordinatorCompactionResourceTest
 
     final Response response = new CoordinatorCompactionResource(mock)
         .getCompactionSnapshotForDataSource("");
-    Assert.assertEquals(new CompactionStatusResponse(List.of(expectedSnapshot)), response.getEntity());
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new CompactionStatusResponse(List.of(expectedSnapshot)), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
   }
 
   @Test
@@ -98,8 +98,8 @@ public class CoordinatorCompactionResourceTest
 
     final Response response = new CoordinatorCompactionResource(mock)
         .getCompactionSnapshotForDataSource(null);
-    Assert.assertEquals(new CompactionStatusResponse(List.of(expectedSnapshot)), response.getEntity());
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new CompactionStatusResponse(List.of(expectedSnapshot)), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
   }
 
   @Test
@@ -113,11 +113,11 @@ public class CoordinatorCompactionResourceTest
 
     final Response response = new CoordinatorCompactionResource(mock)
         .getCompactionSnapshotForDataSource(dataSourceName);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new CompactionStatusResponse(Collections.singletonList(expectedSnapshot)),
         response.getEntity()
     );
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
   }
 
   @Test
@@ -131,7 +131,7 @@ public class CoordinatorCompactionResourceTest
 
     final Response response = new CoordinatorCompactionResource(mock)
         .getCompactionSnapshotForDataSource(dataSourceName);
-    Assert.assertEquals(404, response.getStatus());
+    Assertions.assertEquals(404, response.getStatus());
   }
 
   @Test
@@ -141,10 +141,10 @@ public class CoordinatorCompactionResourceTest
 
     final Response response = new CoordinatorCompactionResource(mock)
         .getCompactionProgress(null);
-    Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
 
     final Object responseEntity = response.getEntity();
-    Assert.assertTrue(responseEntity instanceof ErrorResponse);
+    Assertions.assertTrue(responseEntity instanceof ErrorResponse);
 
     DruidExceptionMatcher.assertThat(
         ((ErrorResponse) responseEntity).getUnderlyingException(),

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorDynamicConfigSyncerTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorDynamicConfigSyncerTest.java
@@ -34,8 +34,8 @@ import org.apache.druid.server.coordinator.CoordinatorConfigManager;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
 import java.util.List;
@@ -53,7 +53,7 @@ public class CoordinatorDynamicConfigSyncerTest
   private CoordinatorConfigManager coordinatorConfigManager;
   private DruidNodeDiscovery druidNodeDiscovery;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     serviceClient = mock(ServiceClient.class);

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorDynamicConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorDynamicConfigTest.java
@@ -27,8 +27,8 @@ import org.apache.druid.error.DruidException;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.apache.druid.utils.JvmUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -256,7 +256,7 @@ public class CoordinatorDynamicConfigTest
 
     CoordinatorDynamicConfig dynamicConfig
         = mapper.readValue(jsonStr, CoordinatorDynamicConfig.class);
-    Assert.assertEquals(15, dynamicConfig.getMaxSegmentsInNodeLoadingQueue());
+    Assertions.assertEquals(15, dynamicConfig.getMaxSegmentsInNodeLoadingQueue());
   }
 
   @Test
@@ -283,7 +283,7 @@ public class CoordinatorDynamicConfigTest
         null,
         null
     );
-    Assert.assertTrue(config.getSpecificDataSourcesToKillUnusedSegmentsIn().isEmpty());
+    Assertions.assertTrue(config.getSpecificDataSourcesToKillUnusedSegmentsIn().isEmpty());
   }
 
   @Test
@@ -310,7 +310,7 @@ public class CoordinatorDynamicConfigTest
         null,
         null
     );
-    Assert.assertEquals(ImmutableSet.of("test1"), config.getSpecificDataSourcesToKillUnusedSegmentsIn());
+    Assertions.assertEquals(ImmutableSet.of("test1"), config.getSpecificDataSourcesToKillUnusedSegmentsIn());
   }
 
   @Test
@@ -576,7 +576,7 @@ public class CoordinatorDynamicConfigTest
         .withSpecificDataSourcesToKillUnusedSegmentsIn(ImmutableSet.of("x"))
         .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         current,
         CoordinatorDynamicConfig.builder().build(current)
     );
@@ -590,8 +590,8 @@ public class CoordinatorDynamicConfigTest
         .withTurboLoadingNodes(ImmutableSet.of("localhost:8083"))
         .build();
 
-    Assert.assertEquals(SegmentLoadingMode.NORMAL, config.getLoadingModeForServer("localhost:8082"));
-    Assert.assertEquals(SegmentLoadingMode.TURBO, config.getLoadingModeForServer("localhost:8083"));
+    Assertions.assertEquals(SegmentLoadingMode.NORMAL, config.getLoadingModeForServer("localhost:8082"));
+    Assertions.assertEquals(SegmentLoadingMode.TURBO, config.getLoadingModeForServer("localhost:8083"));
   }
 
   @Test
@@ -599,8 +599,8 @@ public class CoordinatorDynamicConfigTest
   {
     CoordinatorDynamicConfig config1 = CoordinatorDynamicConfig.builder().build();
     CoordinatorDynamicConfig config2 = CoordinatorDynamicConfig.builder().build();
-    Assert.assertEquals(config1, config2);
-    Assert.assertEquals(config1.hashCode(), config2.hashCode());
+    Assertions.assertEquals(config1, config2);
+    Assertions.assertEquals(config1.hashCode(), config2.hashCode());
   }
 
   private void assertConfig(
@@ -621,26 +621,26 @@ public class CoordinatorDynamicConfigTest
       Map<String, String> cloneServers
   )
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedLeadingTimeMillisBeforeCanMarkAsUnusedOvershadowedSegments,
         config.getMarkSegmentAsUnusedDelayMillis()
     );
-    Assert.assertEquals(expectedMaxSegmentsToMove, config.getMaxSegmentsToMove());
-    Assert.assertEquals(expectedReplicantLifetime, config.getReplicantLifetime());
-    Assert.assertEquals(expectedReplicationThrottleLimit, config.getReplicationThrottleLimit());
-    Assert.assertEquals(expectedBalancerComputeThreads, config.getBalancerComputeThreads());
-    Assert.assertEquals(
+    Assertions.assertEquals(expectedMaxSegmentsToMove, config.getMaxSegmentsToMove());
+    Assertions.assertEquals(expectedReplicantLifetime, config.getReplicantLifetime());
+    Assertions.assertEquals(expectedReplicationThrottleLimit, config.getReplicationThrottleLimit());
+    Assertions.assertEquals(expectedBalancerComputeThreads, config.getBalancerComputeThreads());
+    Assertions.assertEquals(
         expectedSpecificDataSourcesToKillUnusedSegmentsIn,
         config.getSpecificDataSourcesToKillUnusedSegmentsIn()
     );
-    Assert.assertEquals(expectedKillTaskSlotRatio, config.getKillTaskSlotRatio(), 0.001);
-    Assert.assertEquals((int) expectedMaxKillTaskSlots, config.getMaxKillTaskSlots());
-    Assert.assertEquals(expectedMaxSegmentsInNodeLoadingQueue, config.getMaxSegmentsInNodeLoadingQueue());
-    Assert.assertEquals(decommissioningNodes, config.getDecommissioningNodes());
-    Assert.assertEquals(pauseCoordination, config.getPauseCoordination());
-    Assert.assertEquals(replicateAfterLoadTimeout, config.getReplicateAfterLoadTimeout());
-    Assert.assertEquals(turboLoadingNodes, config.getTurboLoadingNodes());
-    Assert.assertEquals(cloneServers, config.getCloneServers());
+    Assertions.assertEquals(expectedKillTaskSlotRatio, config.getKillTaskSlotRatio(), 0.001);
+    Assertions.assertEquals((int) expectedMaxKillTaskSlots, config.getMaxKillTaskSlots());
+    Assertions.assertEquals(expectedMaxSegmentsInNodeLoadingQueue, config.getMaxSegmentsInNodeLoadingQueue());
+    Assertions.assertEquals(decommissioningNodes, config.getDecommissioningNodes());
+    Assertions.assertEquals(pauseCoordination, config.getPauseCoordination());
+    Assertions.assertEquals(replicateAfterLoadTimeout, config.getReplicateAfterLoadTimeout());
+    Assertions.assertEquals(turboLoadingNodes, config.getTurboLoadingNodes());
+    Assertions.assertEquals(cloneServers, config.getCloneServers());
   }
 
   private static int getDefaultNumBalancerThreads()
@@ -659,11 +659,11 @@ public class CoordinatorDynamicConfigTest
     CoordinatorDynamicConfig config = CoordinatorDynamicConfig.builder()
                                                               .withHistoricalTierAliases(aliases)
                                                               .build();
-    Assert.assertEquals(aliases, config.getHistoricalTierAliases());
+    Assertions.assertEquals(aliases, config.getHistoricalTierAliases());
 
     // build(defaults) propagates aliases when not overridden
     CoordinatorDynamicConfig updated = CoordinatorDynamicConfig.builder().build(config);
-    Assert.assertEquals(aliases, updated.getHistoricalTierAliases());
+    Assertions.assertEquals(aliases, updated.getHistoricalTierAliases());
 
     // Serde roundtrip with duplicate values in the JSON array — duplicates must be deduplicated
     String jsonWithDupes = "{"
@@ -675,11 +675,11 @@ public class CoordinatorDynamicConfigTest
         mapper.writeValueAsString(mapper.readValue(jsonWithDupes, CoordinatorDynamicConfig.class)),
         CoordinatorDynamicConfig.class
     );
-    Assert.assertEquals(Set.of("hot_1", "hot_2"), deserialized.getHistoricalTierAliases().get("hot"));
+    Assertions.assertEquals(Set.of("hot_1", "hot_2"), deserialized.getHistoricalTierAliases().get("hot"));
 
     // Absent field defaults to empty map
     CoordinatorDynamicConfig defaultConfig = CoordinatorDynamicConfig.builder().build();
-    Assert.assertEquals(Map.of(), defaultConfig.getHistoricalTierAliases());
+    Assertions.assertEquals(Map.of(), defaultConfig.getHistoricalTierAliases());
   }
 
   @Test
@@ -691,11 +691,11 @@ public class CoordinatorDynamicConfigTest
         "another", Set.of("hot")
     );
 
-    DruidException exception = Assert.assertThrows(
+    DruidException exception = Assertions.assertThrows(
         DruidException.class,
         () -> CoordinatorDynamicConfig.builder().withHistoricalTierAliases(aliases).build()
     );
-    Assert.assertTrue("Throws correct virtual tier alias message", exception.getMessage().contains("A virtual tier alias cannot be a physical tier."));
+    Assertions.assertTrue(exception.getMessage().contains("A virtual tier alias cannot be a physical tier."), "Throws correct virtual tier alias message");
   }
 
   @Test
@@ -706,17 +706,17 @@ public class CoordinatorDynamicConfigTest
         "warm", Set.of("tier_2", "tier_3")
     );
 
-    DruidException exception = Assert.assertThrows(
+    DruidException exception = Assertions.assertThrows(
         DruidException.class,
         () -> CoordinatorDynamicConfig.builder().withHistoricalTierAliases(aliases).build()
     );
-    Assert.assertTrue(
-        "Throws correct multi-alias message",
-        exception.getMessage().contains("cannot belong to more than one alias")
+    Assertions.assertTrue(
+        exception.getMessage().contains("cannot belong to more than one alias"),
+        "Throws correct multi-alias message"
     );
-    Assert.assertTrue(
-        "Names the offending tier",
-        exception.getMessage().contains("tier_2")
+    Assertions.assertTrue(
+        exception.getMessage().contains("tier_2"),
+        "Names the offending tier"
     );
   }
 
@@ -736,10 +736,10 @@ public class CoordinatorDynamicConfigTest
         "hot_2", "hot",
         "cold_1", "cold"
     );
-    Assert.assertEquals(expected, config.getTierToAliasName());
+    Assertions.assertEquals(expected, config.getTierToAliasName());
 
     // No aliases configured -> empty reverse map
-    Assert.assertEquals(Map.of(), CoordinatorDynamicConfig.builder().build().getTierToAliasName());
+    Assertions.assertEquals(Map.of(), CoordinatorDynamicConfig.builder().build().getTierToAliasName());
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorDynamicConfigsResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorDynamicConfigsResourceTest.java
@@ -26,9 +26,9 @@ import org.apache.druid.server.coordinator.CloneStatusManager;
 import org.apache.druid.server.coordinator.CoordinatorConfigManager;
 import org.apache.druid.server.coordinator.ServerCloneStatus;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 import java.util.List;
@@ -40,7 +40,7 @@ public class CoordinatorDynamicConfigsResourceTest
   private CoordinatorDynamicConfigSyncer coordinatorDynamicConfigSyncer;
   private CloneStatusManager cloneStatusManager;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     manager = EasyMock.createStrictMock(CoordinatorConfigManager.class);
@@ -70,14 +70,14 @@ public class CoordinatorDynamicConfigsResourceTest
         cloneStatusManager
     ).getBrokerStatus();
 
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
 
     ConfigSyncStatus expected = new ConfigSyncStatus(
         ImmutableSet.of(
             new BrokerSyncStatus("host1", 8080, 1000)
         )
     );
-    Assert.assertEquals(expected, response.getEntity());
+    Assertions.assertEquals(expected, response.getEntity());
   }
 
   @Test
@@ -100,11 +100,11 @@ public class CoordinatorDynamicConfigsResourceTest
         cloneStatusManager
     );
     Response response = resource.getCloneStatus(null);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(new CloneStatus(statusMetrics), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new CloneStatus(statusMetrics), response.getEntity());
 
     response = resource.getCloneStatus("hist2");
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(ServerCloneStatus.unknown("hist4", "hist3"), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(ServerCloneStatus.unknown("hist4", "hist3"), response.getEntity());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorRedirectInfoTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorRedirectInfoTest.java
@@ -21,9 +21,9 @@ package org.apache.druid.server.http;
 
 import org.apache.druid.server.coordinator.DruidCoordinator;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.URL;
 
@@ -32,7 +32,7 @@ public class CoordinatorRedirectInfoTest
   private DruidCoordinator druidCoordinator;
   private CoordinatorRedirectInfo coordinatorRedirectInfo;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     druidCoordinator = EasyMock.createMock(DruidCoordinator.class);
@@ -44,10 +44,10 @@ public class CoordinatorRedirectInfoTest
   {
     EasyMock.expect(druidCoordinator.isLeader()).andReturn(true).anyTimes();
     EasyMock.replay(druidCoordinator);
-    Assert.assertTrue(coordinatorRedirectInfo.doLocal(null));
-    Assert.assertTrue(coordinatorRedirectInfo.doLocal("/druid/coordinator/v1/leader"));
-    Assert.assertTrue(coordinatorRedirectInfo.doLocal("/druid/coordinator/v1/isLeader"));
-    Assert.assertTrue(coordinatorRedirectInfo.doLocal("/druid/coordinator/v1/other/path"));
+    Assertions.assertTrue(coordinatorRedirectInfo.doLocal(null));
+    Assertions.assertTrue(coordinatorRedirectInfo.doLocal("/druid/coordinator/v1/leader"));
+    Assertions.assertTrue(coordinatorRedirectInfo.doLocal("/druid/coordinator/v1/isLeader"));
+    Assertions.assertTrue(coordinatorRedirectInfo.doLocal("/druid/coordinator/v1/other/path"));
     EasyMock.verify(druidCoordinator);
   }
 
@@ -56,10 +56,10 @@ public class CoordinatorRedirectInfoTest
   {
     EasyMock.expect(druidCoordinator.isLeader()).andReturn(false).anyTimes();
     EasyMock.replay(druidCoordinator);
-    Assert.assertFalse(coordinatorRedirectInfo.doLocal(null));
-    Assert.assertTrue(coordinatorRedirectInfo.doLocal("/druid/coordinator/v1/leader"));
-    Assert.assertTrue(coordinatorRedirectInfo.doLocal("/druid/coordinator/v1/isLeader"));
-    Assert.assertFalse(coordinatorRedirectInfo.doLocal("/druid/coordinator/v1/other/path"));
+    Assertions.assertFalse(coordinatorRedirectInfo.doLocal(null));
+    Assertions.assertTrue(coordinatorRedirectInfo.doLocal("/druid/coordinator/v1/leader"));
+    Assertions.assertTrue(coordinatorRedirectInfo.doLocal("/druid/coordinator/v1/isLeader"));
+    Assertions.assertFalse(coordinatorRedirectInfo.doLocal("/druid/coordinator/v1/other/path"));
     EasyMock.verify(druidCoordinator);
   }
 
@@ -69,7 +69,7 @@ public class CoordinatorRedirectInfoTest
     EasyMock.expect(druidCoordinator.getCurrentLeader()).andReturn(null).anyTimes();
     EasyMock.replay(druidCoordinator);
     URL url = coordinatorRedirectInfo.getRedirectURL("query", "/request");
-    Assert.assertNull(url);
+    Assertions.assertNull(url);
     EasyMock.verify(druidCoordinator);
   }
 
@@ -81,7 +81,7 @@ public class CoordinatorRedirectInfoTest
     EasyMock.expect(druidCoordinator.getCurrentLeader()).andReturn("http://localhost").anyTimes();
     EasyMock.replay(druidCoordinator);
     URL url = coordinatorRedirectInfo.getRedirectURL(query, request);
-    Assert.assertEquals("http://localhost/request?foo=bar&x=y", url.toString());
+    Assertions.assertEquals("http://localhost/request?foo=bar&x=y", url.toString());
     EasyMock.verify(druidCoordinator);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorResourceTest.java
@@ -27,10 +27,10 @@ import org.apache.druid.server.coordinator.loading.TestLoadQueuePeon;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 import java.util.Collections;
@@ -40,13 +40,13 @@ public class CoordinatorResourceTest
 {
   private DruidCoordinator mock;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mock = EasyMock.createStrictMock(DruidCoordinator.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     EasyMock.verify(mock);
@@ -59,8 +59,8 @@ public class CoordinatorResourceTest
     EasyMock.replay(mock);
 
     final Response response = new CoordinatorResource(mock).getLeader();
-    Assert.assertEquals("boz", response.getEntity());
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals("boz", response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
   }
 
   @Test
@@ -72,13 +72,13 @@ public class CoordinatorResourceTest
 
     // true
     final Response response1 = new CoordinatorResource(mock).isLeader();
-    Assert.assertEquals(ImmutableMap.of("leader", true), response1.getEntity());
-    Assert.assertEquals(200, response1.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("leader", true), response1.getEntity());
+    Assertions.assertEquals(200, response1.getStatus());
 
     // false
     final Response response2 = new CoordinatorResource(mock).isLeader();
-    Assert.assertEquals(ImmutableMap.of("leader", false), response2.getEntity());
-    Assert.assertEquals(404, response2.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("leader", false), response2.getEntity());
+    Assertions.assertEquals(404, response2.getStatus());
   }
 
   @Test
@@ -90,7 +90,7 @@ public class CoordinatorResourceTest
     EasyMock.replay(mock);
 
     final Response response = new CoordinatorResource(mock).getLoadQueue("true", null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             "hist1",
             ImmutableMap.of(
@@ -103,7 +103,7 @@ public class CoordinatorResourceTest
         ),
         response.getEntity()
     );
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
   }
 
   @Test
@@ -126,24 +126,24 @@ public class CoordinatorResourceTest
     EasyMock.replay(mock);
 
     final Response response = new CoordinatorResource(mock).getStatusOfDuties();
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
 
     final Object payload = response.getEntity();
-    Assert.assertTrue(payload instanceof CoordinatorDutyStatus);
+    Assertions.assertTrue(payload instanceof CoordinatorDutyStatus);
 
     final List<DutyGroupStatus> observedDutyGroups = ((CoordinatorDutyStatus) payload).getDutyGroups();
-    Assert.assertEquals(1, observedDutyGroups.size());
+    Assertions.assertEquals(1, observedDutyGroups.size());
 
     final DutyGroupStatus observedStatus = observedDutyGroups.get(0);
-    Assert.assertEquals("HistoricalManagementDuties", observedStatus.getName());
-    Assert.assertEquals(Duration.standardMinutes(1), observedStatus.getPeriod());
-    Assert.assertEquals(
+    Assertions.assertEquals("HistoricalManagementDuties", observedStatus.getName());
+    Assertions.assertEquals(Duration.standardMinutes(1), observedStatus.getPeriod());
+    Assertions.assertEquals(
         Collections.singletonList("org.apache.druid.duty.RunRules"),
         observedStatus.getDutyNames()
     );
-    Assert.assertEquals(now.minusMinutes(5), observedStatus.getLastRunStart());
-    Assert.assertEquals(now, observedStatus.getLastRunEnd());
-    Assert.assertEquals(100L, observedStatus.getAvgRuntimeMillis());
-    Assert.assertEquals(500L, observedStatus.getAvgRunGapMillis());
+    Assertions.assertEquals(now.minusMinutes(5), observedStatus.getLastRunStart());
+    Assertions.assertEquals(now, observedStatus.getLastRunEnd());
+    Assertions.assertEquals(100L, observedStatus.getAvgRuntimeMillis());
+    Assertions.assertEquals(500L, observedStatus.getAvgRunGapMillis());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/http/DataSegmentPlusTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/DataSegmentPlusTest.java
@@ -47,9 +47,9 @@ import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -59,7 +59,7 @@ public class DataSegmentPlusTest
   private static final ObjectMapper MAPPER = new DefaultObjectMapper();
   private static final int TEST_VERSION = 0x9;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     InjectableValues.Std injectableValues = new InjectableValues.Std();
@@ -136,34 +136,34 @@ public class DataSegmentPlusTest
         JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
     );
 
-    Assert.assertEquals(8, objectMap.size());
+    Assertions.assertEquals(8, objectMap.size());
     final Map<String, Object> segmentObjectMap = MAPPER.readValue(
         MAPPER.writeValueAsString(segmentPlus.getDataSegment()),
         JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
     );
 
     // verify dataSegment
-    Assert.assertEquals(14, segmentObjectMap.size());
-    Assert.assertEquals("something", segmentObjectMap.get("dataSource"));
-    Assert.assertEquals(interval.toString(), segmentObjectMap.get("interval"));
-    Assert.assertEquals("1", segmentObjectMap.get("version"));
-    Assert.assertEquals(loadSpec, segmentObjectMap.get("loadSpec"));
-    Assert.assertEquals("dim1,dim2", segmentObjectMap.get("dimensions"));
-    Assert.assertEquals("met1,met2", segmentObjectMap.get("metrics"));
-    Assert.assertEquals("proj1,proj2", segmentObjectMap.get("projections"));
-    Assert.assertEquals(
+    Assertions.assertEquals(14, segmentObjectMap.size());
+    Assertions.assertEquals("something", segmentObjectMap.get("dataSource"));
+    Assertions.assertEquals(interval.toString(), segmentObjectMap.get("interval"));
+    Assertions.assertEquals("1", segmentObjectMap.get("version"));
+    Assertions.assertEquals(loadSpec, segmentObjectMap.get("loadSpec"));
+    Assertions.assertEquals("dim1,dim2", segmentObjectMap.get("dimensions"));
+    Assertions.assertEquals("met1,met2", segmentObjectMap.get("metrics"));
+    Assertions.assertEquals("proj1,proj2", segmentObjectMap.get("projections"));
+    Assertions.assertEquals(
         ImmutableMap.of("type", "numbered", "partitionNum", 3, "partitions", 0),
         segmentObjectMap.get("shardSpec")
     );
-    Assert.assertEquals(TEST_VERSION, segmentObjectMap.get("binaryVersion"));
-    Assert.assertEquals(123, segmentObjectMap.get("size"));
-    Assert.assertEquals(12, segmentObjectMap.get("totalRows"));
-    Assert.assertEquals(6, ((Map) segmentObjectMap.get("lastCompactionState")).size());
-    Assert.assertEquals("abc123", segmentObjectMap.get("indexingStateFingerprint"));
+    Assertions.assertEquals(TEST_VERSION, segmentObjectMap.get("binaryVersion"));
+    Assertions.assertEquals(123, segmentObjectMap.get("size"));
+    Assertions.assertEquals(12, segmentObjectMap.get("totalRows"));
+    Assertions.assertEquals(6, ((Map) segmentObjectMap.get("lastCompactionState")).size());
+    Assertions.assertEquals("abc123", segmentObjectMap.get("indexingStateFingerprint"));
 
     // verify extra metadata
-    Assert.assertEquals(createdDateStr, objectMap.get("createdDate"));
-    Assert.assertEquals(usedStatusLastUpdatedDateStr, objectMap.get("usedStatusLastUpdatedDate"));
+    Assertions.assertEquals(createdDateStr, objectMap.get("createdDate"));
+    Assertions.assertEquals(usedStatusLastUpdatedDateStr, objectMap.get("usedStatusLastUpdatedDate"));
 
     DataSegmentPlus deserializedSegmentPlus = MAPPER.readValue(
         MAPPER.writeValueAsString(segmentPlus),
@@ -171,14 +171,14 @@ public class DataSegmentPlusTest
     );
 
     // verify dataSegment
-    Assert.assertEquals(
+    Assertions.assertEquals(
         segmentPlus.getDataSegment().toString(),
         deserializedSegmentPlus.getDataSegment().toString()
     );
 
     // verify extra metadata
-    Assert.assertEquals(segmentPlus.getCreatedDate(), deserializedSegmentPlus.getCreatedDate());
-    Assert.assertEquals(
+    Assertions.assertEquals(segmentPlus.getCreatedDate(), deserializedSegmentPlus.getCreatedDate());
+    Assertions.assertEquals(
         segmentPlus.getUsedStatusLastUpdatedDate(),
         deserializedSegmentPlus.getUsedStatusLastUpdatedDate()
     );

--- a/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
@@ -84,9 +84,9 @@ import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
@@ -114,7 +114,7 @@ public class DataSourcesResourceTest
   
   private DataSourcesResource dataSourcesResource;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     request = EasyMock.createStrictMock(HttpServletRequest.class);
@@ -218,8 +218,8 @@ public class DataSourcesResourceTest
     EasyMock.replay(inventoryView, server, request);
     Response response = dataSourcesResource.getQueryableDataSources("full", null, request);
     Set<ImmutableDruidDataSource> result = (Set<ImmutableDruidDataSource>) response.getEntity();
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(2, result.size());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(2, result.size());
     ImmutableDruidDataSourceTestUtils.assertEquals(
         listDataSources.stream().map(DruidDataSource::toImmutableDruidDataSource).collect(Collectors.toList()),
         new ArrayList<>(result)
@@ -227,10 +227,10 @@ public class DataSourcesResourceTest
 
     response = dataSourcesResource.getQueryableDataSources(null, null, request);
     List<String> result1 = (List<String>) response.getEntity();
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(2, result1.size());
-    Assert.assertTrue(result1.contains(TestDataSource.WIKI));
-    Assert.assertTrue(result1.contains(TestDataSource.KOALA));
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(2, result1.size());
+    Assertions.assertTrue(result1.contains(TestDataSource.WIKI));
+    Assertions.assertTrue(result1.contains(TestDataSource.KOALA));
     EasyMock.verify(inventoryView, server);
   }
 
@@ -294,8 +294,8 @@ public class DataSourcesResourceTest
     Response response = dataSourcesResource.getQueryableDataSources("full", null, request);
     Set<ImmutableDruidDataSource> result = (Set<ImmutableDruidDataSource>) response.getEntity();
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(1, result.size());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(1, result.size());
     ImmutableDruidDataSourceTestUtils.assertEquals(
         listDataSources.get(0).toImmutableDruidDataSource(),
         Iterables.getOnlyElement(result)
@@ -304,9 +304,9 @@ public class DataSourcesResourceTest
     response = dataSourcesResource.getQueryableDataSources(null, null, request);
     List<String> result1 = (List<String>) response.getEntity();
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(1, result1.size());
-    Assert.assertTrue(result1.contains(TestDataSource.WIKI));
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(1, result1.size());
+    Assertions.assertTrue(result1.contains(TestDataSource.WIKI));
 
     EasyMock.verify(inventoryView, server, request);
   }
@@ -329,14 +329,14 @@ public class DataSourcesResourceTest
 
     EasyMock.replay(inventoryView, server, request);
     Response response = dataSourcesResource.getQueryableDataSources(null, "simple", request);
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     List<Map<String, Object>> results = (List<Map<String, Object>>) response.getEntity();
 
-    Assert.assertEquals(2, results.size());
+    Assertions.assertEquals(2, results.size());
     for (Map<String, Object> entry : results) {
-      Assert.assertTrue(((Map) ((Map) entry.get("properties")).get("tiers")).containsKey(null));
-      Assert.assertNotNull((((Map) entry.get("properties")).get("segments")));
-      Assert.assertEquals(1, ((Map) ((Map) entry.get("properties")).get("segments")).get("count"));
+      Assertions.assertTrue(((Map) ((Map) entry.get("properties")).get("tiers")).containsKey(null));
+      Assertions.assertNotNull((((Map) entry.get("properties")).get("segments")));
+      Assertions.assertEquals(1, ((Map) ((Map) entry.get("properties")).get("segments")).get("count"));
     }
     EasyMock.verify(inventoryView, server);
   }
@@ -351,7 +351,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(inventoryView, server);
     Response response = dataSourcesResource.getQueryableDataSource(TestDataSource.WIKI, "full");
     ImmutableDruidDataSource result = (ImmutableDruidDataSource) response.getEntity();
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     ImmutableDruidDataSourceTestUtils.assertEquals(dataSource1.toImmutableDruidDataSource(), result);
     EasyMock.verify(inventoryView, server);
   }
@@ -363,7 +363,7 @@ public class DataSourcesResourceTest
     EasyMock.expect(inventoryView.getInventory()).andReturn(ImmutableList.of(server)).atLeastOnce();
 
     EasyMock.replay(inventoryView, server);
-    Assert.assertEquals(204, dataSourcesResource.getQueryableDataSource("none", null).getStatus());
+    Assertions.assertEquals(204, dataSourcesResource.getQueryableDataSource("none", null).getStatus());
     EasyMock.verify(inventoryView, server);
   }
 
@@ -380,17 +380,17 @@ public class DataSourcesResourceTest
 
     EasyMock.replay(inventoryView, server);
     Response response = dataSourcesResource.getQueryableDataSource(TestDataSource.WIKI, null);
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     Map<String, Map<String, Object>> result = (Map<String, Map<String, Object>>) response.getEntity();
-    Assert.assertEquals(1, ((Map) (result.get("tiers").get(null))).get("segmentCount"));
-    Assert.assertEquals(10L, ((Map) (result.get("tiers").get(null))).get("size"));
-    Assert.assertEquals(10L, ((Map) (result.get("tiers").get(null))).get("replicatedSize"));
-    Assert.assertNotNull(result.get("segments"));
-    Assert.assertEquals("2010-01-01T00:00:00.000Z", result.get("segments").get("minTime").toString());
-    Assert.assertEquals("2010-01-02T00:00:00.000Z", result.get("segments").get("maxTime").toString());
-    Assert.assertEquals(1, result.get("segments").get("count"));
-    Assert.assertEquals(10L, result.get("segments").get("size"));
-    Assert.assertEquals(10L, result.get("segments").get("replicatedSize"));
+    Assertions.assertEquals(1, ((Map) (result.get("tiers").get(null))).get("segmentCount"));
+    Assertions.assertEquals(10L, ((Map) (result.get("tiers").get(null))).get("size"));
+    Assertions.assertEquals(10L, ((Map) (result.get("tiers").get(null))).get("replicatedSize"));
+    Assertions.assertNotNull(result.get("segments"));
+    Assertions.assertEquals("2010-01-01T00:00:00.000Z", result.get("segments").get("minTime").toString());
+    Assertions.assertEquals("2010-01-02T00:00:00.000Z", result.get("segments").get("maxTime").toString());
+    Assertions.assertEquals(1, result.get("segments").get("count"));
+    Assertions.assertEquals(10L, result.get("segments").get("size"));
+    Assertions.assertEquals(10L, result.get("segments").get("replicatedSize"));
     EasyMock.verify(inventoryView, server);
   }
 
@@ -412,19 +412,19 @@ public class DataSourcesResourceTest
 
     EasyMock.replay(inventoryView, server, server2, server3);
     Response response = dataSourcesResource.getQueryableDataSource(TestDataSource.WIKI, null);
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     Map<String, Map<String, Object>> result = (Map<String, Map<String, Object>>) response.getEntity();
-    Assert.assertEquals(2, ((Map) (result.get("tiers").get("cold"))).get("segmentCount"));
-    Assert.assertEquals(30L, ((Map) (result.get("tiers").get("cold"))).get("size"));
-    Assert.assertEquals(30L, ((Map) (result.get("tiers").get("cold"))).get("replicatedSize"));
-    Assert.assertEquals(1, ((Map) (result.get("tiers").get("hot"))).get("segmentCount"));
-    Assert.assertEquals(20L, ((Map) (result.get("tiers").get("hot"))).get("size"));
-    Assert.assertNotNull(result.get("segments"));
-    Assert.assertEquals("2010-01-01T00:00:00.000Z", result.get("segments").get("minTime").toString());
-    Assert.assertEquals("2010-01-23T00:00:00.000Z", result.get("segments").get("maxTime").toString());
-    Assert.assertEquals(2, result.get("segments").get("count"));
-    Assert.assertEquals(30L, result.get("segments").get("size"));
-    Assert.assertEquals(50L, result.get("segments").get("replicatedSize"));
+    Assertions.assertEquals(2, ((Map) (result.get("tiers").get("cold"))).get("segmentCount"));
+    Assertions.assertEquals(30L, ((Map) (result.get("tiers").get("cold"))).get("size"));
+    Assertions.assertEquals(30L, ((Map) (result.get("tiers").get("cold"))).get("replicatedSize"));
+    Assertions.assertEquals(1, ((Map) (result.get("tiers").get("hot"))).get("segmentCount"));
+    Assertions.assertEquals(20L, ((Map) (result.get("tiers").get("hot"))).get("size"));
+    Assertions.assertNotNull(result.get("segments"));
+    Assertions.assertEquals("2010-01-01T00:00:00.000Z", result.get("segments").get("minTime").toString());
+    Assertions.assertEquals("2010-01-23T00:00:00.000Z", result.get("segments").get("maxTime").toString());
+    Assertions.assertEquals(2, result.get("segments").get("count"));
+    Assertions.assertEquals(30L, result.get("segments").get("size"));
+    Assertions.assertEquals(50L, result.get("segments").get("replicatedSize"));
     EasyMock.verify(inventoryView, server, server2, server3);
   }
 
@@ -449,32 +449,32 @@ public class DataSourcesResourceTest
     EasyMock.replay(inventoryView);
 
     Response response = dataSourcesResource.getQueryableDataSource(TestDataSource.WIKI, null);
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     Map<String, Map<String, Object>> result1 = (Map<String, Map<String, Object>>) response.getEntity();
-    Assert.assertEquals(2, ((Map) (result1.get("tiers").get("tier1"))).get("segmentCount"));
-    Assert.assertEquals(30L, ((Map) (result1.get("tiers").get("tier1"))).get("size"));
-    Assert.assertEquals(30L, ((Map) (result1.get("tiers").get("tier1"))).get("replicatedSize"));
-    Assert.assertEquals(2, ((Map) (result1.get("tiers").get("tier2"))).get("segmentCount"));
-    Assert.assertEquals(30L, ((Map) (result1.get("tiers").get("tier2"))).get("size"));
-    Assert.assertNotNull(result1.get("segments"));
-    Assert.assertEquals("2010-01-01T00:00:00.000Z", result1.get("segments").get("minTime").toString());
-    Assert.assertEquals("2010-01-23T00:00:00.000Z", result1.get("segments").get("maxTime").toString());
-    Assert.assertEquals(2, result1.get("segments").get("count"));
-    Assert.assertEquals(30L, result1.get("segments").get("size"));
-    Assert.assertEquals(60L, result1.get("segments").get("replicatedSize"));
+    Assertions.assertEquals(2, ((Map) (result1.get("tiers").get("tier1"))).get("segmentCount"));
+    Assertions.assertEquals(30L, ((Map) (result1.get("tiers").get("tier1"))).get("size"));
+    Assertions.assertEquals(30L, ((Map) (result1.get("tiers").get("tier1"))).get("replicatedSize"));
+    Assertions.assertEquals(2, ((Map) (result1.get("tiers").get("tier2"))).get("segmentCount"));
+    Assertions.assertEquals(30L, ((Map) (result1.get("tiers").get("tier2"))).get("size"));
+    Assertions.assertNotNull(result1.get("segments"));
+    Assertions.assertEquals("2010-01-01T00:00:00.000Z", result1.get("segments").get("minTime").toString());
+    Assertions.assertEquals("2010-01-23T00:00:00.000Z", result1.get("segments").get("maxTime").toString());
+    Assertions.assertEquals(2, result1.get("segments").get("count"));
+    Assertions.assertEquals(30L, result1.get("segments").get("size"));
+    Assertions.assertEquals(60L, result1.get("segments").get("replicatedSize"));
 
     response = dataSourcesResource.getQueryableDataSource(TestDataSource.KOALA, null);
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     Map<String, Map<String, Object>> result2 = (Map<String, Map<String, Object>>) response.getEntity();
-    Assert.assertEquals(1, ((Map) (result2.get("tiers").get("tier1"))).get("segmentCount"));
-    Assert.assertEquals(30L, ((Map) (result2.get("tiers").get("tier1"))).get("size"));
-    Assert.assertEquals(60L, ((Map) (result2.get("tiers").get("tier1"))).get("replicatedSize"));
-    Assert.assertNotNull(result2.get("segments"));
-    Assert.assertEquals("2010-01-01T00:00:00.000Z", result2.get("segments").get("minTime").toString());
-    Assert.assertEquals("2010-01-02T00:00:00.000Z", result2.get("segments").get("maxTime").toString());
-    Assert.assertEquals(1, result2.get("segments").get("count"));
-    Assert.assertEquals(30L, result2.get("segments").get("size"));
-    Assert.assertEquals(60L, result2.get("segments").get("replicatedSize"));
+    Assertions.assertEquals(1, ((Map) (result2.get("tiers").get("tier1"))).get("segmentCount"));
+    Assertions.assertEquals(30L, ((Map) (result2.get("tiers").get("tier1"))).get("size"));
+    Assertions.assertEquals(60L, ((Map) (result2.get("tiers").get("tier1"))).get("replicatedSize"));
+    Assertions.assertNotNull(result2.get("segments"));
+    Assertions.assertEquals("2010-01-01T00:00:00.000Z", result2.get("segments").get("minTime").toString());
+    Assertions.assertEquals("2010-01-02T00:00:00.000Z", result2.get("segments").get("maxTime").toString());
+    Assertions.assertEquals(1, result2.get("segments").get("count"));
+    Assertions.assertEquals(30L, result2.get("segments").get("size"));
+    Assertions.assertEquals(60L, result2.get("segments").get("replicatedSize"));
     EasyMock.verify(inventoryView);
   }
 
@@ -496,7 +496,7 @@ public class DataSourcesResourceTest
         null,
         null
     );
-    Assert.assertNull(response.getEntity());
+    Assertions.assertNull(response.getEntity());
 
     response = dataSourcesResource.getIntervalsWithServedSegmentsOrAllServedSegmentsPerIntervals(
         TestDataSource.WIKI,
@@ -504,9 +504,9 @@ public class DataSourcesResourceTest
         null
     );
     TreeSet<Interval> actualIntervals = (TreeSet) response.getEntity();
-    Assert.assertEquals(2, actualIntervals.size());
-    Assert.assertEquals(expectedIntervals.get(0), actualIntervals.first());
-    Assert.assertEquals(expectedIntervals.get(1), actualIntervals.last());
+    Assertions.assertEquals(2, actualIntervals.size());
+    Assertions.assertEquals(expectedIntervals.get(0), actualIntervals.first());
+    Assertions.assertEquals(expectedIntervals.get(1), actualIntervals.last());
 
     response = dataSourcesResource.getIntervalsWithServedSegmentsOrAllServedSegmentsPerIntervals(
         TestDataSource.WIKI,
@@ -514,11 +514,11 @@ public class DataSourcesResourceTest
         null
     );
     TreeMap<Interval, Map<DataSourcesResource.SimpleProperties, Object>> results = (TreeMap) response.getEntity();
-    Assert.assertEquals(2, results.size());
-    Assert.assertEquals(expectedIntervals.get(0), results.firstKey());
-    Assert.assertEquals(expectedIntervals.get(1), results.lastKey());
-    Assert.assertEquals(1, results.firstEntry().getValue().get(DataSourcesResource.SimpleProperties.count));
-    Assert.assertEquals(1, results.lastEntry().getValue().get(DataSourcesResource.SimpleProperties.count));
+    Assertions.assertEquals(2, results.size());
+    Assertions.assertEquals(expectedIntervals.get(0), results.firstKey());
+    Assertions.assertEquals(expectedIntervals.get(1), results.lastKey());
+    Assertions.assertEquals(1, results.firstEntry().getValue().get(DataSourcesResource.SimpleProperties.count));
+    Assertions.assertEquals(1, results.lastEntry().getValue().get(DataSourcesResource.SimpleProperties.count));
 
     response = dataSourcesResource.getIntervalsWithServedSegmentsOrAllServedSegmentsPerIntervals(
         TestDataSource.WIKI,
@@ -528,8 +528,8 @@ public class DataSourcesResourceTest
     Map<Interval, Map<SegmentId, Object>> results2 = ((Map<Interval, Map<SegmentId, Object>>) response.getEntity());
     int i = 1;
     for (Map.Entry<Interval, Map<SegmentId, Object>> entry : results2.entrySet()) {
-      Assert.assertEquals(dataSegmentList.get(i).getInterval(), entry.getKey());
-      Assert.assertEquals(
+      Assertions.assertEquals(dataSegmentList.get(i).getInterval(), entry.getKey());
+      Assertions.assertEquals(
           dataSegmentList.get(i),
           ((Map<String, Object>) entry.getValue().get(dataSegmentList.get(i).getId())).get("metadata")
       );
@@ -554,7 +554,7 @@ public class DataSourcesResourceTest
         null,
         null
     );
-    Assert.assertNull(response.getEntity());
+    Assertions.assertNull(response.getEntity());
 
     response = dataSourcesResource.getServedSegmentsInInterval(
         TestDataSource.WIKI,
@@ -562,13 +562,13 @@ public class DataSourcesResourceTest
         null,
         null
     ); // interval not present in the datasource
-    Assert.assertEquals(ImmutableSet.of(), response.getEntity());
+    Assertions.assertEquals(ImmutableSet.of(), response.getEntity());
 
     response = dataSourcesResource.getServedSegmentsInInterval(TestDataSource.WIKI, "2010-01-01/P1D", null, null);
-    Assert.assertEquals(ImmutableSet.of(dataSegmentList.get(0).getId()), response.getEntity());
+    Assertions.assertEquals(ImmutableSet.of(dataSegmentList.get(0).getId()), response.getEntity());
 
     response = dataSourcesResource.getServedSegmentsInInterval(TestDataSource.WIKI, "2010-01-01/P1M", null, null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(dataSegmentList.get(1).getId(), dataSegmentList.get(0).getId()),
         response.getEntity()
     );
@@ -581,11 +581,11 @@ public class DataSourcesResourceTest
     );
     Map<Interval, Map<DataSourcesResource.SimpleProperties, Object>> results =
         ((Map<Interval, Map<DataSourcesResource.SimpleProperties, Object>>) response.getEntity());
-    Assert.assertEquals(2, results.size());
+    Assertions.assertEquals(2, results.size());
     int i;
     for (i = 0; i < 2; i++) {
-      Assert.assertTrue(results.containsKey(dataSegmentList.get(i).getInterval()));
-      Assert.assertEquals(
+      Assertions.assertTrue(results.containsKey(dataSegmentList.get(i).getInterval()));
+      Assertions.assertEquals(
           1,
           (results.get(dataSegmentList.get(i).getInterval())).get(DataSourcesResource.SimpleProperties.count)
       );
@@ -595,8 +595,8 @@ public class DataSourcesResourceTest
     Map<Interval, Map<SegmentId, Object>> results1 = ((Map<Interval, Map<SegmentId, Object>>) response.getEntity());
     i = 1;
     for (Map.Entry<Interval, Map<SegmentId, Object>> entry : results1.entrySet()) {
-      Assert.assertEquals(dataSegmentList.get(i).getInterval(), entry.getKey());
-      Assert.assertEquals(
+      Assertions.assertEquals(dataSegmentList.get(i).getInterval(), entry.getKey());
+      Assertions.assertEquals(
           dataSegmentList.get(i),
           ((Map<String, Object>) entry.getValue().get(dataSegmentList.get(i).getId())).get("metadata")
       );
@@ -618,8 +618,8 @@ public class DataSourcesResourceTest
     prepareRequestForAudit();
     Response response = dataSourcesResource.killUnusedSegmentsInInterval(TestDataSource.WIKI, interval, request);
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertNull(response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertNull(response.getEntity());
     EasyMock.verify(overlordClient, server);
   }
 
@@ -647,7 +647,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(overlordClient, server);
     Response response = dataSourcesResource
         .markAsUnusedAllSegmentsOrKillUnusedSegmentsInInterval(TestDataSource.WIKI, null, null, request);
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
 
     EasyMock.verify(overlordClient, request);
   }
@@ -679,7 +679,7 @@ public class DataSourcesResourceTest
 
     String interval1 = "2013-01-01T01:00:00Z/2013-01-01T02:00:00Z";
     Response response1 = dataSourcesResource.isHandOffComplete(TestDataSource.WIKI, interval1, 1, "v1");
-    Assert.assertTrue((boolean) response1.getEntity());
+    Assertions.assertTrue((boolean) response1.getEntity());
 
     EasyMock.verify(databaseRuleManager);
 
@@ -695,7 +695,7 @@ public class DataSourcesResourceTest
 
     String interval2 = "2013-01-02T01:00:00Z/2013-01-02T02:00:00Z";
     Response response2 = dataSourcesResource.isHandOffComplete(TestDataSource.WIKI, interval2, 1, "v1");
-    Assert.assertFalse((boolean) response2.getEntity());
+    Assertions.assertFalse((boolean) response2.getEntity());
 
     EasyMock.verify(inventoryView, databaseRuleManager);
 
@@ -726,7 +726,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(inventoryView, databaseRuleManager);
 
     Response response3 = dataSourcesResource.isHandOffComplete(TestDataSource.WIKI, interval3, 1, "v1");
-    Assert.assertTrue((boolean) response3.getEntity());
+    Assertions.assertTrue((boolean) response3.getEntity());
 
     EasyMock.verify(inventoryView, databaseRuleManager);
   }
@@ -768,7 +768,7 @@ public class DataSourcesResourceTest
 
     String interval = "2013-01-01T01:00:00Z/2013-01-01T02:00:00Z";
     Response response = dataSourcesResource.isHandOffComplete(TestDataSource.WIKI, interval, 1, "v1");
-    Assert.assertTrue((boolean) response.getEntity());
+    Assertions.assertTrue((boolean) response.getEntity());
 
     EasyMock.verify(databaseRuleManager, segmentsMetadataManager);
   }
@@ -815,7 +815,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(inventoryView, databaseRuleManager, segmentsMetadataManager);
 
     Response response = dataSourcesResource.isHandOffComplete(TestDataSource.WIKI, interval, 1, "v1");
-    Assert.assertFalse((boolean) response.getEntity());
+    Assertions.assertFalse((boolean) response.getEntity());
 
     EasyMock.verify(inventoryView, databaseRuleManager, segmentsMetadataManager);
   }
@@ -867,7 +867,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(databaseRuleManager, segmentsMetadataManager);
 
     Response response = dataSourcesResource.isHandOffComplete(TestDataSource.WIKI, interval, 1, "v1");
-    Assert.assertTrue((boolean) response.getEntity());
+    Assertions.assertTrue((boolean) response.getEntity());
 
     EasyMock.verify(databaseRuleManager, segmentsMetadataManager);
   }
@@ -919,7 +919,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(inventoryView, databaseRuleManager, segmentsMetadataManager);
 
     Response response = dataSourcesResource.isHandOffComplete(TestDataSource.WIKI, interval, 1, "v1");
-    Assert.assertFalse((boolean) response.getEntity());
+    Assertions.assertFalse((boolean) response.getEntity());
 
     EasyMock.verify(inventoryView, databaseRuleManager, segmentsMetadataManager);
   }
@@ -956,7 +956,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(overlordClient);
 
     Response response = dataSourcesResource.markSegmentAsUsed(segment.getDataSource(), segment.getId().toString());
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     EasyMock.verify(overlordClient);
   }
 
@@ -974,13 +974,13 @@ public class DataSourcesResourceTest
     EasyMock.replay(overlordClient);
 
     Response response = dataSourcesResource.markSegmentAsUsed(segment.getDataSource(), segment.getId().toString());
-    Assert.assertEquals(404, response.getStatus());
+    Assertions.assertEquals(404, response.getStatus());
 
     final Object payload = response.getEntity();
-    Assert.assertTrue(payload instanceof ErrorResponse);
+    Assertions.assertTrue(payload instanceof ErrorResponse);
 
     final ErrorResponse errorResponse = (ErrorResponse) payload;
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Could not update segments since Overlord is on an older version.",
         errorResponse.getAsMap().get("errorMessage")
     );
@@ -997,8 +997,8 @@ public class DataSourcesResourceTest
     EasyMock.replay(overlordClient);
 
     Response response = dataSourcesResource.markSegmentAsUsed(segment.getDataSource(), segment.getId().toString());
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
     EasyMock.verify(overlordClient);
   }
 
@@ -1016,7 +1016,7 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         segmentFilter
     );
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     EasyMock.verify(overlordClient, inventoryView, server);
   }
 
@@ -1034,7 +1034,7 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         segmentFilter
     );
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     EasyMock.verify(overlordClient, inventoryView, server);
   }
 
@@ -1052,7 +1052,7 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         filter
     );
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     EasyMock.verify(overlordClient, inventoryView, server);
   }
 
@@ -1069,7 +1069,7 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         segmentFilter
     );
-    Assert.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
+    Assertions.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
     EasyMock.verify(overlordClient, inventoryView, server);
   }
 
@@ -1087,7 +1087,7 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         segmentFilter
     );
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     EasyMock.verify(overlordClient, inventoryView, server);
   }
 
@@ -1104,7 +1104,7 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         segmentFilter
     );
-    Assert.assertEquals(500, response.getStatus());
+    Assertions.assertEquals(500, response.getStatus());
     EasyMock.verify(overlordClient, inventoryView, server);
   }
 
@@ -1121,8 +1121,8 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         segmentFilter
     );
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
     EasyMock.verify(overlordClient);
   }
 
@@ -1133,7 +1133,7 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         new SegmentsToUpdateFilter(null, null, null)
     );
-    Assert.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(400, response.getStatus());
   }
 
   @Test
@@ -1150,8 +1150,8 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         segmentFilter
     );
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(new SegmentUpdateResponse(2), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new SegmentUpdateResponse(2), response.getEntity());
     EasyMock.verify(overlordClient);
   }
 
@@ -1169,8 +1169,8 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         segmentFilter
     );
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
 
     EasyMock.verify(overlordClient);
   }
@@ -1182,7 +1182,7 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         new SegmentsToUpdateFilter(Intervals.of("2010-01-22/P1D"), ImmutableSet.of("segment1"), null)
     );
-    Assert.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(400, response.getStatus());
   }
 
   @Test
@@ -1194,7 +1194,7 @@ public class DataSourcesResourceTest
             Intervals.of("2020/2030"), ImmutableSet.of("seg1"), ImmutableList.of("v1", "v2")
         )
     );
-    Assert.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(400, response.getStatus());
   }
 
   @Test
@@ -1204,7 +1204,7 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         new SegmentsToUpdateFilter(null, ImmutableSet.of(), null)
     );
-    Assert.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(400, response.getStatus());
   }
 
   @Test
@@ -1214,7 +1214,7 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         new SegmentsToUpdateFilter(null, null, ImmutableList.of())
     );
-    Assert.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(400, response.getStatus());
   }
 
   @Test
@@ -1224,7 +1224,7 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         new SegmentsToUpdateFilter(null, null, ImmutableList.of("v1", "v2"))
     );
-    Assert.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(400, response.getStatus());
   }
 
   @Test
@@ -1234,7 +1234,7 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         new SegmentsToUpdateFilter(null, ImmutableSet.of("segment1"), ImmutableList.of("v1", "v2"))
     );
-    Assert.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(400, response.getStatus());
   }
 
   @Test
@@ -1251,8 +1251,8 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         segmentFilter
     );
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(new SegmentUpdateResponse(2), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new SegmentUpdateResponse(2), response.getEntity());
     EasyMock.verify(overlordClient);
   }
 
@@ -1269,8 +1269,8 @@ public class DataSourcesResourceTest
         TestDataSource.WIKI,
         segmentFilter
     );
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(new SegmentUpdateResponse(5), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new SegmentUpdateResponse(5), response.getEntity());
 
     EasyMock.verify(overlordClient);
   }
@@ -1279,7 +1279,7 @@ public class DataSourcesResourceTest
   public void testSegmentLoadChecksForVersion()
   {
     Interval interval = Intervals.of("2011-04-01/2011-04-02");
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DataSourcesResource.isSegmentLoaded(
             Collections.singletonList(
                 new ImmutableSegmentLoadInfo(
@@ -1291,7 +1291,7 @@ public class DataSourcesResourceTest
         )
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         DataSourcesResource.isSegmentLoaded(
             Collections.singletonList(
                 new ImmutableSegmentLoadInfo(
@@ -1303,7 +1303,7 @@ public class DataSourcesResourceTest
         )
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         DataSourcesResource.isSegmentLoaded(
             Collections.singletonList(
                 new ImmutableSegmentLoadInfo(
@@ -1321,7 +1321,7 @@ public class DataSourcesResourceTest
   public void testSegmentLoadChecksForAssignableServer()
   {
     Interval interval = Intervals.of("2011-04-01/2011-04-02");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         DataSourcesResource.isSegmentLoaded(
             Collections.singletonList(
                 new ImmutableSegmentLoadInfo(
@@ -1333,7 +1333,7 @@ public class DataSourcesResourceTest
         )
     );
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DataSourcesResource.isSegmentLoaded(
             Collections.singletonList(
                 new ImmutableSegmentLoadInfo(
@@ -1350,7 +1350,7 @@ public class DataSourcesResourceTest
   public void testSegmentLoadChecksForPartitionNumber()
   {
     Interval interval = Intervals.of("2011-04-01/2011-04-02");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         DataSourcesResource.isSegmentLoaded(
             Collections.singletonList(
                 new ImmutableSegmentLoadInfo(
@@ -1362,7 +1362,7 @@ public class DataSourcesResourceTest
         )
     );
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DataSourcesResource.isSegmentLoaded(
             Collections.singletonList(
                 new ImmutableSegmentLoadInfo(
@@ -1380,7 +1380,7 @@ public class DataSourcesResourceTest
   public void testSegmentLoadChecksForInterval()
   {
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DataSourcesResource.isSegmentLoaded(
             Collections.singletonList(
                 new ImmutableSegmentLoadInfo(
@@ -1392,7 +1392,7 @@ public class DataSourcesResourceTest
         )
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         DataSourcesResource.isSegmentLoaded(
             Collections.singletonList(
                 new ImmutableSegmentLoadInfo(
@@ -1430,8 +1430,8 @@ public class DataSourcesResourceTest
 
     prepareRequestForAudit();
     Response response = dataSourcesResource.markSegmentsAsUnused(TestDataSource.WIKI, payload, request);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(new SegmentUpdateResponse(1), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new SegmentUpdateResponse(1), response.getEntity());
     EasyMock.verify(overlordClient, inventoryView, server);
   }
 
@@ -1460,8 +1460,8 @@ public class DataSourcesResourceTest
 
     prepareRequestForAudit();
     Response response = dataSourcesResource.markSegmentsAsUnused(TestDataSource.WIKI, segmentFilter, request);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
     EasyMock.verify(overlordClient, inventoryView, server);
   }
 
@@ -1490,8 +1490,8 @@ public class DataSourcesResourceTest
     EasyMock.replay(overlordClient, inventoryView, server);
 
     Response response = dataSourcesResource.markSegmentsAsUnused(TestDataSource.WIKI, segmentFilter, request);
-    Assert.assertEquals(500, response.getStatus());
-    Assert.assertNotNull(response.getEntity());
+    Assertions.assertEquals(500, response.getStatus());
+    Assertions.assertNotNull(response.getEntity());
     EasyMock.verify(overlordClient, inventoryView, server);
   }
 
@@ -1508,8 +1508,8 @@ public class DataSourcesResourceTest
 
     prepareRequestForAudit();
     Response response = dataSourcesResource.markSegmentsAsUnused(TestDataSource.WIKI, segmentFilter, request);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(new SegmentUpdateResponse(1), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new SegmentUpdateResponse(1), response.getEntity());
     EasyMock.verify(overlordClient, inventoryView, server);
   }
 
@@ -1526,8 +1526,8 @@ public class DataSourcesResourceTest
 
     prepareRequestForAudit();
     Response response = dataSourcesResource.markSegmentsAsUnused(TestDataSource.WIKI, segmentFilter, request);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
     EasyMock.verify(overlordClient, inventoryView, server);
   }
 
@@ -1544,8 +1544,8 @@ public class DataSourcesResourceTest
     EasyMock.replay(overlordClient, inventoryView, server);
 
     Response response = dataSourcesResource.markSegmentsAsUnused(TestDataSource.WIKI, segmentFilter, request);
-    Assert.assertEquals(500, response.getStatus());
-    Assert.assertNotNull(response.getEntity());
+    Assertions.assertEquals(500, response.getStatus());
+    Assertions.assertNotNull(response.getEntity());
     EasyMock.verify(overlordClient, inventoryView, server);
   }
 
@@ -1562,8 +1562,8 @@ public class DataSourcesResourceTest
     prepareRequestForAudit();
 
     Response response = dataSourcesResource.markSegmentsAsUnused(TestDataSource.WIKI, segmentFilter, request);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
     EasyMock.verify(overlordClient);
   }
 
@@ -1580,8 +1580,8 @@ public class DataSourcesResourceTest
     prepareRequestForAudit();
 
     Response response = dataSourcesResource.markSegmentsAsUnused(TestDataSource.WIKI, segmentFilter, request);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(new SegmentUpdateResponse(2), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new SegmentUpdateResponse(2), response.getEntity());
     EasyMock.verify(overlordClient);
   }
 
@@ -1598,8 +1598,8 @@ public class DataSourcesResourceTest
     prepareRequestForAudit();
 
     Response response = dataSourcesResource.markSegmentsAsUnused(TestDataSource.WIKI, segmentFilter, request);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
     EasyMock.verify(overlordClient);
   }
 
@@ -1611,20 +1611,20 @@ public class DataSourcesResourceTest
 
     final SegmentsToUpdateFilter obj =
         mapper.readValue(payload, SegmentsToUpdateFilter.class);
-    Assert.assertEquals(Intervals.of("2023/2024"), obj.getInterval());
-    Assert.assertEquals(ImmutableList.of("v1"), obj.getVersions());
-    Assert.assertNull(obj.getSegmentIds());
+    Assertions.assertEquals(Intervals.of("2023/2024"), obj.getInterval());
+    Assertions.assertEquals(ImmutableList.of("v1"), obj.getVersions());
+    Assertions.assertNull(obj.getSegmentIds());
 
-    Assert.assertEquals(payload, mapper.writeValueAsString(obj));
+    Assertions.assertEquals(payload, mapper.writeValueAsString(obj));
   }
 
   @Test
   public void testMarkSegmentsAsUnusedNullPayload()
   {
     Response response = dataSourcesResource.markSegmentsAsUnused(TestDataSource.WIKI, null, request);
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertNotNull(response.getEntity());
-    Assert.assertEquals(
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertNotNull(response.getEntity());
+    Assertions.assertEquals(
         "Invalid request payload. Specify either 'interval' or 'segmentIds', but not both."
         + " Optionally, include 'versions' only when 'interval' is provided.",
         response.getEntity()
@@ -1638,8 +1638,8 @@ public class DataSourcesResourceTest
         new SegmentsToUpdateFilter(null, null, null);
 
     Response response = dataSourcesResource.markSegmentsAsUnused(TestDataSource.WIKI, payload, request);
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertNotNull(response.getEntity());
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertNotNull(response.getEntity());
   }
 
   @Test
@@ -1655,8 +1655,8 @@ public class DataSourcesResourceTest
 
     Response response = dataSourcesResource.markSegmentsAsUnused(TestDataSource.WIKI, segmentFilter, request);
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(new SegmentUpdateResponse(0), response.getEntity());
 
     EasyMock.verify(overlordClient);
   }
@@ -1665,7 +1665,7 @@ public class DataSourcesResourceTest
   public void testGetDatasourceLoadstatusForceMetadataRefreshNull()
   {
     Response response = dataSourcesResource.getDatasourceLoadstatus(TestDataSource.WIKI, null, null, null, null, null);
-    Assert.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(400, response.getStatus());
   }
 
   @Test
@@ -1678,7 +1678,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(segmentsMetadataManager);
 
     Response response = dataSourcesResource.getDatasourceLoadstatus(TestDataSource.WIKI, true, null, null, null, null);
-    Assert.assertEquals(204, response.getStatus());
+    Assertions.assertEquals(204, response.getStatus());
   }
 
   @Test
@@ -1736,11 +1736,11 @@ public class DataSourcesResourceTest
     EasyMock.replay(segmentsMetadataManager, inventoryView);
 
     Response response = dataSourcesResource.getDatasourceLoadstatus(TestDataSource.WIKI, true, null, null, null, null);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertNotNull(response.getEntity());
-    Assert.assertEquals(1, ((Map) response.getEntity()).size());
-    Assert.assertTrue(((Map) response.getEntity()).containsKey(TestDataSource.WIKI));
-    Assert.assertEquals(100.0, ((Map) response.getEntity()).get(TestDataSource.WIKI));
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertNotNull(response.getEntity());
+    Assertions.assertEquals(1, ((Map) response.getEntity()).size());
+    Assertions.assertTrue(((Map) response.getEntity()).containsKey(TestDataSource.WIKI));
+    Assertions.assertEquals(100.0, ((Map) response.getEntity()).get(TestDataSource.WIKI));
     EasyMock.verify(segmentsMetadataManager, inventoryView);
     EasyMock.reset(segmentsMetadataManager, inventoryView);
 
@@ -1751,11 +1751,11 @@ public class DataSourcesResourceTest
     EasyMock.replay(segmentsMetadataManager, inventoryView);
 
     response = dataSourcesResource.getDatasourceLoadstatus(TestDataSource.WIKI, true, null, null, null, null);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertNotNull(response.getEntity());
-    Assert.assertEquals(1, ((Map) response.getEntity()).size());
-    Assert.assertTrue(((Map) response.getEntity()).containsKey(TestDataSource.WIKI));
-    Assert.assertEquals(50.0, ((Map) response.getEntity()).get(TestDataSource.WIKI));
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertNotNull(response.getEntity());
+    Assertions.assertEquals(1, ((Map) response.getEntity()).size());
+    Assertions.assertTrue(((Map) response.getEntity()).containsKey(TestDataSource.WIKI));
+    Assertions.assertEquals(50.0, ((Map) response.getEntity()).get(TestDataSource.WIKI));
     EasyMock.verify(segmentsMetadataManager, inventoryView);
   }
 
@@ -1814,11 +1814,11 @@ public class DataSourcesResourceTest
     EasyMock.replay(segmentsMetadataManager, inventoryView);
 
     Response response = dataSourcesResource.getDatasourceLoadstatus(TestDataSource.WIKI, true, null, "simple", null, null);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertNotNull(response.getEntity());
-    Assert.assertEquals(1, ((Map) response.getEntity()).size());
-    Assert.assertTrue(((Map) response.getEntity()).containsKey(TestDataSource.WIKI));
-    Assert.assertEquals(0, ((Map) response.getEntity()).get(TestDataSource.WIKI));
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertNotNull(response.getEntity());
+    Assertions.assertEquals(1, ((Map) response.getEntity()).size());
+    Assertions.assertTrue(((Map) response.getEntity()).containsKey(TestDataSource.WIKI));
+    Assertions.assertEquals(0, ((Map) response.getEntity()).get(TestDataSource.WIKI));
     EasyMock.verify(segmentsMetadataManager, inventoryView);
     EasyMock.reset(segmentsMetadataManager, inventoryView);
 
@@ -1829,11 +1829,11 @@ public class DataSourcesResourceTest
     EasyMock.replay(segmentsMetadataManager, inventoryView);
 
     response = dataSourcesResource.getDatasourceLoadstatus(TestDataSource.WIKI, true, null, "simple", null, null);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertNotNull(response.getEntity());
-    Assert.assertEquals(1, ((Map) response.getEntity()).size());
-    Assert.assertTrue(((Map) response.getEntity()).containsKey(TestDataSource.WIKI));
-    Assert.assertEquals(1, ((Map) response.getEntity()).get(TestDataSource.WIKI));
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertNotNull(response.getEntity());
+    Assertions.assertEquals(1, ((Map) response.getEntity()).size());
+    Assertions.assertTrue(((Map) response.getEntity()).containsKey(TestDataSource.WIKI));
+    Assertions.assertEquals(1, ((Map) response.getEntity()).get(TestDataSource.WIKI));
     EasyMock.verify(segmentsMetadataManager, inventoryView);
   }
 
@@ -1886,13 +1886,13 @@ public class DataSourcesResourceTest
     DataSourcesResource dataSourcesResource =
         new DataSourcesResource(null, segmentsMetadataManager, null, null, null, druidCoordinator, auditManager);
     Response response = dataSourcesResource.getDatasourceLoadstatus(TestDataSource.WIKI, true, null, null, "full", null);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertNotNull(response.getEntity());
-    Assert.assertEquals(2, ((Map) response.getEntity()).size());
-    Assert.assertEquals(1, ((Map) ((Map) response.getEntity()).get("tier1")).size());
-    Assert.assertEquals(1, ((Map) ((Map) response.getEntity()).get("tier2")).size());
-    Assert.assertEquals(0L, ((Map) ((Map) response.getEntity()).get("tier1")).get(TestDataSource.WIKI));
-    Assert.assertEquals(3L, ((Map) ((Map) response.getEntity()).get("tier2")).get(TestDataSource.WIKI));
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertNotNull(response.getEntity());
+    Assertions.assertEquals(2, ((Map) response.getEntity()).size());
+    Assertions.assertEquals(1, ((Map) ((Map) response.getEntity()).get("tier1")).size());
+    Assertions.assertEquals(1, ((Map) ((Map) response.getEntity()).get("tier2")).size());
+    Assertions.assertEquals(0L, ((Map) ((Map) response.getEntity()).get("tier1")).get(TestDataSource.WIKI));
+    Assertions.assertEquals(3L, ((Map) ((Map) response.getEntity()).get("tier2")).get(TestDataSource.WIKI));
     EasyMock.verify(segmentsMetadataManager);
   }
 
@@ -1945,13 +1945,13 @@ public class DataSourcesResourceTest
     DataSourcesResource dataSourcesResource =
         new DataSourcesResource(null, segmentsMetadataManager, null, null, null, druidCoordinator, auditManager);
     Response response = dataSourcesResource.getDatasourceLoadstatus(TestDataSource.WIKI, true, null, null, "full", "computeUsingClusterView");
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertNotNull(response.getEntity());
-    Assert.assertEquals(2, ((Map) response.getEntity()).size());
-    Assert.assertEquals(1, ((Map) ((Map) response.getEntity()).get("tier1")).size());
-    Assert.assertEquals(1, ((Map) ((Map) response.getEntity()).get("tier2")).size());
-    Assert.assertEquals(0L, ((Map) ((Map) response.getEntity()).get("tier1")).get(TestDataSource.WIKI));
-    Assert.assertEquals(3L, ((Map) ((Map) response.getEntity()).get("tier2")).get(TestDataSource.WIKI));
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertNotNull(response.getEntity());
+    Assertions.assertEquals(2, ((Map) response.getEntity()).size());
+    Assertions.assertEquals(1, ((Map) ((Map) response.getEntity()).get("tier1")).size());
+    Assertions.assertEquals(1, ((Map) ((Map) response.getEntity()).get("tier2")).size());
+    Assertions.assertEquals(0L, ((Map) ((Map) response.getEntity()).get("tier1")).get(TestDataSource.WIKI));
+    Assertions.assertEquals(3L, ((Map) ((Map) response.getEntity()).get("tier2")).get(TestDataSource.WIKI));
     EasyMock.verify(segmentsMetadataManager);
   }
 

--- a/server/src/test/java/org/apache/druid/server/http/IntervalsResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/IntervalsResourceTest.java
@@ -30,10 +30,10 @@ import org.apache.druid.server.security.AuthenticationResult;
 import org.apache.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
@@ -49,7 +49,7 @@ public class IntervalsResourceTest
   private List<DataSegment> dataSegmentList;
   private HttpServletRequest request;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     inventoryView = EasyMock.createStrictMock(InventoryView.class);
@@ -128,15 +128,15 @@ public class IntervalsResourceTest
 
     Response response = intervalsResource.getIntervals(request);
     TreeMap<Interval, Map<String, Map<String, Object>>> actualIntervals = (TreeMap) response.getEntity();
-    Assert.assertEquals(2, actualIntervals.size());
-    Assert.assertEquals(expectedIntervals.get(1), actualIntervals.firstKey());
-    Assert.assertEquals(10L, actualIntervals.get(expectedIntervals.get(1)).get("datasource1").get("size"));
-    Assert.assertEquals(1, actualIntervals.get(expectedIntervals.get(1)).get("datasource1").get("count"));
-    Assert.assertEquals(expectedIntervals.get(0), actualIntervals.lastKey());
-    Assert.assertEquals(20L, actualIntervals.get(expectedIntervals.get(0)).get("datasource1").get("size"));
-    Assert.assertEquals(1, actualIntervals.get(expectedIntervals.get(0)).get("datasource1").get("count"));
-    Assert.assertEquals(5L, actualIntervals.get(expectedIntervals.get(0)).get("datasource2").get("size"));
-    Assert.assertEquals(1, actualIntervals.get(expectedIntervals.get(0)).get("datasource2").get("count"));
+    Assertions.assertEquals(2, actualIntervals.size());
+    Assertions.assertEquals(expectedIntervals.get(1), actualIntervals.firstKey());
+    Assertions.assertEquals(10L, actualIntervals.get(expectedIntervals.get(1)).get("datasource1").get("size"));
+    Assertions.assertEquals(1, actualIntervals.get(expectedIntervals.get(1)).get("datasource1").get("count"));
+    Assertions.assertEquals(expectedIntervals.get(0), actualIntervals.lastKey());
+    Assertions.assertEquals(20L, actualIntervals.get(expectedIntervals.get(0)).get("datasource1").get("size"));
+    Assertions.assertEquals(1, actualIntervals.get(expectedIntervals.get(0)).get("datasource1").get("count"));
+    Assertions.assertEquals(5L, actualIntervals.get(expectedIntervals.get(0)).get("datasource2").get("size"));
+    Assertions.assertEquals(1, actualIntervals.get(expectedIntervals.get(0)).get("datasource2").get("count"));
 
   }
 
@@ -165,10 +165,10 @@ public class IntervalsResourceTest
 
     Response response = intervalsResource.getSpecificIntervals("2010-01-01T00:00:00.000Z/P1D", "simple", null, request);
     Map<Interval, Map<String, Object>> actualIntervals = (Map) response.getEntity();
-    Assert.assertEquals(1, actualIntervals.size());
-    Assert.assertTrue(actualIntervals.containsKey(expectedIntervals.get(0)));
-    Assert.assertEquals(25L, actualIntervals.get(expectedIntervals.get(0)).get("size"));
-    Assert.assertEquals(2, actualIntervals.get(expectedIntervals.get(0)).get("count"));
+    Assertions.assertEquals(1, actualIntervals.size());
+    Assertions.assertTrue(actualIntervals.containsKey(expectedIntervals.get(0)));
+    Assertions.assertEquals(25L, actualIntervals.get(expectedIntervals.get(0)).get("size"));
+    Assertions.assertEquals(2, actualIntervals.get(expectedIntervals.get(0)).get("count"));
 
   }
 
@@ -197,12 +197,12 @@ public class IntervalsResourceTest
 
     Response response = intervalsResource.getSpecificIntervals("2010-01-01T00:00:00.000Z/P1D", null, "full", request);
     TreeMap<Interval, Map<String, Map<String, Object>>> actualIntervals = (TreeMap) response.getEntity();
-    Assert.assertEquals(1, actualIntervals.size());
-    Assert.assertEquals(expectedIntervals.get(0), actualIntervals.firstKey());
-    Assert.assertEquals(20L, actualIntervals.get(expectedIntervals.get(0)).get("datasource1").get("size"));
-    Assert.assertEquals(1, actualIntervals.get(expectedIntervals.get(0)).get("datasource1").get("count"));
-    Assert.assertEquals(5L, actualIntervals.get(expectedIntervals.get(0)).get("datasource2").get("size"));
-    Assert.assertEquals(1, actualIntervals.get(expectedIntervals.get(0)).get("datasource2").get("count"));
+    Assertions.assertEquals(1, actualIntervals.size());
+    Assertions.assertEquals(expectedIntervals.get(0), actualIntervals.firstKey());
+    Assertions.assertEquals(20L, actualIntervals.get(expectedIntervals.get(0)).get("datasource1").get("size"));
+    Assertions.assertEquals(1, actualIntervals.get(expectedIntervals.get(0)).get("datasource1").get("count"));
+    Assertions.assertEquals(5L, actualIntervals.get(expectedIntervals.get(0)).get("datasource2").get("size"));
+    Assertions.assertEquals(1, actualIntervals.get(expectedIntervals.get(0)).get("datasource2").get("count"));
 
   }
 
@@ -229,12 +229,12 @@ public class IntervalsResourceTest
 
     Response response = intervalsResource.getSpecificIntervals("2010-01-01T00:00:00.000Z/P1D", null, null, request);
     Map<String, Object> actualIntervals = (Map) response.getEntity();
-    Assert.assertEquals(2, actualIntervals.size());
-    Assert.assertEquals(25L, actualIntervals.get("size"));
-    Assert.assertEquals(2, actualIntervals.get("count"));
+    Assertions.assertEquals(2, actualIntervals.size());
+    Assertions.assertEquals(25L, actualIntervals.get("size"));
+    Assertions.assertEquals(2, actualIntervals.get("count"));
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     EasyMock.verify(inventoryView);

--- a/server/src/test/java/org/apache/druid/server/http/LookupCoordinatorResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/LookupCoordinatorResourceTest.java
@@ -36,8 +36,8 @@ import org.apache.druid.server.security.AuthConfig;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.MediaType;
@@ -112,8 +112,8 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
     final Response response = lookupCoordinatorResource.getTiers(false);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(retVal.keySet(), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(retVal.keySet(), response.getEntity());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -130,7 +130,7 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
     final Response response = lookupCoordinatorResource.getTiers(false);
-    Assert.assertEquals(404, response.getStatus());
+    Assertions.assertEquals(404, response.getStatus());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -148,8 +148,8 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
     final Response response = lookupCoordinatorResource.getTiers(false);
-    Assert.assertEquals(500, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("error", errMsg), response.getEntity());
+    Assertions.assertEquals(500, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("error", errMsg), response.getEntity());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -168,9 +168,9 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
     final Response response = lookupCoordinatorResource.getTiers(true);
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
 
-    Assert.assertEquals(ImmutableSet.of("lookupTier", "discoveredLookupTier"), response.getEntity());
+    Assertions.assertEquals(ImmutableSet.of("lookupTier", "discoveredLookupTier"), response.getEntity());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -190,8 +190,8 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
     final Response response = lookupCoordinatorResource.getTiers(true);
-    Assert.assertEquals(500, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("error", errMsg), response.getEntity());
+    Assertions.assertEquals(500, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("error", errMsg), response.getEntity());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -214,8 +214,8 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
     final Response response = lookupCoordinatorResource.getSpecificLookup(LOOKUP_TIER, LOOKUP_NAME);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(container, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(container, response.getEntity());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -231,8 +231,8 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
     final Response response = lookupCoordinatorResource.getSpecificTier(LOOKUP_TIER, true);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(SINGLE_TIER_MAP.get(LOOKUP_TIER), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(SINGLE_TIER_MAP.get(LOOKUP_TIER), response.getEntity());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -251,7 +251,7 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
     final Response response = lookupCoordinatorResource.getSpecificLookup(LOOKUP_TIER, LOOKUP_NAME);
-    Assert.assertEquals(404, response.getStatus());
+    Assertions.assertEquals(404, response.getStatus());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -266,10 +266,10 @@ public class LookupCoordinatorResourceTest
         MAPPER,
         MAPPER
     );
-    Assert.assertEquals(400, lookupCoordinatorResource.getSpecificLookup("foo", null).getStatus());
-    Assert.assertEquals(400, lookupCoordinatorResource.getSpecificLookup("foo", "").getStatus());
-    Assert.assertEquals(400, lookupCoordinatorResource.getSpecificLookup("", "foo").getStatus());
-    Assert.assertEquals(400, lookupCoordinatorResource.getSpecificLookup(null, "foo").getStatus());
+    Assertions.assertEquals(400, lookupCoordinatorResource.getSpecificLookup("foo", null).getStatus());
+    Assertions.assertEquals(400, lookupCoordinatorResource.getSpecificLookup("foo", "").getStatus());
+    Assertions.assertEquals(400, lookupCoordinatorResource.getSpecificLookup("", "foo").getStatus());
+    Assertions.assertEquals(400, lookupCoordinatorResource.getSpecificLookup(null, "foo").getStatus());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -289,8 +289,8 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
     final Response response = lookupCoordinatorResource.getSpecificLookup(LOOKUP_TIER, LOOKUP_NAME);
-    Assert.assertEquals(500, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("error", errMsg), response.getEntity());
+    Assertions.assertEquals(500, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("error", errMsg), response.getEntity());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -319,9 +319,9 @@ public class LookupCoordinatorResourceTest
         request
     );
 
-    Assert.assertEquals(202, response.getStatus());
-    Assert.assertTrue(auditInfoCapture.hasCaptured());
-    Assert.assertEquals(auditInfo, auditInfoCapture.getValue());
+    Assertions.assertEquals(202, response.getStatus());
+    Assertions.assertTrue(auditInfoCapture.hasCaptured());
+    Assertions.assertEquals(auditInfo, auditInfoCapture.getValue());
 
     EasyMock.verify(lookupCoordinatorManager, request);
   }
@@ -353,9 +353,9 @@ public class LookupCoordinatorResourceTest
         request
     );
 
-    Assert.assertEquals(202, response.getStatus());
-    Assert.assertTrue(auditInfoCapture.hasCaptured());
-    Assert.assertEquals(auditInfo, auditInfoCapture.getValue());
+    Assertions.assertEquals(202, response.getStatus());
+    Assertions.assertTrue(auditInfoCapture.hasCaptured());
+    Assertions.assertEquals(auditInfo, auditInfoCapture.getValue());
 
     EasyMock.verify(lookupCoordinatorManager, request);
   }
@@ -388,9 +388,9 @@ public class LookupCoordinatorResourceTest
         request
     );
 
-    Assert.assertEquals(404, response.getStatus());
-    Assert.assertTrue(auditInfoCapture.hasCaptured());
-    Assert.assertEquals(auditInfo, auditInfoCapture.getValue());
+    Assertions.assertEquals(404, response.getStatus());
+    Assertions.assertTrue(auditInfoCapture.hasCaptured());
+    Assertions.assertEquals(auditInfo, auditInfoCapture.getValue());
 
     EasyMock.verify(lookupCoordinatorManager, request);
   }
@@ -425,10 +425,10 @@ public class LookupCoordinatorResourceTest
         request
     );
 
-    Assert.assertEquals(500, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("error", errMsg), response.getEntity());
-    Assert.assertTrue(auditInfoCapture.hasCaptured());
-    Assert.assertEquals(auditInfo, auditInfoCapture.getValue());
+    Assertions.assertEquals(500, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("error", errMsg), response.getEntity());
+    Assertions.assertTrue(auditInfoCapture.hasCaptured());
+    Assertions.assertEquals(auditInfo, auditInfoCapture.getValue());
 
     EasyMock.verify(lookupCoordinatorManager, request);
   }
@@ -444,11 +444,11 @@ public class LookupCoordinatorResourceTest
         MAPPER,
         MAPPER
     );
-    Assert.assertEquals(400, lookupCoordinatorResource.deleteLookup("foo", null, null).getStatus());
-    Assert.assertEquals(400, lookupCoordinatorResource.deleteLookup(null, null, null).getStatus());
-    Assert.assertEquals(400, lookupCoordinatorResource.deleteLookup(null, "foo", null).getStatus());
-    Assert.assertEquals(400, lookupCoordinatorResource.deleteLookup("foo", "", null).getStatus());
-    Assert.assertEquals(400, lookupCoordinatorResource.deleteLookup("", "foo", null).getStatus());
+    Assertions.assertEquals(400, lookupCoordinatorResource.deleteLookup("foo", null, null).getStatus());
+    Assertions.assertEquals(400, lookupCoordinatorResource.deleteLookup(null, null, null).getStatus());
+    Assertions.assertEquals(400, lookupCoordinatorResource.deleteLookup(null, "foo", null).getStatus());
+    Assertions.assertEquals(400, lookupCoordinatorResource.deleteLookup("foo", "", null).getStatus());
+    Assertions.assertEquals(400, lookupCoordinatorResource.deleteLookup("", "foo", null).getStatus());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -475,9 +475,9 @@ public class LookupCoordinatorResourceTest
         request
     );
 
-    Assert.assertEquals(202, response.getStatus());
-    Assert.assertTrue(auditInfoCapture.hasCaptured());
-    Assert.assertEquals(auditInfo, auditInfoCapture.getValue());
+    Assertions.assertEquals(202, response.getStatus());
+    Assertions.assertTrue(auditInfoCapture.hasCaptured());
+    Assertions.assertEquals(auditInfo, auditInfoCapture.getValue());
 
     EasyMock.verify(lookupCoordinatorManager, request);
   }
@@ -509,10 +509,10 @@ public class LookupCoordinatorResourceTest
         request
     );
 
-    Assert.assertEquals(500, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("error", errMsg), response.getEntity());
-    Assert.assertTrue(auditInfoCapture.hasCaptured());
-    Assert.assertEquals(auditInfo, auditInfoCapture.getValue());
+    Assertions.assertEquals(500, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("error", errMsg), response.getEntity());
+    Assertions.assertTrue(auditInfoCapture.hasCaptured());
+    Assertions.assertEquals(auditInfo, auditInfoCapture.getValue());
 
     EasyMock.verify(lookupCoordinatorManager, request);
   }
@@ -542,10 +542,10 @@ public class LookupCoordinatorResourceTest
         request
     );
 
-    Assert.assertEquals(500, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("error", "Unknown error updating configuration"), response.getEntity());
-    Assert.assertTrue(auditInfoCapture.hasCaptured());
-    Assert.assertEquals(auditInfo, auditInfoCapture.getValue());
+    Assertions.assertEquals(500, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("error", "Unknown error updating configuration"), response.getEntity());
+    Assertions.assertTrue(auditInfoCapture.hasCaptured());
+    Assertions.assertEquals(auditInfo, auditInfoCapture.getValue());
 
     EasyMock.verify(lookupCoordinatorManager, request);
   }
@@ -579,9 +579,9 @@ public class LookupCoordinatorResourceTest
         request
     );
 
-    Assert.assertEquals(202, response.getStatus());
-    Assert.assertTrue(auditInfoCapture.hasCaptured());
-    Assert.assertEquals(auditInfo, auditInfoCapture.getValue());
+    Assertions.assertEquals(202, response.getStatus());
+    Assertions.assertTrue(auditInfoCapture.hasCaptured());
+    Assertions.assertEquals(auditInfo, auditInfoCapture.getValue());
 
     EasyMock.verify(lookupCoordinatorManager, request);
   }
@@ -616,10 +616,10 @@ public class LookupCoordinatorResourceTest
         request
     );
 
-    Assert.assertEquals(500, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("error", "Unknown error updating configuration"), response.getEntity());
-    Assert.assertTrue(auditInfoCapture.hasCaptured());
-    Assert.assertEquals(auditInfo, auditInfoCapture.getValue());
+    Assertions.assertEquals(500, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("error", "Unknown error updating configuration"), response.getEntity());
+    Assertions.assertTrue(auditInfoCapture.hasCaptured());
+    Assertions.assertEquals(auditInfo, auditInfoCapture.getValue());
 
     EasyMock.verify(lookupCoordinatorManager, request);
   }
@@ -655,10 +655,10 @@ public class LookupCoordinatorResourceTest
         request
     );
 
-    Assert.assertEquals(500, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("error", errMsg), response.getEntity());
-    Assert.assertTrue(auditInfoCapture.hasCaptured());
-    Assert.assertEquals(auditInfo, auditInfoCapture.getValue());
+    Assertions.assertEquals(500, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("error", errMsg), response.getEntity());
+    Assertions.assertTrue(auditInfoCapture.hasCaptured());
+    Assertions.assertEquals(auditInfo, auditInfoCapture.getValue());
 
     EasyMock.verify(lookupCoordinatorManager, request);
   }
@@ -679,28 +679,28 @@ public class LookupCoordinatorResourceTest
     );
 
     EasyMock.replay(lookupCoordinatorManager, request);
-    Assert.assertEquals(400, lookupCoordinatorResource.createOrUpdateLookup(
+    Assertions.assertEquals(400, lookupCoordinatorResource.createOrUpdateLookup(
         null,
         LOOKUP_NAME,
         EMPTY_MAP_SOURCE.openStream(),
         request
     ).getStatus());
 
-    Assert.assertEquals(400, lookupCoordinatorResource.createOrUpdateLookup(
+    Assertions.assertEquals(400, lookupCoordinatorResource.createOrUpdateLookup(
         LOOKUP_TIER,
         null,
         EMPTY_MAP_SOURCE.openStream(),
         request
     ).getStatus());
 
-    Assert.assertEquals(400, lookupCoordinatorResource.createOrUpdateLookup(
+    Assertions.assertEquals(400, lookupCoordinatorResource.createOrUpdateLookup(
         LOOKUP_TIER,
         "",
         EMPTY_MAP_SOURCE.openStream(),
         request
     ).getStatus());
 
-    Assert.assertEquals(400, lookupCoordinatorResource.createOrUpdateLookup(
+    Assertions.assertEquals(400, lookupCoordinatorResource.createOrUpdateLookup(
         "",
         LOOKUP_NAME,
         EMPTY_MAP_SOURCE.openStream(),
@@ -721,8 +721,8 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
     final Response response = lookupCoordinatorResource.getSpecificTier(LOOKUP_TIER, false);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(SINGLE_TIER_MAP.get(LOOKUP_TIER).keySet(), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(SINGLE_TIER_MAP.get(LOOKUP_TIER).keySet(), response.getEntity());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -741,7 +741,7 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
     final Response response = lookupCoordinatorResource.getSpecificTier(tier, false);
-    Assert.assertEquals(404, response.getStatus());
+    Assertions.assertEquals(404, response.getStatus());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -757,8 +757,8 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
     final Response response = lookupCoordinatorResource.getSpecificTier(tier, false);
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("error", "`tier` required"), response.getEntity());
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("error", "`tier` required"), response.getEntity());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -775,8 +775,8 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
     final Response response = lookupCoordinatorResource.getSpecificTier(tier, false);
-    Assert.assertEquals(404, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("error", "No lookups found"), response.getEntity());
+    Assertions.assertEquals(404, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("error", "No lookups found"), response.getEntity());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -794,8 +794,8 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
     final Response response = lookupCoordinatorResource.getSpecificTier(tier, false);
-    Assert.assertEquals(500, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("error", errMsg), response.getEntity());
+    Assertions.assertEquals(500, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("error", errMsg), response.getEntity());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -818,8 +818,8 @@ public class LookupCoordinatorResourceTest
     );
 
     final Response response = lookupCoordinatorResource.getAllLookupsStatus(false);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(
         ImmutableMap.of(
             LOOKUP_TIER,
             ImmutableMap.of(
@@ -851,8 +851,8 @@ public class LookupCoordinatorResourceTest
     );
 
     final Response response = lookupCoordinatorResource.getLookupStatusForTier(LOOKUP_TIER, false);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(
         ImmutableMap.of(
             LOOKUP_NAME,
             new LookupCoordinatorResource.LookupStatus(true, null)
@@ -881,8 +881,8 @@ public class LookupCoordinatorResourceTest
     );
 
     final Response response = lookupCoordinatorResource.getSpecificLookupStatus(LOOKUP_TIER, LOOKUP_NAME, false);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(
         new LookupCoordinatorResource.LookupStatus(true, null), response.getEntity()
     );
 
@@ -899,7 +899,7 @@ public class LookupCoordinatorResourceTest
     );
 
     HostAndPort newNode = HostAndPort.fromParts("localhost", 4352);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new LookupCoordinatorResource.LookupStatus(false, ImmutableList.of(newNode)),
         lookupCoordinatorResource.getLookupStatus(
             LOOKUP_NAME,
@@ -921,7 +921,7 @@ public class LookupCoordinatorResourceTest
     );
 
     HostAndPort newNode = HostAndPort.fromParts("localhost", 4352);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new LookupCoordinatorResource.LookupStatus(false, null),
         lookupCoordinatorResource.getLookupStatus(
             LOOKUP_NAME,
@@ -952,8 +952,8 @@ public class LookupCoordinatorResourceTest
     );
 
     final Response response = lookupCoordinatorResource.getAllNodesStatus(false, null);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(
         ImmutableMap.of(
             LOOKUP_TIER,
             ImmutableMap.of(
@@ -986,8 +986,8 @@ public class LookupCoordinatorResourceTest
     );
 
     final Response response = lookupCoordinatorResource.getAllNodesStatus(false, false);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(
         ImmutableMap.of(
             LOOKUP_TIER,
             ImmutableMap.of(
@@ -1021,8 +1021,8 @@ public class LookupCoordinatorResourceTest
     );
 
     final Response response = lookupCoordinatorResource.getNodesStatusInTier(LOOKUP_TIER);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(
         ImmutableMap.of(
             LOOKUP_NODE,
             LOOKUP_STATE
@@ -1049,8 +1049,8 @@ public class LookupCoordinatorResourceTest
     );
 
     final Response response = lookupCoordinatorResource.getSpecificNodeStatus(LOOKUP_TIER, LOOKUP_NODE);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(LOOKUP_STATE, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(LOOKUP_STATE, response.getEntity());
 
     EasyMock.verify(lookupCoordinatorManager);
   }
@@ -1094,8 +1094,8 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
     final Response response = lookupCoordinatorResource.getAllLookupSpecs();
-    Assert.assertEquals(Status.OK.getStatusCode(), response.getStatus());
-    Assert.assertEquals(lookups, response.getEntity());
+    Assertions.assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(lookups, response.getEntity());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -1115,7 +1115,7 @@ public class LookupCoordinatorResourceTest
         MAPPER
     );
     final Response response = lookupCoordinatorResource.getAllLookupSpecs();
-    Assert.assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
     EasyMock.verify(lookupCoordinatorManager);
   }
 

--- a/server/src/test/java/org/apache/druid/server/http/MetadataResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/MetadataResourceTest.java
@@ -47,9 +47,9 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.SegmentStatusInCluster;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
@@ -88,7 +88,7 @@ public class MetadataResourceTest
 
   private MetadataResource metadataResource;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     request = Mockito.mock(HttpServletRequest.class);
@@ -154,12 +154,12 @@ public class MetadataResourceTest
     Response response = metadataResource.getAllUsedSegments(request, null, "includeOvershadowedStatus", null);
 
     final List<SegmentStatusInCluster> resultList = extractResponseList(response);
-    Assert.assertEquals(resultList.size(), 4);
-    Assert.assertEquals(new SegmentStatusInCluster(segments[0], false, 2, null, false), resultList.get(0));
-    Assert.assertEquals(new SegmentStatusInCluster(segments[1], false, null, null, false), resultList.get(1));
-    Assert.assertEquals(new SegmentStatusInCluster(segments[2], false, 1, null, false), resultList.get(2));
+    Assertions.assertEquals(resultList.size(), 4);
+    Assertions.assertEquals(new SegmentStatusInCluster(segments[0], false, 2, null, false), resultList.get(0));
+    Assertions.assertEquals(new SegmentStatusInCluster(segments[1], false, null, null, false), resultList.get(1));
+    Assertions.assertEquals(new SegmentStatusInCluster(segments[2], false, 1, null, false), resultList.get(2));
     // Replication factor should be 0 as the segment is overshadowed
-    Assert.assertEquals(new SegmentStatusInCluster(segments[3], true, 0, null, false), resultList.get(3));
+    Assertions.assertEquals(new SegmentStatusInCluster(segments[3], true, 0, null, false), resultList.get(3));
   }
 
   @Test
@@ -251,15 +251,15 @@ public class MetadataResourceTest
     Response response = metadataResource.getAllUsedSegments(request, null, "includeOvershadowedStatus", "includeRealtimeSegments");
 
     final List<SegmentStatusInCluster> resultList = extractResponseList(response);
-    Assert.assertEquals(resultList.size(), 6);
+    Assertions.assertEquals(resultList.size(), 6);
     Map<SegmentId, SegmentStatusInCluster> resultMap = resultList.stream().collect(Collectors.toMap(segmentStatus -> segmentStatus.getDataSegment().getId(), Function.identity()));
-    Assert.assertEquals(new SegmentStatusInCluster(segments[0], false, 2, 20L, false), resultMap.get(segments[0].getId()));
-    Assert.assertEquals(new SegmentStatusInCluster(segments[1], false, null, 30L, false), resultMap.get(segments[1].getId()));
-    Assert.assertEquals(new SegmentStatusInCluster(segments[2], false, 1, null, false), resultMap.get(segments[2].getId()));
+    Assertions.assertEquals(new SegmentStatusInCluster(segments[0], false, 2, 20L, false), resultMap.get(segments[0].getId()));
+    Assertions.assertEquals(new SegmentStatusInCluster(segments[1], false, null, 30L, false), resultMap.get(segments[1].getId()));
+    Assertions.assertEquals(new SegmentStatusInCluster(segments[2], false, 1, null, false), resultMap.get(segments[2].getId()));
     // Replication factor should be 0 as the segment is overshadowed
-    Assert.assertEquals(new SegmentStatusInCluster(segments[3], true, 0, null, false), resultMap.get(segments[3].getId()));
-    Assert.assertEquals(new SegmentStatusInCluster(realTimeSegments[0], false, null, 10L, true), resultMap.get(realTimeSegments[0].getId()));
-    Assert.assertEquals(new SegmentStatusInCluster(realTimeSegments[1], false, null, 40L, true), resultMap.get(realTimeSegments[1].getId()));
+    Assertions.assertEquals(new SegmentStatusInCluster(segments[3], true, 0, null, false), resultMap.get(segments[3].getId()));
+    Assertions.assertEquals(new SegmentStatusInCluster(realTimeSegments[0], false, null, 10L, true), resultMap.get(realTimeSegments[0].getId()));
+    Assertions.assertEquals(new SegmentStatusInCluster(realTimeSegments[1], false, null, 40L, true), resultMap.get(realTimeSegments[1].getId()));
   }
 
 
@@ -269,7 +269,7 @@ public class MetadataResourceTest
     final Response response = metadataResource
         .getUnusedSegmentsInDataSource(request, DATASOURCE1, null, null, null, null);
     final List<DataSegmentPlus> observedSegments = extractResponseList(response);
-    Assert.assertEquals(segmentsPlus, observedSegments);
+    Assertions.assertEquals(segmentsPlus, observedSegments);
   }
 
   @Test
@@ -281,8 +281,8 @@ public class MetadataResourceTest
     final Response response = metadataResource
         .getUnusedSegmentsInDataSource(request, DATASOURCE1, interval, null, null, null);
     final List<DataSegmentPlus> observedSegments = extractResponseList(response);
-    Assert.assertEquals(expectedLimit, observedSegments.size());
-    Assert.assertEquals(segmentsPlus.stream().limit(expectedLimit).collect(Collectors.toList()), observedSegments);
+    Assertions.assertEquals(expectedLimit, observedSegments.size());
+    Assertions.assertEquals(segmentsPlus.stream().limit(expectedLimit).collect(Collectors.toList()), observedSegments);
   }
 
   @Test
@@ -294,8 +294,8 @@ public class MetadataResourceTest
     final Response response = metadataResource
         .getUnusedSegmentsInDataSource(request, DATASOURCE1, interval, limit, null, null);
     final List<DataSegmentPlus> observedSegments = extractResponseList(response);
-    Assert.assertEquals(limit, observedSegments.size());
-    Assert.assertEquals(segmentsPlus.stream().limit(limit).collect(Collectors.toList()), observedSegments);
+    Assertions.assertEquals(limit, observedSegments.size());
+    Assertions.assertEquals(segmentsPlus.stream().limit(limit).collect(Collectors.toList()), observedSegments);
   }
 
   @Test
@@ -307,7 +307,7 @@ public class MetadataResourceTest
     final Response response = metadataResource
         .getUnusedSegmentsInDataSource(request, DATASOURCE1, interval, limit, lastSegmentId, null);
     final List<DataSegmentPlus> observedSegments = extractResponseList(response);
-    Assert.assertEquals(Collections.singletonList(segmentsPlus.get(limit)), observedSegments);
+    Assertions.assertEquals(Collections.singletonList(segmentsPlus.get(limit)), observedSegments);
   }
 
   @Test
@@ -316,7 +316,7 @@ public class MetadataResourceTest
     final Response response = metadataResource
         .getUnusedSegmentsInDataSource(request, "non-existent", null, null, null, null);
     final List<DataSegmentPlus> observedSegments = extractResponseList(response);
-    Assert.assertTrue(observedSegments.isEmpty());
+    Assertions.assertTrue(observedSegments.isEmpty());
   }
 
   @Test
@@ -324,8 +324,8 @@ public class MetadataResourceTest
   {
     final Response response = metadataResource
         .getUnusedSegmentsInDataSource(request, null, null, null, null, null);
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertEquals("dataSourceName must be non-empty.", getExceptionMessage(response));
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertEquals("dataSourceName must be non-empty.", getExceptionMessage(response));
   }
 
   @Test
@@ -333,8 +333,8 @@ public class MetadataResourceTest
   {
     final Response response = metadataResource
         .getUnusedSegmentsInDataSource(request, "", null, null, null, null);
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertEquals("dataSourceName must be non-empty.", getExceptionMessage(response));
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertEquals("dataSourceName must be non-empty.", getExceptionMessage(response));
   }
 
   @Test
@@ -342,8 +342,8 @@ public class MetadataResourceTest
   {
     final Response response = metadataResource
         .getUnusedSegmentsInDataSource(request, DATASOURCE1, null, -1, null, null);
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertEquals("Invalid limit[-1] specified. Limit must be > 0.", getExceptionMessage(response));
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertEquals("Invalid limit[-1] specified. Limit must be > 0.", getExceptionMessage(response));
   }
 
   @Test
@@ -351,8 +351,8 @@ public class MetadataResourceTest
   {
     final Response response = metadataResource
         .getUnusedSegmentsInDataSource(request, DATASOURCE1, null, null, "invalid", null);
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertEquals("Invalid lastSegmentId[invalid] specified.", getExceptionMessage(response));
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertEquals("Invalid lastSegmentId[invalid] specified.", getExceptionMessage(response));
   }
 
   @Test
@@ -360,8 +360,8 @@ public class MetadataResourceTest
   {
     final Response response = metadataResource
         .getUnusedSegmentsInDataSource(request, DATASOURCE1, "2015/2014", null, null, null);
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(
         "Invalid interval[2015/2014]: [The end instant must be greater than the start instant]",
         getExceptionMessage(response)
     );
@@ -372,8 +372,8 @@ public class MetadataResourceTest
   {
     final Response response = metadataResource
         .getUnusedSegmentsInDataSource(request, DATASOURCE1, null, null, null, "Ascd");
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(
         "Unexpected value[Ascd] for SortOrder. Possible values are: [ASC, DESC]",
         getExceptionMessage(response)
     );
@@ -459,30 +459,30 @@ public class MetadataResourceTest
     Response response = metadataResource.getDataSourceInformation(request, Collections.singletonList(DATASOURCE1));
 
     List<DataSourceInformation> dataSourceInformations = extractResponseList(response);
-    Assert.assertEquals(dataSourceInformations.size(), 1);
-    Assert.assertEquals(dataSourceInformations.get(0), dataSourceInformationMap.get(DATASOURCE1));
+    Assertions.assertEquals(dataSourceInformations.size(), 1);
+    Assertions.assertEquals(dataSourceInformations.get(0), dataSourceInformationMap.get(DATASOURCE1));
   }
 
   @Test
   public void testGetSegment()
   {
     // Available in snapshot
-    Assert.assertEquals(
+    Assertions.assertEquals(
         segments[0],
         metadataResource.getSegment(segments[0].getDataSource(), segments[0].getId().toString(), null).getEntity()
     );
 
     // Unavailable in snapshot, but available in metadata
-    Assert.assertEquals(
+    Assertions.assertEquals(
         segments[4],
         metadataResource.getSegment(segments[4].getDataSource(), segments[4].getId().toString(), null).getEntity()
     );
 
     // Unavailable and unused
-    Assert.assertNull(
+    Assertions.assertNull(
         metadataResource.getSegment(segments[5].getDataSource(), segments[5].getId().toString(), null).getEntity()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         segments[5],
         metadataResource.getSegment(segments[5].getDataSource(), segments[5].getId().toString(), true).getEntity()
     );
@@ -495,7 +495,7 @@ public class MetadataResourceTest
 
     Response response = metadataResource.getBootstrapSegments();
     final List<DataSegment> observedSegments = extractResponseList(response);
-    Assert.assertEquals(2, observedSegments.size());
+    Assertions.assertEquals(2, observedSegments.size());
   }
 
   @Test
@@ -505,7 +505,7 @@ public class MetadataResourceTest
 
     Response response = metadataResource.getBootstrapSegments();
     final List<DataSegment> observedSegments = extractResponseList(response);
-    Assert.assertEquals(0, observedSegments.size());
+    Assertions.assertEquals(0, observedSegments.size());
   }
 
   @Test
@@ -514,7 +514,7 @@ public class MetadataResourceTest
     Mockito.doReturn(null).when(coordinator).getBroadcastSegments();
 
     Response response = metadataResource.getBootstrapSegments();
-    Assert.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(503, response.getStatus());
   }
 
   private <T> List<T> extractResponseList(Response response)

--- a/server/src/test/java/org/apache/druid/server/http/OverlordProxyServletTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/OverlordProxyServletTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.server.http;
 import com.google.common.util.concurrent.Futures;
 import org.apache.druid.rpc.indexing.OverlordClient;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
@@ -47,7 +47,7 @@ public class OverlordProxyServletTest
     EasyMock.replay(overlordClient, request);
 
     URI uri = URI.create(new OverlordProxyServlet(overlordClient, null, null).rewriteTarget(request));
-    Assert.assertEquals("https://overlord:port/druid/over%3Alord/worker?param1=test&param2=test2", uri.toString());
+    Assertions.assertEquals("https://overlord:port/druid/over%3Alord/worker?param1=test&param2=test2", uri.toString());
 
     EasyMock.verify(overlordClient, request);
   }

--- a/server/src/test/java/org/apache/druid/server/http/RulesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/RulesResourceTest.java
@@ -29,9 +29,9 @@ import org.apache.druid.metadata.MetadataRuleManager;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 import java.util.List;
@@ -42,7 +42,7 @@ public class RulesResourceTest
   private MetadataRuleManager databaseRuleManager;
   private AuditManager auditManager;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     databaseRuleManager = EasyMock.createStrictMock(MetadataRuleManager.class);
@@ -67,9 +67,9 @@ public class RulesResourceTest
 
     Response response = rulesResource.getDatasourceRuleHistory("datasource1", null, 2);
     List<AuditEntry> rulesHistory = (List) response.getEntity();
-    Assert.assertEquals(2, rulesHistory.size());
-    Assert.assertEquals(entry1, rulesHistory.get(0));
-    Assert.assertEquals(entry2, rulesHistory.get(1));
+    Assertions.assertEquals(2, rulesHistory.size());
+    Assertions.assertEquals(entry1, rulesHistory.get(0));
+    Assertions.assertEquals(entry2, rulesHistory.get(1));
 
     EasyMock.verify(auditManager);
   }
@@ -98,9 +98,9 @@ public class RulesResourceTest
 
     Response response = rulesResource.getDatasourceRuleHistory("datasource1", interval, null);
     List<AuditEntry> rulesHistory = (List) response.getEntity();
-    Assert.assertEquals(2, rulesHistory.size());
-    Assert.assertEquals(entry1, rulesHistory.get(0));
-    Assert.assertEquals(entry2, rulesHistory.get(1));
+    Assertions.assertEquals(2, rulesHistory.size());
+    Assertions.assertEquals(entry1, rulesHistory.get(0));
+    Assertions.assertEquals(entry2, rulesHistory.get(1));
 
     EasyMock.verify(auditManager);
   }
@@ -117,9 +117,9 @@ public class RulesResourceTest
 
     Response response = rulesResource.getDatasourceRuleHistory("datasource1", null, -1);
     Map<String, Object> rulesHistory = (Map) response.getEntity();
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertTrue(rulesHistory.containsKey("error"));
-    Assert.assertEquals("Limit must be greater than zero!", rulesHistory.get("error"));
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertTrue(rulesHistory.containsKey("error"));
+    Assertions.assertEquals("Limit must be greater than zero!", rulesHistory.get("error"));
 
     EasyMock.verify(auditManager);
   }
@@ -142,9 +142,9 @@ public class RulesResourceTest
 
     Response response = rulesResource.getDatasourceRuleHistory(null, 2);
     List<AuditEntry> rulesHistory = (List) response.getEntity();
-    Assert.assertEquals(2, rulesHistory.size());
-    Assert.assertEquals(entry1, rulesHistory.get(0));
-    Assert.assertEquals(entry2, rulesHistory.get(1));
+    Assertions.assertEquals(2, rulesHistory.size());
+    Assertions.assertEquals(entry1, rulesHistory.get(0));
+    Assertions.assertEquals(entry2, rulesHistory.get(1));
 
     EasyMock.verify(auditManager);
   }
@@ -169,9 +169,9 @@ public class RulesResourceTest
 
     Response response = rulesResource.getDatasourceRuleHistory(interval, null);
     List<AuditEntry> rulesHistory = (List) response.getEntity();
-    Assert.assertEquals(2, rulesHistory.size());
-    Assert.assertEquals(entry1, rulesHistory.get(0));
-    Assert.assertEquals(entry2, rulesHistory.get(1));
+    Assertions.assertEquals(2, rulesHistory.size());
+    Assertions.assertEquals(entry1, rulesHistory.get(0));
+    Assertions.assertEquals(entry2, rulesHistory.get(1));
 
     EasyMock.verify(auditManager);
   }
@@ -188,9 +188,9 @@ public class RulesResourceTest
 
     Response response = rulesResource.getDatasourceRuleHistory(null, -1);
     Map<String, Object> rulesHistory = (Map) response.getEntity();
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertTrue(rulesHistory.containsKey("error"));
-    Assert.assertEquals("Limit must be greater than zero!", rulesHistory.get("error"));
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertTrue(rulesHistory.containsKey("error"));
+    Assertions.assertEquals("Limit must be greater than zero!", rulesHistory.get("error"));
 
     EasyMock.verify(auditManager);
   }

--- a/server/src/test/java/org/apache/druid/server/http/SegmentListerResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/SegmentListerResourceTest.java
@@ -34,9 +34,9 @@ import org.apache.druid.server.mocks.MockAsyncContext;
 import org.apache.druid.server.mocks.MockHttpServletRequest;
 import org.apache.druid.server.mocks.MockHttpServletResponse;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Before;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.servlet.http.HttpServletRequest;
@@ -54,7 +54,7 @@ public class SegmentListerResourceTest
   private SegmentListerResource segmentListerResource;
   private BatchDataSegmentAnnouncer segmentAnnouncer;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     final SegmentLoadDropHandler loadDropHandler = Mockito.mock(SegmentLoadDropHandler.class);

--- a/server/src/test/java/org/apache/druid/server/http/SegmentLoadingCapabilitiesTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/SegmentLoadingCapabilitiesTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.server.http;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SegmentLoadingCapabilitiesTest
 {
@@ -36,8 +36,8 @@ public class SegmentLoadingCapabilitiesTest
 
     SegmentLoadingCapabilities reread = jsonMapper.readValue(jsonMapper.writeValueAsString(capabilities), SegmentLoadingCapabilities.class);
 
-    Assert.assertEquals(capabilities.getNumLoadingThreads(), reread.getNumLoadingThreads());
-    Assert.assertEquals(capabilities.getNumTurboLoadingThreads(), reread.getNumTurboLoadingThreads());
+    Assertions.assertEquals(capabilities.getNumLoadingThreads(), reread.getNumLoadingThreads());
+    Assertions.assertEquals(capabilities.getNumTurboLoadingThreads(), reread.getNumTurboLoadingThreads());
   }
 
   @Test
@@ -46,8 +46,8 @@ public class SegmentLoadingCapabilitiesTest
     String json = "{\"numLoadingThreads\":3,\"numTurboLoadingThreads\":5}";
     SegmentLoadingCapabilities reread = jsonMapper.readValue(json, SegmentLoadingCapabilities.class);
 
-    Assert.assertEquals(3, reread.getNumLoadingThreads());
-    Assert.assertEquals(5, reread.getNumTurboLoadingThreads());
+    Assertions.assertEquals(3, reread.getNumLoadingThreads());
+    Assertions.assertEquals(5, reread.getNumTurboLoadingThreads());
   }
 
 }

--- a/server/src/test/java/org/apache/druid/server/http/ServersResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/ServersResourceTest.java
@@ -29,9 +29,9 @@ import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 
@@ -41,7 +41,7 @@ public class ServersResourceTest
   private ServersResource serversResource;
   private ObjectMapper objectMapper = new DefaultObjectMapper();
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     DruidServer dummyServer = new DruidServer("dummy", "host", null, 1234L, null, ServerType.HISTORICAL, "tier", 0);
@@ -75,7 +75,7 @@ public class ServersResourceTest
                       + "{\"dataSource\":\"dataSource\",\"interval\":\"2016-03-22T14:00:00.000Z/2016-03-22T15:00:00.000Z\",\"version\":\"v0\",\"loadSpec\":{},\"dimensions\":\"\",\"metrics\":\"\","
                       + "\"shardSpec\":{\"type\":\"numbered\",\"partitionNum\":0,\"partitions\":1},\"binaryVersion\":null,\"size\":1,\"identifier\":\"dataSource_2016-03-22T14:00:00.000Z_2016-03-22T15:00:00.000Z_v0\"}},"
                       + "\"currSize\":1}]";
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -84,7 +84,7 @@ public class ServersResourceTest
     Response res = serversResource.getClusterServers(null, "simple");
     String result = objectMapper.writeValueAsString(res.getEntity());
     String expected = "[{\"host\":\"host\",\"tier\":\"tier\",\"type\":\"historical\",\"priority\":0,\"currSize\":1,\"maxSize\":1234}]";
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -101,7 +101,7 @@ public class ServersResourceTest
                       + "{\"dataSource\":\"dataSource\",\"interval\":\"2016-03-22T14:00:00.000Z/2016-03-22T15:00:00.000Z\",\"version\":\"v0\",\"loadSpec\":{},\"dimensions\":\"\",\"metrics\":\"\","
                       + "\"shardSpec\":{\"type\":\"numbered\",\"partitionNum\":0,\"partitions\":1},\"binaryVersion\":null,\"size\":1,\"identifier\":\"dataSource_2016-03-22T14:00:00.000Z_2016-03-22T15:00:00.000Z_v0\"}},"
                       + "\"currSize\":1}";
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -110,7 +110,7 @@ public class ServersResourceTest
     Response res = serversResource.getServer(server.getName(), "simple");
     String result = objectMapper.writeValueAsString(res.getEntity());
     String expected = "{\"host\":\"host\",\"tier\":\"tier\",\"type\":\"historical\",\"priority\":0,\"currSize\":1,\"maxSize\":1234}";
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -119,9 +119,9 @@ public class ServersResourceTest
     DruidServer server = new DruidServer("dummy", "dummyHost", null, 1234, null, ServerType.HISTORICAL, "dummyTier", 1);
     String serverJson = objectMapper.writeValueAsString(server);
     String expected = "{\"name\":\"dummy\",\"host\":\"dummyHost\",\"hostAndTlsPort\":null,\"maxSize\":1234,\"storageSize\":1234,\"type\":\"historical\",\"tier\":\"dummyTier\",\"priority\":1}";
-    Assert.assertEquals(expected, serverJson);
+    Assertions.assertEquals(expected, serverJson);
     DruidServer deserializedServer = objectMapper.readValue(serverJson, DruidServer.class);
-    Assert.assertEquals(server, deserializedServer);
+    Assertions.assertEquals(server, deserializedServer);
   }
 
   @Test
@@ -139,9 +139,9 @@ public class ServersResourceTest
     );
     String metadataJson = objectMapper.writeValueAsString(metadata);
     String expected = "{\"name\":\"dummy\",\"host\":\"host\",\"hostAndTlsPort\":null,\"maxSize\":1234,\"storageSize\":1234,\"type\":\"historical\",\"tier\":\"tier\",\"priority\":1}";
-    Assert.assertEquals(expected, metadataJson);
+    Assertions.assertEquals(expected, metadataJson);
     DruidServerMetadata deserializedMetadata = objectMapper.readValue(metadataJson, DruidServerMetadata.class);
-    Assert.assertEquals(metadata, deserializedMetadata);
+    Assertions.assertEquals(metadata, deserializedMetadata);
 
     metadata = new DruidServerMetadata(
         "host:123",
@@ -154,7 +154,7 @@ public class ServersResourceTest
         0
     );
 
-    Assert.assertEquals(metadata, objectMapper.readValue(
+    Assertions.assertEquals(metadata, objectMapper.readValue(
         "{\"name\":\"host:123\",\"maxSize\":0,\"type\":\"HISTORICAL\",\"tier\":\"t1\",\"priority\":0,\"host\":\"host:123\"}",
         DruidServerMetadata.class
     ));
@@ -169,11 +169,11 @@ public class ServersResourceTest
         "t1",
         0
     );
-    Assert.assertEquals(metadata, objectMapper.readValue(
+    Assertions.assertEquals(metadata, objectMapper.readValue(
         "{\"name\":\"host:123\",\"maxSize\":0,\"type\":\"HISTORICAL\",\"tier\":\"t1\",\"priority\":0,\"host\":\"host:123\",\"hostAndTlsPort\":\"host:214\"}",
         DruidServerMetadata.class
     ));
-    Assert.assertEquals(metadata, objectMapper.readValue(
+    Assertions.assertEquals(metadata, objectMapper.readValue(
         objectMapper.writeValueAsString(metadata),
         DruidServerMetadata.class
     ));

--- a/server/src/test/java/org/apache/druid/server/http/ServletResourceUtilsTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/ServletResourceUtilsTest.java
@@ -29,8 +29,8 @@ import org.apache.druid.rpc.HttpResponseException;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.servlet.AsyncEvent;
@@ -46,9 +46,9 @@ public class ServletResourceUtilsTest
   public void testSanitizeException()
   {
     final String message = "some message";
-    Assert.assertEquals(message, ServletResourceUtils.sanitizeException(new Throwable(message)).get("error"));
-    Assert.assertEquals("null", ServletResourceUtils.sanitizeException(null).get("error"));
-    Assert.assertEquals(message, ServletResourceUtils.sanitizeException(new Throwable()
+    Assertions.assertEquals(message, ServletResourceUtils.sanitizeException(new Throwable(message)).get("error"));
+    Assertions.assertEquals("null", ServletResourceUtils.sanitizeException(null).get("error"));
+    Assertions.assertEquals(message, ServletResourceUtils.sanitizeException(new Throwable()
     {
       @Override
       public String toString()
@@ -63,10 +63,10 @@ public class ServletResourceUtilsTest
   {
     DruidException exception = InvalidInput.exception("Invalid value of [%s]", "inputKey");
     Response response = ServletResourceUtils.buildErrorResponseFrom(exception);
-    Assert.assertEquals(exception.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(exception.getStatusCode(), response.getStatus());
 
     Object entity = response.getEntity();
-    Assert.assertTrue(entity instanceof ErrorResponse);
+    Assertions.assertTrue(entity instanceof ErrorResponse);
     DruidExceptionMatcher.assertThat(
         ((ErrorResponse) entity).getUnderlyingException(),
         DruidExceptionMatcher.invalidInput().expectMessageIs("Invalid value of [inputKey]")
@@ -80,7 +80,7 @@ public class ServletResourceUtilsTest
         new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND),
         StandardCharsets.UTF_8
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "abc",
         ServletResourceUtils.getDefaultValueIfCauseIs404ElseThrow(
             new ISE(new HttpResponseException(notFoundResponseHolder), ""),
@@ -92,7 +92,7 @@ public class ServletResourceUtilsTest
         new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST),
         StandardCharsets.UTF_8
     );
-    Assert.assertThrows(
+    Assertions.assertThrows(
         RuntimeException.class,
         () -> ServletResourceUtils.getDefaultValueIfCauseIs404ElseThrow(
             new ISE(new HttpResponseException(badRequestResponseHolder), ""),
@@ -100,7 +100,7 @@ public class ServletResourceUtilsTest
         )
     );
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         RuntimeException.class,
         () -> ServletResourceUtils.getDefaultValueIfCauseIs404ElseThrow(new ISE(""), () -> "abc")
     );
@@ -117,9 +117,9 @@ public class ServletResourceUtilsTest
     // Verify that onTimeout updates the count
     final AsyncEvent event = Mockito.mock(AsyncEvent.class);
     listener.onTimeout(event);
-    Assert.assertEquals(1, timeoutCount.get());
+    Assertions.assertEquals(1, timeoutCount.get());
     listener.onTimeout(event);
-    Assert.assertEquals(2, timeoutCount.get());
+    Assertions.assertEquals(2, timeoutCount.get());
 
     // Verify that other actions on the listener are noop
     timeoutCount.set(0);
@@ -127,7 +127,7 @@ public class ServletResourceUtilsTest
     listener.onComplete(event);
     listener.onError(event);
 
-    Assert.assertEquals(0, timeoutCount.get());
+    Assertions.assertEquals(0, timeoutCount.get());
     Mockito.verifyNoInteractions(event);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/http/security/PreResponseAuthorizationCheckFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/security/PreResponseAuthorizationCheckFilterTest.java
@@ -29,8 +29,8 @@ import org.apache.druid.server.security.AuthConfig;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.apache.druid.server.security.Authenticator;
 import org.apache.druid.server.security.PreResponseAuthorizationCheckFilter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
@@ -73,9 +73,9 @@ public class PreResponseAuthorizationCheckFilterTest
     filter.doFilter(req, resp, (request, response) -> {
     });
 
-    Assert.assertEquals(401, resp.getStatus());
-    Assert.assertEquals("application/json", resp.getContentType());
-    Assert.assertEquals("UTF-8", resp.getCharacterEncoding());
+    Assertions.assertEquals(401, resp.getStatus());
+    Assertions.assertEquals("application/json", resp.getContentType());
+    Assertions.assertEquals("UTF-8", resp.getCharacterEncoding());
   }
 
   @Test
@@ -103,7 +103,7 @@ public class PreResponseAuthorizationCheckFilterTest
     filter.doFilter(req, resp, (request, response) -> {
     });
 
-    Assert.assertEquals(403, resp.getStatus());
+    Assertions.assertEquals(403, resp.getStatus());
   }
 
   @Test
@@ -131,7 +131,7 @@ public class PreResponseAuthorizationCheckFilterTest
     filter.doFilter(req, resp, (request, response) -> {
     });
 
-    Assert.assertEquals(401, resp.getStatus());
+    Assertions.assertEquals(401, resp.getStatus());
   }
 
   @Test
@@ -153,7 +153,7 @@ public class PreResponseAuthorizationCheckFilterTest
     filter.doFilter(req, resp, (request, response) -> {
     });
 
-    Assert.assertEquals(403, resp.getStatus());
+    Assertions.assertEquals(403, resp.getStatus());
   }
 
   @Test
@@ -175,7 +175,7 @@ public class PreResponseAuthorizationCheckFilterTest
     filter.doFilter(req, resp, (request, response) -> {
     });
 
-    Assert.assertEquals(404, resp.getStatus());
+    Assertions.assertEquals(404, resp.getStatus());
   }
 
   @Test
@@ -197,6 +197,6 @@ public class PreResponseAuthorizationCheckFilterTest
     filter.doFilter(req, resp, (request, response) -> {
     });
 
-    Assert.assertEquals(307, resp.getStatus());
+    Assertions.assertEquals(307, resp.getStatus());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/http/security/SecuritySanityCheckFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/security/SecuritySanityCheckFilterTest.java
@@ -24,7 +24,7 @@ import org.apache.druid.server.security.AuthConfig;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.apache.druid.server.security.SecuritySanityCheckFilter;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletOutputStream;

--- a/server/src/test/java/org/apache/druid/server/initialization/AuthorizerMapperModuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/AuthorizerMapperModuleTest.java
@@ -33,9 +33,9 @@ import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.server.security.AuthConfig;
 import org.apache.druid.server.security.AuthValidator;
 import org.apache.druid.server.security.AuthorizerMapper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -43,7 +43,7 @@ public class AuthorizerMapperModuleTest
 {
   private Injector injector;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     injector = Guice.createInjector(
@@ -65,14 +65,14 @@ public class AuthorizerMapperModuleTest
   {
     AuthValidator authValidator = injector.getInstance(AuthValidator.class);
     AuthValidator other = injector.getInstance(AuthValidator.class);
-    Assert.assertSame(authValidator, other);
+    Assertions.assertSame(authValidator, other);
   }
 
   @Test
   public void testEmitAuthMetrics_defaultsFalse_emitterNullInMapper()
   {
     AuthorizerMapper mapper = injector.getInstance(AuthorizerMapper.class);
-    Assert.assertNull(mapper.getServiceEmitter());
+    Assertions.assertNull(mapper.getServiceEmitter());
   }
 
   @Test
@@ -92,6 +92,6 @@ public class AuthorizerMapperModuleTest
         new AuthorizerMapperModule()
     );
     AuthorizerMapper mapper = inj.getInstance(AuthorizerMapper.class);
-    Assert.assertSame(emitter, mapper.getServiceEmitter());
+    Assertions.assertSame(emitter, mapper.getServiceEmitter());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/initialization/BaseJettyTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/BaseJettyTest.java
@@ -37,8 +37,8 @@ import org.eclipse.jetty.ee8.servlet.ServletHolder;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.joda.time.Duration;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import javax.net.ssl.SSLContext;
 import javax.servlet.Filter;
@@ -82,7 +82,7 @@ public abstract class BaseJettyTest
     System.setProperty("druid.global.http.readTimeout", "PT1S");
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception
   {
     setProperties();
@@ -100,7 +100,7 @@ public abstract class BaseJettyTest
 
   protected abstract Injector setupInjector();
 
-  @After
+  @AfterEach
   public void teardown()
   {
     lifecycle.stop();

--- a/server/src/test/java/org/apache/druid/server/initialization/ExternalStorageAccessSecurityModuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/ExternalStorageAccessSecurityModuleTest.java
@@ -28,8 +28,8 @@ import jakarta.validation.Validator;
 import org.apache.druid.guice.DruidGuiceExtensions;
 import org.apache.druid.guice.JsonConfigurator;
 import org.apache.druid.guice.LazySingleton;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -41,13 +41,13 @@ public class ExternalStorageAccessSecurityModuleTest
     JdbcAccessSecurityConfig securityConfig = makeInjectorWithProperties(new Properties()).getInstance(
         JdbcAccessSecurityConfig.class
     );
-    Assert.assertNotNull(securityConfig);
-    Assert.assertEquals(
+    Assertions.assertNotNull(securityConfig);
+    Assertions.assertEquals(
         JdbcAccessSecurityConfig.DEFAULT_ALLOWED_PROPERTIES,
         securityConfig.getAllowedProperties()
     );
-    Assert.assertTrue(securityConfig.isAllowUnknownJdbcUrlFormat());
-    Assert.assertTrue(securityConfig.isEnforceAllowedProperties());
+    Assertions.assertTrue(securityConfig.isAllowUnknownJdbcUrlFormat());
+    Assertions.assertTrue(securityConfig.isEnforceAllowedProperties());
   }
 
   @Test
@@ -60,8 +60,8 @@ public class ExternalStorageAccessSecurityModuleTest
     JdbcAccessSecurityConfig securityConfig = makeInjectorWithProperties(properties).getInstance(
         JdbcAccessSecurityConfig.class
     );
-    Assert.assertNotNull(securityConfig);
-    Assert.assertEquals(
+    Assertions.assertNotNull(securityConfig);
+    Assertions.assertEquals(
         ImmutableSet.of(
             "valid1",
             "valid2",
@@ -69,8 +69,8 @@ public class ExternalStorageAccessSecurityModuleTest
         ),
         securityConfig.getAllowedProperties()
     );
-    Assert.assertFalse(securityConfig.isAllowUnknownJdbcUrlFormat());
-    Assert.assertTrue(securityConfig.isEnforceAllowedProperties());
+    Assertions.assertFalse(securityConfig.isAllowUnknownJdbcUrlFormat());
+    Assertions.assertTrue(securityConfig.isEnforceAllowedProperties());
   }
 
   private static Injector makeInjectorWithProperties(final Properties props)

--- a/server/src/test/java/org/apache/druid/server/initialization/JettyBindOnHostTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/JettyBindOnHostTest.java
@@ -37,8 +37,8 @@ import org.apache.druid.server.initialization.jetty.JettyServerInitializer;
 import org.apache.druid.server.security.AuthTestUtils;
 import org.apache.druid.server.security.AuthorizerMapper;
 import org.eclipse.jetty.server.Server;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -75,14 +75,14 @@ public class JettyBindOnHostTest extends BaseJettyTest
   @Test
   public void testBindOnHost() throws Exception
   {
-    Assert.assertEquals("localhost", server.getURI().getHost());
+    Assertions.assertEquals("localhost", server.getURI().getHost());
 
     final URL url = new URL("http://localhost:" + port + "/default");
     final HttpURLConnection get = (HttpURLConnection) url.openConnection();
-    Assert.assertEquals(DEFAULT_RESPONSE_CONTENT, IOUtils.toString(get.getInputStream(), StandardCharsets.UTF_8));
+    Assertions.assertEquals(DEFAULT_RESPONSE_CONTENT, IOUtils.toString(get.getInputStream(), StandardCharsets.UTF_8));
 
     final HttpURLConnection post = (HttpURLConnection) url.openConnection();
     post.setRequestMethod("POST");
-    Assert.assertEquals(DEFAULT_RESPONSE_CONTENT, IOUtils.toString(post.getInputStream(), StandardCharsets.UTF_8));
+    Assertions.assertEquals(DEFAULT_RESPONSE_CONTENT, IOUtils.toString(post.getInputStream(), StandardCharsets.UTF_8));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/initialization/JettyCertRenewTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/JettyCertRenewTest.java
@@ -46,13 +46,13 @@ import org.apache.druid.server.initialization.jetty.JettyServerInitializer;
 import org.apache.druid.server.initialization.jetty.ServletFilterHolder;
 import org.apache.druid.server.security.AuthTestUtils;
 import org.apache.druid.server.security.AuthorizerMapper;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.eclipse.jetty.server.Server;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -84,8 +84,8 @@ import java.util.zip.GZIPOutputStream;
 
 public class JettyCertRenewTest extends BaseJettyTest
 {
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension folder = new TemporaryFolderExtension();
 
   private Injector injector;
 
@@ -225,10 +225,10 @@ public class JettyCertRenewTest extends BaseJettyTest
     Certificate[] certificatesBefore = getCertificates();
     for (Certificate certificate : certificatesBefore) {
       X509Certificate real = (X509Certificate) certificate;
-      Assert.assertEquals(dateFormat.parse("Fri Mar 29 11:00:40 UTC 2030").toInstant(), real.getNotAfter().toInstant());
+      Assertions.assertEquals(dateFormat.parse("Fri Mar 29 11:00:40 UTC 2030").toInstant(), real.getNotAfter().toInstant());
     }
 
-    Assert.assertEquals(DEFAULT_RESPONSE_CONTENT, getResponseWithProperTrustStore());
+    Assertions.assertEquals(DEFAULT_RESPONSE_CONTENT, getResponseWithProperTrustStore());
 
     // Replace the server and trustore keystores, wait for 3s and perform all the tests.
     File keyStore = new File(JettyCertRenewTest.class.getClassLoader().getResource("server-new.jks").getFile());
@@ -241,10 +241,10 @@ public class JettyCertRenewTest extends BaseJettyTest
     Certificate[] certificatesAfter = getCertificates();
     for (Certificate certificate : certificatesAfter) {
       X509Certificate real = (X509Certificate) certificate;
-      Assert.assertEquals(dateFormat.parse("Thu Aug 19 13:38:51 UTC 2032").toInstant(), real.getNotAfter().toInstant());
+      Assertions.assertEquals(dateFormat.parse("Thu Aug 19 13:38:51 UTC 2032").toInstant(), real.getNotAfter().toInstant());
     }
 
-    Assert.assertEquals(DEFAULT_RESPONSE_CONTENT, getResponseWithProperTrustStore());
+    Assertions.assertEquals(DEFAULT_RESPONSE_CONTENT, getResponseWithProperTrustStore());
   }
 
   private static class AcceptAllForTestX509TrustManager implements X509TrustManager

--- a/server/src/test/java/org/apache/druid/server/initialization/JettyQosTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/JettyQosTest.java
@@ -52,6 +52,7 @@ import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletContext;
@@ -108,7 +109,7 @@ public class JettyQosTest extends BaseJettyTest
   }
 
   @Test
-  @Timeout(120)
+  @Timeout(value = 120, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testQoS() throws Exception
   {
     final int fastThreads = 20;

--- a/server/src/test/java/org/apache/druid/server/initialization/JettyQosTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/JettyQosTest.java
@@ -49,8 +49,9 @@ import org.eclipse.jetty.ee8.servlets.QoSFilter;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.jboss.netty.handler.codec.http.HttpMethod;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletContext;
@@ -100,13 +101,14 @@ public class JettyQosTest extends BaseJettyTest
   public void testNumThreads()
   {
     // Just make sure the injector stuff for this test is actually working.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         10,
         ((QueuedThreadPool) server.getThreadPool()).getMaxThreads()
     );
   }
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(120)
   public void testQoS() throws Exception
   {
     final int fastThreads = 20;
@@ -196,7 +198,7 @@ public class JettyQosTest extends BaseJettyTest
     fastPool.shutdown();
 
     // check that fast requests finished quickly
-    Assert.assertTrue(fastElapsed.get() / fastCount.get() < 500);
+    Assertions.assertTrue(fastElapsed.get() / fastCount.get() < 500);
   }
 
   @Test
@@ -207,7 +209,7 @@ public class JettyQosTest extends BaseJettyTest
                                                                                       Long.MAX_VALUE
     );
     filter.init(new QoSFilterConfig(qosFilterHolder));
-    Assert.assertEquals(Integer.MAX_VALUE, filter.getSuspendMs());
+    Assertions.assertEquals(Integer.MAX_VALUE, filter.getSuspendMs());
   }
 
   @Test
@@ -216,7 +218,7 @@ public class JettyQosTest extends BaseJettyTest
     QoSFilter filter = new QoSFilter();
     JettyBindings.QosFilterHolder qosFilterHolder = new JettyBindings.QosFilterHolder(new String[]{"/slow/*"}, 1);
     filter.init(new QoSFilterConfig(qosFilterHolder));
-    Assert.assertEquals(-1, filter.getSuspendMs());
+    Assertions.assertEquals(-1, filter.getSuspendMs());
   }
 
   private static class QoSFilterConfig implements FilterConfig

--- a/server/src/test/java/org/apache/druid/server/initialization/JettyTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/JettyTest.java
@@ -51,15 +51,15 @@ import org.apache.druid.server.security.AuthTestUtils;
 import org.apache.druid.server.security.AuthorizerMapper;
 import org.apache.druid.server.security.CustomCheckX509TrustManager;
 import org.apache.druid.server.security.TLSCertificateChecker;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -96,8 +96,8 @@ import java.util.zip.GZIPOutputStream;
 
 public class JettyTest extends BaseJettyTest
 {
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension folder = new TemporaryFolderExtension();
 
   private HttpClientConfig sslConfig;
 
@@ -227,7 +227,7 @@ public class JettyTest extends BaseJettyTest
   }
 
   @Test
-  @Ignore // this test will deadlock if it hits an issue, so ignored by default
+  @Disabled // this test will deadlock if it hits an issue, so ignored by default
   public void testTimeouts() throws Exception
   {
     // test for request timeouts properly not locking up all threads
@@ -289,9 +289,9 @@ public class JettyTest extends BaseJettyTest
     final URL url = new URL("http://localhost:" + port + "/default");
     final HttpURLConnection get = (HttpURLConnection) url.openConnection();
     get.setRequestProperty("Accept-Encoding", "gzip");
-    Assert.assertEquals("gzip", get.getContentEncoding());
+    Assertions.assertEquals("gzip", get.getContentEncoding());
     try (final InputStream inputStream = new GZIPInputStream(get.getInputStream())) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           DEFAULT_RESPONSE_CONTENT,
           IOUtils.toString(inputStream, StandardCharsets.UTF_8)
       );
@@ -300,25 +300,25 @@ public class JettyTest extends BaseJettyTest
     final HttpURLConnection post = (HttpURLConnection) url.openConnection();
     post.setRequestProperty("Accept-Encoding", "gzip");
     post.setRequestMethod("POST");
-    Assert.assertEquals("gzip", post.getContentEncoding());
+    Assertions.assertEquals("gzip", post.getContentEncoding());
     try (final InputStream inputStream = new GZIPInputStream(post.getInputStream())) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           DEFAULT_RESPONSE_CONTENT,
           IOUtils.toString(inputStream, StandardCharsets.UTF_8)
       );
     }
 
     final HttpURLConnection getNoGzip = (HttpURLConnection) url.openConnection();
-    Assert.assertNotEquals("gzip", getNoGzip.getContentEncoding());
+    Assertions.assertNotEquals("gzip", getNoGzip.getContentEncoding());
     try (final InputStream inputStream = getNoGzip.getInputStream()) {
-      Assert.assertEquals(DEFAULT_RESPONSE_CONTENT, IOUtils.toString(inputStream, StandardCharsets.UTF_8));
+      Assertions.assertEquals(DEFAULT_RESPONSE_CONTENT, IOUtils.toString(inputStream, StandardCharsets.UTF_8));
     }
 
     final HttpURLConnection postNoGzip = (HttpURLConnection) url.openConnection();
     postNoGzip.setRequestMethod("POST");
-    Assert.assertNotEquals("gzip", postNoGzip.getContentEncoding());
+    Assertions.assertNotEquals("gzip", postNoGzip.getContentEncoding());
     try (final InputStream inputStream = postNoGzip.getInputStream()) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           DEFAULT_RESPONSE_CONTENT,
           IOUtils.toString(inputStream, StandardCharsets.UTF_8)
       );
@@ -328,7 +328,7 @@ public class JettyTest extends BaseJettyTest
   // Tests that threads are not stuck when partial chunk is not finalized
   // https://bugs.eclipse.org/bugs/show_bug.cgi?id=424107
   @Test
-  @Ignore
+  @Disabled
   // above bug is not fixed in jetty for gzip encoding, and the chunk is still finalized instead of throwing exception.
   public void testChunkNotFinalized() throws Exception
   {
@@ -340,7 +340,7 @@ public class JettyTest extends BaseJettyTest
     try {
       StringWriter writer = new StringWriter();
       IOUtils.copy(go.get(), writer, "utf-8");
-      Assert.fail("Should have thrown Exception");
+      Assertions.fail("Should have thrown Exception");
     }
     catch (IOException e) {
       // Expected.
@@ -386,11 +386,11 @@ public class JettyTest extends BaseJettyTest
     URL url = new URL("http://localhost:" + port + "/default");
     HttpURLConnection get = (HttpURLConnection) url.openConnection();
     get.setRequestProperty(DummyAuthFilter.AUTH_HDR, DummyAuthFilter.SECRET_USER);
-    Assert.assertEquals(HttpServletResponse.SC_OK, get.getResponseCode());
+    Assertions.assertEquals(HttpServletResponse.SC_OK, get.getResponseCode());
 
     get = (HttpURLConnection) url.openConnection();
     get.setRequestProperty(DummyAuthFilter.AUTH_HDR, "hacker");
-    Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, get.getResponseCode());
+    Assertions.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, get.getResponseCode());
   }
 
   @Test
@@ -404,7 +404,7 @@ public class JettyTest extends BaseJettyTest
     Request request = new Request(HttpMethod.POST, new URL("http://localhost:" + port + "/return"));
     request.setHeader("Content-Encoding", "gzip");
     request.setContent(MediaType.TEXT_PLAIN, out.toByteArray());
-    Assert.assertEquals(text, new String(IOUtils.toByteArray(client.go(
+    Assertions.assertEquals(text, new String(IOUtils.toByteArray(client.go(
         request,
         new InputStreamResponseHandler()
     ).get()), Charset.defaultCharset()));
@@ -426,17 +426,17 @@ public class JettyTest extends BaseJettyTest
     latchedRequestState.reset();
     waitForJettyServerModuleActiveConnectionsZero(jsm);
 
-    Assert.assertEquals(0, jsm.getActiveConnections());
+    Assertions.assertEquals(0, jsm.getActiveConnections());
     ListenableFuture<InputStream> go = client.go(
         request,
         new InputStreamResponseHandler()
     );
     latchedRequestState.clientWaitForServerToStartRequest();
-    Assert.assertEquals(1, jsm.getActiveConnections());
+    Assertions.assertEquals(1, jsm.getActiveConnections());
     latchedRequestState.clientReadyToFinishRequest();
     go.get();
     waitForJettyServerModuleActiveConnectionsZero(jsm);
-    Assert.assertEquals(0, jsm.getActiveConnections());
+    Assertions.assertEquals(0, jsm.getActiveConnections());
   }
 
   @Test
@@ -465,17 +465,17 @@ public class JettyTest extends BaseJettyTest
     latchedRequestState.reset();
 
     waitForJettyServerModuleActiveConnectionsZero(jsm);
-    Assert.assertEquals(0, jsm.getActiveConnections());
+    Assertions.assertEquals(0, jsm.getActiveConnections());
     ListenableFuture<InputStream> go = client.go(
         request,
         new InputStreamResponseHandler()
     );
     latchedRequestState.clientWaitForServerToStartRequest();
-    Assert.assertEquals(1, jsm.getActiveConnections());
+    Assertions.assertEquals(1, jsm.getActiveConnections());
     latchedRequestState.clientReadyToFinishRequest();
     go.get();
     waitForJettyServerModuleActiveConnectionsZero(jsm);
-    Assert.assertEquals(0, jsm.getActiveConnections());
+    Assertions.assertEquals(0, jsm.getActiveConnections());
   }
 
   @Test
@@ -492,7 +492,7 @@ public class JettyTest extends BaseJettyTest
     X509Certificate[] chain = new X509Certificate[]{mockX509Certificate};
 
     // The EndpointIdentificationAlgorithm should not be null as we set it to HTTPS earlier
-    Assert.assertNotNull(sslEngine.getSSLParameters().getEndpointIdentificationAlgorithm());
+    Assertions.assertNotNull(sslEngine.getSSLParameters().getEndpointIdentificationAlgorithm());
 
     CustomCheckX509TrustManager customCheckX509TrustManager = new CustomCheckX509TrustManager(
         mockX509ExtendedTrustManager,
@@ -513,7 +513,7 @@ public class JettyTest extends BaseJettyTest
     // The EndpointIdentificationAlgorithm should be null or empty Stringas the CustomCheckX509TrustManager
     // has validateServerHostnames set to false
     String endpointIdentificationAlgorithm = transformedSSLEngine.getSSLParameters().getEndpointIdentificationAlgorithm();
-    Assert.assertTrue(endpointIdentificationAlgorithm == null || endpointIdentificationAlgorithm.isEmpty());
+    Assertions.assertTrue(endpointIdentificationAlgorithm == null || endpointIdentificationAlgorithm.isEmpty());
   }
 
   private void waitForJettyServerModuleActiveConnectionsZero(JettyServerModule jsm) throws InterruptedException

--- a/server/src/test/java/org/apache/druid/server/initialization/jetty/CustomExceptionMapperTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/jetty/CustomExceptionMapperTest.java
@@ -25,12 +25,16 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.ws.rs.core.Response;
 
+@ExtendWith(MockitoExtension.class)
 public class CustomExceptionMapperTest
 {
+  @Mock
   private JsonParser jsonParser;
 
   private CustomExceptionMapper customExceptionMapper;
@@ -38,7 +42,6 @@ public class CustomExceptionMapperTest
   @BeforeEach
   public void setUp()
   {
-    jsonParser = Mockito.mock(JsonParser.class);
     customExceptionMapper = new CustomExceptionMapper();
   }
 

--- a/server/src/test/java/org/apache/druid/server/initialization/jetty/CustomExceptionMapperTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/jetty/CustomExceptionMapperTest.java
@@ -28,10 +28,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import javax.ws.rs.core.Response;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class CustomExceptionMapperTest
 {
   @Mock

--- a/server/src/test/java/org/apache/druid/server/initialization/jetty/CustomExceptionMapperTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/jetty/CustomExceptionMapperTest.java
@@ -22,26 +22,23 @@ package org.apache.druid.server.initialization.jetty;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import javax.ws.rs.core.Response;
 
-@RunWith(MockitoJUnitRunner.class)
 public class CustomExceptionMapperTest
 {
-  @Mock
   private JsonParser jsonParser;
 
   private CustomExceptionMapper customExceptionMapper;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
+    jsonParser = Mockito.mock(JsonParser.class);
     customExceptionMapper = new CustomExceptionMapper();
   }
 
@@ -51,12 +48,12 @@ public class CustomExceptionMapperTest
     final JsonMappingException exception = JsonMappingException.from(jsonParser, "Test exception");
     final Response response = customExceptionMapper.toResponse(exception);
 
-    Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-    Assert.assertTrue(response.getEntity() instanceof ImmutableMap);
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    Assertions.assertTrue(response.getEntity() instanceof ImmutableMap);
 
     final ImmutableMap<Object, Object> map = (ImmutableMap<Object, Object>) response.getEntity();
-    Assert.assertEquals(1, map.size());
-    Assert.assertEquals("Test exception", map.get(CustomExceptionMapper.ERROR_KEY));
+    Assertions.assertEquals(1, map.size());
+    Assertions.assertEquals("Test exception", map.get(CustomExceptionMapper.ERROR_KEY));
   }
 
   @Test
@@ -65,11 +62,11 @@ public class CustomExceptionMapperTest
     final JsonMappingException exception = JsonMappingException.from(jsonParser, "Test exception\nStack trace\nMisc details");
     final Response response = customExceptionMapper.toResponse(exception);
 
-    Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-    Assert.assertTrue(response.getEntity() instanceof ImmutableMap);
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    Assertions.assertTrue(response.getEntity() instanceof ImmutableMap);
 
     final ImmutableMap<Object, Object> map = (ImmutableMap<Object, Object>) response.getEntity();
-    Assert.assertEquals(1, map.size());
-    Assert.assertEquals("Test exception", map.get(CustomExceptionMapper.ERROR_KEY));
+    Assertions.assertEquals(1, map.size());
+    Assertions.assertEquals("Test exception", map.get(CustomExceptionMapper.ERROR_KEY));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/initialization/jetty/JettyServerModuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/jetty/JettyServerModuleTest.java
@@ -32,8 +32,8 @@ import org.apache.druid.server.security.TLSCertificateChecker;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Arrays;
@@ -114,7 +114,7 @@ public class JettyServerModuleTest
         certificateChecker
     );
 
-    Assert.assertNotNull(server);
+    Assertions.assertNotNull(server);
   }
 
   @Test
@@ -167,7 +167,7 @@ public class JettyServerModuleTest
         certificateChecker
     );
 
-    Assert.assertNotNull(server);
+    Assertions.assertNotNull(server);
 
     // Verify that custom SSL context factory was used
     Mockito.verify(provider).get();
@@ -231,7 +231,7 @@ public class JettyServerModuleTest
         certificateChecker
     );
 
-    Assert.assertNotNull(server);
+    Assertions.assertNotNull(server);
 
     // Verify that custom SSL context factory was used
     Mockito.verify(provider).get();

--- a/server/src/test/java/org/apache/druid/server/initialization/jetty/LimitRequestsFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/jetty/LimitRequestsFilterTest.java
@@ -23,6 +23,7 @@ import org.apache.druid.java.util.common.ISE;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletRequest;
@@ -35,7 +36,7 @@ import java.util.concurrent.CountDownLatch;
 public class LimitRequestsFilterTest
 {
   @Test
-  @Timeout(60)
+  @Timeout(value = 60, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testSimple() throws Exception
   {
     LimitRequestsFilter filter = new LimitRequestsFilter(2);

--- a/server/src/test/java/org/apache/druid/server/initialization/jetty/LimitRequestsFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/jetty/LimitRequestsFilterTest.java
@@ -21,7 +21,8 @@ package org.apache.druid.server.initialization.jetty;
 
 import org.apache.druid.java.util.common.ISE;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletRequest;
@@ -33,7 +34,8 @@ import java.util.concurrent.CountDownLatch;
  */
 public class LimitRequestsFilterTest
 {
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(60)
   public void testSimple() throws Exception
   {
     LimitRequestsFilter filter = new LimitRequestsFilter(2);

--- a/server/src/test/java/org/apache/druid/server/initialization/jetty/PathExcludingQoSFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/jetty/PathExcludingQoSFilterTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.server.initialization.jetty;
 
 import org.apache.druid.server.mocks.MockHttpServletRequest;
 import org.apache.druid.server.mocks.MockHttpServletResponse;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -56,9 +56,9 @@ public class PathExcludingQoSFilterTest
 
       filter.doFilter(request, response, chain);
 
-      Assert.assertEquals("Excluded request should be passed straight down the chain", 1, chain.invocations);
-      Assert.assertSame(request, chain.lastRequest);
-      Assert.assertEquals("Excluded request should not be rejected", 0, response.getStatus());
+      Assertions.assertEquals(1, chain.invocations, "Excluded request should be passed straight down the chain");
+      Assertions.assertSame(request, chain.lastRequest);
+      Assertions.assertEquals(0, response.getStatus(), "Excluded request should not be rejected");
     }
   }
 
@@ -75,11 +75,11 @@ public class PathExcludingQoSFilterTest
     // A single request with a free semaphore is accepted and passed down the chain by the standard QoSFilter.
     filter.doFilter(request, response, chain);
 
-    Assert.assertEquals("Non-excluded request should be handled by the QoS filter", 1, chain.invocations);
-    Assert.assertNotEquals(
-        "Accepted request must not be rejected with 503",
+    Assertions.assertEquals(1, chain.invocations, "Non-excluded request should be handled by the QoS filter");
+    Assertions.assertNotEquals(
         HttpServletResponse.SC_SERVICE_UNAVAILABLE,
-        response.getStatus()
+        response.getStatus(),
+        "Accepted request must not be rejected with 503"
     );
   }
 
@@ -88,7 +88,7 @@ public class PathExcludingQoSFilterTest
   {
     // A null exclusion list must not blow up; nothing should be treated as excluded.
     final PathExcludingQoSFilter filter = new PathExcludingQoSFilter(null);
-    Assert.assertNotNull(filter);
+    Assertions.assertNotNull(filter);
   }
 
   private static MockHttpServletRequest request(String requestUri)

--- a/server/src/test/java/org/apache/druid/server/initialization/jetty/StandardResponseHeaderFilterHolderTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/jetty/StandardResponseHeaderFilterHolderTest.java
@@ -26,13 +26,10 @@ import org.easymock.EasyMock;
 import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
@@ -52,7 +49,7 @@ public class StandardResponseHeaderFilterHolderTest
   public HttpServletResponse proxyResponse;
   public Response clientResponse;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     serverConfig = EasyMock.strictMock(ServerConfig.class);
@@ -64,7 +61,7 @@ public class StandardResponseHeaderFilterHolderTest
     clientResponse = EasyMock.strictMock(Response.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     EasyMock.verify(serverConfig, httpRequest, httpResponse, filterChain, proxyResponse, clientResponse);
@@ -129,14 +126,10 @@ public class StandardResponseHeaderFilterHolderTest
 
     replayAllMocks();
 
-    final RuntimeException e = Assert.assertThrows(RuntimeException.class, this::makeFilter);
+    final RuntimeException e = Assertions.assertThrows(RuntimeException.class, this::makeFilter);
 
-    MatcherAssert.assertThat(
-        e,
-        ThrowableMessageMatcher.hasMessage(
-            CoreMatchers.containsString("Content-Security-Policy header value must be fully ASCII")
-        )
-    );
+    Assertions.assertNotNull(e.getMessage());
+    Assertions.assertTrue(e.getMessage().contains("Content-Security-Policy header value must be fully ASCII"));
   }
 
   @Test
@@ -202,7 +195,11 @@ public class StandardResponseHeaderFilterHolderTest
     filter.doFilter(httpRequest, httpResponse, filterChain);
 
     for (final Map.Entry<String, String> entry : expectedHeaders.entrySet()) {
-      Assert.assertEquals(entry.getKey(), entry.getValue(), captureMap.get(entry.getKey()).getValue());
+      Assertions.assertEquals(
+          entry.getValue(),
+          captureMap.get(entry.getKey()).getValue(),
+          entry.getKey()
+      );
     }
   }
 

--- a/server/src/test/java/org/apache/druid/test/utils/ImmutableDruidDataSourceTestUtils.java
+++ b/server/src/test/java/org/apache/druid/test/utils/ImmutableDruidDataSourceTestUtils.java
@@ -20,7 +20,7 @@
 package org.apache.druid.test.utils;
 
 import org.apache.druid.client.ImmutableDruidDataSource;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -68,8 +68,8 @@ public class ImmutableDruidDataSourceTestUtils
       return actual == null;
     }
 
-    Assert.assertEquals("expected and actual ImmutableDruidDataSource lists should be of equal size",
-        expected.size(), actual.size());
+    Assertions.assertEquals(expected.size(), actual.size(),
+        "expected and actual ImmutableDruidDataSource lists should be of equal size");
 
     for (ImmutableDruidDataSource e : expected) {
       if (!contains(e, actual)) {

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -274,6 +274,7 @@
             <artifactId>httpclient</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Required by JUnit 4 rule types exposed by server/processing test-jar fixtures. -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -287,16 +288,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-migrationsupport</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -318,16 +309,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest</artifactId>
-          <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -311,6 +311,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <scope>test</scope>

--- a/services/src/test/java/org/apache/druid/cli/CliBrokerTest.java
+++ b/services/src/test/java/org/apache/druid/cli/CliBrokerTest.java
@@ -43,8 +43,8 @@ import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.guice.LifecycleModule;
 import org.apache.druid.jackson.JacksonModule;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Properties;
@@ -59,15 +59,15 @@ public class CliBrokerTest
     final Injector injector = makeBrokerInjector(new Properties());
 
     final ServerSelectorStrategy historicalBalancer = injector.getInstance(ServerSelectorStrategy.class);
-    Assert.assertNotNull(historicalBalancer);
-    Assert.assertTrue(historicalBalancer instanceof RandomServerSelectorStrategy);
+    Assertions.assertNotNull(historicalBalancer);
+    Assertions.assertTrue(historicalBalancer instanceof RandomServerSelectorStrategy);
 
     final ServerSelectorStrategy realtimeBalancer = injector.getInstance(
         Key.get(ServerSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     );
-    Assert.assertNotNull(realtimeBalancer);
-    Assert.assertTrue(realtimeBalancer instanceof RandomServerSelectorStrategy);
-    Assert.assertSame(realtimeBalancer, historicalBalancer);
+    Assertions.assertNotNull(realtimeBalancer);
+    Assertions.assertTrue(realtimeBalancer instanceof RandomServerSelectorStrategy);
+    Assertions.assertSame(realtimeBalancer, historicalBalancer);
   }
 
   @Test
@@ -76,9 +76,9 @@ public class CliBrokerTest
     final Injector injector = makeBrokerInjector(new Properties());
     TierSelectorStrategy historicalTierSelector = injector.getInstance(TierSelectorStrategy.class);
     TierSelectorStrategy realtimeTierSelector = injector.getInstance(Key.get(TierSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR)));
-    Assert.assertTrue(historicalTierSelector instanceof HighestPriorityTierSelectorStrategy);
-    Assert.assertTrue(realtimeTierSelector instanceof HighestPriorityTierSelectorStrategy);
-    Assert.assertSame(realtimeTierSelector, historicalTierSelector);
+    Assertions.assertTrue(historicalTierSelector instanceof HighestPriorityTierSelectorStrategy);
+    Assertions.assertTrue(realtimeTierSelector instanceof HighestPriorityTierSelectorStrategy);
+    Assertions.assertSame(realtimeTierSelector, historicalTierSelector);
   }
 
   @Test
@@ -88,8 +88,8 @@ public class CliBrokerTest
     properties.setProperty("druid.broker.select.tier", "lowestPriority");
 
     final Injector injector = makeBrokerInjector(properties);
-    Assert.assertTrue(injector.getInstance(TierSelectorStrategy.class) instanceof LowestPriorityTierSelectorStrategy);
-    Assert.assertTrue(
+    Assertions.assertTrue(injector.getInstance(TierSelectorStrategy.class) instanceof LowestPriorityTierSelectorStrategy);
+    Assertions.assertTrue(
         injector.getInstance(Key.get(TierSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR)))
         instanceof LowestPriorityTierSelectorStrategy
     );
@@ -109,15 +109,15 @@ public class CliBrokerTest
         Key.get(TierSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     );
 
-    Assert.assertTrue(realtime instanceof CustomTierSelectorStrategy);
-    Assert.assertEquals(List.of(2, 1, 0), ((CustomTierSelectorStrategy) realtime).getConfig().getPriorities());
+    Assertions.assertTrue(realtime instanceof CustomTierSelectorStrategy);
+    Assertions.assertEquals(List.of(2, 1, 0), ((CustomTierSelectorStrategy) realtime).getConfig().getPriorities());
 
-    Assert.assertTrue(injector.getInstance(TierSelectorStrategy.class) instanceof HighestPriorityTierSelectorStrategy);
+    Assertions.assertTrue(injector.getInstance(TierSelectorStrategy.class) instanceof HighestPriorityTierSelectorStrategy);
 
     final ServerSelectorStrategy realtimeBalancer = injector.getInstance(
         Key.get(ServerSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     );
-    Assert.assertTrue(realtimeBalancer instanceof RandomServerSelectorStrategy);
+    Assertions.assertTrue(realtimeBalancer instanceof RandomServerSelectorStrategy);
   }
 
   @Test
@@ -139,11 +139,11 @@ public class CliBrokerTest
     );
 
     // Verify tier selector strategies with strategy-specific config paths
-    Assert.assertTrue(historical instanceof CustomTierSelectorStrategy);
-    Assert.assertEquals(List.of(0), ((CustomTierSelectorStrategy) historical).getConfig().getPriorities());
+    Assertions.assertTrue(historical instanceof CustomTierSelectorStrategy);
+    Assertions.assertEquals(List.of(0), ((CustomTierSelectorStrategy) historical).getConfig().getPriorities());
 
-    Assert.assertTrue(realtime instanceof CustomTierSelectorStrategy);
-    Assert.assertEquals(List.of(2, 1), ((CustomTierSelectorStrategy) realtime).getConfig().getPriorities());
+    Assertions.assertTrue(realtime instanceof CustomTierSelectorStrategy);
+    Assertions.assertEquals(List.of(2, 1), ((CustomTierSelectorStrategy) realtime).getConfig().getPriorities());
 
     // Verify different server selector strategies
     final ServerSelectorStrategy historicalBalancer = injector.getInstance(ServerSelectorStrategy.class);
@@ -151,8 +151,8 @@ public class CliBrokerTest
         Key.get(ServerSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     );
 
-    Assert.assertTrue(historicalBalancer instanceof RandomServerSelectorStrategy);
-    Assert.assertTrue(realtimeBalancer instanceof ConnectionCountServerSelectorStrategy);
+    Assertions.assertTrue(historicalBalancer instanceof RandomServerSelectorStrategy);
+    Assertions.assertTrue(realtimeBalancer instanceof ConnectionCountServerSelectorStrategy);
   }
 
 
@@ -168,13 +168,13 @@ public class CliBrokerTest
     final Injector injector = makeBrokerInjector(properties);
 
     final TierSelectorStrategy historical = injector.getInstance(TierSelectorStrategy.class);
-    Assert.assertTrue(historical instanceof CustomTierSelectorStrategy);
-    Assert.assertEquals(List.of(0), ((CustomTierSelectorStrategy) historical).getConfig().getPriorities());
+    Assertions.assertTrue(historical instanceof CustomTierSelectorStrategy);
+    Assertions.assertEquals(List.of(0), ((CustomTierSelectorStrategy) historical).getConfig().getPriorities());
 
     final TierSelectorStrategy realtime = injector.getInstance(
         Key.get(TierSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     );
-    Assert.assertTrue(realtime instanceof LowestPriorityTierSelectorStrategy);
+    Assertions.assertTrue(realtime instanceof LowestPriorityTierSelectorStrategy);
   }
 
 
@@ -193,12 +193,12 @@ public class CliBrokerTest
         Key.get(ServerSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     );
 
-    Assert.assertTrue(historicalBalancer instanceof RandomServerSelectorStrategy);
-    Assert.assertTrue(realtimeBalancer instanceof RandomServerSelectorStrategy);
+    Assertions.assertTrue(historicalBalancer instanceof RandomServerSelectorStrategy);
+    Assertions.assertTrue(realtimeBalancer instanceof RandomServerSelectorStrategy);
 
     final TierSelectorStrategy historical = injector.getInstance(TierSelectorStrategy.class);
-    Assert.assertTrue(historical instanceof CustomTierSelectorStrategy);
-    Assert.assertEquals(List.of(0), ((CustomTierSelectorStrategy) historical).getConfig().getPriorities());
+    Assertions.assertTrue(historical instanceof CustomTierSelectorStrategy);
+    Assertions.assertEquals(List.of(0), ((CustomTierSelectorStrategy) historical).getConfig().getPriorities());
   }
 
   @Test
@@ -221,23 +221,23 @@ public class CliBrokerTest
         Key.get(TierSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     );
 
-    Assert.assertTrue(historical instanceof PreferredTierSelectorStrategy);
+    Assertions.assertTrue(historical instanceof PreferredTierSelectorStrategy);
     PreferredTierSelectorStrategyConfig historicalPreferredTierConfig = ((PreferredTierSelectorStrategy) historical).getConfig();
-    Assert.assertEquals("historical-tier", historicalPreferredTierConfig.getTier());
-    Assert.assertEquals("highest", historicalPreferredTierConfig.getPriority());
+    Assertions.assertEquals("historical-tier", historicalPreferredTierConfig.getTier());
+    Assertions.assertEquals("highest", historicalPreferredTierConfig.getPriority());
 
-    Assert.assertTrue(realtime instanceof PreferredTierSelectorStrategy);
+    Assertions.assertTrue(realtime instanceof PreferredTierSelectorStrategy);
     PreferredTierSelectorStrategyConfig realtimePreferredTierConfig = ((PreferredTierSelectorStrategy) realtime).getConfig();
-    Assert.assertEquals("realtime-tier", realtimePreferredTierConfig.getTier());
-    Assert.assertEquals("lowest", realtimePreferredTierConfig.getPriority());
+    Assertions.assertEquals("realtime-tier", realtimePreferredTierConfig.getTier());
+    Assertions.assertEquals("lowest", realtimePreferredTierConfig.getPriority());
 
     final ServerSelectorStrategy historicalBalancer = injector.getInstance(ServerSelectorStrategy.class);
     final ServerSelectorStrategy realtimeBalancer = injector.getInstance(
         Key.get(ServerSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     );
 
-    Assert.assertTrue(historicalBalancer instanceof RandomServerSelectorStrategy);
-    Assert.assertTrue(realtimeBalancer instanceof ConnectionCountServerSelectorStrategy);
+    Assertions.assertTrue(historicalBalancer instanceof RandomServerSelectorStrategy);
+    Assertions.assertTrue(realtimeBalancer instanceof ConnectionCountServerSelectorStrategy);
   }
 
   @Test
@@ -254,22 +254,22 @@ public class CliBrokerTest
         Key.get(TierSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     );
 
-    Assert.assertTrue(historical instanceof PreferredTierSelectorStrategy);
+    Assertions.assertTrue(historical instanceof PreferredTierSelectorStrategy);
     PreferredTierSelectorStrategyConfig historicalPreferredTierConfig = ((PreferredTierSelectorStrategy) historical).getConfig();
-    Assert.assertEquals("default-tier", historicalPreferredTierConfig.getTier());
-    Assert.assertEquals("highest", historicalPreferredTierConfig.getPriority());
+    Assertions.assertEquals("default-tier", historicalPreferredTierConfig.getTier());
+    Assertions.assertEquals("highest", historicalPreferredTierConfig.getPriority());
 
-    Assert.assertTrue(realtime instanceof PreferredTierSelectorStrategy);
+    Assertions.assertTrue(realtime instanceof PreferredTierSelectorStrategy);
     PreferredTierSelectorStrategyConfig realtimePreferredTierConfig = ((PreferredTierSelectorStrategy) realtime).getConfig();
-    Assert.assertSame(realtimePreferredTierConfig, historicalPreferredTierConfig);
+    Assertions.assertSame(realtimePreferredTierConfig, historicalPreferredTierConfig);
 
     final ServerSelectorStrategy historicalBalancer = injector.getInstance(ServerSelectorStrategy.class);
     final ServerSelectorStrategy realtimeBalancer = injector.getInstance(
         Key.get(ServerSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     );
 
-    Assert.assertTrue(historicalBalancer instanceof RandomServerSelectorStrategy);
-    Assert.assertSame(realtimeBalancer, historicalBalancer);
+    Assertions.assertTrue(historicalBalancer instanceof RandomServerSelectorStrategy);
+    Assertions.assertSame(realtimeBalancer, historicalBalancer);
   }
 
   @Test
@@ -286,16 +286,16 @@ public class CliBrokerTest
         Key.get(TierSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     );
 
-    Assert.assertTrue(realtime instanceof StrictTierSelectorStrategy);
-    Assert.assertEquals(List.of(2, 1, 0), ((StrictTierSelectorStrategy) realtime).getConfig().getPriorities());
+    Assertions.assertTrue(realtime instanceof StrictTierSelectorStrategy);
+    Assertions.assertEquals(List.of(2, 1, 0), ((StrictTierSelectorStrategy) realtime).getConfig().getPriorities());
 
     // Historical should use default (highest priority)
-    Assert.assertTrue(injector.getInstance(TierSelectorStrategy.class) instanceof HighestPriorityTierSelectorStrategy);
+    Assertions.assertTrue(injector.getInstance(TierSelectorStrategy.class) instanceof HighestPriorityTierSelectorStrategy);
 
     final ServerSelectorStrategy realtimeBalancer = injector.getInstance(
         Key.get(ServerSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     );
-    Assert.assertTrue(realtimeBalancer instanceof RandomServerSelectorStrategy);
+    Assertions.assertTrue(realtimeBalancer instanceof RandomServerSelectorStrategy);
   }
 
   @Test
@@ -316,11 +316,11 @@ public class CliBrokerTest
         Key.get(TierSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     );
 
-    Assert.assertTrue(historical instanceof StrictTierSelectorStrategy);
-    Assert.assertEquals(List.of(0, 1), ((StrictTierSelectorStrategy) historical).getConfig().getPriorities());
+    Assertions.assertTrue(historical instanceof StrictTierSelectorStrategy);
+    Assertions.assertEquals(List.of(0, 1), ((StrictTierSelectorStrategy) historical).getConfig().getPriorities());
 
-    Assert.assertTrue(realtime instanceof StrictTierSelectorStrategy);
-    Assert.assertEquals(List.of(2, 1, 0), ((StrictTierSelectorStrategy) realtime).getConfig().getPriorities());
+    Assertions.assertTrue(realtime instanceof StrictTierSelectorStrategy);
+    Assertions.assertEquals(List.of(2, 1, 0), ((StrictTierSelectorStrategy) realtime).getConfig().getPriorities());
   }
 
   @Test
@@ -331,16 +331,16 @@ public class CliBrokerTest
     properties.setProperty("druid.broker.realtime.select.tier", "strict");
 
     final Injector injector = makeBrokerInjector(properties);
-    ProvisionException e1 = Assert.assertThrows(ProvisionException.class, () -> injector.getInstance(TierSelectorStrategy.class));
-    Assert.assertTrue(e1.getMessage().contains(
+    ProvisionException e1 = Assertions.assertThrows(ProvisionException.class, () -> injector.getInstance(TierSelectorStrategy.class));
+    Assertions.assertTrue(e1.getMessage().contains(
         "Problem parsing object at prefix[druid.broker.select.tier.strict]: Cannot construct instance of"
         + " `StrictTierSelectorStrategyConfig`, problem: priorities must be non-empty when using strict tier selector on the Broker. Found priorities[null]."
     ));
 
-    ProvisionException e2 = Assert.assertThrows(ProvisionException.class, () -> injector.getInstance(
+    ProvisionException e2 = Assertions.assertThrows(ProvisionException.class, () -> injector.getInstance(
         Key.get(TierSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     ));
-    Assert.assertTrue(e2.getMessage().contains(
+    Assertions.assertTrue(e2.getMessage().contains(
         "Problem parsing object at prefix[druid.broker.realtime.select.tier.strict]: Cannot construct instance of"
         + " `StrictTierSelectorStrategyConfig`, problem: priorities must be non-empty when using strict tier selector on the Broker. Found priorities[null]."
     ));
@@ -365,11 +365,11 @@ public class CliBrokerTest
     );
 
     // Verify tier selector strategies with strategy-specific config paths
-    Assert.assertTrue(historical instanceof PooledTierSelectorStrategy);
-    Assert.assertEquals(Set.of(0), ((PooledTierSelectorStrategy) historical).getConfig().getPriorities());
+    Assertions.assertTrue(historical instanceof PooledTierSelectorStrategy);
+    Assertions.assertEquals(Set.of(0), ((PooledTierSelectorStrategy) historical).getConfig().getPriorities());
 
-    Assert.assertTrue(realtime instanceof PooledTierSelectorStrategy);
-    Assert.assertEquals(Set.of(2, 1), ((PooledTierSelectorStrategy) realtime).getConfig().getPriorities());
+    Assertions.assertTrue(realtime instanceof PooledTierSelectorStrategy);
+    Assertions.assertEquals(Set.of(2, 1), ((PooledTierSelectorStrategy) realtime).getConfig().getPriorities());
 
     // Verify different server selector strategies
     final ServerSelectorStrategy historicalBalancer = injector.getInstance(ServerSelectorStrategy.class);
@@ -377,8 +377,8 @@ public class CliBrokerTest
         Key.get(ServerSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     );
 
-    Assert.assertTrue(historicalBalancer instanceof RandomServerSelectorStrategy);
-    Assert.assertTrue(realtimeBalancer instanceof ConnectionCountServerSelectorStrategy);
+    Assertions.assertTrue(historicalBalancer instanceof RandomServerSelectorStrategy);
+    Assertions.assertTrue(realtimeBalancer instanceof ConnectionCountServerSelectorStrategy);
   }
 
   @Test
@@ -395,16 +395,16 @@ public class CliBrokerTest
         Key.get(TierSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     );
 
-    Assert.assertTrue(realtime instanceof PooledTierSelectorStrategy);
-    Assert.assertEquals(Set.of(2, 1, 0), ((PooledTierSelectorStrategy) realtime).getConfig().getPriorities());
+    Assertions.assertTrue(realtime instanceof PooledTierSelectorStrategy);
+    Assertions.assertEquals(Set.of(2, 1, 0), ((PooledTierSelectorStrategy) realtime).getConfig().getPriorities());
 
     // Historical should use default (highest priority)
-    Assert.assertTrue(injector.getInstance(TierSelectorStrategy.class) instanceof HighestPriorityTierSelectorStrategy);
+    Assertions.assertTrue(injector.getInstance(TierSelectorStrategy.class) instanceof HighestPriorityTierSelectorStrategy);
 
     final ServerSelectorStrategy realtimeBalancer = injector.getInstance(
         Key.get(ServerSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     );
-    Assert.assertTrue(realtimeBalancer instanceof RandomServerSelectorStrategy);
+    Assertions.assertTrue(realtimeBalancer instanceof RandomServerSelectorStrategy);
   }
 
   @Test
@@ -415,16 +415,16 @@ public class CliBrokerTest
     properties.setProperty("druid.broker.realtime.select.tier", "pooled");
 
     final Injector injector = makeBrokerInjector(properties);
-    ProvisionException e1 = Assert.assertThrows(ProvisionException.class, () -> injector.getInstance(TierSelectorStrategy.class));
-    Assert.assertTrue(e1.getMessage().contains(
+    ProvisionException e1 = Assertions.assertThrows(ProvisionException.class, () -> injector.getInstance(TierSelectorStrategy.class));
+    Assertions.assertTrue(e1.getMessage().contains(
         "Problem parsing object at prefix[druid.broker.select.tier.pooled]: Cannot construct instance of"
         + " `PooledTierSelectorStrategyConfig`, problem: priorities must be non-empty when using pooled tier selector on the Broker. Found priorities[null]."
     ));
 
-    ProvisionException e2 = Assert.assertThrows(ProvisionException.class, () -> injector.getInstance(
+    ProvisionException e2 = Assertions.assertThrows(ProvisionException.class, () -> injector.getInstance(
         Key.get(TierSelectorStrategy.class, Names.named(BrokerServerView.REALTIME_SELECTOR))
     ));
-    Assert.assertTrue(e2.getMessage().contains(
+    Assertions.assertTrue(e2.getMessage().contains(
         "Problem parsing object at prefix[druid.broker.realtime.select.tier.pooled]: Cannot construct instance of"
         + " `PooledTierSelectorStrategyConfig`, problem: priorities must be non-empty when using pooled tier selector on the Broker. Found priorities[null]."
     ));

--- a/services/src/test/java/org/apache/druid/cli/CliCoordinatorTest.java
+++ b/services/src/test/java/org/apache/druid/cli/CliCoordinatorTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.guice.LifecycleModule;
 import org.apache.druid.jackson.JacksonModule;
 import org.apache.druid.server.initialization.jetty.JettyBindings;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Properties;
@@ -48,9 +48,9 @@ public class CliCoordinatorTest
     final Injector injector = makeCoordinatorInjector(new Properties());
 
     final Set<JettyBindings.QosFilterHolder> qosFilters = getQosFilterHolders(injector);
-    Assert.assertTrue(
-        "Coordinator QoS filter should be bound when maxConcurrentRequests defaults to a positive value",
-        hasCoordinatorQosFilter(qosFilters)
+    Assertions.assertTrue(
+        hasCoordinatorQosFilter(qosFilters),
+        "Coordinator QoS filter should be bound when maxConcurrentRequests defaults to a positive value"
     );
   }
 
@@ -62,9 +62,9 @@ public class CliCoordinatorTest
     final Injector injector = makeCoordinatorInjector(properties);
 
     final Set<JettyBindings.QosFilterHolder> qosFilters = getQosFilterHolders(injector);
-    Assert.assertFalse(
-        "Coordinator QoS filter should not be bound when maxConcurrentRequests is set to a non-positive value",
-        hasCoordinatorQosFilter(qosFilters)
+    Assertions.assertFalse(
+        hasCoordinatorQosFilter(qosFilters),
+        "Coordinator QoS filter should not be bound when maxConcurrentRequests is set to a non-positive value"
     );
   }
 
@@ -81,13 +81,13 @@ public class CliCoordinatorTest
 
 
     final Set<String> excludedPaths = Set.of(coordinatorQosFilter.getExcludedPaths());
-    Assert.assertTrue(
-        "isLeader should be exempt from QoS filtering",
-        excludedPaths.contains("/druid/coordinator/v1/isLeader")
+    Assertions.assertTrue(
+        excludedPaths.contains("/druid/coordinator/v1/isLeader"),
+        "isLeader should be exempt from QoS filtering"
     );
-    Assert.assertTrue(
-        "leader should be exempt from QoS filtering",
-        excludedPaths.contains("/druid/coordinator/v1/leader")
+    Assertions.assertTrue(
+        excludedPaths.contains("/druid/coordinator/v1/leader"),
+        "leader should be exempt from QoS filtering"
     );
   }
 

--- a/services/src/test/java/org/apache/druid/cli/CliMainTest.java
+++ b/services/src/test/java/org/apache/druid/cli/CliMainTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.druid.cli;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CliMainTest
 {

--- a/services/src/test/java/org/apache/druid/cli/CliOverlordTest.java
+++ b/services/src/test/java/org/apache/druid/cli/CliOverlordTest.java
@@ -27,8 +27,8 @@ import org.apache.druid.metadata.segment.SqlSegmentsMetadataManagerV2;
 import org.apache.druid.metadata.segment.cache.HeapMemorySegmentMetadataCache;
 import org.apache.druid.metadata.segment.cache.SegmentMetadataCache;
 import org.apache.druid.server.initialization.ServerConfig;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
@@ -45,11 +45,11 @@ public class CliOverlordTest
 
     final SegmentMetadataCache segmentMetadataCache
         = overlordInjector.getInstance(SegmentMetadataCache.class);
-    Assert.assertTrue(segmentMetadataCache instanceof HeapMemorySegmentMetadataCache);
+    Assertions.assertTrue(segmentMetadataCache instanceof HeapMemorySegmentMetadataCache);
 
     final SegmentsMetadataManager segmentsMetadataManager
         = overlordInjector.getInstance(SegmentsMetadataManager.class);
-    Assert.assertTrue(segmentsMetadataManager instanceof SqlSegmentsMetadataManagerV2);
+    Assertions.assertTrue(segmentsMetadataManager instanceof SqlSegmentsMetadataManagerV2);
   }
 
 
@@ -57,24 +57,24 @@ public class CliOverlordTest
   public void testGetDefaultMaxConcurrentRequests()
   {
     // Small thread count where
-    Assert.assertEquals(8, ServerConfig.getDefaultMaxConcurrentRequests(10));
+    Assertions.assertEquals(8, ServerConfig.getDefaultMaxConcurrentRequests(10));
     
     // Medium thread count where
-    Assert.assertEquals(21, ServerConfig.getDefaultMaxConcurrentRequests(25));
-    Assert.assertEquals(26, ServerConfig.getDefaultMaxConcurrentRequests(30));
+    Assertions.assertEquals(21, ServerConfig.getDefaultMaxConcurrentRequests(25));
+    Assertions.assertEquals(26, ServerConfig.getDefaultMaxConcurrentRequests(30));
 
 
     // Large thread count
-    Assert.assertEquals(46, ServerConfig.getDefaultMaxConcurrentRequests(50));
-    Assert.assertEquals(96, ServerConfig.getDefaultMaxConcurrentRequests(100));
+    Assertions.assertEquals(46, ServerConfig.getDefaultMaxConcurrentRequests(50));
+    Assertions.assertEquals(96, ServerConfig.getDefaultMaxConcurrentRequests(100));
     
     // Test edge cases - return atleast 1 thread
-    Assert.assertEquals(1, ServerConfig.getDefaultMaxConcurrentRequests(-1));
-    Assert.assertEquals(1, ServerConfig.getDefaultMaxConcurrentRequests(0));
+    Assertions.assertEquals(1, ServerConfig.getDefaultMaxConcurrentRequests(-1));
+    Assertions.assertEquals(1, ServerConfig.getDefaultMaxConcurrentRequests(0));
 
     // Test small clustesr
-    Assert.assertEquals(2, ServerConfig.getDefaultMaxConcurrentRequests(3));
-    Assert.assertEquals(3, ServerConfig.getDefaultMaxConcurrentRequests(4));
-    Assert.assertEquals(4, ServerConfig.getDefaultMaxConcurrentRequests(5));
+    Assertions.assertEquals(2, ServerConfig.getDefaultMaxConcurrentRequests(3));
+    Assertions.assertEquals(3, ServerConfig.getDefaultMaxConcurrentRequests(4));
+    Assertions.assertEquals(4, ServerConfig.getDefaultMaxConcurrentRequests(5));
   }
 }

--- a/services/src/test/java/org/apache/druid/cli/CliPeonTest.java
+++ b/services/src/test/java/org/apache/druid/cli/CliPeonTest.java
@@ -78,11 +78,11 @@ import org.apache.druid.server.coordination.BroadcastDatasourceLoadingSpec;
 import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.apache.druid.server.metrics.LoadSpecHolder;
 import org.apache.druid.storage.local.LocalTmpStorageConfig;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -99,8 +99,8 @@ import static org.easymock.EasyMock.mock;
 
 public class CliPeonTest
 {
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   private final ObjectMapper mapper = TestHelper.makeJsonMapper();
 
@@ -116,7 +116,7 @@ public class CliPeonTest
     properties.setProperty("druid.indexer.runner.type", "k8s");
     final Injector peonInjector = makePeonInjector(NoopTask.create(), properties);
     final ExecutorLifecycleConfig executorLifecycleConfig = peonInjector.getInstance(ExecutorLifecycleConfig.class);
-    Assert.assertFalse(executorLifecycleConfig.isParentStreamDefined());
+    Assertions.assertFalse(executorLifecycleConfig.isParentStreamDefined());
   }
 
   @Test
@@ -126,7 +126,7 @@ public class CliPeonTest
     properties.setProperty("druid.indexer.runner.type", "httpRemote");
     final Injector peonInjector = makePeonInjector(NoopTask.create(), properties);
     final ExecutorLifecycleConfig executorLifecycleConfig = peonInjector.getInstance(ExecutorLifecycleConfig.class);
-    Assert.assertTrue(executorLifecycleConfig.isParentStreamDefined());
+    Assertions.assertTrue(executorLifecycleConfig.isParentStreamDefined());
   }
 
   @Test
@@ -136,7 +136,7 @@ public class CliPeonTest
     properties.setProperty("druid.indexer.runner.type", "k8sAndWorker");
     final Injector peonInjector = makePeonInjector(NoopTask.create(), properties);
     final ExecutorLifecycleConfig executorLifecycleConfig = peonInjector.getInstance(ExecutorLifecycleConfig.class);
-    Assert.assertFalse(executorLifecycleConfig.isParentStreamDefined());
+    Assertions.assertFalse(executorLifecycleConfig.isParentStreamDefined());
   }
 
   @Test
@@ -145,7 +145,7 @@ public class CliPeonTest
     final Properties properties = new Properties();
     properties.setProperty("druid.policy.enforcer.type", "restrictAllTables");
     final Injector peonInjector = makePeonInjector(NoopTask.create(), properties);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new RestrictAllTablesPolicyEnforcer(null),
         peonInjector.getInstance(PolicyEnforcer.class)
     );
@@ -159,7 +159,7 @@ public class CliPeonTest
     String groupId = "testGroupId";
     String datasource = "testDatasource";
     Map<String, String> tags = ImmutableMap.of("tag1", "value1");
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             DruidMetrics.TASK_ID, taskId,
             DruidMetrics.GROUP_ID, groupId,
@@ -171,7 +171,7 @@ public class CliPeonTest
 
     // streaming task with empty ags
     String supervisor = "testSupervisor";
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             DruidMetrics.TASK_ID, taskId,
             DruidMetrics.GROUP_ID, groupId,
@@ -183,7 +183,7 @@ public class CliPeonTest
     );
 
     // streaming task with non-empty ags
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             DruidMetrics.TASK_ID, taskId,
             DruidMetrics.GROUP_ID, groupId,
@@ -205,7 +205,7 @@ public class CliPeonTest
     final Injector peonInjector = makePeonInjector(file, properties);
 
     LocalTmpStorageConfig localTmpStorageConfig = peonInjector.getInstance(LocalTmpStorageConfig.class);
-    Assert.assertEquals(new File(file.getParent(), "/tmp").getAbsolutePath(), localTmpStorageConfig.getTmpDir().getAbsolutePath());
+    Assertions.assertEquals(new File(file.getParent(), "/tmp").getAbsolutePath(), localTmpStorageConfig.getTmpDir().getAbsolutePath());
   }
 
   @Test
@@ -285,7 +285,7 @@ public class CliPeonTest
     verifyTaskHolder(peonInjector.getInstance(TaskHolder.class), compactionTask);
 
     Emitter instance = peonInjector.getInstance(Emitter.class);
-    Assert.assertTrue(instance instanceof StubServiceEmitter);
+    Assertions.assertTrue(instance instanceof StubServiceEmitter);
     instance.start();
 
     ServiceMetricEvent.Builder builder = ServiceMetricEvent.builder();
@@ -295,16 +295,16 @@ public class CliPeonTest
     ((StubServiceEmitter) instance).emit(eventBuilder);
 
     StubServiceEmitter stubEmitter = (StubServiceEmitter) instance;
-    Assert.assertEquals(1, stubEmitter.getNumEmittedEvents());
+    Assertions.assertEquals(1, stubEmitter.getNumEmittedEvents());
     List<Event> events = stubEmitter.getEvents();
     for (Event event : events) {
-      Assert.assertTrue(event instanceof ServiceMetricEvent);
+      Assertions.assertTrue(event instanceof ServiceMetricEvent);
       EventMap map = event.toMap();
-      Assert.assertEquals(compactionTask.getDataSource(), map.get("dataSource"));
-      Assert.assertEquals(compactionTask.getId(), map.get("id"));
-      Assert.assertEquals(compactionTask.getId(), map.get("taskId"));
-      Assert.assertEquals(compactionTask.getType(), map.get("taskType"));
-      Assert.assertEquals(compactionTask.getGroupId(), map.get("groupId"));
+      Assertions.assertEquals(compactionTask.getDataSource(), map.get("dataSource"));
+      Assertions.assertEquals(compactionTask.getId(), map.get("id"));
+      Assertions.assertEquals(compactionTask.getId(), map.get("taskId"));
+      Assertions.assertEquals(compactionTask.getType(), map.get("taskType"));
+      Assertions.assertEquals(compactionTask.getGroupId(), map.get("groupId"));
     }
   }
 
@@ -318,7 +318,7 @@ public class CliPeonTest
     return peon.makeInjector(Set.of(NodeRole.PEON));
   }
 
-  public static Injector makePeonInjectorWithStubEmitter(Task task, TemporaryFolder temporaryFolder, ObjectMapper mapper) throws IOException
+  public static Injector makePeonInjectorWithStubEmitter(Task task, TemporaryFolderExtension temporaryFolder, ObjectMapper mapper) throws IOException
   {
     File taskFile = temporaryFolder.newFile("task.json");
     FileUtils.write(taskFile, mapper.writeValueAsString(task), StandardCharsets.UTF_8);
@@ -364,9 +364,9 @@ public class CliPeonTest
 
   private static void verifyLoadSpecHolder(LoadSpecHolder observedLoadSpecHolder, Task task)
   {
-    Assert.assertTrue(observedLoadSpecHolder instanceof PeonLoadSpecHolder);
-    Assert.assertEquals(task.getLookupLoadingSpec(), observedLoadSpecHolder.getLookupLoadingSpec());
-    Assert.assertEquals(
+    Assertions.assertTrue(observedLoadSpecHolder instanceof PeonLoadSpecHolder);
+    Assertions.assertEquals(task.getLookupLoadingSpec(), observedLoadSpecHolder.getLookupLoadingSpec());
+    Assertions.assertEquals(
         task.getBroadcastDatasourceLoadingSpec(),
         observedLoadSpecHolder.getBroadcastDatasourceLoadingSpec()
     );
@@ -374,9 +374,9 @@ public class CliPeonTest
 
   private static void verifyTaskHolder(TaskHolder observedTaskHolder, Task task)
   {
-    Assert.assertTrue(observedTaskHolder instanceof PeonTaskHolder);
-    Assert.assertEquals(task.getId(), observedTaskHolder.getTaskId());
-    Assert.assertEquals(task.getDataSource(), observedTaskHolder.getDataSource());
+    Assertions.assertTrue(observedTaskHolder instanceof PeonTaskHolder);
+    Assertions.assertEquals(task.getId(), observedTaskHolder.getTaskId());
+    Assertions.assertEquals(task.getDataSource(), observedTaskHolder.getDataSource());
   }
 
   private static class TestTask extends NoopTask

--- a/services/src/test/java/org/apache/druid/cli/CoordinatorOverlordRedirectInfoTest.java
+++ b/services/src/test/java/org/apache/druid/cli/CoordinatorOverlordRedirectInfoTest.java
@@ -22,9 +22,9 @@ package org.apache.druid.cli;
 import org.apache.druid.indexing.overlord.DruidOverlord;
 import org.apache.druid.server.coordinator.DruidCoordinator;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CoordinatorOverlordRedirectInfoTest
 {
@@ -32,7 +32,7 @@ public class CoordinatorOverlordRedirectInfoTest
   private DruidCoordinator coordinator;
   private CoordinatorOverlordRedirectInfo redirectInfo;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     overlord = EasyMock.createMock(DruidOverlord.class);
@@ -45,9 +45,9 @@ public class CoordinatorOverlordRedirectInfoTest
   {
     EasyMock.expect(overlord.isLeader()).andReturn(true).anyTimes();
     EasyMock.replay(overlord);
-    Assert.assertTrue(redirectInfo.doLocal("/druid/indexer/v1/leader"));
-    Assert.assertTrue(redirectInfo.doLocal("/druid/indexer/v1/isLeader"));
-    Assert.assertTrue(redirectInfo.doLocal("/druid/indexer/v1/other/path"));
+    Assertions.assertTrue(redirectInfo.doLocal("/druid/indexer/v1/leader"));
+    Assertions.assertTrue(redirectInfo.doLocal("/druid/indexer/v1/isLeader"));
+    Assertions.assertTrue(redirectInfo.doLocal("/druid/indexer/v1/other/path"));
     EasyMock.verify(overlord);
   }
 }

--- a/services/src/test/java/org/apache/druid/cli/CreateTablesTest.java
+++ b/services/src/test/java/org/apache/druid/cli/CreateTablesTest.java
@@ -23,44 +23,44 @@ import com.google.inject.Injector;
 import org.apache.druid.metadata.MetadataStorageConnector;
 import org.apache.druid.metadata.MetadataStorageTablesConfig;
 import org.apache.druid.metadata.TestDerbyConnector;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import java.util.Locale;
 
 public class CreateTablesTest
 {
-  @Rule
-  public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule
-      = new TestDerbyConnector.DerbyConnectorRule();
+  @RegisterExtension
+  public static final TestDerbyConnector.DerbyConnectorRule5 DERBY_CONNECTOR_RULE
+      = new TestDerbyConnector.DerbyConnectorRule5();
 
   private TestDerbyConnector connector;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
-    this.connector = derbyConnectorRule.getConnector();
+    this.connector = DERBY_CONNECTOR_RULE.getConnector();
   }
 
   @Test
   public void testRunCreatesAllTables()
   {
-    final MetadataStorageTablesConfig config = derbyConnectorRule.metadataTablesConfigSupplier().get();
-    Assert.assertNotNull(config);
+    final MetadataStorageTablesConfig config = DERBY_CONNECTOR_RULE.metadataTablesConfigSupplier().get();
+    Assertions.assertNotNull(config);
 
     // Verify that tables do not exist before starting
-    Assert.assertFalse(tableExists(config.getDataSourceTable()));
-    Assert.assertFalse(tableExists(config.getSegmentsTable()));
-    Assert.assertFalse(tableExists(config.getPendingSegmentsTable()));
-    Assert.assertFalse(tableExists(config.getUpgradeSegmentsTable()));
-    Assert.assertFalse(tableExists(config.getConfigTable()));
-    Assert.assertFalse(tableExists(config.getRulesTable()));
-    Assert.assertFalse(tableExists(config.getAuditTable()));
-    Assert.assertFalse(tableExists(config.getSupervisorTable()));
-    Assert.assertFalse(tableExists(config.getTaskLockTable()));
+    Assertions.assertFalse(tableExists(config.getDataSourceTable()));
+    Assertions.assertFalse(tableExists(config.getSegmentsTable()));
+    Assertions.assertFalse(tableExists(config.getPendingSegmentsTable()));
+    Assertions.assertFalse(tableExists(config.getUpgradeSegmentsTable()));
+    Assertions.assertFalse(tableExists(config.getConfigTable()));
+    Assertions.assertFalse(tableExists(config.getRulesTable()));
+    Assertions.assertFalse(tableExists(config.getAuditTable()));
+    Assertions.assertFalse(tableExists(config.getSupervisorTable()));
+    Assertions.assertFalse(tableExists(config.getTaskLockTable()));
 
     // Run CreateTables
     CreateTables createTables = new CreateTables()
@@ -76,15 +76,15 @@ public class CreateTablesTest
     createTables.run();
 
     // Verify that tables have now been created
-    Assert.assertTrue(tableExists(config.getDataSourceTable()));
-    Assert.assertTrue(tableExists(config.getSegmentsTable()));
-    Assert.assertTrue(tableExists(config.getPendingSegmentsTable()));
-    Assert.assertTrue(tableExists(config.getUpgradeSegmentsTable()));
-    Assert.assertTrue(tableExists(config.getConfigTable()));
-    Assert.assertTrue(tableExists(config.getRulesTable()));
-    Assert.assertTrue(tableExists(config.getAuditTable()));
-    Assert.assertTrue(tableExists(config.getSupervisorTable()));
-    Assert.assertTrue(tableExists(config.getTaskLockTable()));
+    Assertions.assertTrue(tableExists(config.getDataSourceTable()));
+    Assertions.assertTrue(tableExists(config.getSegmentsTable()));
+    Assertions.assertTrue(tableExists(config.getPendingSegmentsTable()));
+    Assertions.assertTrue(tableExists(config.getUpgradeSegmentsTable()));
+    Assertions.assertTrue(tableExists(config.getConfigTable()));
+    Assertions.assertTrue(tableExists(config.getRulesTable()));
+    Assertions.assertTrue(tableExists(config.getAuditTable()));
+    Assertions.assertTrue(tableExists(config.getSupervisorTable()));
+    Assertions.assertTrue(tableExists(config.getTaskLockTable()));
   }
 
   private boolean tableExists(String tableName)

--- a/services/src/test/java/org/apache/druid/cli/DiscoverySideEffectsProviderTest.java
+++ b/services/src/test/java/org/apache/druid/cli/DiscoverySideEffectsProviderTest.java
@@ -36,45 +36,41 @@ import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.initialization.ServerInjectorBuilder;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
 import org.apache.druid.server.DruidNode;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@RunWith(MockitoJUnitRunner.class)
 public class DiscoverySideEffectsProviderTest
 {
   private NodeRole nodeRole;
-  @Mock
   private DruidNode druidNode;
   /**
    * This announcer is mocked to fail if it tries to announce a Druid service that is not discoverable.
    */
-  @Mock
   private DruidNodeAnnouncer discoverableOnlyAnnouncer;
-  @Mock
   private Lifecycle lifecycle;
   private List<Lifecycle.Handler> lifecycleHandlers;
 
   private ServerRunnable.DiscoverySideEffectsProvider target;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     nodeRole = NodeRole.HISTORICAL;
+    druidNode = Mockito.mock(DruidNode.class);
+    discoverableOnlyAnnouncer = Mockito.mock(DruidNodeAnnouncer.class);
+    lifecycle = Mockito.mock(Lifecycle.class);
     lifecycleHandlers = new ArrayList<>();
     Mockito.doAnswer((invocation) -> {
       DiscoveryDruidNode discoveryDruidNode = invocation.getArgument(0);
       boolean isAllServicesDiscoverable =
           discoveryDruidNode.getServices().values().stream().allMatch(DruidService::isDiscoverable);
-      Assert.assertTrue(isAllServicesDiscoverable);
+      Assertions.assertTrue(isAllServicesDiscoverable);
       return null;
     }).when(discoverableOnlyAnnouncer).announce(ArgumentMatchers.any(DiscoveryDruidNode.class));
     Mockito
@@ -91,8 +87,8 @@ public class DiscoverySideEffectsProviderTest
         ImmutableList.of(new DiscoverableServiceTestModule(), new UndiscoverableServiceTestModule())
     ).injectMembers(target);
     ServerRunnable.DiscoverySideEffectsProvider.Child child = target.get();
-    Assert.assertNotNull(child);
-    Assert.assertEquals(1, lifecycleHandlers.size());
+    Assertions.assertNotNull(child);
+    Assertions.assertEquals(1, lifecycleHandlers.size());
     // Start the lifecycle handler. This will make announcements via the announcer
     lifecycleHandlers.get(0).start();
   }
@@ -102,8 +98,8 @@ public class DiscoverySideEffectsProviderTest
   {
     createInjector(ImmutableList.of()).injectMembers(target);
     ServerRunnable.DiscoverySideEffectsProvider.Child child = target.get();
-    Assert.assertNotNull(child);
-    Assert.assertEquals(1, lifecycleHandlers.size());
+    Assertions.assertNotNull(child);
+    Assertions.assertEquals(1, lifecycleHandlers.size());
     // Start the lifecycle handler. This will make announcements via the announcer
     lifecycleHandlers.get(0).start();
   }

--- a/services/src/test/java/org/apache/druid/cli/DiscoverySideEffectsProviderTest.java
+++ b/services/src/test/java/org/apache/druid/cli/DiscoverySideEffectsProviderTest.java
@@ -44,11 +44,14 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class DiscoverySideEffectsProviderTest
 {
   private NodeRole nodeRole;

--- a/services/src/test/java/org/apache/druid/cli/DiscoverySideEffectsProviderTest.java
+++ b/services/src/test/java/org/apache/druid/cli/DiscoverySideEffectsProviderTest.java
@@ -39,20 +39,27 @@ import org.apache.druid.server.DruidNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@ExtendWith(MockitoExtension.class)
 public class DiscoverySideEffectsProviderTest
 {
   private NodeRole nodeRole;
+  @Mock
   private DruidNode druidNode;
   /**
    * This announcer is mocked to fail if it tries to announce a Druid service that is not discoverable.
    */
+  @Mock
   private DruidNodeAnnouncer discoverableOnlyAnnouncer;
+  @Mock
   private Lifecycle lifecycle;
   private List<Lifecycle.Handler> lifecycleHandlers;
 
@@ -62,9 +69,6 @@ public class DiscoverySideEffectsProviderTest
   public void setUp()
   {
     nodeRole = NodeRole.HISTORICAL;
-    druidNode = Mockito.mock(DruidNode.class);
-    discoverableOnlyAnnouncer = Mockito.mock(DruidNodeAnnouncer.class);
-    lifecycle = Mockito.mock(Lifecycle.class);
     lifecycleHandlers = new ArrayList<>();
     Mockito.doAnswer((invocation) -> {
       DiscoveryDruidNode discoveryDruidNode = invocation.getArgument(0);

--- a/services/src/test/java/org/apache/druid/cli/DumpSegmentTest.java
+++ b/services/src/test/java/org/apache/druid/cli/DumpSegmentTest.java
@@ -66,11 +66,11 @@ import org.apache.druid.segment.file.SegmentFileMetadata;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.index.semantic.DictionaryEncodedStringValueIndex;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.apache.druid.testing.TemporaryFolderExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -84,8 +84,8 @@ public class DumpSegmentTest extends InitializedNullHandlingTest
 {
   private final Closer closer;
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension tempFolder = new TemporaryFolderExtension();
 
   public DumpSegmentTest()
   {
@@ -93,7 +93,7 @@ public class DumpSegmentTest extends InitializedNullHandlingTest
     this.closer = Closer.create();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     closer.close();
@@ -119,7 +119,7 @@ public class DumpSegmentTest extends InitializedNullHandlingTest
     Mockito.when(mergeRunner.run(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(expected);
     Mockito.when(index.getOrdering()).thenReturn(Collections.emptyList());
     Sequence actual = DumpSegment.executeQuery(injector, index, query);
-    Assert.assertSame(expected, actual);
+    Assertions.assertSame(expected, actual);
   }
 
   @Test
@@ -157,7 +157,7 @@ public class DumpSegmentTest extends InitializedNullHandlingTest
                             + "{\"__time\":1609459200000,\"nest\":{\"x\":200,\"z\":\"b\"},\"count\":1}\n"
                             + "{\"__time\":1609459200000,\"nest\":{\"x\":100,\"y\":1.1,\"z\":\"a\"},\"count\":1}\n"
                             + "{\"__time\":1609459200000,\"nest\":{\"y\":3.3,\"z\":\"b\"},\"count\":1}\n";
-    Assert.assertEquals(expected, output);
+    Assertions.assertEquals(expected, output);
   }
 
   @Test
@@ -193,7 +193,7 @@ public class DumpSegmentTest extends InitializedNullHandlingTest
         ImmutableList.of("x", "y"),
         false
     );
-    Assert.assertTrue(true);
+    Assertions.assertTrue(true);
   }
 
   @Test
@@ -223,7 +223,7 @@ public class DumpSegmentTest extends InitializedNullHandlingTest
     );
     final byte[] fileBytes = Files.readAllBytes(outputFile.toPath());
     final String output = StringUtils.fromUtf8(fileBytes);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "{\"nest\":{\"fields\":[{\"path\":\"$.x\",\"types\":[\"LONG\"]},{\"path\":\"$.y\",\"types\":[\"DOUBLE\"]},{\"path\":\"$.z\",\"types\":[\"STRING\"]}],\"dictionaries\":{\"strings\":[{\"globalId\":0,\"value\":null},{\"globalId\":1,\"value\":\"a\"},{\"globalId\":2,\"value\":\"b\"}],\"longs\":[{\"globalId\":3,\"value\":100},{\"globalId\":4,\"value\":200},{\"globalId\":5,\"value\":400}],\"doubles\":[{\"globalId\":6,\"value\":1.1},{\"globalId\":7,\"value\":2.2},{\"globalId\":8,\"value\":3.3}],\"nullRows\":[]}}}",
         output
     );
@@ -257,7 +257,7 @@ public class DumpSegmentTest extends InitializedNullHandlingTest
     );
     final byte[] fileBytes = Files.readAllBytes(outputFile.toPath());
     final String output = StringUtils.fromUtf8(fileBytes);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "{\"bitmapSerdeFactory\":{\"type\":\"roaring\"},\"nest\":{\"$.x\":{\"types\":[\"LONG\"],\"dictionary\":[{\"localId\":0,\"globalId\":0,\"value\":null,\"rows\":[4]},{\"localId\":1,\"globalId\":3,\"value\":\"100\",\"rows\":[3]},{\"localId\":2,\"globalId\":4,\"value\":\"200\",\"rows\":[0,2]},{\"localId\":3,\"globalId\":5,\"value\":\"400\",\"rows\":[1]}],\"column\":[{\"row\":0,\"raw\":{\"x\":200,\"y\":2.2},\"fieldId\":2,\"fieldValue\":\"200\"},{\"row\":1,\"raw\":{\"x\":400,\"y\":1.1,\"z\":\"a\"},\"fieldId\":3,\"fieldValue\":\"400\"},{\"row\":2,\"raw\":{\"x\":200,\"z\":\"b\"},\"fieldId\":2,\"fieldValue\":\"200\"},{\"row\":3,\"raw\":{\"x\":100,\"y\":1.1,\"z\":\"a\"},\"fieldId\":1,\"fieldValue\":\"100\"},{\"row\":4,\"raw\":{\"y\":3.3,\"z\":\"b\"},\"fieldId\":0,\"fieldValue\":null}]}}}",
         output
     );
@@ -272,10 +272,10 @@ public class DumpSegmentTest extends InitializedNullHandlingTest
         Collections.emptySet(),
         dumpSegment.getModules()
     );
-    Assert.assertNotNull(injector.getInstance(ColumnConfig.class));
-    Assert.assertEquals("druid/tool", injector.getInstance(Key.get(String.class, Names.named("serviceName"))));
-    Assert.assertEquals(9999, (int) injector.getInstance(Key.get(Integer.class, Names.named("servicePort"))));
-    Assert.assertEquals(-1, (int) injector.getInstance(Key.get(Integer.class, Names.named("tlsServicePort"))));
+    Assertions.assertNotNull(injector.getInstance(ColumnConfig.class));
+    Assertions.assertEquals("druid/tool", injector.getInstance(Key.get(String.class, Names.named("serviceName"))));
+    Assertions.assertEquals(9999, (int) injector.getInstance(Key.get(Integer.class, Names.named("servicePort"))));
+    Assertions.assertEquals(-1, (int) injector.getInstance(Key.get(Integer.class, Names.named("tlsServicePort"))));
   }
 
   @Test
@@ -303,10 +303,10 @@ public class DumpSegmentTest extends InitializedNullHandlingTest
     );
     final byte[] fileBytes = Files.readAllBytes(outputFile.toPath());
     SegmentFileMetadata dumped = mapper.readValue(fileBytes, SegmentFileMetadata.class);
-    Assert.assertNotNull(dumped);
-    Assert.assertEquals(1, dumped.getContainers().size());
-    Assert.assertEquals(2, dumped.getColumnDescriptors().size());
-    Assert.assertEquals(12, dumped.getFiles().size());
+    Assertions.assertNotNull(dumped);
+    Assertions.assertEquals(1, dumped.getContainers().size());
+    Assertions.assertEquals(2, dumped.getColumnDescriptors().size());
+    Assertions.assertEquals(12, dumped.getFiles().size());
   }
 
 
@@ -346,7 +346,7 @@ public class DumpSegmentTest extends InitializedNullHandlingTest
 
 
   public static List<Segment> createSegments(
-      TemporaryFolder tempFolder,
+      TemporaryFolderExtension tempFolder,
       Closer closer
   ) throws Exception
   {

--- a/services/src/test/java/org/apache/druid/cli/Log4JShutdownPropertyCheckerTest.java
+++ b/services/src/test/java/org/apache/druid/cli/Log4JShutdownPropertyCheckerTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.cli;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -33,11 +33,11 @@ public class Log4JShutdownPropertyCheckerTest
     Properties properties = new Properties();
     checker.checkProperties(properties);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "org.apache.druid.common.config.Log4jShutdown",
         properties.getProperty("log4j.shutdownCallbackRegistry")
     );
-    Assert.assertEquals("true", properties.getProperty("log4j.shutdownHookEnabled"));
-    Assert.assertEquals("false", properties.getProperty("log4j2.is.webapp"));
+    Assertions.assertEquals("true", properties.getProperty("log4j.shutdownHookEnabled"));
+    Assertions.assertEquals("false", properties.getProperty("log4j2.is.webapp"));
   }
 }

--- a/services/src/test/java/org/apache/druid/cli/PullDependenciesTest.java
+++ b/services/src/test/java/org/apache/druid/cli/PullDependenciesTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.cli;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.guice.ExtensionsConfig;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
@@ -46,11 +47,10 @@ import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.transport.http.HttpTransporterFactory;
 import org.eclipse.aether.util.artifact.JavaScopes;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.io.IOException;
@@ -75,14 +75,14 @@ public class PullDependenciesTest
   private static final String DEPENDENCY_GROUPID = "groupid";
   private static File localRepo; // a mock local repository that stores jars
   private static Map<Artifact, List<String>> extensionToDependency;
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
   private final Artifact extension_A = new DefaultArtifact(EXTENSION_A_COORDINATE);
   private final Artifact extension_B = new DefaultArtifact(EXTENSION_B_COORDINATE);
   private PullDependencies pullDependencies;
   private File rootExtensionsDir;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     localRepo = temporaryFolder.newFolder("local_repo");
@@ -184,12 +184,12 @@ public class PullDependenciesTest
   /**
    * A file exists on the root extension directory path, but it's not a directory, throw exception.
    */
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testPullDependencies_root_extension_dir_bad_state() throws IOException
   {
-    Assert.assertTrue(rootExtensionsDir.delete());
-    Assert.assertTrue(rootExtensionsDir.createNewFile());
-    pullDependencies.run();
+    Assertions.assertTrue(rootExtensionsDir.delete());
+    Assertions.assertTrue(rootExtensionsDir.createNewFile());
+    Assertions.assertThrows(RuntimeException.class, pullDependencies::run);
   }
 
   @Test
@@ -198,29 +198,29 @@ public class PullDependenciesTest
     pullDependencies.run();
     final File[] actualExtensions = rootExtensionsDir.listFiles();
     Arrays.sort(actualExtensions);
-    Assert.assertEquals(2, actualExtensions.length);
-    Assert.assertEquals(extension_A.getArtifactId(), actualExtensions[0].getName());
-    Assert.assertEquals(extension_B.getArtifactId(), actualExtensions[1].getName());
+    Assertions.assertEquals(2, actualExtensions.length);
+    Assertions.assertEquals(extension_A.getArtifactId(), actualExtensions[0].getName());
+    Assertions.assertEquals(extension_B.getArtifactId(), actualExtensions[1].getName());
 
     final List<File> jarsUnderExtensionA = Arrays.asList(actualExtensions[0].listFiles());
     Collections.sort(jarsUnderExtensionA);
-    Assert.assertEquals(getExpectedJarFiles(extension_A), jarsUnderExtensionA);
+    Assertions.assertEquals(getExpectedJarFiles(extension_A), jarsUnderExtensionA);
 
     final List<File> jarsUnderExtensionB = Arrays.asList(actualExtensions[1].listFiles());
     Collections.sort(jarsUnderExtensionB);
-    Assert.assertEquals(getExpectedJarFiles(extension_B), jarsUnderExtensionB);
+    Assertions.assertEquals(getExpectedJarFiles(extension_B), jarsUnderExtensionB);
   }
 
   @Test
   public void testPullDependenciesCleanFlag() throws IOException
   {
     File dummyFile1 = new File(rootExtensionsDir, "dummy.txt");
-    Assert.assertTrue(dummyFile1.createNewFile());
+    Assertions.assertTrue(dummyFile1.createNewFile());
 
     pullDependencies.clean = true;
     pullDependencies.run();
 
-    Assert.assertFalse(dummyFile1.exists());
+    Assertions.assertFalse(dummyFile1.exists());
   }
 
   @Test
@@ -232,8 +232,8 @@ public class PullDependenciesTest
     pullDependencies.run();
 
     List<RemoteRepository> repositories = pullDependencies.getRemoteRepositories();
-    Assert.assertEquals(1, repositories.size());
-    Assert.assertEquals("https://custom.repo", repositories.get(0).getUrl());
+    Assertions.assertEquals(1, repositories.size());
+    Assertions.assertEquals("https://custom.repo", repositories.get(0).getUrl());
   }
 
   @Test
@@ -242,9 +242,9 @@ public class PullDependenciesTest
     if (rootExtensionsDir.exists()) {
       rootExtensionsDir.delete();
     }
-    Assert.assertTrue(rootExtensionsDir.createNewFile());
+    Assertions.assertTrue(rootExtensionsDir.createNewFile());
 
-    Assert.assertThrows(IllegalArgumentException.class, () -> pullDependencies.run());
+    Assertions.assertThrows(IllegalArgumentException.class, () -> pullDependencies.run());
   }
 
   @Test
@@ -252,19 +252,19 @@ public class PullDependenciesTest
   {
     String coordinate = "groupX:artifactX:1.0.0";
     DefaultArtifact artifact = (DefaultArtifact) pullDependencies.getArtifact(coordinate);
-    Assert.assertEquals("groupX", artifact.getGroupId());
-    Assert.assertEquals("artifactX", artifact.getArtifactId());
-    Assert.assertEquals("1.0.0", artifact.getVersion());
+    Assertions.assertEquals("groupX", artifact.getGroupId());
+    Assertions.assertEquals("artifactX", artifact.getArtifactId());
+    Assertions.assertEquals("1.0.0", artifact.getVersion());
   }
 
   @Test
   public void testGetArtifactwithCoordinateWithoutDefaultVersion()
   {
     String coordinate = "groupY:artifactY";
-    Assert.assertThrows(
-        "Bad artifact coordinates groupY:artifactY, expected format is <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>",
+    Assertions.assertThrows(
         IllegalArgumentException.class,
-        () -> pullDependencies.getArtifact(coordinate)
+        () -> pullDependencies.getArtifact(coordinate),
+        "Bad artifact coordinates groupY:artifactY, expected format is <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>"
     );
 
   }
@@ -275,9 +275,9 @@ public class PullDependenciesTest
     pullDependencies.defaultVersion = "2.0.0";
     String coordinate = "groupY:artifactY";
     DefaultArtifact artifact = (DefaultArtifact) pullDependencies.getArtifact(coordinate);
-    Assert.assertEquals("groupY", artifact.getGroupId());
-    Assert.assertEquals("artifactY", artifact.getArtifactId());
-    Assert.assertEquals("2.0.0", artifact.getVersion());
+    Assertions.assertEquals("groupY", artifact.getGroupId());
+    Assertions.assertEquals("artifactY", artifact.getArtifactId());
+    Assertions.assertEquals("2.0.0", artifact.getVersion());
   }
 
   @Test
@@ -287,9 +287,9 @@ public class PullDependenciesTest
     pullDependencies.remoteRepositories = ImmutableList.of("https://custom.repo");
 
     List<RemoteRepository> repositories = pullDependencies.getRemoteRepositories();
-    Assert.assertEquals(2, repositories.size());
-    Assert.assertEquals("https://repo1.maven.org/maven2/", repositories.get(0).getUrl());
-    Assert.assertEquals("https://custom.repo", repositories.get(1).getUrl());
+    Assertions.assertEquals(2, repositories.size());
+    Assertions.assertEquals("https://repo1.maven.org/maven2/", repositories.get(0).getUrl());
+    Assertions.assertEquals("https://custom.repo", repositories.get(1).getUrl());
   }
 
   @Test
@@ -305,7 +305,7 @@ public class PullDependenciesTest
     DefaultRepositorySystemSession session = (DefaultRepositorySystemSession) pullDependencies.getRepositorySystemSession();
 
     LocalRepository localRepo = session.getLocalRepositoryManager().getRepository();
-    Assert.assertEquals(pullDependencies.localRepository, localRepo.getBasedir().getAbsolutePath());
+    Assertions.assertEquals(pullDependencies.localRepository, localRepo.getBasedir().getAbsolutePath());
 
     Proxy proxy = session.getProxySelector().getProxy(
         new RemoteRepository.Builder("test", "default", "http://example.com").build()
@@ -314,13 +314,13 @@ public class PullDependenciesTest
         .setProxy(proxy)
         .build();
 
-    Assert.assertNotNull(proxy);
-    Assert.assertEquals("localhost", proxy.getHost());
-    Assert.assertEquals(8080, proxy.getPort());
-    Assert.assertEquals("http", proxy.getType());
+    Assertions.assertNotNull(proxy);
+    Assertions.assertEquals("localhost", proxy.getHost());
+    Assertions.assertEquals(8080, proxy.getPort());
+    Assertions.assertEquals("http", proxy.getType());
 
     Authentication auth = new AuthenticationBuilder().addUsername("user").addPassword("password").build();
-    Assert.assertEquals(auth, proxy.getAuthentication());
+    Assertions.assertEquals(auth, proxy.getAuthentication());
   }
 
   @Test
@@ -329,11 +329,11 @@ public class PullDependenciesTest
     pullDependencies.useProxy = false;
     DefaultRepositorySystemSession session = (DefaultRepositorySystemSession) pullDependencies.getRepositorySystemSession();
     LocalRepository localRepo = session.getLocalRepositoryManager().getRepository();
-    Assert.assertEquals(pullDependencies.localRepository, localRepo.getBasedir().getAbsolutePath());
+    Assertions.assertEquals(pullDependencies.localRepository, localRepo.getBasedir().getAbsolutePath());
     Proxy proxy = session.getProxySelector().getProxy(
         new RemoteRepository.Builder("test", "default", "http://example.com").build()
     );
-    Assert.assertNull(proxy);
+    Assertions.assertNull(proxy);
   }
 
   private static class RealRepositorySystemUtil

--- a/services/src/test/java/org/apache/druid/cli/ValidateSegmentsTest.java
+++ b/services/src/test/java/org/apache/druid/cli/ValidateSegmentsTest.java
@@ -35,10 +35,10 @@ import org.apache.druid.segment.column.ColumnConfig;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.apache.druid.testing.TemporaryFolderExtension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -48,8 +48,8 @@ import java.util.Collections;
 
 public class ValidateSegmentsTest extends InitializedNullHandlingTest
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   @Test
   public void testValidateSegments() throws IOException
@@ -109,9 +109,9 @@ public class ValidateSegmentsTest extends InitializedNullHandlingTest
         Collections.emptySet(),
         validator.getModules()
     );
-    Assert.assertNotNull(injector.getInstance(ColumnConfig.class));
-    Assert.assertEquals("druid/tool", injector.getInstance(Key.get(String.class, Names.named("serviceName"))));
-    Assert.assertEquals(9999, (int) injector.getInstance(Key.get(Integer.class, Names.named("servicePort"))));
-    Assert.assertEquals(-1, (int) injector.getInstance(Key.get(Integer.class, Names.named("tlsServicePort"))));
+    Assertions.assertNotNull(injector.getInstance(ColumnConfig.class));
+    Assertions.assertEquals("druid/tool", injector.getInstance(Key.get(String.class, Names.named("serviceName"))));
+    Assertions.assertEquals(9999, (int) injector.getInstance(Key.get(Integer.class, Names.named("servicePort"))));
+    Assertions.assertEquals(-1, (int) injector.getInstance(Key.get(Integer.class, Names.named("tlsServicePort"))));
   }
 }

--- a/services/src/test/java/org/apache/druid/cli/validate/DruidJsonValidatorTest.java
+++ b/services/src/test/java/org/apache/druid/cli/validate/DruidJsonValidatorTest.java
@@ -34,12 +34,12 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.segment.IndexSpec;
 import org.apache.druid.segment.indexing.DataSchema;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.apache.druid.testing.TemporaryFolderExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,10 +49,10 @@ public class DruidJsonValidatorTest
   private File inputFile;
   private final Injector injector = GuiceInjectors.makeStartupInjector();
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
     inputFile = temporaryFolder.newFile();
@@ -65,22 +65,28 @@ public class DruidJsonValidatorTest
                        .build();
 
     Object command = parser.parse(args);
-    Assert.assertTrue(command instanceof Runnable);
+    Assertions.assertTrue(command instanceof Runnable);
 
     injector.injectMembers(command);
     return (Runnable) command;
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testExceptionCase()
   {
-    parseCommand("validator", "-f", inputFile.getAbsolutePath(), "-t", "").run();
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () -> parseCommand("validator", "-f", inputFile.getAbsolutePath(), "-t", "").run()
+    );
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testExceptionCaseNoFile()
   {
-    parseCommand("validator", "-f", "", "-t", "query").run();
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> parseCommand("validator", "-f", "", "-t", "query").run()
+    );
   }
 
   @Test
@@ -140,8 +146,8 @@ public class DruidJsonValidatorTest
     parseCommand("validator", "-f", tmp.getAbsolutePath(), "-t", "task").run();
   }
 
-  @After
-  public void tearDown()
+  @AfterEach
+  public void tearDown() throws IOException
   {
     temporaryFolder.delete();
   }

--- a/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -100,9 +100,10 @@ import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -143,7 +144,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
   private static int port2;
 
   @Override
-  @Before
+  @BeforeEach
   public void setup() throws Exception
   {
     setProperties();
@@ -204,19 +205,19 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
 
     final HttpURLConnection get = (HttpURLConnection) url.openConnection();
     get.setRequestProperty("Accept-Encoding", "gzip");
-    Assert.assertEquals("gzip", get.getContentEncoding());
+    Assertions.assertEquals("gzip", get.getContentEncoding());
 
     final HttpURLConnection post = (HttpURLConnection) url.openConnection();
     post.setRequestProperty("Accept-Encoding", "gzip");
     post.setRequestMethod("POST");
-    Assert.assertEquals("gzip", post.getContentEncoding());
+    Assertions.assertEquals("gzip", post.getContentEncoding());
 
     final HttpURLConnection getNoGzip = (HttpURLConnection) url.openConnection();
-    Assert.assertNotEquals("gzip", getNoGzip.getContentEncoding());
+    Assertions.assertNotEquals("gzip", getNoGzip.getContentEncoding());
 
     final HttpURLConnection postNoGzip = (HttpURLConnection) url.openConnection();
     postNoGzip.setRequestMethod("POST");
-    Assert.assertNotEquals("gzip", postNoGzip.getContentEncoding());
+    Assertions.assertNotEquals("gzip", postNoGzip.getContentEncoding());
   }
 
   @Test
@@ -225,11 +226,12 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     final URL url = URI.create("http://localhost:" + port + "/proxy/response-context").toURL();
     final HttpURLConnection get = (HttpURLConnection) url.openConnection();
 
-    Assert.assertEquals(DEFAULT_RESPONSE_CONTENT, IOUtils.toString(get.getInputStream(), StandardCharsets.UTF_8));
-    Assert.assertEquals(RESPONSE_CONTEXT, get.getHeaderField(QueryResource.HEADER_RESPONSE_CONTEXT));
+    Assertions.assertEquals(DEFAULT_RESPONSE_CONTENT, IOUtils.toString(get.getInputStream(), StandardCharsets.UTF_8));
+    Assertions.assertEquals(RESPONSE_CONTEXT, get.getHeaderField(QueryResource.HEADER_RESPONSE_CONTEXT));
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(60)
   public void testDeleteBroadcast() throws Exception
   {
     CountDownLatch latch = new CountDownLatch(2);
@@ -240,7 +242,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     final HttpURLConnection post = (HttpURLConnection) url.openConnection();
     post.setRequestMethod("DELETE");
     int code = post.getResponseCode();
-    Assert.assertEquals(200, code);
+    Assertions.assertEquals(200, code);
 
     latch.await();
   }
@@ -309,10 +311,10 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         (servlet, request, response, mapper)
             -> servlet.handleException(response, mapper, new IllegalStateException(errorMessage))
     );
-    Assert.assertTrue(captor.getValue() instanceof QueryException);
-    Assert.assertEquals("Unknown exception", ((QueryException) captor.getValue()).getErrorCode());
-    Assert.assertEquals(errorMessage, captor.getValue().getMessage());
-    Assert.assertEquals(IllegalStateException.class.getName(), ((QueryException) captor.getValue()).getErrorClass());
+    Assertions.assertTrue(captor.getValue() instanceof QueryException);
+    Assertions.assertEquals("Unknown exception", ((QueryException) captor.getValue()).getErrorCode());
+    Assertions.assertEquals(errorMessage, captor.getValue().getMessage());
+    Assertions.assertEquals(IllegalStateException.class.getName(), ((QueryException) captor.getValue()).getErrorClass());
   }
 
   @Test
@@ -338,11 +340,11 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         (servlet, request, response, mapper)
             -> servlet.handleException(response, mapper, new IllegalStateException(errorMessage))
     );
-    Assert.assertTrue(captor.getValue() instanceof QueryException);
-    Assert.assertEquals("Unknown exception", ((QueryException) captor.getValue()).getErrorCode());
-    Assert.assertNull(captor.getValue().getMessage());
-    Assert.assertNull(((QueryException) captor.getValue()).getErrorClass());
-    Assert.assertNull(((QueryException) captor.getValue()).getHost());
+    Assertions.assertTrue(captor.getValue() instanceof QueryException);
+    Assertions.assertEquals("Unknown exception", ((QueryException) captor.getValue()).getErrorCode());
+    Assertions.assertNull(captor.getValue().getMessage());
+    Assertions.assertNull(((QueryException) captor.getValue()).getErrorClass());
+    Assertions.assertNull(((QueryException) captor.getValue()).getHost());
   }
 
   @Test
@@ -368,11 +370,11 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         (servlet, request, response, mapper)
             -> servlet.handleException(response, mapper, new IllegalStateException(errorMessage))
     );
-    Assert.assertTrue(captor.getValue() instanceof QueryException);
-    Assert.assertEquals("Unknown exception", ((QueryException) captor.getValue()).getErrorCode());
-    Assert.assertEquals(errorMessage, captor.getValue().getMessage());
-    Assert.assertNull(((QueryException) captor.getValue()).getErrorClass());
-    Assert.assertNull(((QueryException) captor.getValue()).getHost());
+    Assertions.assertTrue(captor.getValue() instanceof QueryException);
+    Assertions.assertEquals("Unknown exception", ((QueryException) captor.getValue()).getErrorCode());
+    Assertions.assertEquals(errorMessage, captor.getValue().getMessage());
+    Assertions.assertNull(((QueryException) captor.getValue()).getErrorClass());
+    Assertions.assertNull(((QueryException) captor.getValue()).getHost());
   }
 
   @Test
@@ -385,10 +387,10 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         (servlet, request, response, mapper)
             -> servlet.handleQueryParseException(request, response, mapper, new IOException(errorMessage), false)
     );
-    Assert.assertTrue(captor.getValue() instanceof QueryException);
-    Assert.assertEquals("Unknown exception", ((QueryException) captor.getValue()).getErrorCode());
-    Assert.assertEquals(errorMessage, captor.getValue().getMessage());
-    Assert.assertEquals(IOException.class.getName(), ((QueryException) captor.getValue()).getErrorClass());
+    Assertions.assertTrue(captor.getValue() instanceof QueryException);
+    Assertions.assertEquals("Unknown exception", ((QueryException) captor.getValue()).getErrorCode());
+    Assertions.assertEquals(errorMessage, captor.getValue().getMessage());
+    Assertions.assertEquals(IOException.class.getName(), ((QueryException) captor.getValue()).getErrorClass());
   }
 
   @Test
@@ -413,11 +415,11 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         (servlet, request, response, mapper)
             -> servlet.handleQueryParseException(request, response, mapper, new IOException(errorMessage), false)
     );
-    Assert.assertTrue(captor.getValue() instanceof QueryException);
-    Assert.assertEquals("Unknown exception", ((QueryException) captor.getValue()).getErrorCode());
-    Assert.assertNull(captor.getValue().getMessage());
-    Assert.assertNull(((QueryException) captor.getValue()).getErrorClass());
-    Assert.assertNull(((QueryException) captor.getValue()).getHost());
+    Assertions.assertTrue(captor.getValue() instanceof QueryException);
+    Assertions.assertEquals("Unknown exception", ((QueryException) captor.getValue()).getErrorCode());
+    Assertions.assertNull(captor.getValue().getMessage());
+    Assertions.assertNull(((QueryException) captor.getValue()).getErrorClass());
+    Assertions.assertNull(((QueryException) captor.getValue()).getHost());
   }
 
   @Test
@@ -443,11 +445,11 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         (servlet, request, response, mapper)
             -> servlet.handleQueryParseException(request, response, mapper, new IOException(errorMessage), false)
     );
-    Assert.assertTrue(captor.getValue() instanceof QueryException);
-    Assert.assertEquals("Unknown exception", ((QueryException) captor.getValue()).getErrorCode());
-    Assert.assertEquals(errorMessage, captor.getValue().getMessage());
-    Assert.assertNull(((QueryException) captor.getValue()).getErrorClass());
-    Assert.assertNull(((QueryException) captor.getValue()).getHost());
+    Assertions.assertTrue(captor.getValue() instanceof QueryException);
+    Assertions.assertEquals("Unknown exception", ((QueryException) captor.getValue()).getErrorCode());
+    Assertions.assertEquals(errorMessage, captor.getValue().getMessage());
+    Assertions.assertNull(((QueryException) captor.getValue()).getErrorClass());
+    Assertions.assertNull(((QueryException) captor.getValue()).getHost());
   }
 
   @Test
@@ -582,14 +584,14 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     }
 
     stubServiceEmitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals("test-query-504", stubServiceEmitter.getEvents().get(0).toMap().get("id"));
-    Assert.assertEquals(
+    Assertions.assertEquals("test-query-504", stubServiceEmitter.getEvents().get(0).toMap().get("id"));
+    Assertions.assertEquals(
         504,
         stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
     );
     assertNativeQueryStatusCodeMatchesMetric(requestLogger, getEmittedStatusCode(stubServiceEmitter));
-    Assert.assertEquals("false", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("success"));
-    Assert.assertEquals("testUser", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("identity"));
+    Assertions.assertEquals("false", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("success"));
+    Assertions.assertEquals("testUser", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("identity"));
   }
 
   @Test
@@ -655,13 +657,13 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     }
 
     stubServiceEmitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals("closed-test", stubServiceEmitter.getEvents().get(0).toMap().get("id"));
-    Assert.assertEquals(
+    Assertions.assertEquals("closed-test", stubServiceEmitter.getEvents().get(0).toMap().get("id"));
+    Assertions.assertEquals(
         500,
         stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
     );
-    Assert.assertEquals("false", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("success"));
-    Assert.assertEquals("testUser", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("identity"));
+    Assertions.assertEquals("false", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("success"));
+    Assertions.assertEquals("testUser", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("identity"));
   }
 
   @Test
@@ -711,14 +713,14 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     }
 
     stubServiceEmitter.verifyEmitted("query/time", 1);
-    Assert.assertEquals("zero-status-test", stubServiceEmitter.getEvents().get(0).toMap().get("id"));
-    Assert.assertEquals(
+    Assertions.assertEquals("zero-status-test", stubServiceEmitter.getEvents().get(0).toMap().get("id"));
+    Assertions.assertEquals(
         500, // Should default to 500 when status is 0
         stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
     );
     assertNativeQueryStatusCodeMatchesMetric(requestLogger, getEmittedStatusCode(stubServiceEmitter));
-    Assert.assertEquals("false", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("success"));
-    Assert.assertEquals("testUser", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("identity"));
+    Assertions.assertEquals("false", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("success"));
+    Assertions.assertEquals("testUser", stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get("identity"));
   }
 
 
@@ -979,15 +981,15 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     }
     stubServiceEmitter.verifyEmitted("query/time", 1);
     if (!isJDBCSql) {
-      Assert.assertEquals("dummy", stubServiceEmitter.getEvents().get(0).toMap().get("id"));
+      Assertions.assertEquals("dummy", stubServiceEmitter.getEvents().get(0).toMap().get("id"));
     }
     if (isFailure) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           500,
           stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
       );
     } else {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           200,
           stubServiceEmitter.getMetricEvents("query/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
       );
@@ -998,7 +1000,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
 
     // This test is mostly about verifying that the servlet calls the right methods the right number of times.
     EasyMock.verify(hostFinder, requestMock);
-    Assert.assertEquals(1, didService.get());
+    Assertions.assertEquals(1, didService.get());
   }
 
   private static int getEmittedStatusCode(StubServiceEmitter stubServiceEmitter)
@@ -1033,7 +1035,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
 
   private static void assertStatusCode(RequestLogLine requestLogLine, int metricStatusCode)
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         metricStatusCode,
         requestLogLine.getQueryStats().getStats().get(DruidMetrics.STATUS_CODE)
     );
@@ -1166,14 +1168,14 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
   {
 
     // test params
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "http://localhost:1234/some/path?param=1",
         AsyncQueryForwardingServlet.makeURI("http", "localhost:1234", "/some/path", "param=1")
     );
 
     // HttpServletRequest.getQueryString returns encoded form
     // use ascii representation in case URI is using non-ascii characters
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "http://[2a00:1450:4007:805::1007]:1234/some/path?param=1&param2=%E2%82%AC",
         AsyncQueryForwardingServlet.makeURI(
             "http",
@@ -1184,14 +1186,14 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
     );
 
     // test null query
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "http://localhost/",
         AsyncQueryForwardingServlet.makeURI("http", "localhost", "/", null)
     );
 
     // Test reWrite Encoded interval with timezone info
     // decoded parameters 1900-01-01T00:00:00.000+01.00 -> 1900-01-01T00:00:00.000+01:00
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "http://localhost:1234/some/path?intervals=1900-01-01T00%3A00%3A00.000%2B01%3A00%2F3000-01-01T00%3A00%3A00.000%2B01%3A00",
         AsyncQueryForwardingServlet.makeURI(
             "http",
@@ -1234,10 +1236,10 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
 
     for (Service.Request request : jsonRequests) {
       final String json = mapper.writeValueAsString(request);
-      Assert.assertEquals(
-          StringUtils.format("Failed %s", json),
+      Assertions.assertEquals(
           connectionId,
-          AsyncQueryForwardingServlet.getAvaticaConnectionId(asMap(json, mapper))
+          AsyncQueryForwardingServlet.getAvaticaConnectionId(asMap(json, mapper)),
+          StringUtils.format("Failed %s", json)
       );
     }
   }
@@ -1273,10 +1275,10 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
 
 
     for (Service.Request request : avaticaRequests) {
-      Assert.assertEquals(
-          "failed",
+      Assertions.assertEquals(
           connectionId,
-          AsyncQueryForwardingServlet.getAvaticaProtobufConnectionId(request)
+          AsyncQueryForwardingServlet.getAvaticaProtobufConnectionId(request),
+          "failed"
       );
     }
   }

--- a/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -104,6 +104,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -231,7 +232,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
   }
 
   @Test
-  @Timeout(60)
+  @Timeout(value = 60, threadMode = ThreadMode.SEPARATE_THREAD)
   public void testDeleteBroadcast() throws Exception
   {
     CountDownLatch latch = new CountDownLatch(2);

--- a/services/src/test/java/org/apache/druid/server/http/security/SecurityResourceFilterTest.java
+++ b/services/src/test/java/org/apache/druid/server/http/security/SecurityResourceFilterTest.java
@@ -42,18 +42,18 @@ import org.apache.druid.server.http.ServersResource;
 import org.apache.druid.server.http.TiersResource;
 import org.apache.druid.server.security.ForbiddenException;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collection;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "{index}: requestPath={0}, requestMethod={1}, resourceFilter={2}")
+@MethodSource("data")
 public class SecurityResourceFilterTest extends ResourceFilterTestHelper
 {
-  @Parameterized.Parameters(name = "{index}: requestPath={0}, requestMethod={1}, resourceFilter={2}")
   public static Collection<Object[]> data()
   {
     return ImmutableList.copyOf(
@@ -97,7 +97,7 @@ public class SecurityResourceFilterTest extends ResourceFilterTestHelper
     this.injector = injector;
   }
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     setUp(resourceFilter);
@@ -112,18 +112,12 @@ public class SecurityResourceFilterTest extends ResourceFilterTestHelper
     EasyMock.verify(req, request, authorizerMapper);
   }
 
-  @Test(expected = ForbiddenException.class)
+  @Test
   public void testResourcesFilteringNoAccess()
   {
     setUpMockExpectations(requestPath, false, requestMethod);
     EasyMock.replay(req, request, authorizerMapper);
-    try {
-      resourceFilter.getRequestFilter().filter(request);
-      Assert.fail();
-    }
-    catch (ForbiddenException e) {
-      EasyMock.verify(req, request, authorizerMapper);
-      throw e;
-    }
+    Assertions.assertThrows(ForbiddenException.class, () -> resourceFilter.getRequestFilter().filter(request));
+    EasyMock.verify(req, request, authorizerMapper);
   }
 }

--- a/services/src/test/java/org/apache/druid/server/router/CoordinatorRuleManagerTest.java
+++ b/services/src/test/java/org/apache/druid/server/router/CoordinatorRuleManagerTest.java
@@ -39,9 +39,8 @@ import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -57,9 +56,6 @@ public class CoordinatorRuleManagerTest
       new ForeverLoadRule(ImmutableMap.of("__default", 2), null)
   );
 
-  @org.junit.Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   private final TieredBrokerConfig tieredBrokerConfig = new TieredBrokerConfig();
 
   @Test
@@ -70,8 +66,10 @@ public class CoordinatorRuleManagerTest
         mockClient()
     );
     final Map<String, List<Rule>> rules = manager.getRules();
-    expectedException.expect(UnsupportedOperationException.class);
-    rules.put("testKey", Collections.emptyList());
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () -> rules.put("testKey", Collections.emptyList())
+    );
   }
 
   @Test
@@ -83,8 +81,10 @@ public class CoordinatorRuleManagerTest
     );
     manager.poll();
     final Map<String, List<Rule>> rules = manager.getRules();
-    expectedException.expect(UnsupportedOperationException.class);
-    rules.get(DATASOURCE1).add(new ForeverDropRule());
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () -> rules.get(DATASOURCE1).add(new ForeverDropRule())
+    );
   }
 
   @Test
@@ -108,7 +108,7 @@ public class CoordinatorRuleManagerTest
         client
     );
 
-    Assert.assertThrows(ISE.class, manager::poll);
+    Assertions.assertThrows(ISE.class, manager::poll);
   }
 
 
@@ -121,7 +121,7 @@ public class CoordinatorRuleManagerTest
     );
     manager.poll();
     final List<Rule> rules = manager.getRulesWithDefault("unknown");
-    Assert.assertEquals(DEFAULT_RULES, rules);
+    Assertions.assertEquals(DEFAULT_RULES, rules);
   }
 
   @Test
@@ -137,7 +137,7 @@ public class CoordinatorRuleManagerTest
     expectedRules.add(new ForeverLoadRule(null, null));
     expectedRules.add(new IntervalDropRule(Intervals.of("2020-01-01/2020-01-02")));
     expectedRules.addAll(DEFAULT_RULES);
-    Assert.assertEquals(expectedRules, rules);
+    Assertions.assertEquals(expectedRules, rules);
   }
 
   private CoordinatorClient mockClient()

--- a/services/src/test/java/org/apache/druid/server/router/JavaScriptTieredBrokerSelectorStrategyTest.java
+++ b/services/src/test/java/org/apache/druid/server/router/JavaScriptTieredBrokerSelectorStrategyTest.java
@@ -30,19 +30,13 @@ import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.query.topn.TopNQueryBuilder;
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
 
 public class JavaScriptTieredBrokerSelectorStrategyTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   private final TieredBrokerSelectorStrategy STRATEGY = new JavaScriptTieredBrokerSelectorStrategy(
       "function (config, query) { if (query.getAggregatorSpecs && query.getDimensionSpec && query.getDimensionSpec().getDimension() == 'bigdim' && query.getAggregatorSpecs().size() >= 3) { var size = config.getTierToBrokerMap().values().size(); if (size > 0) { return config.getTierToBrokerMap().values().toArray()[size-1] } else { return config.getDefaultBrokerServiceName() } } else { return null } }",
       JavaScriptConfig.getEnabledInstance()
@@ -59,7 +53,7 @@ public class JavaScriptTieredBrokerSelectorStrategyTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         STRATEGY,
         mapper.readValue(
             mapper.writeValueAsString(STRATEGY),
@@ -81,11 +75,12 @@ public class JavaScriptTieredBrokerSelectorStrategyTest
 
     final String strategyString = mapper.writeValueAsString(STRATEGY);
 
-    expectedException.expect(JsonMappingException.class);
-    expectedException.expectCause(CoreMatchers.instanceOf(IllegalStateException.class));
-    expectedException.expectMessage("JavaScript is disabled");
-
-    mapper.readValue(strategyString, JavaScriptTieredBrokerSelectorStrategy.class);
+    final JsonMappingException exception = Assertions.assertThrows(
+        JsonMappingException.class,
+        () -> mapper.readValue(strategyString, JavaScriptTieredBrokerSelectorStrategy.class)
+    );
+    Assertions.assertInstanceOf(IllegalStateException.class, exception.getCause());
+    Assertions.assertTrue(exception.getMessage().contains("JavaScript is disabled"));
   }
 
   @Test
@@ -117,7 +112,7 @@ public class JavaScriptTieredBrokerSelectorStrategyTest
                                                                 .threshold(1)
                                                                 .aggregators(new CountAggregatorFactory("count"));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Optional.absent(),
         STRATEGY.getBrokerServiceName(
             tieredBrokerConfig,
@@ -126,7 +121,7 @@ public class JavaScriptTieredBrokerSelectorStrategyTest
     );
 
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Optional.absent(),
         STRATEGY.getBrokerServiceName(
             tieredBrokerConfig,
@@ -134,7 +129,7 @@ public class JavaScriptTieredBrokerSelectorStrategyTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Optional.of("druid/slowBroker"),
         STRATEGY.getBrokerServiceName(
             tieredBrokerConfig,
@@ -148,7 +143,7 @@ public class JavaScriptTieredBrokerSelectorStrategyTest
 
     // in absence of tiers, expect the default
     tierBrokerMap.clear();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Optional.of("druid/broker"),
         STRATEGY.getBrokerServiceName(
             tieredBrokerConfig,

--- a/services/src/test/java/org/apache/druid/server/router/ManualTieredBrokerSelectorStrategyTest.java
+++ b/services/src/test/java/org/apache/druid/server/router/ManualTieredBrokerSelectorStrategyTest.java
@@ -29,23 +29,24 @@ import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
 import org.apache.druid.sql.http.SqlQuery;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+
+
+
 
 public class ManualTieredBrokerSelectorStrategyTest
 {
   private TieredBrokerConfig tieredBrokerConfig;
   private Druids.TimeseriesQueryBuilder queryBuilder;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     tieredBrokerConfig = new TieredBrokerConfig()
@@ -89,18 +90,18 @@ public class ManualTieredBrokerSelectorStrategyTest
         json,
         TieredBrokerSelectorStrategy.class
     );
-    assertTrue(strategy instanceof ManualTieredBrokerSelectorStrategy);
+    Assertions.assertTrue(strategy instanceof ManualTieredBrokerSelectorStrategy);
 
     ManualTieredBrokerSelectorStrategy queryContextStrategy =
         (ManualTieredBrokerSelectorStrategy) strategy;
-    assertNull(queryContextStrategy.getDefaultManualBrokerService());
+    Assertions.assertNull(queryContextStrategy.getDefaultManualBrokerService());
 
     json = "{\"type\":\"manual\",\"defaultManualBrokerService\":\"hotBroker\"}";
     queryContextStrategy = mapper.readValue(
         json,
         ManualTieredBrokerSelectorStrategy.class
     );
-    assertEquals(queryContextStrategy.getDefaultManualBrokerService(), "hotBroker");
+    Assertions.assertEquals(queryContextStrategy.getDefaultManualBrokerService(), "hotBroker");
   }
 
   @Test
@@ -109,11 +110,11 @@ public class ManualTieredBrokerSelectorStrategyTest
     final ManualTieredBrokerSelectorStrategy strategy =
         new ManualTieredBrokerSelectorStrategy(null);
 
-    assertEquals(
+    Assertions.assertEquals(
         Optional.absent(),
         strategy.getBrokerServiceName(tieredBrokerConfig, queryBuilder.build())
     );
-    assertEquals(
+    Assertions.assertEquals(
         Optional.absent(),
         strategy.getBrokerServiceName(
             tieredBrokerConfig,
@@ -122,7 +123,7 @@ public class ManualTieredBrokerSelectorStrategyTest
                 .build()
         )
     );
-    assertEquals(
+    Assertions.assertEquals(
         Optional.of(Names.BROKER_SVC_HOT),
         strategy.getBrokerServiceName(
             tieredBrokerConfig,
@@ -131,7 +132,7 @@ public class ManualTieredBrokerSelectorStrategyTest
                 .build()
         )
     );
-    assertEquals(
+    Assertions.assertEquals(
         Optional.of(Names.BROKER_SVC_COLD),
         strategy.getBrokerServiceName(
             tieredBrokerConfig,
@@ -148,11 +149,11 @@ public class ManualTieredBrokerSelectorStrategyTest
     final ManualTieredBrokerSelectorStrategy strategy =
         new ManualTieredBrokerSelectorStrategy(Names.BROKER_SVC_MEDIUM);
 
-    assertEquals(
+    Assertions.assertEquals(
         Optional.of(Names.BROKER_SVC_MEDIUM),
         strategy.getBrokerServiceName(tieredBrokerConfig, queryBuilder.build())
     );
-    assertEquals(
+    Assertions.assertEquals(
         Optional.of(Names.BROKER_SVC_MEDIUM),
         strategy.getBrokerServiceName(
             tieredBrokerConfig,
@@ -161,7 +162,7 @@ public class ManualTieredBrokerSelectorStrategyTest
                 .build()
         )
     );
-    assertEquals(
+    Assertions.assertEquals(
         Optional.of(Names.BROKER_SVC_HOT),
         strategy.getBrokerServiceName(
             tieredBrokerConfig,
@@ -178,11 +179,11 @@ public class ManualTieredBrokerSelectorStrategyTest
     final ManualTieredBrokerSelectorStrategy strategy =
         new ManualTieredBrokerSelectorStrategy("noSuchBroker");
 
-    assertEquals(
+    Assertions.assertEquals(
         Optional.absent(),
         strategy.getBrokerServiceName(tieredBrokerConfig, queryBuilder.build())
     );
-    assertEquals(
+    Assertions.assertEquals(
         Optional.absent(),
         strategy.getBrokerServiceName(
             tieredBrokerConfig,
@@ -191,7 +192,7 @@ public class ManualTieredBrokerSelectorStrategyTest
                 .build()
         )
     );
-    assertEquals(
+    Assertions.assertEquals(
         Optional.of(Names.BROKER_SVC_HOT),
         strategy.getBrokerServiceName(
             tieredBrokerConfig,
@@ -208,11 +209,11 @@ public class ManualTieredBrokerSelectorStrategyTest
     final ManualTieredBrokerSelectorStrategy strategy =
         new ManualTieredBrokerSelectorStrategy(null);
 
-    assertEquals(
+    Assertions.assertEquals(
         Optional.absent(),
         strategy.getBrokerServiceName(tieredBrokerConfig, createSqlQueryWithContext(null))
     );
-    assertEquals(
+    Assertions.assertEquals(
         Optional.absent(),
         strategy.getBrokerServiceName(
             tieredBrokerConfig,
@@ -221,7 +222,7 @@ public class ManualTieredBrokerSelectorStrategyTest
             )
         )
     );
-    assertEquals(
+    Assertions.assertEquals(
         Optional.of(Names.BROKER_SVC_HOT),
         strategy.getBrokerServiceName(
             tieredBrokerConfig,
@@ -230,7 +231,7 @@ public class ManualTieredBrokerSelectorStrategyTest
             )
         )
     );
-    assertEquals(
+    Assertions.assertEquals(
         Optional.of(Names.BROKER_SVC_COLD),
         strategy.getBrokerServiceName(
             tieredBrokerConfig,

--- a/services/src/test/java/org/apache/druid/server/router/QueryHostFinderTest.java
+++ b/services/src/test/java/org/apache/druid/server/router/QueryHostFinderTest.java
@@ -27,10 +27,10 @@ import org.apache.druid.query.TableDataSource;
 import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
 import org.apache.druid.query.timeboundary.TimeBoundaryQuery;
 import org.easymock.EasyMock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -41,7 +41,7 @@ public class QueryHostFinderTest
   private TieredBrokerHostSelector brokerSelector;
   private Server server;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     brokerSelector = EasyMock.createMock(TieredBrokerHostSelector.class);
@@ -79,7 +79,7 @@ public class QueryHostFinderTest
     EasyMock.replay(brokerSelector);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     EasyMock.verify(brokerSelector);
@@ -103,6 +103,6 @@ public class QueryHostFinderTest
         )
     );
 
-    Assert.assertEquals("foo", server.getHost());
+    Assertions.assertEquals("foo", server.getHost());
   }
 }

--- a/services/src/test/java/org/apache/druid/server/router/TieredBrokerHostSelectorTest.java
+++ b/services/src/test/java/org/apache/druid/server/router/TieredBrokerHostSelectorTest.java
@@ -44,10 +44,10 @@ import org.apache.druid.server.coordinator.rules.IntervalLoadRule;
 import org.apache.druid.server.coordinator.rules.Rule;
 import org.apache.druid.sql.http.SqlQuery;
 import org.easymock.EasyMock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -69,7 +69,7 @@ public class TieredBrokerHostSelectorTest
   private DiscoveryDruidNode node2;
   private DiscoveryDruidNode node3;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     druidNodeDiscoveryProvider = EasyMock.createStrictMock(DruidNodeDiscoveryProvider.class);
@@ -146,7 +146,7 @@ public class TieredBrokerHostSelectorTest
     brokerSelector.start();
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     brokerSelector.stop();
@@ -166,16 +166,16 @@ public class TieredBrokerHostSelectorTest
                                   .build();
 
     Pair<String, Server> p = brokerSelector.select(query);
-    Assert.assertEquals("coldBroker", p.lhs);
-    Assert.assertEquals("coldHost1:8080", p.rhs.getHost());
+    Assertions.assertEquals("coldBroker", p.lhs);
+    Assertions.assertEquals("coldHost1:8080", p.rhs.getHost());
 
     p = brokerSelector.select(query);
-    Assert.assertEquals("coldBroker", p.lhs);
-    Assert.assertEquals("coldHost2:8080", p.rhs.getHost());
+    Assertions.assertEquals("coldBroker", p.lhs);
+    Assertions.assertEquals("coldHost2:8080", p.rhs.getHost());
 
     p = brokerSelector.select(query);
-    Assert.assertEquals("coldBroker", p.lhs);
-    Assert.assertEquals("coldHost1:8080", p.rhs.getHost());
+    Assertions.assertEquals("coldBroker", p.lhs);
+    Assertions.assertEquals("coldHost1:8080", p.rhs.getHost());
   }
 
 
@@ -191,8 +191,8 @@ public class TieredBrokerHostSelectorTest
               .build()
     );
 
-    Assert.assertEquals("hotBroker", p.lhs);
-    Assert.assertEquals("hotHost:8080", p.rhs.getHost());
+    Assertions.assertEquals("hotBroker", p.lhs);
+    Assertions.assertEquals("hotHost:8080", p.rhs.getHost());
   }
 
   @Test
@@ -207,7 +207,7 @@ public class TieredBrokerHostSelectorTest
               .build()
     ).lhs;
 
-    Assert.assertEquals("hotBroker", brokerName);
+    Assertions.assertEquals("hotBroker", brokerName);
   }
 
   @Test
@@ -228,7 +228,7 @@ public class TieredBrokerHostSelectorTest
               ).build()
     ).lhs;
 
-    Assert.assertEquals("coldBroker", brokerName);
+    Assertions.assertEquals("coldBroker", brokerName);
   }
 
   @Test
@@ -249,7 +249,7 @@ public class TieredBrokerHostSelectorTest
               ).build()
     ).lhs;
 
-    Assert.assertEquals("coldBroker", brokerName);
+    Assertions.assertEquals("coldBroker", brokerName);
   }
 
   @Test
@@ -272,7 +272,7 @@ public class TieredBrokerHostSelectorTest
               .build()
     ).lhs;
 
-    Assert.assertEquals("hotBroker", brokerName);
+    Assertions.assertEquals("hotBroker", brokerName);
   }
 
   @Test
@@ -295,7 +295,7 @@ public class TieredBrokerHostSelectorTest
               .build()
     ).lhs;
 
-    Assert.assertEquals("hotBroker", brokerName);
+    Assertions.assertEquals("hotBroker", brokerName);
   }
 
   @Test
@@ -311,11 +311,11 @@ public class TieredBrokerHostSelectorTest
                   )
               );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         brokerSelector.getDefaultServiceName(),
         brokerSelector.select(queryBuilder.build()).lhs
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "hotBroker",
         brokerSelector.select(
             queryBuilder
@@ -323,7 +323,7 @@ public class TieredBrokerHostSelectorTest
                 .build()
         ).lhs
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "coldBroker",
         brokerSelector.select(
             queryBuilder
@@ -336,13 +336,13 @@ public class TieredBrokerHostSelectorTest
   @Test
   public void testSelectForSql()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         brokerSelector.getDefaultServiceName(),
         brokerSelector.selectForSql(
             createSqlQueryWithContext(null)
         ).lhs
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "hotBroker",
         brokerSelector.selectForSql(
             createSqlQueryWithContext(
@@ -350,7 +350,7 @@ public class TieredBrokerHostSelectorTest
             )
         ).lhs
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "coldBroker",
         brokerSelector.selectForSql(
             createSqlQueryWithContext(
@@ -363,7 +363,7 @@ public class TieredBrokerHostSelectorTest
   @Test
   public void testGetAllBrokers()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             "mediumBroker", ImmutableList.of(),
             "coldBroker", ImmutableList.of("coldHost1:8080", "coldHost2:8080"),


### PR DESCRIPTION
## Summary

- Migrate the scoped services, embedded-tests, server HTTP, Jetty, and server-initialization tests to JUnit 5.
- Preserve class-wide parameterization in SecurityResourceFilterTest with @ParameterizedClass and @MethodSource.
- Replace JUnit 4 rules, runners, lifecycle annotations, expected exceptions, and internal Hamcrest matchers with Jupiter equivalents.
- Keep PR3-owned top-level initialization files, server/pom.xml, and shared POMs unchanged.

## Validation

- mvn -ntp -DskipTests -pl server,services,embedded-tests -am test-compile -Pskip-static-checks -Dweb.console.skip=true -T1C — PASS.
- Focused services tests — PASS: 153 + 56 + 13 tests across the migrated classes; CreateTablesTest rerun after final Checkstyle fix: 1 test.
- Focused server tests — PASS: 245 tests, 0 failures/errors, 2 skips; JettyCertRenewTest had one automatic flake retry and then passed.
- Focused embedded tests — PASS: 25 tests, 0 failures/errors.
- mvn -ntp -DskipTests -pl server,services,embedded-tests -am checkstyle:check -Dweb.console.skip=true -T1C — PASS, 0 violations.
- SpotBugs — PASS for server/services; embedded-tests completed with no main classes to analyze.
- git diff --check and added-static-import audit — PASS.

No POM dependency was removed: services still consumes JUnit 4 through shared druid-server test fixtures, and embedded-tests retains live Hamcrest consumers.

Part of #13948