### PR TITLE
test(multi-stage-query): migrate tests to JUnit 5

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskActionTestKit.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskActionTestKit.java
@@ -55,14 +55,13 @@ import org.joda.time.Period;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.rules.ExternalResource;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
-public class TaskActionTestKit extends ExternalResource implements BeforeEachCallback, AfterEachCallback
+public class TaskActionTestKit implements BeforeEachCallback, AfterEachCallback
 {
   private final MetadataStorageTablesConfig metadataStorageTablesConfig = MetadataStorageTablesConfig.fromBase("druid");
 
@@ -194,7 +193,6 @@ public class TaskActionTestKit extends ExternalResource implements BeforeEachCal
     taskActionDelegate.put(actionType, function);
   }
 
-  @Override
   public void before()
   {
     Preconditions.checkState(configFinalized.compareAndSet(false, true));
@@ -336,7 +334,6 @@ public class TaskActionTestKit extends ExternalResource implements BeforeEachCal
     };
   }
 
-  @Override
   public void after()
   {
     testDerbyConnector.tearDown();

--- a/multi-stage-query/pom.xml
+++ b/multi-stage-query/pom.xml
@@ -202,11 +202,6 @@
 
         <!-- Tests -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>net.hydromatic</groupId>
             <artifactId>quidem</artifactId>
             <scope>test</scope>
@@ -248,11 +243,6 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-migrationsupport</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
@@ -277,23 +267,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>nl.jqno.equalsverifier</groupId>
-            <artifactId>equalsverifier</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>pl.pragmatists</groupId>
-            <artifactId>JUnitParams</artifactId>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -339,6 +324,12 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-testlib</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
 

--- a/multi-stage-query/pom.xml
+++ b/multi-stage-query/pom.xml
@@ -267,6 +267,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.opentest4j</groupId>
+            <artifactId>opentest4j</artifactId>
+            <version>1.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/multi-stage-query/pom.xml
+++ b/multi-stage-query/pom.xml
@@ -252,16 +252,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/multi-stage-query/pom.xml
+++ b/multi-stage-query/pom.xml
@@ -257,12 +257,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.opentest4j</groupId>
-            <artifactId>opentest4j</artifactId>
-            <version>1.3.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/counters/CountersSnapshotTreeTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/counters/CountersSnapshotTreeTest.java
@@ -29,8 +29,8 @@ import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.loading.AcquireSegmentResult;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Objects;
 
@@ -73,8 +73,8 @@ public class CountersSnapshotTreeTest
     final CounterSnapshotsTree snapshotsTree2 = serializationMapper.readValue(json, CounterSnapshotsTree.class);
     final CounterSnapshotsTree snapshotsTree3 = deserializationMapper.readValue(json, CounterSnapshotsTree.class);
 
-    Assert.assertEquals(snapshotsTree.copyMap(), snapshotsTree2.copyMap());
-    Assert.assertNotEquals(snapshotsTree.copyMap(), snapshotsTree3.copyMap());
+    Assertions.assertEquals(snapshotsTree.copyMap(), snapshotsTree2.copyMap());
+    Assertions.assertNotEquals(snapshotsTree.copyMap(), snapshotsTree3.copyMap());
 
     // Confirm that deserializationMapper reads the TestCounterSnapshot as a NilQueryCounterSnapshot.
     MatcherAssert.assertThat(

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/counters/CountersSnapshotTreeTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/counters/CountersSnapshotTreeTest.java
@@ -27,8 +27,6 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.loading.AcquireSegmentResult;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -77,9 +75,9 @@ public class CountersSnapshotTreeTest
     Assertions.assertNotEquals(snapshotsTree.copyMap(), snapshotsTree3.copyMap());
 
     // Confirm that deserializationMapper reads the TestCounterSnapshot as a NilQueryCounterSnapshot.
-    MatcherAssert.assertThat(
-        snapshotsTree3.copyMap().get(1).get(2).getMap().get("ctr"),
-        CoreMatchers.instanceOf(NilQueryCounterSnapshot.class)
+    Assertions.assertInstanceOf(
+        NilQueryCounterSnapshot.class,
+        snapshotsTree3.copyMap().get(1).get(2).getMap().get("ctr")
     );
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/counters/CpuCountersTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/counters/CpuCountersTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.msq.counters;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CpuCountersTest
 {
@@ -34,7 +34,7 @@ public class CpuCountersTest
     final CpuCounter counter = counters.forName("xyz");
     counter.run(() -> { /* Nothing in particular */ });
     final CpuCounters.Snapshot snapshot = counters.snapshot();
-    Assert.assertEquals(ImmutableSet.of("xyz"), snapshot.getCountersMap().keySet());
+    Assertions.assertEquals(ImmutableSet.of("xyz"), snapshot.getCountersMap().keySet());
   }
 
   @Test
@@ -42,9 +42,9 @@ public class CpuCountersTest
   {
     final CpuCounters counters = new CpuCounters();
     final CpuCounter counter = counters.forName("xyz");
-    Assert.assertEquals("boo", counter.run(() -> "boo"));
+    Assertions.assertEquals("boo", counter.run(() -> "boo"));
     final CpuCounters.Snapshot snapshot = counters.snapshot();
-    Assert.assertEquals(ImmutableSet.of("xyz"), snapshot.getCountersMap().keySet());
+    Assertions.assertEquals(ImmutableSet.of("xyz"), snapshot.getCountersMap().keySet());
   }
 
   @Test
@@ -54,7 +54,7 @@ public class CpuCountersTest
     final CpuCounter counter = counters.forName("xyz");
     counter.accumulate(1L, 1L);
     final CpuCounters.Snapshot snapshot = counters.snapshot();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of("xyz", new CpuCounter.Snapshot(1L, 1L)),
         snapshot.getCountersMap()
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/counters/SegmentGenerationProgressCounterTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/counters/SegmentGenerationProgressCounterTest.java
@@ -20,7 +20,7 @@
 package org.apache.druid.msq.counters;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SegmentGenerationProgressCounterTest
 {

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/counters/StorageCountersTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/counters/StorageCountersTest.java
@@ -25,8 +25,8 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.frame.channel.ByteTracker;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StorageCountersTest
 {
@@ -36,12 +36,12 @@ public class StorageCountersTest
     final StorageCounters counters = new StorageCounters(null);
     final StorageCounters.Snapshot snapshot = (StorageCounters.Snapshot) counters.snapshot();
 
-    Assert.assertNull(snapshot.getLocalBytesMax());
-    Assert.assertEquals(0, snapshot.getLocalBytesReserved());
-    Assert.assertEquals(0, snapshot.getLocalFilesWritten());
-    Assert.assertEquals(0, snapshot.getLocalBytesWritten());
-    Assert.assertEquals(0, snapshot.getDurableFileCount());
-    Assert.assertEquals(0, snapshot.getDurableBytesWritten());
+    Assertions.assertNull(snapshot.getLocalBytesMax());
+    Assertions.assertEquals(0, snapshot.getLocalBytesReserved());
+    Assertions.assertEquals(0, snapshot.getLocalFilesWritten());
+    Assertions.assertEquals(0, snapshot.getLocalBytesWritten());
+    Assertions.assertEquals(0, snapshot.getDurableFileCount());
+    Assertions.assertEquals(0, snapshot.getDurableBytesWritten());
   }
 
   @Test
@@ -53,8 +53,8 @@ public class StorageCountersTest
     final StorageCounters counters = new StorageCounters(tracker);
 
     final StorageCounters.Snapshot snapshot = (StorageCounters.Snapshot) counters.snapshot();
-    Assert.assertEquals(1000L, (long) snapshot.getLocalBytesMax());
-    Assert.assertEquals(300, snapshot.getLocalBytesReserved());
+    Assertions.assertEquals(1000L, (long) snapshot.getLocalBytesMax());
+    Assertions.assertEquals(300, snapshot.getLocalBytesReserved());
   }
 
   @Test
@@ -67,14 +67,14 @@ public class StorageCountersTest
 
     // Take first snapshot
     final StorageCounters.Snapshot snapshot1 = (StorageCounters.Snapshot) counters.snapshot();
-    Assert.assertEquals(300, snapshot1.getLocalBytesReserved());
+    Assertions.assertEquals(300, snapshot1.getLocalBytesReserved());
 
     // Change tracker state
     tracker.reserve(200);
 
     // Second snapshot reflects new state
     final StorageCounters.Snapshot snapshot2 = (StorageCounters.Snapshot) counters.snapshot();
-    Assert.assertEquals(500, snapshot2.getLocalBytesReserved());
+    Assertions.assertEquals(500, snapshot2.getLocalBytesReserved());
   }
 
   @Test
@@ -87,10 +87,10 @@ public class StorageCountersTest
     counters.incrementLocalBytes(300);
 
     final StorageCounters.Snapshot snapshot = (StorageCounters.Snapshot) counters.snapshot();
-    Assert.assertEquals(2, snapshot.getLocalFilesWritten());
-    Assert.assertEquals(800, snapshot.getLocalBytesWritten());
-    Assert.assertEquals(0, snapshot.getDurableFileCount());
-    Assert.assertEquals(0, snapshot.getDurableBytesWritten());
+    Assertions.assertEquals(2, snapshot.getLocalFilesWritten());
+    Assertions.assertEquals(800, snapshot.getLocalBytesWritten());
+    Assertions.assertEquals(0, snapshot.getDurableFileCount());
+    Assertions.assertEquals(0, snapshot.getDurableBytesWritten());
   }
 
   @Test
@@ -103,10 +103,10 @@ public class StorageCountersTest
     counters.incrementDurableBytes(2000);
 
     final StorageCounters.Snapshot snapshot = (StorageCounters.Snapshot) counters.snapshot();
-    Assert.assertEquals(0, snapshot.getLocalFilesWritten());
-    Assert.assertEquals(0, snapshot.getLocalBytesWritten());
-    Assert.assertEquals(2, snapshot.getDurableFileCount());
-    Assert.assertEquals(3000, snapshot.getDurableBytesWritten());
+    Assertions.assertEquals(0, snapshot.getLocalFilesWritten());
+    Assertions.assertEquals(0, snapshot.getLocalBytesWritten());
+    Assertions.assertEquals(2, snapshot.getDurableFileCount());
+    Assertions.assertEquals(3000, snapshot.getDurableBytesWritten());
   }
 
   @Test
@@ -120,7 +120,7 @@ public class StorageCountersTest
     final String json = mapper.writeValueAsString(snapshot);
     final StorageCounters.Snapshot deserialized = mapper.readValue(json, StorageCounters.Snapshot.class);
 
-    Assert.assertEquals(snapshot, deserialized);
+    Assertions.assertEquals(snapshot, deserialized);
   }
 
   @Test
@@ -136,7 +136,7 @@ public class StorageCountersTest
     final String json = mapper.writeValueAsString(tree);
     final CounterSnapshotsTree deserialized = mapper.readValue(json, CounterSnapshotsTree.class);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         snapshot,
         deserialized.copyMap().get(0).get(0).getMap().get(CounterNames.storage())
     );
@@ -152,13 +152,13 @@ public class StorageCountersTest
 
     // First call creates the counter
     final StorageCounters counters = counterTracker.storage(tracker1);
-    Assert.assertSame(tracker1, counters.getLocalByteTracker());
+    Assertions.assertSame(tracker1, counters.getLocalByteTracker());
 
     // Second call with same tracker succeeds
-    Assert.assertSame(counters, counterTracker.storage(tracker1));
+    Assertions.assertSame(counters, counterTracker.storage(tracker1));
 
     // Call with different tracker fails
-    Assert.assertThrows(IllegalStateException.class, () -> counterTracker.storage(tracker2));
+    Assertions.assertThrows(IllegalStateException.class, () -> counterTracker.storage(tracker2));
   }
 
   @Test

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/DartWorkerManagerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/DartWorkerManagerTest.java
@@ -32,7 +32,6 @@ import org.apache.druid.msq.dart.worker.DartWorkerClientImpl;
 import org.apache.druid.msq.dart.worker.WorkerId;
 import org.apache.druid.msq.exec.WorkerManager;
 import org.apache.druid.msq.exec.WorkerStats;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -124,7 +123,7 @@ public class DartWorkerManagerTest
     Assertions.assertTrue(workerManager.launchWorkersIfNeeded(0).isEmpty()); // Does nothing, less than WORKERS.size()
     Assertions.assertTrue(workerManager.launchWorkersIfNeeded(1).isEmpty()); // Does nothing, less than WORKERS.size()
     Assertions.assertTrue(workerManager.launchWorkersIfNeeded(2).isEmpty()); // Does nothing, equal to WORKERS.size()
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> workerManager.launchWorkersIfNeeded(3)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java
@@ -95,6 +95,7 @@ import org.apache.druid.sql.http.SqlResourceQueryResultPusherFactory;
 import org.apache.druid.sql.http.StandardQueryState;
 import org.apache.druid.sql.http.SupportedEnginesResponse;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -105,6 +106,7 @@ import org.mockito.MockitoAnnotations;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -116,8 +118,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Functional test of {@link SqlResource}, {@link DartSqlEngine}, and {@link DartQueryMaker}.
@@ -655,7 +655,7 @@ public class DartSqlResourceTest extends MSQTestBase
 
     Assertions.assertEquals("InvalidNullByte", e.get("errorCode"));
     Assertions.assertEquals("INVALID_INPUT", e.get("category"));
-    assertThat((String) e.get("errorMessage"), CoreMatchers.startsWith("InvalidNullByte: "));
+    MatcherAssert.assertThat((String) e.get("errorMessage"), CoreMatchers.startsWith("InvalidNullByte: "));
   }
 
   @Test
@@ -781,7 +781,7 @@ public class DartSqlResourceTest extends MSQTestBase
         (MSQTaskReport) Iterables.getOnlyElement(Iterables.getOnlyElement(reportMaps)).get(MSQTaskReport.REPORT_KEY);
     final MSQErrorReport errorReport = report.getPayload().getStatus().getErrorReport();
     Assertions.assertNotNull(errorReport);
-    assertThat(errorReport.getFault(), CoreMatchers.instanceOf(InvalidNullByteFault.class));
+    MatcherAssert.assertThat(errorReport.getFault(), CoreMatchers.instanceOf(InvalidNullByteFault.class));
   }
 
   @Test

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java
@@ -94,7 +94,6 @@ import org.apache.druid.sql.http.SqlResource;
 import org.apache.druid.sql.http.SqlResourceQueryResultPusherFactory;
 import org.apache.druid.sql.http.StandardQueryState;
 import org.apache.druid.sql.http.SupportedEnginesResponse;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -120,8 +119,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Functional test of {@link SqlResource}, {@link DartSqlEngine}, and {@link DartQueryMaker}.
@@ -656,7 +653,7 @@ public class DartSqlResourceTest extends MSQTestBase
 
     Assertions.assertEquals("InvalidNullByte", e.get("errorCode"));
     Assertions.assertEquals("INVALID_INPUT", e.get("category"));
-    assertThat((String) e.get("errorMessage"), CoreMatchers.startsWith("InvalidNullByte: "));
+    Assertions.assertTrue(((String) e.get("errorMessage")).startsWith("InvalidNullByte: "));
   }
 
   @Test
@@ -782,7 +779,7 @@ public class DartSqlResourceTest extends MSQTestBase
         (MSQTaskReport) Iterables.getOnlyElement(Iterables.getOnlyElement(reportMaps)).get(MSQTaskReport.REPORT_KEY);
     final MSQErrorReport errorReport = report.getPayload().getStatus().getErrorReport();
     Assertions.assertNotNull(errorReport);
-    assertThat(errorReport.getFault(), CoreMatchers.instanceOf(InvalidNullByteFault.class));
+    Assertions.assertInstanceOf(InvalidNullByteFault.class, errorReport.getFault());
   }
 
   @Test

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java
@@ -95,14 +95,16 @@ import org.apache.druid.sql.http.SqlResourceQueryResultPusherFactory;
 import org.apache.druid.sql.http.StandardQueryState;
 import org.apache.druid.sql.http.SupportedEnginesResponse;
 import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
@@ -119,10 +121,14 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * Functional test of {@link SqlResource}, {@link DartSqlEngine}, and {@link DartQueryMaker}.
  * Other classes are mocked when possible.
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class DartSqlResourceTest extends MSQTestBase
 {
   private static final DruidNode SELF_NODE = new DruidNode("none", "localhost", false, 8080, -1, true, false);
@@ -152,7 +158,6 @@ public class DartSqlResourceTest extends MSQTestBase
   private SqlResource sqlResource;
   private DartControllerRegistry controllerRegistry;
   private ControllerThreadPool controllerThreadPool;
-  private AutoCloseable mockCloser;
   private final StubServiceEmitter serviceEmitter = new StubServiceEmitter();
 
   // Mocks below this line.
@@ -184,8 +189,6 @@ public class DartSqlResourceTest extends MSQTestBase
   @BeforeEach
   void setUp()
   {
-    mockCloser = MockitoAnnotations.openMocks(this);
-
     final DruidSchemaCatalog rootSchema = QueryFrameworkUtils.createMockRootSchema(
         CalciteTests.INJECTOR,
         queryFramework().conglomerate(),
@@ -299,8 +302,6 @@ public class DartSqlResourceTest extends MSQTestBase
   @AfterEach
   void tearDown() throws Exception
   {
-    mockCloser.close();
-
     // shutdown(), not shutdownNow(), to ensure controllers stop timely on their own.
     controllerThreadPool.getRunExecutorService().shutdown();
 
@@ -655,7 +656,7 @@ public class DartSqlResourceTest extends MSQTestBase
 
     Assertions.assertEquals("InvalidNullByte", e.get("errorCode"));
     Assertions.assertEquals("INVALID_INPUT", e.get("category"));
-    MatcherAssert.assertThat((String) e.get("errorMessage"), CoreMatchers.startsWith("InvalidNullByte: "));
+    assertThat((String) e.get("errorMessage"), CoreMatchers.startsWith("InvalidNullByte: "));
   }
 
   @Test
@@ -781,7 +782,7 @@ public class DartSqlResourceTest extends MSQTestBase
         (MSQTaskReport) Iterables.getOnlyElement(Iterables.getOnlyElement(reportMaps)).get(MSQTaskReport.REPORT_KEY);
     final MSQErrorReport errorReport = report.getPayload().getStatus().getErrorReport();
     Assertions.assertNotNull(errorReport);
-    MatcherAssert.assertThat(errorReport.getFault(), CoreMatchers.instanceOf(InvalidNullByteFault.class));
+    assertThat(errorReport.getFault(), CoreMatchers.instanceOf(InvalidNullByteFault.class));
   }
 
   @Test
@@ -814,8 +815,9 @@ public class DartSqlResourceTest extends MSQTestBase
            .thenReturn(asyncContext);
 
     // Cancellation request.
-    Mockito.when(httpServletRequest2.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT))
-           .thenReturn(makeAuthenticationResult(REGULAR_USER_NAME));
+    Mockito.doReturn(makeAuthenticationResult(REGULAR_USER_NAME))
+           .when(httpServletRequest2)
+           .getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT);
 
     // Block up the controllerExecutor so the controller runs long enough to cancel it.
     final Future<?> sleepFuture = controllerThreadPool.getRunExecutorService().submit(() -> {

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/dart/worker/DartFrameContextTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/dart/worker/DartFrameContextTest.java
@@ -24,9 +24,9 @@ import org.apache.druid.error.DruidException;
 import org.apache.druid.msq.exec.ProcessingBuffers;
 import org.apache.druid.msq.exec.ProcessingBuffersSet;
 import org.apache.druid.msq.kernel.StageId;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
@@ -36,7 +36,7 @@ public class DartFrameContextTest
 
   private ProcessingBuffersSet buffersSet;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     final ByteBuffer buffer = ByteBuffer.allocate(1024);
@@ -48,12 +48,12 @@ public class DartFrameContextTest
   {
     final DartFrameContext context = makeContext(null);
 
-    final DruidException e = Assert.assertThrows(
+    final DruidException e = Assertions.assertThrows(
         DruidException.class,
         () -> context.acquireProcessingBuffers(1)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Stage[" + STAGE_ID + "] does not use processing buffers",
         e.getMessage()
     );
@@ -65,12 +65,12 @@ public class DartFrameContextTest
     final DartFrameContext context = makeContext(buffersSet);
     context.acquireProcessingBuffers(1);
 
-    final DruidException e = Assert.assertThrows(
+    final DruidException e = Assertions.assertThrows(
         DruidException.class,
         () -> context.acquireProcessingBuffers(1)
     );
 
-    Assert.assertEquals("Processing buffers already acquired", e.getMessage());
+    Assertions.assertEquals("Processing buffers already acquired", e.getMessage());
 
     context.close();
   }
@@ -80,12 +80,12 @@ public class DartFrameContextTest
   {
     final DartFrameContext context = makeContext(buffersSet);
 
-    final DruidException e = Assert.assertThrows(
+    final DruidException e = Assertions.assertThrows(
         DruidException.class,
         context::processingBuffers
     );
 
-    Assert.assertEquals("Processing buffers not yet acquired", e.getMessage());
+    Assertions.assertEquals("Processing buffers not yet acquired", e.getMessage());
   }
 
   @Test
@@ -95,9 +95,9 @@ public class DartFrameContextTest
     context.acquireProcessingBuffers(1);
 
     final ProcessingBuffers buffers = context.processingBuffers();
-    Assert.assertNotNull(buffers);
-    Assert.assertNotNull(buffers.getBufferPool());
-    Assert.assertNotNull(buffers.getBouncer());
+    Assertions.assertNotNull(buffers);
+    Assertions.assertNotNull(buffers.getBufferPool());
+    Assertions.assertNotNull(buffers.getBouncer());
 
     context.close();
   }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/dart/worker/DartProcessingBuffersProviderTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/dart/worker/DartProcessingBuffersProviderTest.java
@@ -26,12 +26,12 @@ import org.apache.druid.msq.exec.ProcessingBuffers;
 import org.apache.druid.msq.exec.ProcessingBuffersSet;
 import org.apache.druid.msq.indexing.error.CanceledFault;
 import org.apache.druid.msq.indexing.error.MSQException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -41,7 +41,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class DartProcessingBuffersProviderTest
 {
   private static final int PROCESSING_THREADS = 4;
@@ -57,7 +57,7 @@ public class DartProcessingBuffersProviderTest
   private DartProcessingBuffersProvider provider;
   private ByteBuffer testBuffer;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     provider = new DartProcessingBuffersProvider(mockMergeBufferPool, PROCESSING_THREADS);
@@ -69,8 +69,8 @@ public class DartProcessingBuffersProviderTest
   {
     final ResourceHolder<ProcessingBuffersSet> result = provider.acquire(0, TIMEOUT_MILLIS);
 
-    Assert.assertNotNull(result);
-    Assert.assertEquals(ProcessingBuffersSet.EMPTY, result.get());
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(ProcessingBuffersSet.EMPTY, result.get());
 
     // Should be able to close without issues
     result.close();
@@ -90,10 +90,10 @@ public class DartProcessingBuffersProviderTest
       final ResourceHolder<ProcessingBuffers> holder = result.get().acquire(1);
       try {
         final ProcessingBuffers buffers = holder.get();
-        Assert.assertEquals(1, buffers.getBouncer().getMaxCount());
+        Assertions.assertEquals(1, buffers.getBouncer().getMaxCount());
 
         final ResourceHolder<ByteBuffer> sliceHolder = buffers.getBufferPool().take();
-        Assert.assertEquals(BUFFER_SIZE, sliceHolder.get().capacity());
+        Assertions.assertEquals(BUFFER_SIZE, sliceHolder.get().capacity());
         sliceHolder.close();
       }
       finally {
@@ -118,13 +118,13 @@ public class DartProcessingBuffersProviderTest
       final ResourceHolder<ProcessingBuffers> holder = result.get().acquire(PROCESSING_THREADS);
       try {
         final ProcessingBuffers buffers = holder.get();
-        Assert.assertEquals(PROCESSING_THREADS, buffers.getBouncer().getMaxCount());
+        Assertions.assertEquals(PROCESSING_THREADS, buffers.getBouncer().getMaxCount());
 
         final List<ResourceHolder<ByteBuffer>> sliceHolders = new ArrayList<>();
         try {
           for (int i = 0; i < PROCESSING_THREADS; i++) {
             final ResourceHolder<ByteBuffer> sliceHolder = buffers.getBufferPool().take();
-            Assert.assertEquals(BUFFER_SIZE / PROCESSING_THREADS, sliceHolder.get().capacity());
+            Assertions.assertEquals(BUFFER_SIZE / PROCESSING_THREADS, sliceHolder.get().capacity());
             sliceHolders.add(sliceHolder);
           }
         }
@@ -155,14 +155,14 @@ public class DartProcessingBuffersProviderTest
     try {
       // First acquisition with 2 slices.
       final ResourceHolder<ProcessingBuffers> holder1 = result.get().acquire(2);
-      Assert.assertEquals(2, holder1.get().getBouncer().getMaxCount());
-      Assert.assertEquals(BUFFER_SIZE / 2, holder1.get().getBufferPool().take().get().capacity());
+      Assertions.assertEquals(2, holder1.get().getBouncer().getMaxCount());
+      Assertions.assertEquals(BUFFER_SIZE / 2, holder1.get().getBufferPool().take().get().capacity());
       holder1.close();
 
       // Second acquisition with 4 slices — same chunk, different slicing.
       final ResourceHolder<ProcessingBuffers> holder2 = result.get().acquire(4);
-      Assert.assertEquals(4, holder2.get().getBouncer().getMaxCount());
-      Assert.assertEquals(BUFFER_SIZE / 4, holder2.get().getBufferPool().take().get().capacity());
+      Assertions.assertEquals(4, holder2.get().getBouncer().getMaxCount());
+      Assertions.assertEquals(BUFFER_SIZE / 4, holder2.get().getBufferPool().take().get().capacity());
       holder2.close();
     }
     finally {
@@ -180,9 +180,9 @@ public class DartProcessingBuffersProviderTest
     final int poolSize = 2;
     final ResourceHolder<ProcessingBuffersSet> result = provider.acquire(poolSize, TIMEOUT_MILLIS);
 
-    Assert.assertNotNull(result);
+    Assertions.assertNotNull(result);
     final ProcessingBuffersSet buffersSet = result.get();
-    Assert.assertNotNull(buffersSet);
+    Assertions.assertNotNull(buffersSet);
 
     // Each slot's chunk has capacity BUFFER_SIZE/poolSize. Requesting PROCESSING_THREADS slices yields slices
     // of size (BUFFER_SIZE/poolSize)/PROCESSING_THREADS.
@@ -190,13 +190,13 @@ public class DartProcessingBuffersProviderTest
       final ResourceHolder<ProcessingBuffers> buffersHolder = buffersSet.acquire(PROCESSING_THREADS);
       try {
         final ProcessingBuffers buffers = buffersHolder.get();
-        Assert.assertEquals(PROCESSING_THREADS, buffers.getBouncer().getMaxCount());
+        Assertions.assertEquals(PROCESSING_THREADS, buffers.getBouncer().getMaxCount());
 
         final int expectedSliceSize = BUFFER_SIZE / poolSize / PROCESSING_THREADS;
         final List<ResourceHolder<ByteBuffer>> resourceHolders = new ArrayList<>();
         for (int j = 0; j < PROCESSING_THREADS; j++) {
           final ResourceHolder<ByteBuffer> sliceHolder = buffers.getBufferPool().take();
-          Assert.assertEquals(expectedSliceSize, sliceHolder.get().capacity());
+          Assertions.assertEquals(expectedSliceSize, sliceHolder.get().capacity());
           resourceHolders.add(sliceHolder);
         }
         for (final ResourceHolder<ByteBuffer> resourceHolder : resourceHolders) {
@@ -217,12 +217,12 @@ public class DartProcessingBuffersProviderTest
     when(mockMergeBufferPool.takeBatch(eq(1), eq(TIMEOUT_MILLIS)))
         .thenReturn(Collections.emptyList());
 
-    MSQException exception = Assert.assertThrows(
+    MSQException exception = Assertions.assertThrows(
         MSQException.class,
         () -> provider.acquire(1, TIMEOUT_MILLIS)
     );
 
-    Assert.assertTrue(exception.getFault() instanceof CanceledFault);
-    Assert.assertEquals("Canceled", exception.getFault().getErrorCode());
+    Assertions.assertTrue(exception.getFault() instanceof CanceledFault);
+    Assertions.assertEquals("Canceled", exception.getFault().getErrorCode());
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/dart/worker/DartWorkerClientImplTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/dart/worker/DartWorkerClientImplTest.java
@@ -26,8 +26,6 @@ import org.apache.druid.rpc.ServiceClient;
 import org.apache.druid.rpc.ServiceClientFactoryImpl;
 import org.apache.druid.rpc.ServiceClosedException;
 import org.apache.druid.segment.TestHelper;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -119,6 +117,6 @@ public class DartWorkerClientImplTest
         () -> workerClient.stopWorker(WORKER_ID.toString()).get()
     );
 
-    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(ServiceClosedException.class));
+    Assertions.assertInstanceOf(ServiceClosedException.class, e.getCause());
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/dart/worker/DartWorkerRunnerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/dart/worker/DartWorkerRunnerTest.java
@@ -26,6 +26,7 @@ import org.apache.druid.discovery.DruidNodeDiscovery;
 import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
 import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.error.DruidException;
+import org.apache.druid.error.ThrowableMatcher;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.concurrent.Execs;
@@ -37,15 +38,13 @@ import org.apache.druid.msq.exec.WorkerImpl;
 import org.apache.druid.query.QueryContext;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.security.AuthorizerMapper;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -54,7 +53,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -79,8 +77,8 @@ public class DartWorkerRunnerTest
   private DartWorkerRunner workerRunner;
   private AutoCloseable mockCloser;
 
-  @TempDir
-  public Path temporaryFolder;
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   @Mock
   private DartWorkerContextFactory workerFactory;
@@ -110,7 +108,7 @@ public class DartWorkerRunnerTest
         discoveryProvider,
         new DartResourcePermissionMapper(),
         authorizerMapper,
-        temporaryFolder.toFile()
+        temporaryFolder.getRoot()
     );
 
     // "discoveryProvider" provides "discovery".
@@ -121,7 +119,7 @@ public class DartWorkerRunnerTest
         workerFactory.build(
             QUERY_ID,
             CONTROLLER_SERVER_HOST,
-            temporaryFolder.toFile(),
+            temporaryFolder.getRoot(),
             QueryContext.empty()
         )
     ).thenReturn(workerContext);
@@ -169,15 +167,15 @@ public class DartWorkerRunnerTest
     workerRunner.stop();
 
     // Create an empty directory "x".
-    FileUtils.mkdirp(new File(temporaryFolder.toFile(), "x"));
+    FileUtils.mkdirp(new File(temporaryFolder.getRoot(), "x"));
     Assertions.assertArrayEquals(
-        new File[]{new File(temporaryFolder.toFile(), "x")},
-        temporaryFolder.toFile().listFiles()
+        new File[]{new File(temporaryFolder.getRoot(), "x")},
+        temporaryFolder.getRoot().listFiles()
     );
 
     // Run "createAndCleanTempDirectory", which will delete it.
     workerRunner.createAndCleanTempDirectory();
-    Assertions.assertArrayEquals(new File[]{}, temporaryFolder.toFile().listFiles());
+    Assertions.assertArrayEquals(new File[]{}, temporaryFolder.getRoot().listFiles());
   }
 
   @Test
@@ -188,11 +186,9 @@ public class DartWorkerRunnerTest
         () -> workerRunner.startWorker("abc", CONTROLLER_SERVER_HOST, QueryContext.empty())
     );
 
-    MatcherAssert.assertThat(
-        e,
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
-            "Received startWorker request for unknown controller"))
-    );
+    ThrowableMatcher.of(DruidException.class)
+                   .expectMessageContains("Received startWorker request for unknown controller")
+                   .assertThat(e);
   }
 
   @Test

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/ControllerHolderTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/ControllerHolderTest.java
@@ -35,12 +35,13 @@ import org.apache.druid.msq.indexing.report.MSQTaskReportPayload;
 import org.apache.druid.msq.test.NoopQueryListener;
 import org.apache.druid.query.QueryContext;
 import org.apache.druid.query.QueryContexts;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -54,7 +55,7 @@ public class ControllerHolderTest
   private static final Logger log = new Logger(ControllerHolderTest.class);
   private ControllerThreadPool controllerThreadPool;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     controllerThreadPool = new ControllerThreadPool(
@@ -65,7 +66,7 @@ public class ControllerHolderTest
     );
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws InterruptedException
   {
     final ListeningExecutorService exec = controllerThreadPool.getRunExecutorService();
@@ -118,8 +119,8 @@ public class ControllerHolderTest
       // ignore
     }
 
-    Assert.assertTrue("Controller should have been interrupted", wasInterrupted.get());
-    Assert.assertEquals(ControllerHolder.State.CANCELED, holder.getState());
+    Assertions.assertTrue(wasInterrupted.get(), "Controller should have been interrupted");
+    Assertions.assertEquals(ControllerHolder.State.CANCELED, holder.getState());
   }
 
   @Test
@@ -160,7 +161,7 @@ public class ControllerHolderTest
     holder.cancel(CancellationReason.USER_REQUEST, null);
     controllerFinished.await();
 
-    Assert.assertTrue("stop() should have been called as failsafe", stopCalled.get());
+    Assertions.assertTrue(stopCalled.get(), "stop() should have been called as failsafe");
   }
 
   @Test
@@ -202,7 +203,7 @@ public class ControllerHolderTest
     holder.cancel(CancellationReason.UNKNOWN, cause);
     controllerFinished.await();
 
-    Assert.assertSame("stop() should have received the cause", cause, stopCause.get());
+    Assertions.assertSame(cause, stopCause.get(), "stop() should have received the cause");
   }
 
   @Test
@@ -221,7 +222,7 @@ public class ControllerHolderTest
     final ListenableFuture<?> future = holder.runAsync(new NoopQueryListener(), null, controllerThreadPool);
     future.get(5, TimeUnit.SECONDS);
 
-    Assert.assertEquals(ControllerHolder.State.SUCCESS, holder.getState());
+    Assertions.assertEquals(ControllerHolder.State.SUCCESS, holder.getState());
   }
 
   @Test
@@ -242,13 +243,13 @@ public class ControllerHolderTest
 
     // Cancel before run
     holder.cancel(CancellationReason.USER_REQUEST, null);
-    Assert.assertEquals(ControllerHolder.State.CANCELED, holder.getState());
+    Assertions.assertEquals(ControllerHolder.State.CANCELED, holder.getState());
 
     // Run should complete quickly without running the controller
     final ListenableFuture<?> future = holder.runAsync(new NoopQueryListener(), null, controllerThreadPool);
     future.get(5, TimeUnit.SECONDS);
 
-    Assert.assertFalse("Controller should not have run", controllerRan.get());
+    Assertions.assertFalse(controllerRan.get(), "Controller should not have run");
   }
 
   @Test
@@ -285,7 +286,7 @@ public class ControllerHolderTest
     holder.cancel(CancellationReason.USER_REQUEST, null);
     controllerFinished.await();
 
-    Assert.assertEquals(ControllerHolder.State.CANCELED, holder.getState());
+    Assertions.assertEquals(ControllerHolder.State.CANCELED, holder.getState());
   }
 
   @Test
@@ -304,11 +305,11 @@ public class ControllerHolderTest
     final ListenableFuture<?> future = holder.runAsync(new NoopQueryListener(), null, controllerThreadPool);
     future.get(5, TimeUnit.SECONDS);
 
-    Assert.assertEquals(ControllerHolder.State.SUCCESS, holder.getState());
+    Assertions.assertEquals(ControllerHolder.State.SUCCESS, holder.getState());
 
     // Cancel after completion — should be a no-op
     holder.cancel(CancellationReason.USER_REQUEST, null);
-    Assert.assertEquals(ControllerHolder.State.SUCCESS, holder.getState());
+    Assertions.assertEquals(ControllerHolder.State.SUCCESS, holder.getState());
   }
 
   @Test
@@ -335,7 +336,7 @@ public class ControllerHolderTest
     );
     future.get(5, TimeUnit.SECONDS);
 
-    Assert.assertEquals(ControllerHolder.State.SUCCESS, holder.getState());
+    Assertions.assertEquals(ControllerHolder.State.SUCCESS, holder.getState());
   }
 
   @Test
@@ -371,8 +372,8 @@ public class ControllerHolderTest
     final ListenableFuture<?> future = holder.runAsync(new NoopQueryListener(), registry, controllerThreadPool);
     future.get(5, TimeUnit.SECONDS);
 
-    Assert.assertTrue("Should have been registered", registered.get());
-    Assert.assertTrue("Should have been deregistered", deregistered.get());
+    Assertions.assertTrue(registered.get(), "Should have been registered");
+    Assertions.assertTrue(deregistered.get(), "Should have been deregistered");
   }
 
   @Test
@@ -405,7 +406,7 @@ public class ControllerHolderTest
     final ListenableFuture<?> future = holder.runAsync(new NoopQueryListener(), null, controllerThreadPool);
     future.get(30, TimeUnit.SECONDS);
 
-    Assert.assertEquals(ControllerHolder.State.CANCELED, holder.getState());
+    Assertions.assertEquals(ControllerHolder.State.CANCELED, holder.getState());
   }
 
   private static MSQTaskReportPayload makeSuccessReport()

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/ControllerImplTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/ControllerImplTest.java
@@ -28,18 +28,16 @@ import org.apache.druid.msq.indexing.error.InsertLockPreemptedFault;
 import org.apache.druid.msq.indexing.error.MSQException;
 import org.apache.druid.msq.kernel.StageDefinition;
 import org.apache.druid.msq.kernel.StageId;
-import org.easymock.EasyMock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 import java.util.Collections;
-
-import static org.mockito.Mockito.doReturn;
 
 public class ControllerImplTest
 {
@@ -51,12 +49,12 @@ public class ControllerImplTest
   private AutoCloseable mocks;
 
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mocks = MockitoAnnotations.openMocks(this);
-    doReturn(StageId.fromString("1_1")).when(stageDefinition).getId();
-    doReturn(clusterBy).when(stageDefinition).getClusterBy();
+    Mockito.doReturn(StageId.fromString("1_1")).when(stageDefinition).getId();
+    Mockito.doReturn(clusterBy).when(stageDefinition).getClusterBy();
 
   }
 
@@ -66,13 +64,12 @@ public class ControllerImplTest
     final SegmentTransactionalInsertAction action =
         SegmentTransactionalInsertAction.appendAction(Collections.emptySet(), null, null, null, null, null);
 
-    final TaskActionClient taskActionClient = EasyMock.mock(TaskActionClient.class);
-    EasyMock.expect(taskActionClient.submit(action)).andReturn(SegmentPublishResult.ok(Collections.emptySet()));
-    EasyMock.replay(taskActionClient);
+    final TaskActionClient taskActionClient = Mockito.mock(TaskActionClient.class);
+    Mockito.when(taskActionClient.submit(action)).thenReturn(SegmentPublishResult.ok(Collections.emptySet()));
 
     // All OK.
     ControllerImpl.performSegmentPublish(taskActionClient, action);
-    EasyMock.verify(taskActionClient);
+    Mockito.verify(taskActionClient).submit(action);
   }
 
   @Test
@@ -81,17 +78,16 @@ public class ControllerImplTest
     final SegmentTransactionalInsertAction action =
         SegmentTransactionalInsertAction.appendAction(Collections.emptySet(), null, null, null, null, null);
 
-    final TaskActionClient taskActionClient = EasyMock.mock(TaskActionClient.class);
-    EasyMock.expect(taskActionClient.submit(action)).andReturn(SegmentPublishResult.fail("oops"));
-    EasyMock.replay(taskActionClient);
+    final TaskActionClient taskActionClient = Mockito.mock(TaskActionClient.class);
+    Mockito.when(taskActionClient.submit(action)).thenReturn(SegmentPublishResult.fail("oops"));
 
-    final MSQException e = Assert.assertThrows(
+    final MSQException e = Assertions.assertThrows(
         MSQException.class,
         () -> ControllerImpl.performSegmentPublish(taskActionClient, action)
     );
 
-    Assert.assertEquals(InsertLockPreemptedFault.instance(), e.getFault());
-    EasyMock.verify(taskActionClient);
+    Assertions.assertEquals(InsertLockPreemptedFault.instance(), e.getFault());
+    Mockito.verify(taskActionClient).submit(action);
   }
 
   @Test
@@ -100,17 +96,16 @@ public class ControllerImplTest
     final SegmentTransactionalInsertAction action =
         SegmentTransactionalInsertAction.appendAction(Collections.emptySet(), null, null, null, null, null);
 
-    final TaskActionClient taskActionClient = EasyMock.mock(TaskActionClient.class);
-    EasyMock.expect(taskActionClient.submit(action)).andThrow(new ISE("oops"));
-    EasyMock.replay(taskActionClient);
+    final TaskActionClient taskActionClient = Mockito.mock(TaskActionClient.class);
+    Mockito.when(taskActionClient.submit(action)).thenThrow(new ISE("oops"));
 
-    final ISE e = Assert.assertThrows(
+    final ISE e = Assertions.assertThrows(
         ISE.class,
         () -> ControllerImpl.performSegmentPublish(taskActionClient, action)
     );
 
-    Assert.assertEquals("oops", e.getMessage());
-    EasyMock.verify(taskActionClient);
+    Assertions.assertEquals("oops", e.getMessage());
+    Mockito.verify(taskActionClient).submit(action);
   }
 
   @Test
@@ -119,17 +114,16 @@ public class ControllerImplTest
     final SegmentTransactionalInsertAction action =
         SegmentTransactionalInsertAction.appendAction(Collections.emptySet(), null, null, null, null, null);
 
-    final TaskActionClient taskActionClient = EasyMock.mock(TaskActionClient.class);
-    EasyMock.expect(taskActionClient.submit(action)).andThrow(new ISE("are not covered by locks"));
-    EasyMock.replay(taskActionClient);
+    final TaskActionClient taskActionClient = Mockito.mock(TaskActionClient.class);
+    Mockito.when(taskActionClient.submit(action)).thenThrow(new ISE("are not covered by locks"));
 
-    final MSQException e = Assert.assertThrows(
+    final MSQException e = Assertions.assertThrows(
         MSQException.class,
         () -> ControllerImpl.performSegmentPublish(taskActionClient, action)
     );
 
-    Assert.assertEquals(InsertLockPreemptedFault.instance(), e.getFault());
-    EasyMock.verify(taskActionClient);
+    Assertions.assertEquals(InsertLockPreemptedFault.instance(), e.getFault());
+    Mockito.verify(taskActionClient).submit(action);
   }
 
 
@@ -137,12 +131,12 @@ public class ControllerImplTest
   public void test_belowThresholds_ShouldBeParallel()
   {
     // Cluster by bucket count not 0
-    doReturn(1).when(clusterBy).getBucketByCount();
+    Mockito.doReturn(1).when(clusterBy).getBucketByCount();
 
     // Worker count below threshold
-    doReturn(1).when(stageDefinition).getMaxWorkerCount();
+    Mockito.doReturn(1).when(stageDefinition).getMaxWorkerCount();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ClusterStatisticsMergeMode.PARALLEL,
         ControllerImpl.finalizeClusterStatisticsMergeMode(
             stageDefinition,
@@ -157,12 +151,12 @@ public class ControllerImplTest
   {
 
     // Cluster by bucket count 0
-    doReturn(ClusterBy.none()).when(stageDefinition).getClusterBy();
+    Mockito.doReturn(ClusterBy.none()).when(stageDefinition).getClusterBy();
 
     // Worker count above threshold
-    doReturn((int) Limits.MAX_WORKERS_FOR_PARALLEL_MERGE + 1).when(stageDefinition).getMaxWorkerCount();
+    Mockito.doReturn((int) Limits.MAX_WORKERS_FOR_PARALLEL_MERGE + 1).when(stageDefinition).getMaxWorkerCount();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ClusterStatisticsMergeMode.PARALLEL,
         ControllerImpl.finalizeClusterStatisticsMergeMode(
             stageDefinition,
@@ -176,12 +170,12 @@ public class ControllerImplTest
   public void test_numWorkersAboveThreshold_shouldBeSequential()
   {
     // Cluster by bucket count not 0
-    doReturn(1).when(clusterBy).getBucketByCount();
+    Mockito.doReturn(1).when(clusterBy).getBucketByCount();
 
     // Worker count above threshold
-    doReturn((int) Limits.MAX_WORKERS_FOR_PARALLEL_MERGE + 1).when(stageDefinition).getMaxWorkerCount();
+    Mockito.doReturn((int) Limits.MAX_WORKERS_FOR_PARALLEL_MERGE + 1).when(stageDefinition).getMaxWorkerCount();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ClusterStatisticsMergeMode.SEQUENTIAL,
         ControllerImpl.finalizeClusterStatisticsMergeMode(
             stageDefinition,
@@ -195,17 +189,17 @@ public class ControllerImplTest
   public void test_mode_should_not_change()
   {
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ClusterStatisticsMergeMode.SEQUENTIAL,
         ControllerImpl.finalizeClusterStatisticsMergeMode(null, ClusterStatisticsMergeMode.SEQUENTIAL)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ClusterStatisticsMergeMode.PARALLEL,
         ControllerImpl.finalizeClusterStatisticsMergeMode(null, ClusterStatisticsMergeMode.PARALLEL)
     );
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception
   {
     mocks.close();

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/ControllerMemoryParametersTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/ControllerMemoryParametersTest.java
@@ -23,8 +23,8 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.druid.msq.indexing.error.MSQException;
 import org.apache.druid.msq.indexing.error.NotEnoughMemoryFault;
 import org.apache.druid.sql.calcite.util.TestLookupProvider;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ControllerMemoryParametersTest
 {
@@ -40,7 +40,7 @@ public class ControllerMemoryParametersTest
         WorkerMemoryParameters.DEFAULT_FRAME_SIZE
     );
 
-    Assert.assertEquals(101_400_000, memoryParameters.getPartitionStatisticsMaxRetainedBytes());
+    Assertions.assertEquals(101_400_000, memoryParameters.getPartitionStatisticsMaxRetainedBytes());
   }
 
   @Test
@@ -52,7 +52,7 @@ public class ControllerMemoryParametersTest
         WorkerMemoryParameters.DEFAULT_FRAME_SIZE
     );
 
-    Assert.assertEquals(104_800_000, memoryParameters.getPartitionStatisticsMaxRetainedBytes());
+    Assertions.assertEquals(104_800_000, memoryParameters.getPartitionStatisticsMaxRetainedBytes());
   }
 
   @Test
@@ -64,7 +64,7 @@ public class ControllerMemoryParametersTest
         WorkerMemoryParameters.DEFAULT_FRAME_SIZE
     );
 
-    Assert.assertEquals(50_200_000, memoryParameters.getPartitionStatisticsMaxRetainedBytes());
+    Assertions.assertEquals(50_200_000, memoryParameters.getPartitionStatisticsMaxRetainedBytes());
   }
 
   @Test
@@ -76,13 +76,13 @@ public class ControllerMemoryParametersTest
         WorkerMemoryParameters.DEFAULT_FRAME_SIZE
     );
 
-    Assert.assertEquals(300_000_000, memoryParameters.getPartitionStatisticsMaxRetainedBytes());
+    Assertions.assertEquals(300_000_000, memoryParameters.getPartitionStatisticsMaxRetainedBytes());
   }
 
   @Test
   public void test_notEnoughMemory()
   {
-    final MSQException e = Assert.assertThrows(
+    final MSQException e = Assertions.assertThrows(
         MSQException.class,
         () -> ControllerMemoryParameters.createProductionInstance(
             makeMemoryIntrospector(30_000_000, 1),
@@ -92,10 +92,10 @@ public class ControllerMemoryParametersTest
     );
 
     final NotEnoughMemoryFault fault = (NotEnoughMemoryFault) e.getFault();
-    Assert.assertEquals(30_000_000, fault.getServerMemory());
-    Assert.assertEquals(1, fault.getServerWorkers());
-    Assert.assertEquals(NUM_PROCESSORS_IN_JVM, fault.getServerThreads());
-    Assert.assertEquals(24_000_000, fault.getUsableMemory());
+    Assertions.assertEquals(30_000_000, fault.getServerMemory());
+    Assertions.assertEquals(1, fault.getServerWorkers());
+    Assertions.assertEquals(NUM_PROCESSORS_IN_JVM, fault.getServerThreads());
+    Assertions.assertEquals(24_000_000, fault.getUsableMemory());
   }
 
   @Test
@@ -107,7 +107,7 @@ public class ControllerMemoryParametersTest
         WorkerMemoryParameters.DEFAULT_FRAME_SIZE
     );
 
-    Assert.assertEquals(26_000_000, memoryParameters.getPartitionStatisticsMaxRetainedBytes());
+    Assertions.assertEquals(26_000_000, memoryParameters.getPartitionStatisticsMaxRetainedBytes());
   }
 
   private MemoryIntrospector makeMemoryIntrospector(

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQExportTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQExportTest.java
@@ -28,7 +28,7 @@ import org.apache.druid.msq.util.MultiStageQueryContext;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.util.CalciteTests;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -77,14 +77,14 @@ public class MSQExportTest extends MSQTestBase
                      .setExpectedResultRows(ImmutableList.of())
                      .verifyResults();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2, // result file and manifest file
         Objects.requireNonNull(exportDir.listFiles()).length
     );
 
     File resultFile = new File(exportDir, "query-test-query-worker0-partition0.csv");
     List<String> results = readResultsFromFile(resultFile);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedFooFileContents(true),
         results
     );
@@ -109,7 +109,7 @@ public class MSQExportTest extends MSQTestBase
                      .setExpectedResultRows(ImmutableList.of())
                      .verifyResults();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2,
         Objects.requireNonNull(exportDir.listFiles()).length
     );
@@ -117,7 +117,7 @@ public class MSQExportTest extends MSQTestBase
 
     File resultFile = new File(exportDir, "query-test-query-worker0-partition0.csv");
     List<String> results = readResultsFromFile(resultFile);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedFoo2FileContents(true),
         results
     );
@@ -154,14 +154,14 @@ public class MSQExportTest extends MSQTestBase
                      .setExpectedResultRows(ImmutableList.of())
                      .verifyResults();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2, // result file and manifest file
         Objects.requireNonNull(exportDir.listFiles()).length
     );
 
     File resultFile = new File(exportDir, "query-test-query-worker0-partition0.csv");
     List<String> results = readResultsFromFile(resultFile);
-    Assert.assertEquals(expectedResultRows, results);
+    Assertions.assertEquals(expectedResultRows, results);
   }
 
   @MethodSource("data")
@@ -188,7 +188,7 @@ public class MSQExportTest extends MSQTestBase
                      .setExpectedResultRows(ImmutableList.of())
                      .verifyResults();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedFooFileContents(false).size() + 1, // + 1 for the manifest file
         Objects.requireNonNull(exportDir.listFiles()).length
     );
@@ -230,14 +230,14 @@ public class MSQExportTest extends MSQTestBase
                      .setExpectedResultRows(ImmutableList.of())
                      .verifyResults();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2, // result file and manifest file
         Objects.requireNonNull(exportDir.listFiles()).length
     );
 
     File resultFile = new File(exportDir, "query-test-query-worker0-partition0.csv");
     List<String> results = readResultsFromFile(resultFile);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             "a,b,c_json", "1,1,\"{\"\"c\"\":1}\"", "2,2,\"{\"\"c\"\":2}\""
         ),
@@ -282,14 +282,14 @@ public class MSQExportTest extends MSQTestBase
                      .setExpectedResultRows(ImmutableList.of())
                      .verifyResults();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2, // result file and manifest file
         Objects.requireNonNull(exportDir.listFiles()).length
     );
 
     File resultFile = new File(exportDir, "query-test-query-worker0-partition0.csv");
     List<String> results = readResultsFromFile(resultFile);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             "a,b,c_ds_hll", "1,b1,\"\"\"AgEHDAMIAQBa1y0L\"\"\"", "2,b2,\"\"\"AgEHDAMIAQCi6V0G\"\"\""
         ),
@@ -323,14 +323,14 @@ public class MSQExportTest extends MSQTestBase
                      .setExpectedResultRows(ImmutableList.of())
                      .verifyResults();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2, // result file and manifest file
         Objects.requireNonNull(exportDir.listFiles()).length
     );
 
     File resultFile = new File(exportDir, "query-test-query-worker0-partition0.csv");
     List<String> results = readResultsFromFile(resultFile);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             "cnt,dim"
         ),
@@ -402,21 +402,21 @@ public class MSQExportTest extends MSQTestBase
                      .setExpectedResultRows(ImmutableList.of())
                      .verifyResults();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             "cnt,dim1",
             "1,"
         ),
         readResultsFromFile(new File(exportDir, "query-test-query-worker0-partition0.csv"))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             "cnt,dim1",
             "1,10.1"
         ),
         readResultsFromFile(new File(exportDir, "query-test-query-worker0-partition1.csv"))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             "cnt,dim1",
             "1,2"
@@ -434,12 +434,12 @@ public class MSQExportTest extends MSQTestBase
         )
     ) {
       for (File file : resultFiles) {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             StringUtils.format("file:%s", file.getAbsolutePath()),
             bufferedReader.readLine()
         );
       }
-      Assert.assertNull(bufferedReader.readLine());
+      Assertions.assertNull(bufferedReader.readLine());
     }
 
     final File metaFile = new File(exportDir, ExportMetadataManager.META_FILE);
@@ -448,11 +448,11 @@ public class MSQExportTest extends MSQTestBase
             new InputStreamReader(Files.newInputStream(metaFile.toPath()), StringUtils.UTF8_STRING)
         )
     ) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           StringUtils.format("version: %s", ExportMetadataManager.MANIFEST_FILE_VERSION),
           bufferedReader.readLine()
       );
-      Assert.assertNull(bufferedReader.readLine());
+      Assertions.assertNull(bufferedReader.readLine());
     }
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQLoadedSegmentTests.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQLoadedSegmentTests.java
@@ -52,7 +52,7 @@ import org.apache.druid.sql.calcite.planner.ColumnMappings;
 import org.apache.druid.sql.calcite.util.CalciteTests;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.LinearShardSpec;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -167,7 +167,7 @@ public class MSQLoadedSegmentTests extends MSQTestBase
         invocationOnMock -> {
           ScanQuery query = invocationOnMock.getArgument(0);
           ScanQuery.verifyOrderByForNativeExecution(query);
-          Assert.assertEquals(Long.MAX_VALUE, query.getScanRowsLimit());
+          Assertions.assertEquals(Long.MAX_VALUE, query.getScanRowsLimit());
           return Futures.immediateFuture(
               new DataServerQueryResult<>(
                   ImmutableList.of(

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
@@ -91,7 +91,7 @@ import org.apache.druid.sql.calcite.planner.ColumnMapping;
 import org.apache.druid.sql.calcite.planner.ColumnMappings;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.apache.druid.sql.calcite.util.CalciteTests;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -2535,7 +2535,7 @@ public class MSQSelectTest extends MSQTestBase
       result.add(new Object[]{1});
     }
 
-    Assert.assertTrue(result.size() > Limits.MAX_SELECT_RESULT_ROWS);
+    Assertions.assertTrue(result.size() > Limits.MAX_SELECT_RESULT_ROWS);
 
     testSelectQuery()
         .setSql(StringUtils.format(

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQTasksTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQTasksTest.java
@@ -51,16 +51,14 @@ import org.apache.druid.msq.indexing.error.WorkerRpcFailedFault;
 import org.apache.druid.rpc.indexing.NoopOverlordClient;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.utils.CollectionUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.fail;
 
 public class MSQTasksTest
 {
@@ -72,7 +70,7 @@ public class MSQTasksTest
   @Test
   public void test_makeErrorReport_allNull()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         MSQErrorReport.fromFault(
             CONTROLLER_ID,
             CONTROLLER_HOST,
@@ -93,7 +91,7 @@ public class MSQTasksTest
         null
     );
 
-    Assert.assertEquals(controllerReport, MSQTasks.makeErrorReport(WORKER_ID, WORKER_HOST, controllerReport, null));
+    Assertions.assertEquals(controllerReport, MSQTasks.makeErrorReport(WORKER_ID, WORKER_HOST, controllerReport, null));
   }
 
   @Test
@@ -106,7 +104,7 @@ public class MSQTasksTest
         null
     );
 
-    Assert.assertEquals(workerReport, MSQTasks.makeErrorReport(WORKER_ID, WORKER_HOST, null, workerReport));
+    Assertions.assertEquals(workerReport, MSQTasks.makeErrorReport(WORKER_ID, WORKER_HOST, null, workerReport));
   }
 
   @Test
@@ -126,7 +124,7 @@ public class MSQTasksTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         controllerReport,
         MSQTasks.makeErrorReport(WORKER_ID, WORKER_HOST, controllerReport, workerReport)
     );
@@ -149,7 +147,7 @@ public class MSQTasksTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         workerReport,
         MSQTasks.makeErrorReport(WORKER_ID, WORKER_HOST, controllerReport, workerReport)
     );
@@ -172,7 +170,7 @@ public class MSQTasksTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         workerReport,
         MSQTasks.makeErrorReport(WORKER_ID, WORKER_HOST, controllerReport, workerReport)
     );
@@ -195,7 +193,7 @@ public class MSQTasksTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         workerReport,
         MSQTasks.makeErrorReport(WORKER_ID, WORKER_HOST, controllerReport, workerReport)
     );
@@ -205,19 +203,19 @@ public class MSQTasksTest
   @Test
   public void test_getWorkerFromTaskId()
   {
-    Assert.assertEquals(1, MSQTasks.workerFromTaskId("xxxx-worker1_0"));
-    Assert.assertEquals(10, MSQTasks.workerFromTaskId("xxxx-worker10_0"));
-    Assert.assertEquals(0, MSQTasks.workerFromTaskId("xxdsadxx-worker0_0"));
-    Assert.assertEquals(90, MSQTasks.workerFromTaskId("dx-worker90_0"));
-    Assert.assertEquals(9, MSQTasks.workerFromTaskId("12dsa1-worker9_0"));
+    Assertions.assertEquals(1, MSQTasks.workerFromTaskId("xxxx-worker1_0"));
+    Assertions.assertEquals(10, MSQTasks.workerFromTaskId("xxxx-worker10_0"));
+    Assertions.assertEquals(0, MSQTasks.workerFromTaskId("xxdsadxx-worker0_0"));
+    Assertions.assertEquals(90, MSQTasks.workerFromTaskId("dx-worker90_0"));
+    Assertions.assertEquals(9, MSQTasks.workerFromTaskId("12dsa1-worker9_0"));
 
-    Assert.assertThrows(ISE.class, () -> MSQTasks.workerFromTaskId("xxxx-worker-0"));
-    Assert.assertThrows(ISE.class, () -> MSQTasks.workerFromTaskId("worker-0"));
-    Assert.assertThrows(ISE.class, () -> MSQTasks.workerFromTaskId("xxxx-worker1-0"));
-    Assert.assertThrows(ISE.class, () -> MSQTasks.workerFromTaskId("xxxx-worker0-"));
-    Assert.assertThrows(ISE.class, () -> MSQTasks.workerFromTaskId("xxxx-worr1_0"));
-    Assert.assertThrows(ISE.class, () -> MSQTasks.workerFromTaskId("xxxx-worker-1-0"));
-    Assert.assertThrows(ISE.class, () -> MSQTasks.workerFromTaskId("xx"));
+    Assertions.assertThrows(ISE.class, () -> MSQTasks.workerFromTaskId("xxxx-worker-0"));
+    Assertions.assertThrows(ISE.class, () -> MSQTasks.workerFromTaskId("worker-0"));
+    Assertions.assertThrows(ISE.class, () -> MSQTasks.workerFromTaskId("xxxx-worker1-0"));
+    Assertions.assertThrows(ISE.class, () -> MSQTasks.workerFromTaskId("xxxx-worker0-"));
+    Assertions.assertThrows(ISE.class, () -> MSQTasks.workerFromTaskId("xxxx-worr1_0"));
+    Assertions.assertThrows(ISE.class, () -> MSQTasks.workerFromTaskId("xxxx-worker-1-0"));
+    Assertions.assertThrows(ISE.class, () -> MSQTasks.workerFromTaskId("xx"));
   }
 
   @Test
@@ -240,10 +238,10 @@ public class MSQTasksTest
     try {
       msqWorkerTaskLauncher.start();
       msqWorkerTaskLauncher.launchWorkersIfNeeded(numTasks);
-      fail();
+      Assertions.fail();
     }
     catch (Exception e) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           MSQFaultUtils.generateMessageWithErrorCode(new TaskStartTimeoutFault(5, numTasks + 1, 5000)),
           MSQFaultUtils.generateMessageWithErrorCode(((MSQException) e.getCause()).getFault())
       );
@@ -253,28 +251,28 @@ public class MSQTasksTest
   @Test
   public void test_getPrimaryTimestampFromObjectForInsert_longValue()
   {
-    Assert.assertEquals(100, MSQTasks.primaryTimestampFromObjectForInsert(100L));
+    Assertions.assertEquals(100, MSQTasks.primaryTimestampFromObjectForInsert(100L));
   }
 
   @Test
   public void test_getPrimaryTimestampFromObjectForInsert_nullValueShouldThrowError()
   {
-    final MSQException e = Assert.assertThrows(
+    final MSQException e = Assertions.assertThrows(
         MSQException.class,
         () -> MSQTasks.primaryTimestampFromObjectForInsert(null)
     );
-    Assert.assertEquals(InsertTimeNullFault.INSTANCE, e.getFault());
+    Assertions.assertEquals(InsertTimeNullFault.INSTANCE, e.getFault());
   }
 
   @Test
   public void test_getPrimaryTimestampFromObjectForInsert_DoubleValueShouldThrowError()
   {
     final Object timestamp = 1.693837200123456E15;
-    final MSQException e = Assert.assertThrows(
+    final MSQException e = Assertions.assertThrows(
         MSQException.class,
         () -> MSQTasks.primaryTimestampFromObjectForInsert(timestamp)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         UnknownFault.forMessage(
             StringUtils.format(
                 "Incorrect type for column [%s]. Expected LONG but got type [%s]. Please ensure that the value is cast to LONG.",

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/ProcessingBuffersSetTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/ProcessingBuffersSetTest.java
@@ -23,8 +23,8 @@ import com.google.common.collect.ImmutableList;
 import org.apache.druid.collections.ResourceHolder;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.utils.CloseableUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -35,12 +35,12 @@ public class ProcessingBuffersSetTest
   @Test
   public void test_empty_acquire()
   {
-    final DruidException e = Assert.assertThrows(
+    final DruidException e = Assertions.assertThrows(
         DruidException.class,
         () -> ProcessingBuffersSet.EMPTY.acquire(1)
     );
 
-    Assert.assertEquals("Processing buffers not available", e.getMessage());
+    Assertions.assertEquals("Processing buffers not available", e.getMessage());
   }
 
   @Test
@@ -64,17 +64,17 @@ public class ProcessingBuffersSetTest
     final ResourceHolder<ProcessingBuffers> holder2 = buffersSet.acquire(1);
     final ResourceHolder<ProcessingBuffers> holder3 = buffersSet.acquire(1);
 
-    Assert.assertNotNull(holder1.get());
-    Assert.assertNotNull(holder2.get());
-    Assert.assertNotNull(holder3.get());
+    Assertions.assertNotNull(holder1.get());
+    Assertions.assertNotNull(holder2.get());
+    Assertions.assertNotNull(holder3.get());
 
     // Verify each has a buffer pool and bouncer
-    Assert.assertNotNull(holder1.get().getBufferPool());
-    Assert.assertNotNull(holder1.get().getBouncer());
-    Assert.assertNotNull(holder2.get().getBufferPool());
-    Assert.assertNotNull(holder2.get().getBouncer());
-    Assert.assertNotNull(holder3.get().getBufferPool());
-    Assert.assertNotNull(holder3.get().getBouncer());
+    Assertions.assertNotNull(holder1.get().getBufferPool());
+    Assertions.assertNotNull(holder1.get().getBouncer());
+    Assertions.assertNotNull(holder2.get().getBufferPool());
+    Assertions.assertNotNull(holder2.get().getBouncer());
+    Assertions.assertNotNull(holder3.get().getBufferPool());
+    Assertions.assertNotNull(holder3.get().getBouncer());
 
     // Clean up
     CloseableUtils.closeAll(holder1, holder2, holder3);

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/QueryValidatorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/QueryValidatorTest.java
@@ -29,17 +29,14 @@ import org.apache.druid.msq.kernel.StageDefinitionBuilder;
 import org.apache.druid.msq.querykit.common.OffsetLimitStageProcessor;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 import java.util.stream.IntStream;
 
 public class QueryValidatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testValidQueryDefination()
@@ -54,42 +51,41 @@ public class QueryValidatorTest
   @Test
   public void testNegativeWorkers()
   {
-    expectedException.expect(ISE.class);
-    expectedException.expectMessage("Number of workers must be greater than 0");
-    QueryValidator.validateQueryDef(createQueryDefinition(1, -1));
+    Throwable exception = Assertions.assertThrows(ISE.class, () ->
+      QueryValidator.validateQueryDef(createQueryDefinition(1, -1)));
+    Assertions.assertTrue(exception.getMessage().contains("Number of workers must be greater than 0"));
   }
 
   @Test
   public void testZeroWorkers()
   {
-    expectedException.expect(ISE.class);
-    expectedException.expectMessage("Number of workers must be greater than 0");
-    QueryValidator.validateQueryDef(createQueryDefinition(1, 0));
+    Throwable exception = Assertions.assertThrows(ISE.class, () ->
+      QueryValidator.validateQueryDef(createQueryDefinition(1, 0)));
+    Assertions.assertTrue(exception.getMessage().contains("Number of workers must be greater than 0"));
   }
 
   @Test
   public void testGreaterThanMaxWorkers()
   {
-    expectedException.expect(MSQException.class);
-    expectedException.expectMessage(
-        StringUtils.format(
-            "Too many workers (current = %d; max = %d)",
-            Limits.MAX_WORKERS + 1,
-            Limits.MAX_WORKERS
-        ));
-    QueryValidator.validateQueryDef(createQueryDefinition(1, Limits.MAX_WORKERS + 1));
+    Throwable exception = Assertions.assertThrows(MSQException.class, () ->
+      QueryValidator.validateQueryDef(createQueryDefinition(1, Limits.MAX_WORKERS + 1)));
+    Assertions.assertTrue(exception.getMessage().contains(StringUtils.format(
+        "Too many workers (current = %d; max = %d)",
+        Limits.MAX_WORKERS + 1,
+        Limits.MAX_WORKERS
+    )));
   }
 
   @Test
   public void testGreaterThanMaxColumns()
   {
-    expectedException.expect(MSQException.class);
-    expectedException.expectMessage(StringUtils.format(
+    Throwable exception = Assertions.assertThrows(MSQException.class, () ->
+      QueryValidator.validateQueryDef(createQueryDefinition(Limits.MAX_FRAME_COLUMNS + 1, 1)));
+    Assertions.assertTrue(exception.getMessage().contains(StringUtils.format(
         "Too many output columns (requested = %d, max = %d)",
         Limits.MAX_FRAME_COLUMNS + 1,
         Limits.MAX_FRAME_COLUMNS
-    ));
-    QueryValidator.validateQueryDef(createQueryDefinition(Limits.MAX_FRAME_COLUMNS + 1, 1));
+    )));
   }
 
   public static QueryDefinition createQueryDefinition(int numColumns, int numWorkers)

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/ResultsContextSerdeTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/ResultsContextSerdeTest.java
@@ -47,9 +47,9 @@ import org.apache.druid.sql.calcite.schema.ViewSchema;
 import org.apache.druid.sql.calcite.util.CalciteTests;
 import org.apache.druid.sql.hook.DruidHookDispatcher;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -58,7 +58,7 @@ public class ResultsContextSerdeTest
   private ResultsContext resultsContext;
   private ObjectMapper objectMapper;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     final PlannerToolbox toolbox = new PlannerToolbox(
@@ -110,6 +110,6 @@ public class ResultsContextSerdeTest
     String s = objectMapper.writeValueAsString(resultsContext);
 
     ResultsContext deserialized = objectMapper.readValue(s, ResultsContext.class);
-    Assert.assertEquals(resultsContext, deserialized);
+    Assertions.assertEquals(resultsContext, deserialized);
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/RunWorkOrderTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/RunWorkOrderTest.java
@@ -24,8 +24,8 @@ import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.msq.counters.CounterTracker;
 import org.apache.druid.msq.indexing.error.MSQException;
 import org.apache.druid.msq.kernel.WorkOrder;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -97,7 +97,7 @@ public class RunWorkOrderTest
 
     final ISE exception = new ISE("oops");
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalStateException.class,
         () -> runWorkOrder.stop(exception)
     );
@@ -138,7 +138,7 @@ public class RunWorkOrderTest
             listener
         );
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalStateException.class,
         () -> runWorkOrder.stop(null)
     );
@@ -176,7 +176,7 @@ public class RunWorkOrderTest
             listener
         );
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalStateException.class,
         () -> runWorkOrder.stop(null)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/SegmentLoadStatusFetcherTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/SegmentLoadStatusFetcherTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.query.http.ClientSqlQuery;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -186,10 +186,10 @@ public class SegmentLoadStatusFetcherTest
     // call close from main thread
     segmentLoadWaiter.close();
     t.join(1000);
-    Assert.assertFalse(t.isAlive());
+    Assertions.assertFalse(t.isAlive());
 
-    Assert.assertTrue(segmentLoadWaiter.status().getState().isFinished());
-    Assert.assertTrue(segmentLoadWaiter.status().getState() == SegmentLoadStatusFetcher.State.FAILED);
+    Assertions.assertTrue(segmentLoadWaiter.status().getState().isFinished());
+    Assertions.assertTrue(segmentLoadWaiter.status().getState() == SegmentLoadStatusFetcher.State.FAILED);
   }
 
   private static DataSegment createTestDataSegment(String version, int partitionNumber)

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/WorkerImplTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/WorkerImplTest.java
@@ -23,8 +23,8 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.druid.msq.kernel.WorkOrder;
 import org.apache.druid.msq.util.MultiStageQueryContext;
 import org.apache.druid.query.QueryContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
@@ -45,7 +45,7 @@ public class WorkerImplTest
         ImmutableMap.of("foo", "bar")
     );
 
-    Assert.assertSame(
+    Assertions.assertSame(
         workOrder,
         WorkerImpl.makeWorkOrderToUse(
             workOrder,
@@ -71,7 +71,7 @@ public class WorkerImplTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkOrder(
             workOrder.getQueryDefinition(),
             workOrder.getStageNumber(),

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/WorkerMemoryParametersTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/WorkerMemoryParametersTest.java
@@ -33,8 +33,8 @@ import org.apache.druid.msq.input.stage.ReadablePartitions;
 import org.apache.druid.msq.input.stage.StageInputSlice;
 import org.apache.druid.msq.kernel.GlobalSortTargetSizeShuffleSpec;
 import org.apache.druid.msq.kernel.ShuffleSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -53,7 +53,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(973_000_000, frameSize, 1, 874, 97_300_000, 0),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 1, 1)
     );
@@ -73,7 +73,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.singleton(1);
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(673_000_000, frameSize, 1, 604, 67_300_000, 200_000_000),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 1, 1)
     );
@@ -90,7 +90,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(892_000_000, frameSize, 4, 199, 89_200_000, 0),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 1, 1)
     );
@@ -110,7 +110,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.singleton(1);
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(592_000_000, frameSize, 4, 132, 59_200_000, 200_000_000),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 1, 1)
     );
@@ -127,7 +127,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = null;
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(892_000_000, frameSize, 4, 222, 0, 0),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 1, 1)
     );
@@ -144,7 +144,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(392_000_000, frameSize, 4, 87, 39_200_000, 0),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 2, 1)
     );
@@ -161,7 +161,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(2_392_000_000L, frameSize, 4, 537, 239_200_000, 0),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 2, 1)
     );
@@ -178,7 +178,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(136_000_000, frameSize, 32, 2, 13_600_000, 0),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 1, 1)
     );
@@ -195,7 +195,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(109_000_000, frameSize, 32, 2, 10_900_000, 0),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 1, 1)
     );
@@ -212,7 +212,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    final MSQException e = Assert.assertThrows(
+    final MSQException e = Assertions.assertThrows(
         MSQException.class,
         () -> WorkerMemoryParameters.createInstance(
             memoryIntrospector,
@@ -225,7 +225,7 @@ public class WorkerMemoryParametersTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new NotEnoughMemoryFault(1_366_250_000, 1_250_000_000, 1_000_000_000, 1, 40, 1, 1),
         e.getFault()
     );
@@ -244,7 +244,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    final MSQException e = Assert.assertThrows(
+    final MSQException e = Assertions.assertThrows(
         MSQException.class,
         () -> WorkerMemoryParameters.createInstance(
             memoryIntrospector,
@@ -257,7 +257,7 @@ public class WorkerMemoryParametersTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new NotEnoughMemoryFault(1_366_250_000, 1_366_249_999, 1_092_999_999, 1, 40, 1, 1),
         e.getFault()
     );
@@ -275,7 +275,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(13_000_000, frameSize, 1, 2, 10_000_000, 0),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 1, 1)
     );
@@ -292,7 +292,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    final MSQException e = Assert.assertThrows(
+    final MSQException e = Assertions.assertThrows(
         MSQException.class,
         () -> WorkerMemoryParameters.createInstance(
             memoryIntrospector,
@@ -305,7 +305,7 @@ public class WorkerMemoryParametersTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new NotEnoughMemoryFault(2_732_500_000L, 1_250_000_000, 1_000_000_000, 1, 40, 1, 2),
         e.getFault()
     );
@@ -324,7 +324,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(13_000_000, frameSize, 1, 2, 10_000_000, 0),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 2, 1)
     );
@@ -341,7 +341,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(1_096_000_000, frameSize, 4, 245, 109_600_000, 0),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 1, 1)
     );
@@ -358,7 +358,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(1_548_000_000, frameSize, 4, 347, 154_800_000, 0),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 1, 1)
     );
@@ -375,7 +375,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(96_000_000, frameSize, 4, 20, 10_000_000, 0),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 2, 1)
     );
@@ -392,7 +392,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(1_762_666_666, frameSize, 64, 23, 176_266_666, 0),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 1, 1)
     );
@@ -409,7 +409,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(429_333_333, frameSize, 64, 5, 42_933_333, 0),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 2, 1)
     );
@@ -427,7 +427,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(448_000_000, frameSize, 2, 200, 44_800_000, 0),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 2, 1)
     );
@@ -445,7 +445,7 @@ public class WorkerMemoryParametersTest
     final IntSet broadcastInputs = IntSets.emptySet();
     final ShuffleSpec shuffleSpec = makeSortShuffleSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new WorkerMemoryParameters(974_000_000, frameSize, 1, 875, 97_400_000, 0),
         WorkerMemoryParameters.createInstance(memoryIntrospector, frameSize, slices, broadcastInputs, shuffleSpec, 1, 1)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/WorkerRunRefTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/WorkerRunRefTest.java
@@ -30,10 +30,10 @@ import org.apache.druid.msq.counters.CounterSnapshotsTree;
 import org.apache.druid.msq.kernel.StageId;
 import org.apache.druid.msq.kernel.WorkOrder;
 import org.apache.druid.msq.statistics.ClusterByStatisticsSnapshot;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.util.concurrent.CountDownLatch;
@@ -46,13 +46,13 @@ public class WorkerRunRefTest
   private static final Logger log = new Logger(WorkerRunRefTest.class);
   private ListeningExecutorService exec;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     exec = MoreExecutors.listeningDecorator(Execs.multiThreaded(2, "worker-run-ref-test-%s"));
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws InterruptedException
   {
     exec.shutdownNow();
@@ -111,9 +111,9 @@ public class WorkerRunRefTest
     // it returns immediately (even when the worker is still running).
     workerFinished.await();
 
-    Assert.assertTrue("Future should be done", future.isDone());
-    Assert.assertFalse("Future should not be canceled", future.isCancelled());
-    Assert.assertTrue("Worker should have been interrupted", wasInterrupted.get());
+    Assertions.assertTrue(future.isDone(), "Future should be done");
+    Assertions.assertFalse(future.isCancelled(), "Future should not be canceled");
+    Assertions.assertTrue(wasInterrupted.get(), "Worker should have been interrupted");
 
     // awaitStop should return immediately since the worker is done
     runRef.awaitStop();
@@ -148,8 +148,8 @@ public class WorkerRunRefTest
     }
 
     // Future should be done and not canceled
-    Assert.assertTrue("Future should be done", future.isDone());
-    Assert.assertFalse("Future should not be canceled", future.isCancelled());
+    Assertions.assertTrue(future.isDone(), "Future should be done");
+    Assertions.assertFalse(future.isCancelled(), "Future should not be canceled");
 
     // awaitStop should return immediately since the worker is done
     runRef.awaitStop();
@@ -185,8 +185,8 @@ public class WorkerRunRefTest
     }
 
     // Future should be done and not canceled
-    Assert.assertTrue("Future should be done", future.isDone());
-    Assert.assertFalse("Future should not be canceled", future.isCancelled());
+    Assertions.assertTrue(future.isDone(), "Future should be done");
+    Assertions.assertFalse(future.isCancelled(), "Future should not be canceled");
 
     // awaitStop should not throw even though the worker failed
     runRef.awaitStop();
@@ -217,11 +217,11 @@ public class WorkerRunRefTest
 
     // Run should return a completed future
     final ListenableFuture<?> future = runRef.run(worker, exec);
-    Assert.assertTrue("Future should be done", future.isDone());
-    Assert.assertFalse("Future should not be canceled", future.isCancelled());
+    Assertions.assertTrue(future.isDone(), "Future should be done");
+    Assertions.assertFalse(future.isCancelled(), "Future should not be canceled");
 
     // Worker should not have run
-    Assert.assertEquals(1, workerStarted.getCount());
+    Assertions.assertEquals(1, workerStarted.getCount());
   }
 
   @Test
@@ -247,7 +247,7 @@ public class WorkerRunRefTest
     runRef.run(worker, exec);
 
     // Second run should throw
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> runRef.run(worker, exec)
     );
@@ -259,7 +259,7 @@ public class WorkerRunRefTest
     final WorkerRunRef runRef = new WorkerRunRef();
 
     // awaitStop without run should throw
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         runRef::awaitStop
     );
@@ -302,7 +302,7 @@ public class WorkerRunRefTest
     runRef.cancel();
     workerFinished.await();
 
-    Assert.assertTrue(stopCalled.get());
+    Assertions.assertTrue(stopCalled.get());
   }
 
   @Test
@@ -327,12 +327,12 @@ public class WorkerRunRefTest
     final WorkerRunRef runRef = new WorkerRunRef();
     runRef.cancel();
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         ExecutionException.class,
         () -> runRef.run(worker, exec).get()
     );
 
-    Assert.assertFalse(stopCalled.get());
+    Assertions.assertFalse(stopCalled.get());
   }
 
   /**

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/WorkerSketchFetcherTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/WorkerSketchFetcherTest.java
@@ -30,10 +30,10 @@ import org.apache.druid.msq.kernel.controller.ControllerQueryKernel;
 import org.apache.druid.msq.rpc.SketchEncoding;
 import org.apache.druid.msq.statistics.ClusterByStatisticsSnapshot;
 import org.apache.druid.msq.statistics.CompleteKeyStatisticsInformation;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -72,7 +72,7 @@ public class WorkerSketchFetcherTest
   private static final String TASK_2 = "task-worker2_1";
   private static final List<String> TASK_IDS = ImmutableList.of(TASK_0, TASK_1, TASK_2);
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mocks = MockitoAnnotations.openMocks(this);
@@ -87,7 +87,7 @@ public class WorkerSketchFetcherTest
     doReturn(true).when(workerManager).isWorkerActive(any());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception
   {
     mocks.close();
@@ -115,7 +115,7 @@ public class WorkerSketchFetcherTest
       latch.countDown();
     }, stageDefinition.getId(), ImmutableSet.copyOf(TASK_IDS), ((queryKernel, integer, msqFault) -> {}));
 
-    Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
+    Assertions.assertTrue(latch.await(5, TimeUnit.SECONDS));
 
   }
 
@@ -144,7 +144,7 @@ public class WorkerSketchFetcherTest
         ((queryKernel, integer, msqFault) -> {})
     );
 
-    Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
+    Assertions.assertTrue(latch.await(5, TimeUnit.SECONDS));
 
   }
 
@@ -154,7 +154,7 @@ public class WorkerSketchFetcherTest
 
     doReturn(false).when(completeKeyStatisticsInformation).isComplete();
     target = spy(new WorkerSketchFetcher(workerClient, workerManager, true, SketchEncoding.OCTET_STREAM));
-    Assert.assertThrows(ISE.class, () -> target.sequentialTimeChunkMerging(
+    Assertions.assertThrows(ISE.class, () -> target.sequentialTimeChunkMerging(
         (ignore) -> {},
         completeKeyStatisticsInformation,
         stageDefinition.getId(),
@@ -187,8 +187,8 @@ public class WorkerSketchFetcherTest
         })
     );
 
-    Assert.assertTrue(latch.await(500, TimeUnit.SECONDS));
-    Assert.assertTrue(retryLatch.await(500, TimeUnit.SECONDS));
+    Assertions.assertTrue(latch.await(500, TimeUnit.SECONDS));
+    Assertions.assertTrue(retryLatch.await(500, TimeUnit.SECONDS));
   }
 
   @Test
@@ -216,8 +216,8 @@ public class WorkerSketchFetcherTest
         })
     );
 
-    Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
-    Assert.assertTrue(retryLatch.await(5, TimeUnit.SECONDS));
+    Assertions.assertTrue(latch.await(5, TimeUnit.SECONDS));
+    Assertions.assertTrue(retryLatch.await(5, TimeUnit.SECONDS));
   }
 
   @Test
@@ -239,13 +239,13 @@ public class WorkerSketchFetcherTest
       );
     }
     catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Task fetch failed"));
+      Assertions.assertTrue(e.getMessage().contains("Task fetch failed"));
     }
 
     while (!target.executorService.isShutdown()) {
       Thread.sleep(100);
     }
-    Assert.assertTrue((target.getError().getMessage().contains("Task fetch failed")));
+    Assertions.assertTrue((target.getError().getMessage().contains("Task fetch failed")));
 
   }
 
@@ -268,13 +268,13 @@ public class WorkerSketchFetcherTest
       );
     }
     catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Task fetch failed"));
+      Assertions.assertTrue(e.getMessage().contains("Task fetch failed"));
     }
 
     while (!target.executorService.isShutdown()) {
       Thread.sleep(100);
     }
-    Assert.assertTrue((target.getError().getMessage().contains("Task fetch failed")));
+    Assertions.assertTrue((target.getError().getMessage().contains("Task fetch failed")));
 
   }
 
@@ -290,9 +290,8 @@ public class WorkerSketchFetcherTest
 
     try {
       target.sequentialTimeChunkMerging(
-          (kernelConsumer) -> {
-            kernelConsumer.accept(kernel);
-          },
+          (kernelConsumer) ->
+            kernelConsumer.accept(kernel),
           completeKeyStatisticsInformation,
           stageDefinition.getId(),
           ImmutableSet.copyOf(TASK_IDS),
@@ -302,13 +301,13 @@ public class WorkerSketchFetcherTest
       );
     }
     catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Task fetch failed"));
+      Assertions.assertTrue(e.getMessage().contains("Task fetch failed"));
     }
 
     while (!target.executorService.isShutdown()) {
       Thread.sleep(100);
     }
-    Assert.assertTrue(target.getError().getMessage().contains("Task fetch failed"));
+    Assertions.assertTrue(target.getError().getMessage().contains("Task fetch failed"));
 
   }
 
@@ -322,9 +321,8 @@ public class WorkerSketchFetcherTest
 
     try {
       target.sequentialTimeChunkMerging(
-          (kernelConsumer) -> {
-            kernelConsumer.accept(kernel);
-          },
+          (kernelConsumer) ->
+            kernelConsumer.accept(kernel),
           completeKeyStatisticsInformation,
           stageDefinition.getId(),
           ImmutableSet.copyOf(TASK_IDS),
@@ -334,13 +332,13 @@ public class WorkerSketchFetcherTest
       );
     }
     catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Task fetch failed"));
+      Assertions.assertTrue(e.getMessage().contains("Task fetch failed"));
     }
 
     while (!target.executorService.isShutdown()) {
       Thread.sleep(100);
     }
-    Assert.assertTrue(target.getError().getMessage().contains(TASK_1));
+    Assertions.assertTrue(target.getError().getMessage().contains(TASK_1));
 
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/WorkerStorageParametersTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/WorkerStorageParametersTest.java
@@ -21,24 +21,24 @@ package org.apache.druid.msq.exec;
 
 import org.apache.druid.msq.indexing.error.MSQException;
 import org.apache.druid.msq.indexing.error.NotEnoughTemporaryStorageFault;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class WorkerStorageParametersTest
 {
   @Test
   public void test_WorkerStorageParameter_createInstance()
   {
-    Assert.assertEquals(WorkerStorageParameters.createInstanceForTests(1000000000), WorkerStorageParameters.createInstance(2_250_000_000L, true));
+    Assertions.assertEquals(WorkerStorageParameters.createInstanceForTests(1000000000), WorkerStorageParameters.createInstance(2_250_000_000L, true));
   }
 
   @Test
   public void test_insufficientTemporaryStorage()
   {
-    final MSQException e = Assert.assertThrows(
+    final MSQException e = Assertions.assertThrows(
         MSQException.class,
         () -> WorkerStorageParameters.createInstance(2_000L, true)
     );
-    Assert.assertEquals(new NotEnoughTemporaryStorageFault(2250000000L, 2000), e.getFault());
+    Assertions.assertEquals(new NotEnoughTemporaryStorageFault(2250000000L, 2000), e.getFault());
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/ColumnMappingTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/ColumnMappingTest.java
@@ -21,7 +21,7 @@ package org.apache.druid.msq.indexing;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.sql.calcite.planner.ColumnMapping;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ColumnMappingTest
 {

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/DurableStorageCleanerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/DurableStorageCleanerTest.java
@@ -37,32 +37,32 @@ import org.apache.druid.msq.indexing.cleaner.DurableStorageCleaner;
 import org.apache.druid.msq.indexing.cleaner.DurableStorageCleanerConfig;
 import org.apache.druid.storage.NilStorageConnector;
 import org.apache.druid.storage.StorageConnector;
-import org.easymock.Capture;
-import org.easymock.EasyMock;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
 public class DurableStorageCleanerTest
 {
-  private static final TaskStorage TASK_STORAGE = EasyMock.mock(TaskStorage.class);
-  private static final TaskMaster TASK_MASTER = EasyMock.mock(TaskMaster.class);
-  private static final TaskRunner TASK_RUNNER = EasyMock.mock(TaskRunner.class);
-  private static final StorageConnector STORAGE_CONNECTOR = EasyMock.mock(StorageConnector.class);
-  private static final TaskRunnerWorkItem TASK_RUNNER_WORK_ITEM = EasyMock.mock(TaskRunnerWorkItem.class);
+  private static final TaskStorage TASK_STORAGE = Mockito.mock(TaskStorage.class);
+  private static final TaskMaster TASK_MASTER = Mockito.mock(TaskMaster.class);
+  private static final TaskRunner TASK_RUNNER = Mockito.mock(TaskRunner.class);
+  private static final StorageConnector STORAGE_CONNECTOR = Mockito.mock(StorageConnector.class);
+  private static final TaskRunnerWorkItem TASK_RUNNER_WORK_ITEM = Mockito.mock(TaskRunnerWorkItem.class);
   private static final String TASK_ID = "dummyTaskId";
   private static final String STRAY_DIR = "strayDirectory";
   private DurableStorageCleaner durableStorageCleaner;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
-    EasyMock.reset(TASK_STORAGE, TASK_RUNNER, TASK_RUNNER_WORK_ITEM, STORAGE_CONNECTOR, TASK_MASTER);
+    Mockito.reset(TASK_STORAGE, TASK_RUNNER, TASK_RUNNER_WORK_ITEM, STORAGE_CONNECTOR, TASK_MASTER);
     DurableStorageCleanerConfig durableStorageCleanerConfig = new DurableStorageCleanerConfig();
     durableStorageCleanerConfig.delaySeconds = 1L;
     durableStorageCleanerConfig.enabled = true;
@@ -78,86 +78,61 @@ public class DurableStorageCleanerTest
   @Test
   public void testRun() throws Exception
   {
-    EasyMock.expect(TASK_STORAGE.getCompletedTasksInfo(EasyMock.anyObject(), EasyMock.anyInt()))
-            .andReturn(List.of())
-            .anyTimes();
-    EasyMock.expect(STORAGE_CONNECTOR.listDir(EasyMock.anyString()))
-            .andReturn(ImmutableList.of(DurableStorageUtils.getControllerDirectory(TASK_ID), STRAY_DIR)
-                                    .stream()
-                                    .iterator())
-            .anyTimes();
-    EasyMock.expect(TASK_RUNNER_WORK_ITEM.getTaskId()).andReturn(TASK_ID)
-            .anyTimes();
-    EasyMock.expect((Collection<TaskRunnerWorkItem>) TASK_RUNNER.getRunningTasks())
-            .andReturn(ImmutableList.of(TASK_RUNNER_WORK_ITEM))
-            .anyTimes();
-    EasyMock.expect(TASK_MASTER.getTaskRunner()).andReturn(Optional.of(TASK_RUNNER)).anyTimes();
-    Capture<Set<String>> capturedArguments = EasyMock.newCapture();
-    STORAGE_CONNECTOR.deleteFiles(EasyMock.capture(capturedArguments));
-    EasyMock.expectLastCall().once();
-    EasyMock.replay(TASK_STORAGE, TASK_MASTER, TASK_RUNNER, TASK_RUNNER_WORK_ITEM, STORAGE_CONNECTOR);
+    Mockito.when(TASK_STORAGE.getCompletedTasksInfo(ArgumentMatchers.any(), ArgumentMatchers.isNull())).thenReturn(List.of());
+    Mockito.when(STORAGE_CONNECTOR.listDir(ArgumentMatchers.anyString())).thenReturn(
+        ImmutableList.of(DurableStorageUtils.getControllerDirectory(TASK_ID), STRAY_DIR).iterator()
+    );
+    Mockito.when(TASK_RUNNER_WORK_ITEM.getTaskId()).thenReturn(TASK_ID);
+    Mockito.doReturn(ImmutableList.of(TASK_RUNNER_WORK_ITEM)).when(TASK_RUNNER).getRunningTasks();
+    Mockito.when(TASK_MASTER.getTaskRunner()).thenReturn(Optional.of(TASK_RUNNER));
+    final ArgumentCaptor<Set<String>> capturedArguments = ArgumentCaptor.captor();
 
     durableStorageCleaner.run();
 
-    Assert.assertEquals(Sets.newHashSet(STRAY_DIR), capturedArguments.getValue());
+    Mockito.verify(STORAGE_CONNECTOR).deleteFiles(capturedArguments.capture());
+    Assertions.assertEquals(Sets.newHashSet(STRAY_DIR), capturedArguments.getValue());
   }
 
   @Test
   public void testRunClearsStaleOrNotFoundTask() throws Exception
   {
-    EasyMock.expect(TASK_STORAGE.getCompletedTasksInfo(EasyMock.anyObject(), EasyMock.anyInt()))
-            .andReturn(List.of())
-            .anyTimes();
-    EasyMock.expect(STORAGE_CONNECTOR.listDir(EasyMock.anyString()))
-            .andReturn(ImmutableList.of(DurableStorageUtils.getControllerDirectory(TASK_ID))
-                                    .stream()
-                                    .iterator())
-            .anyTimes();
-    EasyMock.expect(TASK_RUNNER_WORK_ITEM.getTaskId()).andReturn(TASK_ID)
-            .anyTimes();
-    EasyMock.expect((Collection<TaskRunnerWorkItem>) TASK_RUNNER.getRunningTasks())
-            .andReturn(ImmutableList.of())
-            .anyTimes();
-    EasyMock.expect(TASK_MASTER.getTaskRunner()).andReturn(Optional.of(TASK_RUNNER)).anyTimes();
-    Capture<Set<String>> capturedArguments = EasyMock.newCapture();
-    STORAGE_CONNECTOR.deleteFiles(EasyMock.capture(capturedArguments));
-    EasyMock.expectLastCall().once();
-    EasyMock.replay(TASK_STORAGE, TASK_MASTER, TASK_RUNNER, TASK_RUNNER_WORK_ITEM, STORAGE_CONNECTOR);
+    Mockito.when(TASK_STORAGE.getCompletedTasksInfo(ArgumentMatchers.any(), ArgumentMatchers.isNull())).thenReturn(List.of());
+    Mockito.when(STORAGE_CONNECTOR.listDir(ArgumentMatchers.anyString())).thenReturn(
+        ImmutableList.of(DurableStorageUtils.getControllerDirectory(TASK_ID)).iterator()
+    );
+    Mockito.when(TASK_RUNNER_WORK_ITEM.getTaskId()).thenReturn(TASK_ID);
+    Mockito.doReturn(ImmutableList.of()).when(TASK_RUNNER).getRunningTasks();
+    Mockito.when(TASK_MASTER.getTaskRunner()).thenReturn(Optional.of(TASK_RUNNER));
+    final ArgumentCaptor<Set<String>> capturedArguments = ArgumentCaptor.captor();
 
     durableStorageCleaner.run();
 
-    Assert.assertEquals(Set.of(DurableStorageUtils.getControllerDirectory(TASK_ID)), capturedArguments.getValue());
+    Mockito.verify(STORAGE_CONNECTOR).deleteFiles(capturedArguments.capture());
+    Assertions.assertEquals(Set.of(DurableStorageUtils.getControllerDirectory(TASK_ID)), capturedArguments.getValue());
   }
 
   @Test
   public void testRunExcludesQueryDirectory() throws Exception
   {
     Task completedTask = new NoopTask(TASK_ID, null, null, 1, 0, null);
-    EasyMock.expect(TASK_STORAGE.getCompletedTasksInfo(EasyMock.anyObject(), EasyMock.anyInt()))
-            .andReturn(List.of(new TaskInfo(DateTimes.of("2020-01-01"), TaskStatus.success("not-used"), completedTask)))
-            .anyTimes();
+    Mockito.when(TASK_STORAGE.getCompletedTasksInfo(ArgumentMatchers.any(), ArgumentMatchers.isNull())).thenReturn(
+        List.of(new TaskInfo(DateTimes.of("2020-01-01"), TaskStatus.success("not-used"), completedTask))
+    );
     final String resultPath = DurableStorageUtils.QUERY_RESULTS_DIR + "/" + DurableStorageUtils.getControllerDirectory(
         TASK_ID) + "/results.json";
     final String intermediateFilesPath = DurableStorageUtils.getControllerDirectory(TASK_ID) + "/intermediate.frame";
-    EasyMock.expect(STORAGE_CONNECTOR.listDir(EasyMock.anyString()))
-            .andReturn(ImmutableList.of(resultPath, STRAY_DIR, intermediateFilesPath)
-                                    .stream()
-                                    .iterator())
-            .anyTimes();
-    EasyMock.expect(TASK_MASTER.getTaskRunner()).andReturn(Optional.of(TASK_RUNNER)).anyTimes();
-    EasyMock.expect(TASK_RUNNER_WORK_ITEM.getTaskId()).andReturn(TASK_ID)
-            .anyTimes();
-    EasyMock.expect((Collection<TaskRunnerWorkItem>) TASK_RUNNER.getRunningTasks())
-            .andReturn(ImmutableList.of())
-            .anyTimes();
-    Capture<Set<String>> capturedArguments = EasyMock.newCapture();
-    STORAGE_CONNECTOR.deleteFiles(EasyMock.capture(capturedArguments));
-    EasyMock.expectLastCall().once();
-    EasyMock.replay(TASK_STORAGE, TASK_MASTER, TASK_RUNNER, TASK_RUNNER_WORK_ITEM, STORAGE_CONNECTOR);
+    Mockito.when(STORAGE_CONNECTOR.listDir(ArgumentMatchers.anyString())).thenReturn(
+        ImmutableList.of(resultPath, STRAY_DIR, intermediateFilesPath).iterator()
+    );
+    Mockito.when(TASK_MASTER.getTaskRunner()).thenReturn(Optional.of(TASK_RUNNER));
+    Mockito.when(TASK_RUNNER_WORK_ITEM.getTaskId()).thenReturn(TASK_ID);
+    Mockito.doReturn(ImmutableList.of()).when(TASK_RUNNER).getRunningTasks();
+    final ArgumentCaptor<Set<String>> capturedArguments = ArgumentCaptor.captor();
 
     durableStorageCleaner.run();
 
-    Assert.assertEquals(Sets.newHashSet(STRAY_DIR, intermediateFilesPath), capturedArguments.getValue());
+    Mockito.verify(STORAGE_CONNECTOR).deleteFiles(capturedArguments.capture());
+    Assertions.assertEquals(Sets.newHashSet(STRAY_DIR, intermediateFilesPath), capturedArguments.getValue());
   }
 
   @Test
@@ -174,7 +149,7 @@ public class DurableStorageCleanerTest
     );
 
     DutySchedule schedule = durableStorageCleaner.getSchedule();
-    Assert.assertEquals(cleanerConfig.delaySeconds * 1000, schedule.getPeriodMillis());
-    Assert.assertEquals(cleanerConfig.delaySeconds * 1000, schedule.getInitialDelayMillis());
+    Assertions.assertEquals(cleanerConfig.delaySeconds * 1000, schedule.getPeriodMillis());
+    Assertions.assertEquals(cleanerConfig.delaySeconds * 1000, schedule.getInitialDelayMillis());
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/IndexerDataServerQueryHandlerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/IndexerDataServerQueryHandlerTest.java
@@ -55,11 +55,11 @@ import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -73,7 +73,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class IndexerDataServerQueryHandlerTest
 {
   private static final String DATASOURCE1 = "dataSource1";
@@ -115,7 +115,7 @@ public class IndexerDataServerQueryHandlerTest
   private ScanQuery query;
   private IndexerDataServerQueryHandler target;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     dataServerClient1 = mock(DataServerClient.class);
@@ -175,12 +175,12 @@ public class IndexerDataServerQueryHandlerTest
         Closer.create()
     ).get();
 
-    Assert.assertTrue(dataServerQueryResult.getHandedOffSegments().getDescriptors().isEmpty());
+    Assertions.assertTrue(dataServerQueryResult.getHandedOffSegments().getDescriptors().isEmpty());
     List<List<Object>> events = (List<List<Object>>) scanResultValue.getEvents();
     Yielder<Object[]> yielder = dataServerQueryResult.getResultsYielders().get(0);
     events.forEach(
         event -> {
-          Assert.assertArrayEquals(event.toArray(), yielder.get());
+          Assertions.assertArrayEquals(event.toArray(), yielder.get());
           yielder.next(null);
         }
     );
@@ -242,12 +242,12 @@ public class IndexerDataServerQueryHandlerTest
         Closer.create()
     ).get();
 
-    Assert.assertTrue(dataServerQueryResult.getHandedOffSegments().getDescriptors().isEmpty());
+    Assertions.assertTrue(dataServerQueryResult.getHandedOffSegments().getDescriptors().isEmpty());
 
     Yielder<Object[]> yielder1 = dataServerQueryResult.getResultsYielders().get(0);
     ((List<List<Object>>) scanResultValue1.getEvents()).forEach(
         event -> {
-          Assert.assertArrayEquals(event.toArray(), yielder1.get());
+          Assertions.assertArrayEquals(event.toArray(), yielder1.get());
           yielder1.next(null);
         }
     );
@@ -255,7 +255,7 @@ public class IndexerDataServerQueryHandlerTest
     Yielder<Object[]> yielder2 = dataServerQueryResult.getResultsYielders().get(1);
     ((List<List<Object>>) scanResultValue2.getEvents()).forEach(
         event -> {
-          Assert.assertArrayEquals(event.toArray(), yielder2.get());
+          Assertions.assertArrayEquals(event.toArray(), yielder2.get());
           yielder2.next(null);
         }
     );
@@ -288,8 +288,8 @@ public class IndexerDataServerQueryHandlerTest
         Closer.create()
     ).get();
 
-    Assert.assertEquals(ImmutableList.of(SEGMENT_1, SEGMENT_2), dataServerQueryResult.getHandedOffSegments().getDescriptors());
-    Assert.assertTrue(dataServerQueryResult.getResultsYielders().isEmpty());
+    Assertions.assertEquals(ImmutableList.of(SEGMENT_1, SEGMENT_2), dataServerQueryResult.getHandedOffSegments().getDescriptors());
+    Assertions.assertTrue(dataServerQueryResult.getResultsYielders().isEmpty());
   }
 
   @Test
@@ -306,7 +306,7 @@ public class IndexerDataServerQueryHandlerTest
     ScanQuery queryWithRetry =
         query.withOverriddenContext(ImmutableMap.of(QueryContexts.NUM_RETRIES_ON_MISSING_SEGMENTS_KEY, 3));
 
-    Assert.assertThrows(DruidException.class, () ->
+    Assertions.assertThrows(DruidException.class, () ->
         target.fetchRowsFromDataServer(
             queryWithRetry,
             ScanQueryFrameProcessor.SCAN_RESULT_VALUE_TYPE,
@@ -339,8 +339,8 @@ public class IndexerDataServerQueryHandlerTest
         Closer.create()
     ).get();
 
-    Assert.assertEquals(ImmutableList.of(SEGMENT_1, SEGMENT_2), dataServerQueryResult.getHandedOffSegments().getDescriptors());
-    Assert.assertTrue(dataServerQueryResult.getResultsYielders().isEmpty());
+    Assertions.assertEquals(ImmutableList.of(SEGMENT_1, SEGMENT_2), dataServerQueryResult.getHandedOffSegments().getDescriptors());
+    Assertions.assertTrue(dataServerQueryResult.getResultsYielders().isEmpty());
   }
 
   @Test
@@ -355,7 +355,7 @@ public class IndexerDataServerQueryHandlerTest
     }).when(dataServerClient1).run(any(), any(), any(), any());
     doReturn(Futures.immediateFuture(Boolean.FALSE)).when(coordinatorClient).isHandoffComplete(DATASOURCE1, segmentDescriptorWithFullInterval);
 
-    Assert.assertThrows(DruidException.class, () ->
+    Assertions.assertThrows(DruidException.class, () ->
         target.fetchRowsFromDataServer(
             query,
             ScanQueryFrameProcessor.SCAN_RESULT_VALUE_TYPE,

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/IndexerDataServerRetryPolicyTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/IndexerDataServerRetryPolicyTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.msq.indexing;
 
 import org.apache.druid.java.util.common.RetryUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -32,9 +32,9 @@ public class IndexerDataServerRetryPolicyTest
   {
     final IndexerDataServerRetryPolicy policy = IndexerDataServerRetryPolicy.standard();
 
-    Assert.assertEquals(5, policy.maxAttempts());
-    Assert.assertEquals(RetryUtils.BASE_SLEEP_MILLIS, policy.minWaitMillis());
-    Assert.assertEquals(RetryUtils.MAX_SLEEP_MILLIS, policy.maxWaitMillis());
+    Assertions.assertEquals(5, policy.maxAttempts());
+    Assertions.assertEquals(RetryUtils.BASE_SLEEP_MILLIS, policy.minWaitMillis());
+    Assertions.assertEquals(RetryUtils.MAX_SLEEP_MILLIS, policy.maxWaitMillis());
   }
 
   @Test
@@ -42,9 +42,9 @@ public class IndexerDataServerRetryPolicyTest
   {
     final IndexerDataServerRetryPolicy policy = IndexerDataServerRetryPolicy.noRetries();
 
-    Assert.assertEquals(1, policy.maxAttempts());
-    Assert.assertEquals(0, policy.minWaitMillis());
-    Assert.assertEquals(0, policy.maxWaitMillis());
+    Assertions.assertEquals(1, policy.maxAttempts());
+    Assertions.assertEquals(0, policy.minWaitMillis());
+    Assertions.assertEquals(0, policy.maxWaitMillis());
   }
 
   @Test
@@ -52,8 +52,8 @@ public class IndexerDataServerRetryPolicyTest
   {
     final IndexerDataServerRetryPolicy policy = IndexerDataServerRetryPolicy.standard();
 
-    Assert.assertTrue(policy.retryThrowable(new IOException("test")));
-    Assert.assertTrue(policy.retryThrowable(new RuntimeException("test")));
+    Assertions.assertTrue(policy.retryThrowable(new IOException("test")));
+    Assertions.assertTrue(policy.retryThrowable(new RuntimeException("test")));
   }
 
   @Test
@@ -62,7 +62,7 @@ public class IndexerDataServerRetryPolicyTest
     final IndexerDataServerRetryPolicy policy = IndexerDataServerRetryPolicy.standard();
 
     // Chains including InterruptedException should not be retried
-    Assert.assertFalse(policy.retryThrowable(new InterruptedException()));
-    Assert.assertFalse(policy.retryThrowable(new RuntimeException(new InterruptedException())));
+    Assertions.assertFalse(policy.retryThrowable(new InterruptedException()));
+    Assertions.assertFalse(policy.retryThrowable(new RuntimeException(new InterruptedException())));
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/IndexerFrameContextTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/IndexerFrameContextTest.java
@@ -24,9 +24,9 @@ import org.apache.druid.error.DruidException;
 import org.apache.druid.msq.exec.ProcessingBuffers;
 import org.apache.druid.msq.exec.ProcessingBuffersSet;
 import org.apache.druid.msq.kernel.StageId;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
@@ -36,7 +36,7 @@ public class IndexerFrameContextTest
 
   private ProcessingBuffersSet buffersSet;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     final ByteBuffer buffer = ByteBuffer.allocate(1024);
@@ -48,12 +48,12 @@ public class IndexerFrameContextTest
   {
     final IndexerFrameContext context = makeContext(null);
 
-    final DruidException e = Assert.assertThrows(
+    final DruidException e = Assertions.assertThrows(
         DruidException.class,
         () -> context.acquireProcessingBuffers(1)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Stage[" + STAGE_ID + "] does not use processing buffers",
         e.getMessage()
     );
@@ -65,12 +65,12 @@ public class IndexerFrameContextTest
     final IndexerFrameContext context = makeContext(buffersSet);
     context.acquireProcessingBuffers(1);
 
-    final DruidException e = Assert.assertThrows(
+    final DruidException e = Assertions.assertThrows(
         DruidException.class,
         () -> context.acquireProcessingBuffers(1)
     );
 
-    Assert.assertEquals("Processing buffers already acquired", e.getMessage());
+    Assertions.assertEquals("Processing buffers already acquired", e.getMessage());
 
     context.close();
   }
@@ -80,12 +80,12 @@ public class IndexerFrameContextTest
   {
     final IndexerFrameContext context = makeContext(buffersSet);
 
-    final DruidException e = Assert.assertThrows(
+    final DruidException e = Assertions.assertThrows(
         DruidException.class,
         context::processingBuffers
     );
 
-    Assert.assertEquals("Processing buffers not yet acquired", e.getMessage());
+    Assertions.assertEquals("Processing buffers not yet acquired", e.getMessage());
   }
 
   @Test
@@ -95,9 +95,9 @@ public class IndexerFrameContextTest
     context.acquireProcessingBuffers(1);
 
     final ProcessingBuffers buffers = context.processingBuffers();
-    Assert.assertNotNull(buffers);
-    Assert.assertNotNull(buffers.getBufferPool());
-    Assert.assertNotNull(buffers.getBouncer());
+    Assertions.assertNotNull(buffers);
+    Assertions.assertNotNull(buffers.getBufferPool());
+    Assertions.assertNotNull(buffers.getBouncer());
 
     context.close();
   }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQCompactionRunnerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQCompactionRunnerTest.java
@@ -88,10 +88,11 @@ import org.apache.druid.server.initialization.AuthorizerMapperModule;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.sql.calcite.parser.DruidSqlInsert;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -188,8 +189,8 @@ public class MSQCompactionRunnerTest
         compactionTask,
         intervalDataschemas
     );
-    Assert.assertFalse(validationResult.isValid());
-    Assert.assertEquals(
+    Assertions.assertFalse(validationResult.isValid());
+    Assertions.assertEquals(
         StringUtils.format("MSQ: Disjoint compaction intervals[%s] not supported", intervalDataschemas.keySet()),
         validationResult.getReason()
     );
@@ -205,7 +206,7 @@ public class MSQCompactionRunnerTest
         null,
         null
     );
-    Assert.assertFalse(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
+    Assertions.assertFalse(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
   }
 
   @Test
@@ -218,7 +219,7 @@ public class MSQCompactionRunnerTest
         null,
         null
     );
-    Assert.assertTrue(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
+    Assertions.assertTrue(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
   }
 
   @Test
@@ -237,8 +238,8 @@ public class MSQCompactionRunnerTest
         compactionTask,
         INTERVAL_DATASCHEMAS
     );
-    Assert.assertFalse(validationResult.isValid());
-    Assert.assertEquals(
+    Assertions.assertFalse(validationResult.isValid());
+    Assertions.assertEquals(
         "MSQ: Non-string partition dimension[long_dim] of type[LONG] not supported with 'range' partition spec",
         validationResult.getReason()
     );
@@ -260,8 +261,8 @@ public class MSQCompactionRunnerTest
         compactionTask,
         INTERVAL_DATASCHEMAS
     );
-    Assert.assertFalse(validationResult.isValid());
-    Assert.assertEquals(
+    Assertions.assertFalse(validationResult.isValid());
+    Assertions.assertEquals(
         "MSQ: Multi-valued string partition dimension[mv_string_dim] not supported with 'range' partition spec",
         validationResult.getReason()
     );
@@ -277,7 +278,7 @@ public class MSQCompactionRunnerTest
         null,
         null
     );
-    Assert.assertFalse(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
+    Assertions.assertFalse(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
   }
 
   @Test
@@ -290,7 +291,7 @@ public class MSQCompactionRunnerTest
         null,
         null
     );
-    Assert.assertTrue(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
+    Assertions.assertTrue(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
   }
 
   @Test
@@ -303,7 +304,7 @@ public class MSQCompactionRunnerTest
         new ClientCompactionTaskGranularitySpec(null, Granularities.ALL, null),
         null
     );
-    Assert.assertTrue(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
+    Assertions.assertTrue(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
   }
 
   @Test
@@ -316,7 +317,7 @@ public class MSQCompactionRunnerTest
         new ClientCompactionTaskGranularitySpec(null, null, false),
         AGGREGATORS.toArray(new AggregatorFactory[0])
     );
-    Assert.assertFalse(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
+    Assertions.assertFalse(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
   }
 
   @Test
@@ -329,7 +330,7 @@ public class MSQCompactionRunnerTest
         new ClientCompactionTaskGranularitySpec(null, null, true),
         null
     );
-    Assert.assertFalse(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
+    Assertions.assertFalse(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
   }
 
   @Test
@@ -349,8 +350,8 @@ public class MSQCompactionRunnerTest
         compactionTask,
         INTERVAL_DATASCHEMAS
     );
-    Assert.assertFalse(validationResult.isValid());
-    Assert.assertEquals(
+    Assertions.assertFalse(validationResult.isValid());
+    Assertions.assertEquals(
         "MSQ: Aggregator[sum_added] not supported in 'metricsSpec'",
         validationResult.getReason()
     );
@@ -361,7 +362,7 @@ public class MSQCompactionRunnerTest
   {
     CompactionTask compactionTask = createCompactionTask(null, null, Collections.emptyMap(), null, null);
     TaskStatus taskStatus = MSQ_COMPACTION_RUNNER.runCompactionTasks(compactionTask, Collections.emptyMap(), null);
-    Assert.assertTrue(taskStatus.isFailure());
+    Assertions.assertTrue(taskStatus.isFailure());
   }
 
   @Test
@@ -403,11 +404,11 @@ public class MSQCompactionRunnerTest
 
     LegacyMSQSpec actualMSQSpec = msqControllerTask.getQuerySpec();
 
-    Assert.assertEquals(getExpectedTuningConfig(), actualMSQSpec.getTuningConfig());
-    Assert.assertEquals(getExpectedDestination(), actualMSQSpec.getDestination());
+    Assertions.assertEquals(getExpectedTuningConfig(), actualMSQSpec.getTuningConfig());
+    Assertions.assertEquals(getExpectedDestination(), actualMSQSpec.getDestination());
 
     Query<?> query = actualMSQSpec.getQuery();
-    Assert.assertTrue(query instanceof ScanQuery);
+    Assertions.assertTrue(query instanceof ScanQuery);
     ScanQuery scanQuery = (ScanQuery) query;
 
     List<String> expectedColumns = new ArrayList<>();
@@ -423,20 +424,20 @@ public class MSQCompactionRunnerTest
     expectedColumns.addAll(DIMENSIONS.stream().map(DimensionSchema::getName).collect(Collectors.toList()));
     expectedColumnTypes.addAll(DIMENSIONS.stream().map(DimensionSchema::getColumnType).collect(Collectors.toList()));
 
-    Assert.assertEquals(expectedColumns, scanQuery.getColumns());
-    Assert.assertEquals(expectedColumnTypes, scanQuery.getColumnTypes());
+    Assertions.assertEquals(expectedColumns, scanQuery.getColumns());
+    Assertions.assertEquals(expectedColumnTypes, scanQuery.getColumnTypes());
 
-    Assert.assertEquals(dimFilter, scanQuery.getFilter());
-    Assert.assertEquals(
+    Assertions.assertEquals(dimFilter, scanQuery.getFilter());
+    Assertions.assertEquals(
         JSON_MAPPER.writeValueAsString(SEGMENT_GRANULARITY.toString()),
         msqControllerTask.getContext().get(DruidSqlInsert.SQL_INSERT_SEGMENT_GRANULARITY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         JSON_MAPPER.writeValueAsString(QUERY_GRANULARITY.toString()),
         msqControllerTask.getContext().get(DruidSqlInsert.SQL_INSERT_QUERY_GRANULARITY)
     );
-    Assert.assertEquals(WorkerAssignmentStrategy.MAX, actualMSQSpec.getAssignmentStrategy());
-    Assert.assertEquals(
+    Assertions.assertEquals(WorkerAssignmentStrategy.MAX, actualMSQSpec.getAssignmentStrategy());
+    Assertions.assertEquals(
         PARTITION_DIMENSIONS.stream().map(OrderBy::ascending).collect(Collectors.toList()),
         scanQuery.getOrderBys()
     );
@@ -486,11 +487,11 @@ public class MSQCompactionRunnerTest
     LegacyMSQSpec actualMSQSpec = Iterables.getOnlyElement(msqControllerTasks).getQuerySpec();
 
     Query<?> query = actualMSQSpec.getQuery();
-    Assert.assertTrue(query instanceof ScanQuery);
+    Assertions.assertTrue(query instanceof ScanQuery);
     ScanQuery scanQuery = (ScanQuery) query;
 
     // Dimensions should already list __time and the order should remain intact
-    Assert.assertEquals(
+    Assertions.assertEquals(
         nonTimeSortedDimensions.stream().map(DimensionSchema::getName).collect(Collectors.toList()),
         scanQuery.getColumns()
     );
@@ -536,23 +537,23 @@ public class MSQCompactionRunnerTest
 
     LegacyMSQSpec actualMSQSpec = msqControllerTask.getQuerySpec();
 
-    Assert.assertEquals(getExpectedTuningConfig(), actualMSQSpec.getTuningConfig());
-    Assert.assertEquals(getExpectedDestination(), actualMSQSpec.getDestination());
+    Assertions.assertEquals(getExpectedTuningConfig(), actualMSQSpec.getTuningConfig());
+    Assertions.assertEquals(getExpectedDestination(), actualMSQSpec.getDestination());
 
     Query<?> query = actualMSQSpec.getQuery();
-    Assert.assertTrue(query instanceof GroupByQuery);
+    Assertions.assertTrue(query instanceof GroupByQuery);
     GroupByQuery groupByQuery = (GroupByQuery) query;
 
-    Assert.assertEquals(dimFilter, groupByQuery.getFilter());
-    Assert.assertEquals(
+    Assertions.assertEquals(dimFilter, groupByQuery.getFilter());
+    Assertions.assertEquals(
         JSON_MAPPER.writeValueAsString(SEGMENT_GRANULARITY.toString()),
         msqControllerTask.getContext().get(DruidSqlInsert.SQL_INSERT_SEGMENT_GRANULARITY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         JSON_MAPPER.writeValueAsString(QUERY_GRANULARITY.toString()),
         msqControllerTask.getContext().get(DruidSqlInsert.SQL_INSERT_QUERY_GRANULARITY)
     );
-    Assert.assertEquals(WorkerAssignmentStrategy.MAX, actualMSQSpec.getAssignmentStrategy());
+    Assertions.assertEquals(WorkerAssignmentStrategy.MAX, actualMSQSpec.getAssignmentStrategy());
 
     List<DimensionSpec> expectedDimensionSpec = new ArrayList<>();
     expectedDimensionSpec.add(
@@ -579,7 +580,7 @@ public class MSQCompactionRunnerTest
                                                         dim.getColumnType()
                                                     ))
                                            .collect(Collectors.toList()));
-    Assert.assertEquals(expectedDimensionSpec, groupByQuery.getDimensions());
+    Assertions.assertEquals(expectedDimensionSpec, groupByQuery.getDimensions());
   }
 
   @Test
@@ -622,10 +623,10 @@ public class MSQCompactionRunnerTest
 
     LegacyMSQSpec actualMSQSpec = msqControllerTask.getQuerySpec();
 
-    Assert.assertEquals(getExpectedTuningConfig(), actualMSQSpec.getTuningConfig());
-    Assert.assertEquals(getExpectedDestinationWithProjections(), actualMSQSpec.getDestination());
+    Assertions.assertEquals(getExpectedTuningConfig(), actualMSQSpec.getTuningConfig());
+    Assertions.assertEquals(getExpectedDestinationWithProjections(), actualMSQSpec.getDestination());
 
-    Assert.assertTrue(actualMSQSpec.getQuery() instanceof ScanQuery);
+    Assertions.assertTrue(actualMSQSpec.getQuery() instanceof ScanQuery);
     ScanQuery scanQuery = (ScanQuery) actualMSQSpec.getQuery();
 
     List<String> expectedColumns = new ArrayList<>();
@@ -641,20 +642,20 @@ public class MSQCompactionRunnerTest
     expectedColumns.addAll(DIMENSIONS.stream().map(DimensionSchema::getName).collect(Collectors.toList()));
     expectedColumnTypes.addAll(DIMENSIONS.stream().map(DimensionSchema::getColumnType).collect(Collectors.toList()));
 
-    Assert.assertEquals(expectedColumns, scanQuery.getColumns());
-    Assert.assertEquals(expectedColumnTypes, scanQuery.getColumnTypes());
+    Assertions.assertEquals(expectedColumns, scanQuery.getColumns());
+    Assertions.assertEquals(expectedColumnTypes, scanQuery.getColumnTypes());
 
-    Assert.assertEquals(dimFilter, scanQuery.getFilter());
-    Assert.assertEquals(
+    Assertions.assertEquals(dimFilter, scanQuery.getFilter());
+    Assertions.assertEquals(
         JSON_MAPPER.writeValueAsString(SEGMENT_GRANULARITY.toString()),
         msqControllerTask.getContext().get(DruidSqlInsert.SQL_INSERT_SEGMENT_GRANULARITY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         JSON_MAPPER.writeValueAsString(QUERY_GRANULARITY.toString()),
         msqControllerTask.getContext().get(DruidSqlInsert.SQL_INSERT_QUERY_GRANULARITY)
     );
-    Assert.assertEquals(WorkerAssignmentStrategy.MAX, actualMSQSpec.getAssignmentStrategy());
-    Assert.assertEquals(
+    Assertions.assertEquals(WorkerAssignmentStrategy.MAX, actualMSQSpec.getAssignmentStrategy());
+    Assertions.assertEquals(
         PARTITION_DIMENSIONS.stream().map(OrderBy::ascending).collect(Collectors.toList()),
         scanQuery.getOrderBys()
     );
@@ -701,23 +702,23 @@ public class MSQCompactionRunnerTest
     LegacyMSQSpec actualMSQSpec = msqControllerTask.getQuerySpec();
 
     // Clustered base tables are never rollup, so the query is always a Scan, never a GroupBy.
-    Assert.assertTrue(actualMSQSpec.getQuery() instanceof ScanQuery);
+    Assertions.assertTrue(actualMSQSpec.getQuery() instanceof ScanQuery);
     ScanQuery scanQuery = (ScanQuery) actualMSQSpec.getQuery();
 
     // Columns follow the spec's declared order: clustering prefix, remaining columns, then the explicit __time marker.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(tenant.getName(), region.getName(), ColumnHolder.TIME_COLUMN_NAME),
         scanQuery.getColumns()
     );
 
     // Destination is base-table-mode: it carries the spec and no legacy dimensionSchemas.
-    Assert.assertTrue(actualMSQSpec.getDestination() instanceof DataSourceMSQDestination);
+    Assertions.assertTrue(actualMSQSpec.getDestination() instanceof DataSourceMSQDestination);
     DataSourceMSQDestination destination = (DataSourceMSQDestination) actualMSQSpec.getDestination();
-    Assert.assertEquals(baseTable, destination.getBaseTable());
-    Assert.assertNull(destination.getDimensionSchemas());
+    Assertions.assertEquals(baseTable, destination.getBaseTable());
+    Assertions.assertNull(destination.getDimensionSchemas());
 
     // Column mappings carry the same columns in declared order.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(tenant.getName(), region.getName(), ColumnHolder.TIME_COLUMN_NAME),
         actualMSQSpec.getColumnMappings().getOutputColumnNames()
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQControllerTaskTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQControllerTaskTest.java
@@ -41,8 +41,8 @@ import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.apache.druid.sql.calcite.planner.ColumnMapping;
 import org.apache.druid.sql.calcite.planner.ColumnMappings;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -76,21 +76,21 @@ public class MSQControllerTaskTest
   @Test
   public void testGetInputSourceResources()
   {
-    Assert.assertTrue(createControllerTask(msqSpecBuilder()).getInputSourceResources().isEmpty());
+    Assertions.assertTrue(createControllerTask(msqSpecBuilder()).getInputSourceResources().isEmpty());
   }
 
   @Test
   public void testGetDefaultLookupLoadingSpec()
   {
     MSQControllerTask controllerTask = createControllerTask(msqSpecBuilder());
-    Assert.assertEquals(LookupLoadingSpec.NONE, controllerTask.getLookupLoadingSpec());
+    Assertions.assertEquals(LookupLoadingSpec.NONE, controllerTask.getLookupLoadingSpec());
   }
 
   @Test
   public void testGetDefaultBroadcastDatasourceLoadingSpec()
   {
     MSQControllerTask controllerTask = createControllerTask(msqSpecBuilder());
-    Assert.assertEquals(BroadcastDatasourceLoadingSpec.NONE, controllerTask.getBroadcastDatasourceLoadingSpec());
+    Assertions.assertEquals(BroadcastDatasourceLoadingSpec.NONE, controllerTask.getBroadcastDatasourceLoadingSpec());
   }
 
   @Test
@@ -112,14 +112,14 @@ public class MSQControllerTaskTest
         .tuningConfig(MSQTuningConfig.defaultConfig());
 
     // Validate that MSQ Controller task doesn't load any lookups even if context has lookup info populated.
-    Assert.assertEquals(LookupLoadingSpec.NONE, createControllerTask(builder).getLookupLoadingSpec());
+    Assertions.assertEquals(LookupLoadingSpec.NONE, createControllerTask(builder).getLookupLoadingSpec());
   }
 
   @Test
   public void testGetTaskAllocatorId()
   {
     MSQControllerTask controllerTask = createControllerTask(msqSpecBuilder());
-    Assert.assertEquals(controllerTask.getId(), controllerTask.getTaskAllocatorId());
+    Assertions.assertEquals(controllerTask.getId(), controllerTask.getTaskAllocatorId());
   }
 
   @Test
@@ -127,14 +127,14 @@ public class MSQControllerTaskTest
   {
     final DataSourceMSQDestination appendDestination
         = new DataSourceMSQDestination("target", Granularities.DAY, null, null, null, null, null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TaskLockType.SHARED,
         createControllerTask(msqSpecBuilder().destination(appendDestination)).getTaskLockType()
     );
 
     final DataSourceMSQDestination replaceDestination
         = new DataSourceMSQDestination("target", Granularities.DAY, null, INTERVALS, null, null, null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TaskLockType.EXCLUSIVE,
         createControllerTask(msqSpecBuilder().destination(replaceDestination)).getTaskLockType()
     );
@@ -151,7 +151,7 @@ public class MSQControllerTaskTest
         null,
         taskContext
     );
-    Assert.assertEquals(TaskLockType.APPEND, appendTaskWithContext.getTaskLockType());
+    Assertions.assertEquals(TaskLockType.APPEND, appendTaskWithContext.getTaskLockType());
 
     final MSQControllerTask replaceTaskWithContext = new MSQControllerTask(
         null,
@@ -163,7 +163,7 @@ public class MSQControllerTaskTest
         null,
         taskContext
     );
-    Assert.assertEquals(TaskLockType.REPLACE, replaceTaskWithContext.getTaskLockType());
+    Assertions.assertEquals(TaskLockType.REPLACE, replaceTaskWithContext.getTaskLockType());
 
     // With 'useConcurrentLocks' in query context
     final Map<String, Object> queryContext = Collections.singletonMap(Tasks.USE_CONCURRENT_LOCKS, true);
@@ -173,11 +173,11 @@ public class MSQControllerTaskTest
         .dataSource("target")
         .context(queryContext)
         .build();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TaskLockType.APPEND,
         createControllerTask(msqSpecBuilder().query(query).destination(appendDestination)).getTaskLockType()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TaskLockType.REPLACE,
         createControllerTask(msqSpecBuilder().query(query).destination(replaceDestination)).getTaskLockType()
     );
@@ -196,7 +196,7 @@ public class MSQControllerTaskTest
             0
         )
     );
-    Assert.assertTrue(createControllerTask(msqSpecBuilder()).isReady(taskActionClient));
+    Assertions.assertTrue(createControllerTask(msqSpecBuilder()).isReady(taskActionClient));
   }
 
   @Test
@@ -214,11 +214,11 @@ public class MSQControllerTaskTest
             true
         )
     );
-    DruidException exception = Assert.assertThrows(
+    DruidException exception = Assertions.assertThrows(
         DruidException.class,
         () -> controllerTask.isReady(taskActionClient)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Lock of type[REPLACE] for interval[2011-04-01T00:00:00.000Z/2011-04-03T00:00:00.000Z] was revoked",
         exception.getMessage()
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQPartitionAssignmentTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQPartitionAssignmentTest.java
@@ -26,7 +26,8 @@ import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.Interval;
 import org.joda.time.chrono.ISOChronology;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
@@ -34,23 +35,27 @@ import java.util.Map;
 public class MSQPartitionAssignmentTest
 {
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testNullPartition()
   {
-    new MSQPartitionAssignment(null, Collections.emptyMap());
+    Assertions.assertThrows(NullPointerException.class, () -> {
+      new MSQPartitionAssignment(null, Collections.emptyMap());
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidPartition()
   {
-    SegmentIdWithShardSpec segmentId = new SegmentIdWithShardSpec(
-        "ds",
-        new Interval(0, 1, ISOChronology.getInstanceUTC()),
-        "v1",
-        new NumberedShardSpec(0, 1)
-    );
-    Map<Integer, SegmentIdWithShardSpec> allocations = ImmutableMap.of(-1, segmentId);
-    new MSQPartitionAssignment(ClusterByPartitions.oneUniversalPartition(), allocations);
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      SegmentIdWithShardSpec segmentId = new SegmentIdWithShardSpec(
+          "ds",
+          new Interval(0, 1, ISOChronology.getInstanceUTC()),
+          "v1",
+          new NumberedShardSpec(0, 1)
+      );
+      Map<Integer, SegmentIdWithShardSpec> allocations = ImmutableMap.of(-1, segmentId);
+      new MSQPartitionAssignment(ClusterByPartitions.oneUniversalPartition(), allocations);
+    });
   }
 
   @Test

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQSpecTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQSpecTest.java
@@ -22,7 +22,7 @@ package org.apache.druid.msq.indexing;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.segment.IndexSpec;
 import org.apache.druid.segment.data.CompressionStrategy;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MSQSpecTest
 {

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQTuningConfigTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQTuningConfigTest.java
@@ -27,8 +27,8 @@ import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.StringEncodingStrategy;
 import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.data.FrontCodedIndexed;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class MSQTuningConfigTest
 {
@@ -37,7 +37,7 @@ public class MSQTuningConfigTest
   {
     final ObjectMapper mapper = TestHelper.makeJsonMapper();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         MSQTuningConfig.defaultConfig(),
         mapper.readValue(
             mapper.writeValueAsString(MSQTuningConfig.defaultConfig()),
@@ -62,7 +62,7 @@ public class MSQTuningConfigTest
                  .build()
     );
 
-    Assert.assertEquals(config, mapper.readValue(mapper.writeValueAsString(config), MSQTuningConfig.class));
+    Assertions.assertEquals(config, mapper.readValue(mapper.writeValueAsString(config), MSQTuningConfig.class));
   }
 
   @Test
@@ -82,21 +82,21 @@ public class MSQTuningConfigTest
   public void testDefaultValuesForElements()
   {
     MSQTuningConfig msqTuningConfig = new MSQTuningConfig(null, null, null, null, null);
-    Assert.assertEquals(1, msqTuningConfig.getMaxNumWorkers());
-    Assert.assertEquals(100000, msqTuningConfig.getMaxRowsInMemory());
-    Assert.assertEquals(PartitionsSpec.DEFAULT_MAX_ROWS_PER_SEGMENT, msqTuningConfig.getRowsPerSegment());
-    Assert.assertEquals(null, msqTuningConfig.getMaxNumSegments());
-    Assert.assertEquals(IndexSpec.getDefault(), msqTuningConfig.getIndexSpec());
+    Assertions.assertEquals(1, msqTuningConfig.getMaxNumWorkers());
+    Assertions.assertEquals(100000, msqTuningConfig.getMaxRowsInMemory());
+    Assertions.assertEquals(PartitionsSpec.DEFAULT_MAX_ROWS_PER_SEGMENT, msqTuningConfig.getRowsPerSegment());
+    Assertions.assertEquals(null, msqTuningConfig.getMaxNumSegments());
+    Assertions.assertEquals(IndexSpec.getDefault(), msqTuningConfig.getIndexSpec());
   }
 
   @Test
   public void testCustomValuesForElements()
   {
     MSQTuningConfig msqTuningConfig = new MSQTuningConfig(5, 200000, 5000, 10, IndexSpec.builder().build());
-    Assert.assertEquals(5, msqTuningConfig.getMaxNumWorkers());
-    Assert.assertEquals(200000, msqTuningConfig.getMaxRowsInMemory());
-    Assert.assertEquals(5000, msqTuningConfig.getRowsPerSegment());
-    Assert.assertEquals(Integer.valueOf(10), msqTuningConfig.getMaxNumSegments());
-    Assert.assertEquals(IndexSpec.builder().build(), msqTuningConfig.getIndexSpec());
+    Assertions.assertEquals(5, msqTuningConfig.getMaxNumWorkers());
+    Assertions.assertEquals(200000, msqTuningConfig.getMaxRowsInMemory());
+    Assertions.assertEquals(5000, msqTuningConfig.getRowsPerSegment());
+    Assertions.assertEquals(Integer.valueOf(10), msqTuningConfig.getMaxNumSegments());
+    Assertions.assertEquals(IndexSpec.builder().build(), msqTuningConfig.getIndexSpec());
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQWorkerTaskLauncherTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQWorkerTaskLauncherTest.java
@@ -25,9 +25,9 @@ import org.apache.druid.msq.exec.Limits;
 import org.apache.druid.msq.exec.WorkerFailureListener;
 import org.apache.druid.msq.indexing.MSQWorkerTaskLauncher.MSQWorkerTaskLauncherConfig;
 import org.apache.druid.rpc.indexing.OverlordClient;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.concurrent.TimeUnit;
@@ -37,7 +37,7 @@ public class MSQWorkerTaskLauncherTest
 
   MSQWorkerTaskLauncher target;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     target = new MSQWorkerTaskLauncher(
@@ -58,7 +58,7 @@ public class MSQWorkerTaskLauncherTest
     target.reportFailedInactiveWorker(1);
     target.retryInactiveTasksIfNeeded(5);
 
-    Assert.assertEquals(target.getWorkersToRelaunch(), ImmutableSet.of(1));
+    Assertions.assertEquals(target.getWorkersToRelaunch(), ImmutableSet.of(1));
   }
 
   
@@ -67,7 +67,7 @@ public class MSQWorkerTaskLauncherTest
   {
     // Test that launchWorkersIfNeeded returns empty set when no workers fail
     var result = target.launchWorkersIfNeeded(0);
-    Assert.assertTrue(result.isEmpty());
+    Assertions.assertTrue(result.isEmpty());
   }
   
   @Test
@@ -75,7 +75,7 @@ public class MSQWorkerTaskLauncherTest
   {
     // Test that waitForWorkers returns empty set when no workers fail
     var result = target.waitForWorkers(ImmutableSet.of());
-    Assert.assertTrue(result.isEmpty());
+    Assertions.assertTrue(result.isEmpty());
   }
 
   private static WorkerFailureListener getWorkerFailureListener()

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQWorkerTaskTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQWorkerTaskTest.java
@@ -24,8 +24,8 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.guice.PeonProcessingModule;
 import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,15 +54,15 @@ public class MSQWorkerTaskTest
   @Test
   public void testEquals()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         msqWorkerTask,
         new MSQWorkerTask(controllerTaskId, dataSource, workerNumber, context, retryCount)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         msqWorkerTask.getRetryTask(),
         new MSQWorkerTask(controllerTaskId, dataSource, workerNumber, context, retryCount + 1)
     );
-    Assert.assertNotEquals(msqWorkerTask, msqWorkerTask.getRetryTask());
+    Assertions.assertNotEquals(msqWorkerTask, msqWorkerTask.getRetryTask());
   }
 
   @Test
@@ -72,19 +72,19 @@ public class MSQWorkerTaskTest
 
     msqWorkerTaskSet.add(msqWorkerTask);
     msqWorkerTaskSet.add(new MSQWorkerTask(controllerTaskId, dataSource, workerNumber, context, retryCount));
-    Assert.assertTrue(msqWorkerTaskSet.size() == 1);
+    Assertions.assertTrue(msqWorkerTaskSet.size() == 1);
 
     msqWorkerTaskSet.add(msqWorkerTask.getRetryTask());
-    Assert.assertTrue(msqWorkerTaskSet.size() == 2);
+    Assertions.assertTrue(msqWorkerTaskSet.size() == 2);
 
     msqWorkerTaskSet.add(new MSQWorkerTask(controllerTaskId + 1, dataSource, workerNumber, context, retryCount));
-    Assert.assertTrue(msqWorkerTaskSet.size() == 3);
+    Assertions.assertTrue(msqWorkerTaskSet.size() == 3);
 
     msqWorkerTaskSet.add(new MSQWorkerTask(controllerTaskId, dataSource + 1, workerNumber, context, retryCount));
-    Assert.assertTrue(msqWorkerTaskSet.size() == 4);
+    Assertions.assertTrue(msqWorkerTaskSet.size() == 4);
 
     msqWorkerTaskSet.add(new MSQWorkerTask(controllerTaskId, dataSource, workerNumber + 1, context, retryCount));
-    Assert.assertTrue(msqWorkerTaskSet.size() == 5);
+    Assertions.assertTrue(msqWorkerTaskSet.size() == 5);
 
     msqWorkerTaskSet.add(new MSQWorkerTask(
         controllerTaskId,
@@ -93,42 +93,42 @@ public class MSQWorkerTaskTest
         ImmutableMap.of("key1", "v1"),
         retryCount
     ));
-    Assert.assertTrue(msqWorkerTaskSet.size() == 6);
+    Assertions.assertTrue(msqWorkerTaskSet.size() == 6);
 
     msqWorkerTaskSet.add(new MSQWorkerTask(controllerTaskId, dataSource, workerNumber, context, retryCount + 1));
-    Assert.assertTrue(msqWorkerTaskSet.size() == 6);
+    Assertions.assertTrue(msqWorkerTaskSet.size() == 6);
   }
 
   @Test
   public void testGetter()
   {
-    Assert.assertEquals(controllerTaskId, msqWorkerTask.getControllerTaskId());
-    Assert.assertEquals(dataSource, msqWorkerTask.getDataSource());
-    Assert.assertEquals(workerNumber, msqWorkerTask.getWorkerNumber());
-    Assert.assertEquals(retryCount, msqWorkerTask.getRetryCount());
+    Assertions.assertEquals(controllerTaskId, msqWorkerTask.getControllerTaskId());
+    Assertions.assertEquals(dataSource, msqWorkerTask.getDataSource());
+    Assertions.assertEquals(workerNumber, msqWorkerTask.getWorkerNumber());
+    Assertions.assertEquals(retryCount, msqWorkerTask.getRetryCount());
   }
 
   @Test
   public void testGetInputSourceResources()
   {
     MSQWorkerTask msqWorkerTask = new MSQWorkerTask(controllerTaskId, dataSource, workerNumber, context, retryCount);
-    Assert.assertTrue(msqWorkerTask.getInputSourceResources().isEmpty());
+    Assertions.assertTrue(msqWorkerTask.getInputSourceResources().isEmpty());
   }
 
   @Test
   public void testGetPeonProcessingModuleConfig()
   {
     final PeonProcessingModule.Config config = msqWorkerTask.getPeonProcessingModuleConfig();
-    Assert.assertTrue(config.hasProcessingThreads());
-    Assert.assertTrue(config.hasProcessingBuffers());
-    Assert.assertFalse(config.hasMergeBuffers());
+    Assertions.assertTrue(config.hasProcessingThreads());
+    Assertions.assertTrue(config.hasProcessingBuffers());
+    Assertions.assertFalse(config.hasMergeBuffers());
   }
 
   @Test
   public void testGetDefaultLookupLoadingSpec()
   {
     MSQWorkerTask msqWorkerTask = new MSQWorkerTask(controllerTaskId, dataSource, workerNumber, context, retryCount);
-    Assert.assertEquals(LookupLoadingSpec.ALL, msqWorkerTask.getLookupLoadingSpec());
+    Assertions.assertEquals(LookupLoadingSpec.ALL, msqWorkerTask.getLookupLoadingSpec());
   }
 
   @Test
@@ -136,7 +136,7 @@ public class MSQWorkerTaskTest
   {
     final ImmutableMap<String, Object> context = ImmutableMap.of(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.NONE);
     MSQWorkerTask msqWorkerTask = new MSQWorkerTask(controllerTaskId, dataSource, workerNumber, context, retryCount);
-    Assert.assertEquals(LookupLoadingSpec.NONE, msqWorkerTask.getLookupLoadingSpec());
+    Assertions.assertEquals(LookupLoadingSpec.NONE, msqWorkerTask.getLookupLoadingSpec());
   }
 
   @Test
@@ -146,8 +146,8 @@ public class MSQWorkerTaskTest
         LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, Arrays.asList("lookupName1", "lookupName2"),
         LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ONLY_REQUIRED);
     MSQWorkerTask msqWorkerTask = new MSQWorkerTask(controllerTaskId, dataSource, workerNumber, context, retryCount);
-    Assert.assertEquals(LookupLoadingSpec.Mode.ONLY_REQUIRED, msqWorkerTask.getLookupLoadingSpec().getMode());
-    Assert.assertEquals(ImmutableSet.of("lookupName1", "lookupName2"), msqWorkerTask.getLookupLoadingSpec().getLookupsToLoad());
+    Assertions.assertEquals(LookupLoadingSpec.Mode.ONLY_REQUIRED, msqWorkerTask.getLookupLoadingSpec().getMode());
+    Assertions.assertEquals(ImmutableSet.of("lookupName1", "lookupName2"), msqWorkerTask.getLookupLoadingSpec().getLookupsToLoad());
   }
 
   @Test
@@ -160,11 +160,11 @@ public class MSQWorkerTaskTest
     context.put(LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, null);
 
     MSQWorkerTask taskWithNullLookups = new MSQWorkerTask(controllerTaskId, dataSource, workerNumber, context, retryCount);
-    DruidException exception = Assert.assertThrows(
+    DruidException exception = Assertions.assertThrows(
         DruidException.class,
         taskWithNullLookups::getLookupLoadingSpec
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Set of lookups to load cannot be null for mode[ONLY_REQUIRED].",
         exception.getMessage());
 
@@ -172,11 +172,11 @@ public class MSQWorkerTaskTest
     context.put(LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, Collections.emptyList());
 
     MSQWorkerTask taskWithEmptyLookups = new MSQWorkerTask(controllerTaskId, dataSource, workerNumber, context, retryCount);
-    exception = Assert.assertThrows(
+    exception = Assertions.assertThrows(
         DruidException.class,
         taskWithEmptyLookups::getLookupLoadingSpec
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Set of lookups to load cannot be [] for mode[ONLY_REQUIRED].",
         exception.getMessage());
   }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/PeriodicControllerCheckerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/PeriodicControllerCheckerTest.java
@@ -23,10 +23,10 @@ import com.google.common.util.concurrent.Futures;
 import org.apache.druid.rpc.ServiceLocation;
 import org.apache.druid.rpc.ServiceLocations;
 import org.apache.druid.rpc.ServiceLocator;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -49,7 +49,7 @@ public class PeriodicControllerCheckerTest
   private AutoCloseable mockCloser;
   private CountDownLatch workerCanceled;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mockCloser = MockitoAnnotations.openMocks(this);
@@ -57,7 +57,7 @@ public class PeriodicControllerCheckerTest
     workerCanceled = new CountDownLatch(1);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception
   {
     testExecutor.shutdownNow();
@@ -92,7 +92,7 @@ public class PeriodicControllerCheckerTest
     checker.start();
 
     // Wait for checker to finish
-    Assert.assertTrue(workerCanceled.await(1, TimeUnit.MINUTES));
+    Assertions.assertTrue(workerCanceled.await(1, TimeUnit.MINUTES));
 
     // Verify ServiceLocator was called exactly four times
     Mockito.verify(controllerLocator, Mockito.times(4)).locate();

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/TaskReportQueryListenerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/TaskReportQueryListenerTest.java
@@ -51,8 +51,8 @@ import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.planner.ColumnMappings;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -114,7 +114,7 @@ public class TaskReportQueryListenerTest
         resultsContext
     );
 
-    Assert.assertTrue(listener.readResults());
+    Assertions.assertTrue(listener.readResults());
     listener.onResultsStart(frameReader);
 
     // Create a frame with two rows
@@ -122,7 +122,7 @@ public class TaskReportQueryListenerTest
         ImmutableMap.of("x", "foo"),
         ImmutableMap.of("x", "bar")
     ));
-    Assert.assertTrue(listener.onResultBatch(frame.asRAC()));
+    Assertions.assertTrue(listener.onResultBatch(frame.asRAC()));
 
     listener.onResultsComplete();
     listener.onQueryComplete(
@@ -158,14 +158,14 @@ public class TaskReportQueryListenerTest
             new TypeReference<>() {}
         );
 
-    Assert.assertEquals(ImmutableSet.of("multiStageQuery", TaskContextReport.REPORT_KEY), reportMap.keySet());
-    Assert.assertEquals(TASK_CONTEXT, ((TaskContextReport) reportMap.get(TaskContextReport.REPORT_KEY)).getPayload());
+    Assertions.assertEquals(ImmutableSet.of("multiStageQuery", TaskContextReport.REPORT_KEY), reportMap.keySet());
+    Assertions.assertEquals(TASK_CONTEXT, ((TaskContextReport) reportMap.get(TaskContextReport.REPORT_KEY)).getPayload());
 
     final MSQTaskReport report = (MSQTaskReport) reportMap.get("multiStageQuery");
     final List<List<Object>> results =
         report.getPayload().getResults().getResults().stream().map(Arrays::asList).collect(Collectors.toList());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             ImmutableList.of("foo"),
             ImmutableList.of("bar")
@@ -173,8 +173,8 @@ public class TaskReportQueryListenerTest
         results
     );
 
-    Assert.assertFalse(report.getPayload().getResults().isResultsTruncated());
-    Assert.assertEquals(TaskState.SUCCESS, report.getPayload().getStatus().getStatus());
+    Assertions.assertFalse(report.getPayload().getResults().isResultsTruncated());
+    Assertions.assertEquals(TaskState.SUCCESS, report.getPayload().getStatus().getStatus());
   }
 
   @Test
@@ -193,7 +193,7 @@ public class TaskReportQueryListenerTest
         resultsContext
     );
 
-    Assert.assertTrue(listener.readResults());
+    Assertions.assertTrue(listener.readResults());
     listener.onResultsStart(frameReader);
 
     // Create frames with rows up to MAX_SELECT_RESULT_ROWS
@@ -212,7 +212,7 @@ public class TaskReportQueryListenerTest
     }
 
     // Should have stopped accepting results after MAX_SELECT_RESULT_ROWS
-    Assert.assertFalse(keepGoing);
+    Assertions.assertFalse(keepGoing);
 
     listener.onQueryComplete(
         new MSQTaskReportPayload(
@@ -247,22 +247,22 @@ public class TaskReportQueryListenerTest
             new TypeReference<>() {}
         );
 
-    Assert.assertEquals(ImmutableSet.of("multiStageQuery", TaskContextReport.REPORT_KEY), reportMap.keySet());
-    Assert.assertEquals(TASK_CONTEXT, ((TaskContextReport) reportMap.get(TaskContextReport.REPORT_KEY)).getPayload());
+    Assertions.assertEquals(ImmutableSet.of("multiStageQuery", TaskContextReport.REPORT_KEY), reportMap.keySet());
+    Assertions.assertEquals(TASK_CONTEXT, ((TaskContextReport) reportMap.get(TaskContextReport.REPORT_KEY)).getPayload());
 
     final MSQTaskReport report = (MSQTaskReport) reportMap.get("multiStageQuery");
     final List<List<Object>> results =
         report.getPayload().getResults().getResults().stream().map(Arrays::asList).collect(Collectors.toList());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         IntStream.range(0, (int) Limits.MAX_SELECT_RESULT_ROWS)
                  .mapToObj(i -> ImmutableList.of("foo"))
                  .collect(Collectors.toList()),
         results
     );
 
-    Assert.assertTrue(report.getPayload().getResults().isResultsTruncated());
-    Assert.assertEquals(TaskState.SUCCESS, report.getPayload().getStatus().getStatus());
+    Assertions.assertTrue(report.getPayload().getResults().isResultsTruncated());
+    Assertions.assertEquals(TaskState.SUCCESS, report.getPayload().getStatus().getStatus());
   }
 
   /**

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/WorkerChatHandlerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/WorkerChatHandlerTest.java
@@ -32,10 +32,10 @@ import org.apache.druid.server.security.AuthConfig;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.apache.druid.server.security.AuthorizerMapper;
 import org.apache.druid.sql.calcite.util.CalciteTests;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -43,6 +43,7 @@ import org.mockito.MockitoAnnotations;
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
+
 import java.io.InputStream;
 
 public class WorkerChatHandlerTest
@@ -58,7 +59,7 @@ public class WorkerChatHandlerTest
 
   private final TestWorker worker = new TestWorker();
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     authorizerMapper = CalciteTests.TEST_AUTHORIZER_MAPPER;
@@ -71,7 +72,7 @@ public class WorkerChatHandlerTest
   public void testFetchSnapshot()
   {
     WorkerChatHandler chatHandler = new WorkerChatHandler(worker, authorizerMapper, DATASOURCE);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ClusterByStatisticsSnapshot.empty(),
         chatHandler.httpFetchKeyStatistics(TEST_STAGE.getQueryId(), TEST_STAGE.getStageNumber(), null, req)
                    .getEntity()
@@ -82,7 +83,7 @@ public class WorkerChatHandlerTest
   public void testFetchSnapshot404()
   {
     WorkerChatHandler chatHandler = new WorkerChatHandler(worker, authorizerMapper, DATASOURCE);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.BAD_REQUEST.getStatusCode(),
         chatHandler.httpFetchKeyStatistics("123", 2, null, req)
                    .getStatus()
@@ -93,7 +94,7 @@ public class WorkerChatHandlerTest
   public void testFetchSnapshotWithTimeChunk()
   {
     WorkerChatHandler chatHandler = new WorkerChatHandler(worker, authorizerMapper, DATASOURCE);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ClusterByStatisticsSnapshot.empty(),
         chatHandler.httpFetchKeyStatisticsWithSnapshot(TEST_STAGE.getQueryId(), TEST_STAGE.getStageNumber(), 1, null, req)
                    .getEntity()
@@ -104,7 +105,7 @@ public class WorkerChatHandlerTest
   public void testFetchSnapshotWithTimeChunk404()
   {
     WorkerChatHandler chatHandler = new WorkerChatHandler(worker, authorizerMapper, DATASOURCE);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.BAD_REQUEST.getStatusCode(),
         chatHandler.httpFetchKeyStatisticsWithSnapshot("123", 2, 1, null, req)
                    .getStatus()
@@ -194,7 +195,7 @@ public class WorkerChatHandlerTest
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     try {

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/client/ControllerChatHandlerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/client/ControllerChatHandlerTest.java
@@ -24,8 +24,8 @@ import org.apache.druid.indexer.report.TaskReport;
 import org.apache.druid.msq.exec.Controller;
 import org.apache.druid.segment.TestDataSource;
 import org.apache.druid.server.security.AuthorizerMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -54,7 +54,7 @@ public class ControllerChatHandlerTest
            .thenReturn("allow-all");
     Response response = chatHandler.httpGetLiveReports(httpRequest);
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(reportMap, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(reportMap, response.getEntity());
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/destination/DataSourceMSQDestinationTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/destination/DataSourceMSQDestinationTest.java
@@ -34,8 +34,8 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
@@ -132,20 +132,20 @@ public class DataSourceMSQDestinationTest
     );
     final DataSourceMSQDestination roundTrip =
         mapper.readValue(mapper.writeValueAsString(destination), DataSourceMSQDestination.class);
-    Assert.assertEquals(destination, roundTrip);
-    Assert.assertNotNull(roundTrip.getBaseTable());
+    Assertions.assertEquals(destination, roundTrip);
+    Assertions.assertNotNull(roundTrip.getBaseTable());
   }
 
   @Test
   public void testBackwardCompatibility() throws JsonProcessingException
   {
     DataSourceMSQDestination destination = new DataSourceMSQDestination("foo1", Granularities.ALL, null, null, null, null, null);
-    Assert.assertEquals(SegmentGenerationStageSpec.instance(), destination.getTerminalStageSpec());
+    Assertions.assertEquals(SegmentGenerationStageSpec.instance(), destination.getTerminalStageSpec());
 
     DataSourceMSQDestination dataSourceMSQDestination = new DefaultObjectMapper().readValue(
         "{\"type\":\"dataSource\",\"dataSource\":\"datasource1\",\"segmentGranularity\":\"DAY\",\"rowsInTaskReport\":0,\"destinationResource\":{\"empty\":false,\"present\":true}}",
         DataSourceMSQDestination.class
     );
-    Assert.assertEquals(SegmentGenerationStageSpec.instance(), dataSourceMSQDestination.getTerminalStageSpec());
+    Assertions.assertEquals(SegmentGenerationStageSpec.instance(), dataSourceMSQDestination.getTerminalStageSpec());
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/destination/ExportMSQDestinationTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/destination/ExportMSQDestinationTest.java
@@ -26,8 +26,8 @@ import org.apache.druid.sql.http.ResultFormat;
 import org.apache.druid.storage.StorageConfig;
 import org.apache.druid.storage.StorageConnectorModule;
 import org.apache.druid.storage.local.LocalFileExportStorageProvider;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -49,6 +49,6 @@ public class ExportMSQDestinationTest
     );
 
     ExportMSQDestination newDest = objectMapper.readValue(string, ExportMSQDestination.class);
-    Assert.assertEquals(exportDestination, newDest);
+    Assertions.assertEquals(exportDestination, newDest);
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/error/CanceledFaultTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/error/CanceledFaultTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.msq.indexing.error;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CanceledFaultTest
 {
@@ -33,7 +33,7 @@ public class CanceledFaultTest
   {
     String serde = "{\"errorCode\":\"Canceled\",\"errorMessage\":\"Query canceled by user or by task shutdown.\"}";
     CanceledFault fault = jsonMapper.readValue(serde, CanceledFault.class);
-    Assert.assertEquals(CanceledFault.unknown(), fault);
+    Assertions.assertEquals(CanceledFault.unknown(), fault);
   }
 
   @Test
@@ -41,6 +41,6 @@ public class CanceledFaultTest
   {
     String serde = "{\"errorCode\":\"Canceled\",\"reason\":\"FUTURE_REASON\",\"errorMessage\":\"Query canceled due to [mysterious future reason].\"}";
     CanceledFault fault = jsonMapper.readValue(serde, CanceledFault.class);
-    Assert.assertEquals(CanceledFault.unknown(), fault);
+    Assertions.assertEquals(CanceledFault.unknown(), fault);
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/error/MSQErrorReportTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/error/MSQErrorReportTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.indexing.common.task.batch.TooManyBucketsException;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.query.QueryTimeoutException;
 import org.apache.druid.query.groupby.epinephelinae.UnexpectedMultiValueDimensionException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class MSQErrorReportTest
 {
@@ -36,42 +36,42 @@ public class MSQErrorReportTest
   @Test
   public void testErrorReportFault()
   {
-    Assert.assertEquals(UnknownFault.forException(null), MSQErrorReport.getFaultFromException(null));
+    Assertions.assertEquals(UnknownFault.forException(null), MSQErrorReport.getFaultFromException(null));
 
     MSQException msqException = new MSQException(null, UnknownFault.forMessage(ERROR_MESSAGE));
-    Assert.assertEquals(msqException.getFault(), MSQErrorReport.getFaultFromException(msqException));
+    Assertions.assertEquals(msqException.getFault(), MSQErrorReport.getFaultFromException(msqException));
 
     ParseException parseException = new ParseException(null, ERROR_MESSAGE);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new CannotParseExternalDataFault(ERROR_MESSAGE),
         MSQErrorReport.getFaultFromException(parseException)
     );
 
     UnsupportedColumnTypeException columnTypeException = new UnsupportedColumnTypeException(ERROR_MESSAGE, null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new ColumnTypeNotSupportedFault(ERROR_MESSAGE, null),
         MSQErrorReport.getFaultFromException(columnTypeException)
     );
 
     TooManyBucketsException tooManyBucketsException = new TooManyBucketsException(10);
-    Assert.assertEquals(new TooManyBucketsFault(10), MSQErrorReport.getFaultFromException(tooManyBucketsException));
+    Assertions.assertEquals(new TooManyBucketsFault(10), MSQErrorReport.getFaultFromException(tooManyBucketsException));
 
     FrameRowTooLargeException tooLargeException = new FrameRowTooLargeException(10);
-    Assert.assertEquals(new RowTooLargeFault(10), MSQErrorReport.getFaultFromException(tooLargeException));
+    Assertions.assertEquals(new RowTooLargeFault(10), MSQErrorReport.getFaultFromException(tooLargeException));
 
     UnexpectedMultiValueDimensionException mvException = new UnexpectedMultiValueDimensionException(ERROR_MESSAGE);
-    Assert.assertEquals(DruidExceptionFault.CODE, MSQErrorReport.getFaultFromException(mvException).getErrorCode());
+    Assertions.assertEquals(DruidExceptionFault.CODE, MSQErrorReport.getFaultFromException(mvException).getErrorCode());
 
     // QueryTimeoutException (legacy QueryException, not a DruidException) becomes an UnknownFault.
     // Only DruidExceptions become nice faults.
     QueryTimeoutException queryException = new QueryTimeoutException(ERROR_MESSAGE);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         UnknownFault.forException(queryException),
         MSQErrorReport.getFaultFromException(queryException)
     );
 
     RuntimeException runtimeException = new RuntimeException(ERROR_MESSAGE);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         UnknownFault.forException(runtimeException),
         MSQErrorReport.getFaultFromException(runtimeException)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/error/MSQFaultSerdeTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/error/MSQFaultSerdeTest.java
@@ -29,9 +29,9 @@ import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.query.JoinAlgorithm;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnType;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -41,7 +41,7 @@ public class MSQFaultSerdeTest
 {
   private ObjectMapper objectMapper;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     objectMapper = TestHelper.makeJsonMapper();
@@ -128,6 +128,6 @@ public class MSQFaultSerdeTest
   {
     final String json = objectMapper.writeValueAsString(fault);
     final MSQFault fault2 = objectMapper.readValue(json, MSQFault.class);
-    Assert.assertEquals(json, fault, fault2);
+    Assertions.assertEquals(fault, fault2, json);
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/error/MSQFaultToDruidExceptionTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/error/MSQFaultToDruidExceptionTest.java
@@ -24,8 +24,8 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.JoinAlgorithm;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,54 +36,54 @@ public class MSQFaultToDruidExceptionTest
   public void testBroadcastTablesTooLargeFault()
   {
     final DruidException e = new BroadcastTablesTooLargeFault(10, JoinAlgorithm.SORT_MERGE).toDruidException();
-    Assert.assertEquals("BroadcastTablesTooLarge", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("BroadcastTablesTooLarge", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testCanceledFaultShutdown()
   {
     final DruidException e = CanceledFault.shutdown().toDruidException();
-    Assert.assertEquals("Canceled", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CANCELED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("Canceled", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CANCELED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testCanceledFaultTimeout()
   {
     final DruidException e = CanceledFault.timeout().toDruidException();
-    Assert.assertEquals("Canceled", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.TIMEOUT, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("Canceled", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.TIMEOUT, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testCanceledFaultUserRequest()
   {
     final DruidException e = CanceledFault.userRequest().toDruidException();
-    Assert.assertEquals("Canceled", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CANCELED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("Canceled", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CANCELED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testCanceledFaultUnknown()
   {
     final DruidException e = CanceledFault.unknown().toDruidException();
-    Assert.assertEquals("Canceled", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CANCELED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("Canceled", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CANCELED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testCannotParseExternalDataFault()
   {
     final DruidException e = new CannotParseExternalDataFault("the message").toDruidException();
-    Assert.assertEquals("CannotParseExternalData", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("CannotParseExternalData", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
@@ -96,10 +96,10 @@ public class MSQFaultToDruidExceptionTest
         "test message",
         Collections.singletonMap("key", "value")
     ).toDruidException();
-    Assert.assertEquals("custom", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
-    Assert.assertEquals(Collections.singletonMap("key", "value"), e.getContext());
+    Assertions.assertEquals("custom", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals(Collections.singletonMap("key", "value"), e.getContext());
   }
 
   @Test
@@ -112,18 +112,18 @@ public class MSQFaultToDruidExceptionTest
         "test message",
         Collections.emptyMap()
     ).toDruidException();
-    Assert.assertEquals("custom", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.UNCATEGORIZED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.DEVELOPER, e.getTargetPersona());
+    Assertions.assertEquals("custom", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.UNCATEGORIZED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.DEVELOPER, e.getTargetPersona());
   }
 
   @Test
   public void testDurableStorageConfigurationFault()
   {
     final DruidException e = new DurableStorageConfigurationFault("some error").toDruidException();
-    Assert.assertEquals("DurableStorageConfiguration", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
+    Assertions.assertEquals("DurableStorageConfiguration", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
   }
 
   @Test
@@ -134,36 +134,36 @@ public class MSQFaultToDruidExceptionTest
         Intervals.ETERNITY,
         null
     ).toDruidException();
-    Assert.assertEquals("InsertCannotAllocateSegment", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("InsertCannotAllocateSegment", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testInsertCannotBeEmptyFault()
   {
     final DruidException e = new InsertCannotBeEmptyFault("the datasource").toDruidException();
-    Assert.assertEquals("InsertCannotBeEmpty", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("InsertCannotBeEmpty", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testInsertLockPreemptedFault()
   {
     final DruidException e = InsertLockPreemptedFault.INSTANCE.toDruidException();
-    Assert.assertEquals("InsertLockPreempted", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CONFLICT, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("InsertLockPreempted", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CONFLICT, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testInsertTimeNullFault()
   {
     final DruidException e = InsertTimeNullFault.INSTANCE.toDruidException();
-    Assert.assertEquals("InsertTimeNull", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("InsertTimeNull", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
@@ -173,9 +173,9 @@ public class MSQFaultToDruidExceptionTest
         Intervals.of("2001/2002"),
         Collections.singletonList(Intervals.of("2000/2001"))
     ).toDruidException();
-    Assert.assertEquals("InsertTimeOutOfBounds", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("InsertTimeOutOfBounds", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
@@ -188,9 +188,9 @@ public class MSQFaultToDruidExceptionTest
         "the error",
         "the log msg"
     ).toDruidException();
-    Assert.assertEquals("InvalidField", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.DEVELOPER, e.getTargetPersona());
+    Assertions.assertEquals("InvalidField", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.DEVELOPER, e.getTargetPersona());
   }
 
   @Test
@@ -203,9 +203,9 @@ public class MSQFaultToDruidExceptionTest
         "the value",
         2
     ).toDruidException();
-    Assert.assertEquals("InvalidNullByte", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("InvalidNullByte", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
@@ -220,126 +220,126 @@ public class MSQFaultToDruidExceptionTest
         2,
         2
     ).toDruidException();
-    Assert.assertEquals("NotEnoughMemory", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
+    Assertions.assertEquals("NotEnoughMemory", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
   }
 
   @Test
   public void testNotEnoughTemporaryStorageFault()
   {
     final DruidException e = new NotEnoughTemporaryStorageFault(250, 2).toDruidException();
-    Assert.assertEquals("NotEnoughTemporaryStorageFault", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
+    Assertions.assertEquals("NotEnoughTemporaryStorageFault", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
   }
 
   @Test
   public void testQueryNotSupportedFault()
   {
     final DruidException e = QueryNotSupportedFault.INSTANCE.toDruidException();
-    Assert.assertEquals("QueryNotSupported", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.UNSUPPORTED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.DEVELOPER, e.getTargetPersona());
+    Assertions.assertEquals("QueryNotSupported", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.UNSUPPORTED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.DEVELOPER, e.getTargetPersona());
   }
 
   @Test
   public void testQueryRuntimeFault()
   {
     final DruidException e = new QueryRuntimeFault("new error", "base error").toDruidException();
-    Assert.assertEquals("QueryRuntimeError", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.DEVELOPER, e.getTargetPersona());
+    Assertions.assertEquals("QueryRuntimeError", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.DEVELOPER, e.getTargetPersona());
   }
 
   @Test
   public void testRowTooLargeFault()
   {
     final DruidException e = new RowTooLargeFault(1000).toDruidException();
-    Assert.assertEquals("RowTooLarge", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("RowTooLarge", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testTaskStartTimeoutFault()
   {
     final DruidException e = new TaskStartTimeoutFault(1, 10, 11).toDruidException();
-    Assert.assertEquals("TaskStartTimeout", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
+    Assertions.assertEquals("TaskStartTimeout", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
   }
 
   @Test
   public void testTooManyAttemptsForJob()
   {
     final DruidException e = new TooManyAttemptsForJob(2, 2, "taskId", "rootError").toDruidException();
-    Assert.assertEquals("TooManyAttemptsForJob", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
+    Assertions.assertEquals("TooManyAttemptsForJob", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
   }
 
   @Test
   public void testTooManyAttemptsForWorker()
   {
     final DruidException e = new TooManyAttemptsForWorker(2, "taskId", 1, "rootError").toDruidException();
-    Assert.assertEquals("TooManyAttemptsForWorker", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
+    Assertions.assertEquals("TooManyAttemptsForWorker", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
   }
 
   @Test
   public void testTooManyBucketsFault()
   {
     final DruidException e = new TooManyBucketsFault(10).toDruidException();
-    Assert.assertEquals("TooManyBuckets", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("TooManyBuckets", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testTooManyClusteredByColumnsFault()
   {
     final DruidException e = new TooManyClusteredByColumnsFault(10, 8, 1).toDruidException();
-    Assert.assertEquals("TooManyClusteredByColumns", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("TooManyClusteredByColumns", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testTooManyColumnsFault()
   {
     final DruidException e = new TooManyColumnsFault(10, 8).toDruidException();
-    Assert.assertEquals("TooManyColumns", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("TooManyColumns", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testTooManyInputFilesFault()
   {
     final DruidException e = new TooManyInputFilesFault(15, 10, 5).toDruidException();
-    Assert.assertEquals("TooManyInputFiles", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("TooManyInputFiles", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testTooManyPartitionsFault()
   {
     final DruidException e = new TooManyPartitionsFault(10).toDruidException();
-    Assert.assertEquals("TooManyPartitions", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("TooManyPartitions", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testTooManyRowsInAWindowFault()
   {
     final DruidException e = new TooManyRowsInAWindowFault(10, 20).toDruidException();
-    Assert.assertEquals("TooManyRowsInAWindow", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("TooManyRowsInAWindow", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
@@ -348,9 +348,9 @@ public class MSQFaultToDruidExceptionTest
     final DruidException e = new TooManyRowsWithSameKeyFault(
         Arrays.asList("foo", 123), 1, 2
     ).toDruidException();
-    Assert.assertEquals("TooManyRowsWithSameKey", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("TooManyRowsWithSameKey", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
@@ -359,53 +359,53 @@ public class MSQFaultToDruidExceptionTest
     final DruidException e = new TooManySegmentsInTimeChunkFault(
         DateTimes.nowUtc(), 10, 1, Granularities.ALL
     ).toDruidException();
-    Assert.assertEquals("TooManySegmentsInTimeChunk", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("TooManySegmentsInTimeChunk", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testTooManyWarningsFault()
   {
     final DruidException e = new TooManyWarningsFault(10, "the error").toDruidException();
-    Assert.assertEquals("TooManyWarnings", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("TooManyWarnings", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testTooManyWorkersFault()
   {
     final DruidException e = new TooManyWorkersFault(10, 5).toDruidException();
-    Assert.assertEquals("TooManyWorkers", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+    Assertions.assertEquals("TooManyWorkers", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.CAPACITY_EXCEEDED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
   }
 
   @Test
   public void testUnknownFault()
   {
     final DruidException e = UnknownFault.forMessage("the message").toDruidException();
-    Assert.assertEquals("UnknownError", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.UNCATEGORIZED, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.DEVELOPER, e.getTargetPersona());
+    Assertions.assertEquals("UnknownError", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.UNCATEGORIZED, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.DEVELOPER, e.getTargetPersona());
   }
 
   @Test
   public void testWorkerFailedFault()
   {
     final DruidException e = new WorkerFailedFault("the worker task", "the error msg").toDruidException();
-    Assert.assertEquals("WorkerFailed", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
+    Assertions.assertEquals("WorkerFailed", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
   }
 
   @Test
   public void testWorkerRpcFailedFault()
   {
     final DruidException e = new WorkerRpcFailedFault("the worker task", "the error msg").toDruidException();
-    Assert.assertEquals("WorkerRpcFailed", e.getErrorCode());
-    Assert.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
-    Assert.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
+    Assertions.assertEquals("WorkerRpcFailed", e.getErrorCode());
+    Assertions.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
+    Assertions.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/error/MSQWarningsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/error/MSQWarningsTest.java
@@ -43,7 +43,7 @@ import org.apache.druid.sql.calcite.filtration.Filtration;
 import org.apache.druid.sql.calcite.planner.ColumnMapping;
 import org.apache.druid.sql.calcite.planner.ColumnMappings;
 import org.apache.druid.sql.calcite.util.CalciteTests;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -411,7 +411,7 @@ public class MSQWarningsTest extends MSQTestBase
                      .verifyResults();
 
     // Temporary directory should not contain any controller-related folders
-    Assert.assertEquals(0, localFileStorageDir.listFiles().length);
+    Assertions.assertEquals(0, localFileStorageDir.listFiles().length);
   }
 
   @Test

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/report/MSQTaskReportTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/report/MSQTaskReportTest.java
@@ -43,10 +43,10 @@ import org.apache.druid.msq.querykit.common.OffsetLimitStageProcessor;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.apache.druid.testing.TemporaryFolderExtension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.util.ArrayDeque;
@@ -79,8 +79,8 @@ public class MSQTaskReportTest
           )
           .build();
 
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   @Test
   public void testSerdeResultsReport() throws Exception
@@ -132,17 +132,17 @@ public class MSQTaskReportTest
         TaskReport.class
     );
 
-    Assert.assertEquals(TASK_ID, report2.getTaskId());
-    Assert.assertEquals(report.getPayload().getStatus().getStatus(), report2.getPayload().getStatus().getStatus());
-    Assert.assertNull(report2.getPayload().getStatus().getErrorReport());
-    Assert.assertEquals(report.getPayload().getStatus().getRunningTasks(), report2.getPayload().getStatus().getRunningTasks());
-    Assert.assertEquals(report.getPayload().getStatus().getPendingTasks(), report2.getPayload().getStatus().getPendingTasks());
-    Assert.assertEquals(report.getPayload().getStages(), report2.getPayload().getStages());
+    Assertions.assertEquals(TASK_ID, report2.getTaskId());
+    Assertions.assertEquals(report.getPayload().getStatus().getStatus(), report2.getPayload().getStatus().getStatus());
+    Assertions.assertNull(report2.getPayload().getStatus().getErrorReport());
+    Assertions.assertEquals(report.getPayload().getStatus().getRunningTasks(), report2.getPayload().getStatus().getRunningTasks());
+    Assertions.assertEquals(report.getPayload().getStatus().getPendingTasks(), report2.getPayload().getStatus().getPendingTasks());
+    Assertions.assertEquals(report.getPayload().getStages(), report2.getPayload().getStages());
 
     final List<Object[]> results2 = report2.getPayload().getResults().getResults();
-    Assert.assertEquals(results.size(), results2.size());
+    Assertions.assertEquals(results.size(), results2.size());
     for (int i = 0; i < results.size(); i++) {
-      Assert.assertArrayEquals(results.get(i), results2.get(i));
+      Assertions.assertArrayEquals(results.get(i), results2.get(i));
     }
   }
 
@@ -187,13 +187,13 @@ public class MSQTaskReportTest
         TaskReport.class
     );
 
-    Assert.assertEquals(TASK_ID, report2.getTaskId());
-    Assert.assertEquals(report.getPayload().getStatus().getStatus(), report2.getPayload().getStatus().getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(TASK_ID, report2.getTaskId());
+    Assertions.assertEquals(report.getPayload().getStatus().getStatus(), report2.getPayload().getStatus().getStatus());
+    Assertions.assertEquals(
         report.getPayload().getStatus().getErrorReport(),
         report2.getPayload().getStatus().getErrorReport()
     );
-    Assert.assertEquals(report.getPayload().getStages(), report2.getPayload().getStages());
+    Assertions.assertEquals(report.getPayload().getStages(), report2.getPayload().getStages());
   }
 
   @Test
@@ -243,8 +243,8 @@ public class MSQTaskReportTest
 
     final MSQTaskReport report2 = (MSQTaskReport) reportMap.get(MSQTaskReport.REPORT_KEY);
 
-    Assert.assertEquals(TASK_ID, report2.getTaskId());
-    Assert.assertEquals(report.getPayload().getStatus().getStatus(), report2.getPayload().getStatus().getStatus());
-    Assert.assertEquals(report.getPayload().getStages(), report2.getPayload().getStages());
+    Assertions.assertEquals(TASK_ID, report2.getTaskId());
+    Assertions.assertEquals(report.getPayload().getStatus().getStatus(), report2.getPayload().getStatus().getStatus());
+    Assertions.assertEquals(report.getPayload().getStages(), report2.getPayload().getStages());
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/InputSpecsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/InputSpecsTest.java
@@ -25,15 +25,15 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSets;
 import org.apache.druid.msq.input.stage.StageInputSpec;
 import org.apache.druid.msq.input.table.TableInputSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class InputSpecsTest
 {
   @Test
   public void test_getStageNumbers()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(1, 2),
         InputSpecs.getStageNumbers(
             ImmutableList.of(
@@ -47,7 +47,7 @@ public class InputSpecsTest
   @Test
   public void test_getHasLeafInputs_allStages()
   {
-    Assert.assertFalse(
+    Assertions.assertFalse(
         InputSpecs.hasLeafInputs(
             ImmutableList.of(
                 new StageInputSpec(1),
@@ -61,7 +61,7 @@ public class InputSpecsTest
   @Test
   public void test_getHasLeafInputs_broadcastTable()
   {
-    Assert.assertFalse(
+    Assertions.assertFalse(
         InputSpecs.hasLeafInputs(
             ImmutableList.of(new TableInputSpec("tbl", null, null)),
             IntSet.of(0)
@@ -72,7 +72,7 @@ public class InputSpecsTest
   @Test
   public void test_getHasLeafInputs_oneTableOneStage()
   {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         InputSpecs.hasLeafInputs(
             ImmutableList.of(
                 new TableInputSpec("tbl", null, null),
@@ -86,7 +86,7 @@ public class InputSpecsTest
   @Test
   public void test_getHasLeafInputs_oneTableOneBroadcastStage()
   {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         InputSpecs.hasLeafInputs(
             ImmutableList.of(
                 new TableInputSpec("tbl", null, null),
@@ -100,7 +100,7 @@ public class InputSpecsTest
   @Test
   public void test_getHasLeafInputs_oneBroadcastTableOneStage()
   {
-    Assert.assertFalse(
+    Assertions.assertFalse(
         InputSpecs.hasLeafInputs(
             ImmutableList.of(
                 new TableInputSpec("tbl", null, null),
@@ -114,7 +114,7 @@ public class InputSpecsTest
   @Test
   public void test_getHasLeafInputs_oneTableOneBroadcastTable()
   {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         InputSpecs.hasLeafInputs(
             ImmutableList.of(
                 new TableInputSpec("tbl", null, null),

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/NilInputSliceTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/NilInputSliceTest.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class NilInputSliceTest
 {
@@ -36,7 +36,7 @@ public class NilInputSliceTest
 
     final NilInputSlice slice = NilInputSlice.INSTANCE;
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         slice,
         mapper.readValue(mapper.writeValueAsString(slice), InputSlice.class)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/RegularLoadableSegmentTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/RegularLoadableSegmentTest.java
@@ -61,6 +61,7 @@ import org.apache.druid.segment.loading.StorageLocationConfig;
 import org.apache.druid.server.SegmentManager;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.utils.CompressionUtils;
@@ -70,6 +71,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
@@ -93,8 +95,10 @@ class RegularLoadableSegmentTest extends InitializedNullHandlingTest
   private static final int THREADS = 8;
   private static File SEGMENT_ZIP_FILE;
 
-  @TempDir
-  public Path tempDir;
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
+
+  private Path tempDir;
 
   private List<DataSegment> segments;
   private File cacheDir;
@@ -121,6 +125,7 @@ class RegularLoadableSegmentTest extends InitializedNullHandlingTest
   @BeforeEach
   public void setUp() throws Exception
   {
+    tempDir = temporaryFolder.getRoot().toPath();
     final ObjectMapper jsonMapper = TestHelper.makeJsonMapper();
     jsonMapper.registerSubtypes(TestLoadSpec.class);
     jsonMapper.registerModule(new SegmentizerModule());

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/external/ExternalInputSliceTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/external/ExternalInputSliceTest.java
@@ -26,8 +26,8 @@ import org.apache.druid.data.input.impl.systemfield.SystemFields;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.msq.input.InputSlice;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Collections;
@@ -53,7 +53,7 @@ public class ExternalInputSliceTest
         ExternalInputSpecSlicerTest.SIGNATURE
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         slice,
         mapper.readValue(mapper.writeValueAsString(slice), InputSlice.class)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/external/ExternalInputSpecSlicerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/external/ExternalInputSpecSlicerTest.java
@@ -32,11 +32,12 @@ import org.apache.druid.data.input.impl.SplittableInputSource;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.utils.Streams;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
@@ -53,7 +54,7 @@ public class ExternalInputSpecSlicerTest
 
   private ExternalInputSpecSlicer slicer;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     slicer = new ExternalInputSpecSlicer();
@@ -62,25 +63,25 @@ public class ExternalInputSpecSlicerTest
   @Test
   public void test_canSliceDynamic_splittable()
   {
-    Assert.assertTrue(slicer.canSliceDynamic(splittableSpec()));
+    Assertions.assertTrue(slicer.canSliceDynamic(splittableSpec()));
   }
 
   @Test
   public void test_canSliceDynamic_splittableThatIgnoresSplitHints()
   {
-    Assert.assertTrue(slicer.canSliceDynamic(splittableSpecThatIgnoresSplitHints()));
+    Assertions.assertTrue(slicer.canSliceDynamic(splittableSpecThatIgnoresSplitHints()));
   }
 
   @Test
   public void test_canSliceDynamic_unsplittable()
   {
-    Assert.assertFalse(slicer.canSliceDynamic(unsplittableSpec()));
+    Assertions.assertFalse(slicer.canSliceDynamic(unsplittableSpec()));
   }
 
   @Test
   public void test_sliceStatic_unsplittable()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(unsplittableSlice("foo", "bar", "baz")),
         slicer.sliceStatic(unsplittableSpec("foo", "bar", "baz"), null, 2)
     );
@@ -89,7 +90,7 @@ public class ExternalInputSpecSlicerTest
   @Test
   public void test_sliceStatic_unsplittable_empty()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(unsplittableSlice()),
         slicer.sliceStatic(unsplittableSpec(), null, 2)
     );
@@ -98,7 +99,7 @@ public class ExternalInputSpecSlicerTest
   @Test
   public void test_sliceStatic_splittable()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             splittableSlice("foo", "baz"),
             splittableSlice("bar")
@@ -110,7 +111,7 @@ public class ExternalInputSpecSlicerTest
   @Test
   public void test_sliceStatic_splittable_someWorkersEmpty()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             splittableSlice("foo"),
             splittableSlice("bar"),
@@ -123,7 +124,7 @@ public class ExternalInputSpecSlicerTest
   @Test
   public void test_sliceStatic_splittable_empty()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(),
         slicer.sliceStatic(splittableSpec(), null, 2)
     );
@@ -132,7 +133,7 @@ public class ExternalInputSpecSlicerTest
   @Test
   public void test_sliceStatic_splittableThatIgnoresSplitHints()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             splittableSlice("foo", "baz"),
             splittableSlice("bar")
@@ -144,7 +145,7 @@ public class ExternalInputSpecSlicerTest
   @Test
   public void test_sliceDynamic_unsplittable()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             unsplittableSlice("foo", "bar", "baz")
         ),
@@ -155,7 +156,7 @@ public class ExternalInputSpecSlicerTest
   @Test
   public void test_sliceDynamic_splittable_needOne()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             splittableSlice("foo", "bar", "baz")
         ),
@@ -166,7 +167,7 @@ public class ExternalInputSpecSlicerTest
   @Test
   public void test_sliceDynamic_splittable_needTwoDueToFiles()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             splittableSlice("foo", "bar"),
             splittableSlice("baz")
@@ -178,7 +179,7 @@ public class ExternalInputSpecSlicerTest
   @Test
   public void test_sliceDynamic_splittable_needTwoDueToBytes()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             splittableSlice("foo", "bar"),
             splittableSlice("baz")
@@ -190,7 +191,7 @@ public class ExternalInputSpecSlicerTest
   @Test
   public void test_sliceDynamic_splittableFilesWithCompression_needThreeDueToBytes()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             splittableSlice("foo.gz"),
             splittableSlice("bar.gz"),
@@ -203,7 +204,7 @@ public class ExternalInputSpecSlicerTest
   @Test
   public void test_sliceDynamic_splittableThatIgnoresSplitHints_oneHundredMax()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             splittableSlice("foo"),
             splittableSlice("bar"),
@@ -216,7 +217,7 @@ public class ExternalInputSpecSlicerTest
   @Test
   public void test_sliceDynamic_splittableThatIgnoresSplitHints_twoMax()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             splittableSlice("foo", "baz"),
             splittableSlice("bar")
@@ -228,7 +229,7 @@ public class ExternalInputSpecSlicerTest
   @Test
   public void test_sliceDynamic_splittableThatIgnoresSplitHints_oneMax()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             splittableSlice("foo", "bar", "baz")
         ),

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/external/ExternalInputSpecTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/external/ExternalInputSpecTest.java
@@ -26,8 +26,8 @@ import org.apache.druid.data.input.impl.systemfield.SystemFields;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.msq.input.InputSpec;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Collections;
@@ -51,7 +51,7 @@ public class ExternalInputSpecTest
         ExternalInputSpecSlicerTest.SIGNATURE
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         spec,
         mapper.readValue(mapper.writeValueAsString(spec), InputSpec.class)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/external/NilInputSourceTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/external/NilInputSourceTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.msq.input.external;
 
 import org.apache.druid.msq.input.NilInputSource;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class NilInputSourceTest
 {
@@ -30,6 +30,6 @@ public class NilInputSourceTest
   @Test
   public void testGetTypes()
   {
-    Assert.assertTrue(NIL_INPUT_SOURCE.getTypes().isEmpty());
+    Assertions.assertTrue(NIL_INPUT_SOURCE.getTypes().isEmpty());
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/inline/InlineInputSliceTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/inline/InlineInputSliceTest.java
@@ -27,8 +27,8 @@ import org.apache.druid.query.InlineDataSource;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -47,7 +47,7 @@ public class InlineInputSliceTest
 
     final InlineInputSlice slice = new InlineInputSlice(dataSource);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         slice,
         mapper.readValue(mapper.writeValueAsString(slice), InputSlice.class)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/inline/InlineInputSpecTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/inline/InlineInputSpecTest.java
@@ -27,8 +27,8 @@ import org.apache.druid.query.InlineDataSource;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -47,7 +47,7 @@ public class InlineInputSpecTest
 
     final InlineInputSpec spec = new InlineInputSpec(dataSource);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         spec,
         mapper.readValue(mapper.writeValueAsString(spec), InputSpec.class)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/lookup/LookupInputSliceTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/lookup/LookupInputSliceTest.java
@@ -24,8 +24,8 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.msq.input.InputSlice;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LookupInputSliceTest
 {
@@ -37,7 +37,7 @@ public class LookupInputSliceTest
 
     final LookupInputSlice slice = new LookupInputSlice("myLookup");
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         slice,
         mapper.readValue(mapper.writeValueAsString(slice), InputSlice.class)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/lookup/LookupInputSpecTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/lookup/LookupInputSpecTest.java
@@ -24,8 +24,8 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.msq.input.InputSpec;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LookupInputSpecTest
 {
@@ -37,7 +37,7 @@ public class LookupInputSpecTest
 
     final LookupInputSpec spec = new LookupInputSpec("myLookup");
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         spec,
         mapper.readValue(mapper.writeValueAsString(spec), InputSpec.class)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/CollectedReadablePartitionsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/CollectedReadablePartitionsTest.java
@@ -25,8 +25,8 @@ import com.google.common.collect.ImmutableMap;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CollectedReadablePartitionsTest
 {
@@ -35,7 +35,7 @@ public class CollectedReadablePartitionsTest
   {
     final CollectedReadablePartitions partitions =
         (CollectedReadablePartitions) ReadablePartitions.collected(1, ImmutableMap.of(0, 1, 1, 2, 2, 1));
-    Assert.assertEquals(ImmutableMap.of(0, 1, 1, 2, 2, 1), partitions.getPartitionToWorkerMap());
+    Assertions.assertEquals(ImmutableMap.of(0, 1, 1, 2, 2, 1), partitions.getPartitionToWorkerMap());
   }
 
   @Test
@@ -43,7 +43,7 @@ public class CollectedReadablePartitionsTest
   {
     final CollectedReadablePartitions partitions =
         (CollectedReadablePartitions) ReadablePartitions.collected(1, ImmutableMap.of(0, 1, 1, 2, 2, 1));
-    Assert.assertEquals(1, partitions.getStageNumber());
+    Assertions.assertEquals(1, partitions.getStageNumber());
   }
 
   @Test
@@ -52,7 +52,7 @@ public class CollectedReadablePartitionsTest
     final CollectedReadablePartitions partitions =
         (CollectedReadablePartitions) ReadablePartitions.collected(1, ImmutableMap.of(0, 1, 1, 2, 2, 1));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             ReadablePartitions.collected(1, ImmutableMap.of(0, 1, 2, 1)),
             ReadablePartitions.collected(1, ImmutableMap.of(1, 2))
@@ -70,7 +70,7 @@ public class CollectedReadablePartitionsTest
     final CollectedReadablePartitions partitions =
         (CollectedReadablePartitions) ReadablePartitions.collected(1, ImmutableMap.of(0, 1, 1, 2, 2, 1));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         partitions,
         mapper.readValue(
             mapper.writeValueAsString(partitions),

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/CombinedReadablePartitionsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/CombinedReadablePartitionsTest.java
@@ -26,8 +26,8 @@ import it.unimi.dsi.fastutil.ints.IntAVLTreeSet;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CombinedReadablePartitionsTest
 {
@@ -41,19 +41,19 @@ public class CombinedReadablePartitionsTest
   @Test
   public void testEmpty()
   {
-    Assert.assertEquals(0, Iterables.size(ReadablePartitions.empty()));
+    Assertions.assertEquals(0, Iterables.size(ReadablePartitions.empty()));
   }
 
   @Test
   public void testSplitOne()
   {
-    Assert.assertEquals(ImmutableList.of(PARTITIONS), PARTITIONS.split(1));
+    Assertions.assertEquals(ImmutableList.of(PARTITIONS), PARTITIONS.split(1));
   }
 
   @Test
   public void testSplitTwo()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             ReadablePartitions.combine(
                 ImmutableList.of(
@@ -78,7 +78,7 @@ public class CombinedReadablePartitionsTest
     final ObjectMapper mapper = TestHelper.makeJsonMapper()
                                           .registerModules(new MSQIndexingModule().getJacksonModules());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         PARTITIONS,
         mapper.readValue(
             mapper.writeValueAsString(PARTITIONS),

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/ReadablePartitionTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/ReadablePartitionTest.java
@@ -20,7 +20,7 @@
 package org.apache.druid.msq.input.stage;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReadablePartitionTest
 {

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/SparseStripedReadablePartitionsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/SparseStripedReadablePartitionsTest.java
@@ -27,8 +27,8 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SparseStripedReadablePartitionsTest
 {
@@ -37,7 +37,7 @@ public class SparseStripedReadablePartitionsTest
   {
     final SparseStripedReadablePartitions partitions =
         (SparseStripedReadablePartitions) ReadablePartitions.striped(1, new IntAVLTreeSet(new int[]{1, 3}), 3);
-    Assert.assertEquals(ImmutableSet.of(0, 1, 2), partitions.getPartitionNumbers());
+    Assertions.assertEquals(ImmutableSet.of(0, 1, 2), partitions.getPartitionNumbers());
   }
 
   @Test
@@ -45,7 +45,7 @@ public class SparseStripedReadablePartitionsTest
   {
     final SparseStripedReadablePartitions partitions =
         (SparseStripedReadablePartitions) ReadablePartitions.striped(1, new IntAVLTreeSet(new int[]{1, 3}), 3);
-    Assert.assertEquals(IntSet.of(1, 3), partitions.getWorkers());
+    Assertions.assertEquals(IntSet.of(1, 3), partitions.getWorkers());
   }
 
   @Test
@@ -53,7 +53,7 @@ public class SparseStripedReadablePartitionsTest
   {
     final SparseStripedReadablePartitions partitions =
         (SparseStripedReadablePartitions) ReadablePartitions.striped(1, new IntAVLTreeSet(new int[]{1, 3}), 3);
-    Assert.assertEquals(1, partitions.getStageNumber());
+    Assertions.assertEquals(1, partitions.getStageNumber());
   }
 
   @Test
@@ -63,7 +63,7 @@ public class SparseStripedReadablePartitionsTest
     final SparseStripedReadablePartitions partitions =
         (SparseStripedReadablePartitions) ReadablePartitions.striped(1, workers, 3);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new SparseStripedReadablePartitions(1, workers, new IntAVLTreeSet(new int[]{0, 2})),
             new SparseStripedReadablePartitions(1, workers, new IntAVLTreeSet(new int[]{1}))
@@ -81,7 +81,7 @@ public class SparseStripedReadablePartitionsTest
     final IntAVLTreeSet workers = new IntAVLTreeSet(new int[]{1, 3});
     final ReadablePartitions partitions = ReadablePartitions.striped(1, workers, 3);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         partitions,
         mapper.readValue(
             mapper.writeValueAsString(partitions),

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/StageInputSliceTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/StageInputSliceTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.msq.exec.OutputChannelMode;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.msq.input.InputSlice;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StageInputSliceTest
 {
@@ -42,7 +42,7 @@ public class StageInputSliceTest
         OutputChannelMode.MEMORY
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         slice,
         mapper.readValue(mapper.writeValueAsString(slice), InputSlice.class)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/StageInputSpecSlicerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/StageInputSpecSlicerTest.java
@@ -27,9 +27,9 @@ import it.unimi.dsi.fastutil.ints.IntAVLTreeSet;
 import org.apache.druid.msq.exec.OutputChannelMode;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -55,7 +55,7 @@ public class StageInputSpecSlicerTest
 
   private StageInputSpecSlicer slicer;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     slicer = new StageInputSpecSlicer(STAGE_PARTITIONS_MAP, STAGE_OUTPUT_MODE_MAP);
@@ -64,13 +64,13 @@ public class StageInputSpecSlicerTest
   @Test
   public void test_canSliceDynamic()
   {
-    Assert.assertFalse(slicer.canSliceDynamic(new StageInputSpec(0)));
+    Assertions.assertFalse(slicer.canSliceDynamic(new StageInputSpec(0)));
   }
 
   @Test
   public void test_sliceStatic_stageZeroOneSlice()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singletonList(
             new StageInputSlice(
                 0,
@@ -85,7 +85,7 @@ public class StageInputSpecSlicerTest
   @Test
   public void test_sliceStatic_stageZeroTwoSlices()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new StageInputSlice(
                 0,
@@ -105,7 +105,7 @@ public class StageInputSpecSlicerTest
   @Test
   public void test_sliceStatic_stageOneTwoSlices()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new StageInputSlice(
                 1,
@@ -125,7 +125,7 @@ public class StageInputSpecSlicerTest
   @Test
   public void test_sliceStatic_notAvailable()
   {
-    final IllegalStateException e = Assert.assertThrows(
+    final IllegalStateException e = Assertions.assertThrows(
         IllegalStateException.class,
         () -> slicer.sliceStatic(new StageInputSpec(3), null, 1)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/StageInputSpecSlicerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/StageInputSpecSlicerTest.java
@@ -25,8 +25,6 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntAVLTreeSet;
 import org.apache.druid.msq.exec.OutputChannelMode;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -130,6 +128,6 @@ public class StageInputSpecSlicerTest
         () -> slicer.sliceStatic(new StageInputSpec(3), null, 1)
     );
 
-    MatcherAssert.assertThat(e.getMessage(), CoreMatchers.equalTo("Stage[3] output partitions not available"));
+    Assertions.assertEquals("Stage[3] output partitions not available", e.getMessage());
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/StageInputSpecTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/StageInputSpecTest.java
@@ -24,8 +24,8 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.msq.input.InputSpec;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StageInputSpecTest
 {
@@ -37,7 +37,7 @@ public class StageInputSpecTest
 
     final StageInputSpec spec = new StageInputSpec(2);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         spec,
         mapper.readValue(mapper.writeValueAsString(spec), InputSpec.class)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/StripedReadablePartitionsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/StripedReadablePartitionsTest.java
@@ -26,8 +26,6 @@ import it.unimi.dsi.fastutil.ints.IntAVLTreeSet;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.segment.TestHelper;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -44,10 +42,7 @@ public class StripedReadablePartitionsTest
 
     final ReadablePartitions readablePartitionsFromSet = ReadablePartitions.striped(1, workers, 3);
 
-    MatcherAssert.assertThat(
-        readablePartitionsFromSet,
-        CoreMatchers.instanceOf(StripedReadablePartitions.class)
-    );
+    Assertions.assertInstanceOf(StripedReadablePartitions.class, readablePartitionsFromSet);
 
     Assertions.assertEquals(
         ReadablePartitions.striped(1, 2, 3),

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/StripedReadablePartitionsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/StripedReadablePartitionsTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.segment.TestHelper;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StripedReadablePartitionsTest
 {
@@ -49,7 +49,7 @@ public class StripedReadablePartitionsTest
         CoreMatchers.instanceOf(StripedReadablePartitions.class)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ReadablePartitions.striped(1, 2, 3),
         readablePartitionsFromSet
     );
@@ -59,21 +59,21 @@ public class StripedReadablePartitionsTest
   public void testPartitionNumbers()
   {
     final StripedReadablePartitions partitions = (StripedReadablePartitions) ReadablePartitions.striped(1, 2, 3);
-    Assert.assertEquals(ImmutableSet.of(0, 1, 2), partitions.getPartitionNumbers());
+    Assertions.assertEquals(ImmutableSet.of(0, 1, 2), partitions.getPartitionNumbers());
   }
 
   @Test
   public void testNumWorkers()
   {
     final StripedReadablePartitions partitions = (StripedReadablePartitions) ReadablePartitions.striped(1, 2, 3);
-    Assert.assertEquals(2, partitions.getNumWorkers());
+    Assertions.assertEquals(2, partitions.getNumWorkers());
   }
 
   @Test
   public void testStageNumber()
   {
     final StripedReadablePartitions partitions = (StripedReadablePartitions) ReadablePartitions.striped(1, 2, 3);
-    Assert.assertEquals(1, partitions.getStageNumber());
+    Assertions.assertEquals(1, partitions.getStageNumber());
   }
 
   @Test
@@ -81,7 +81,7 @@ public class StripedReadablePartitionsTest
   {
     final ReadablePartitions partitions = ReadablePartitions.striped(1, 2, 3);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new StripedReadablePartitions(1, 2, new IntAVLTreeSet(new int[]{0, 2})),
             new StripedReadablePartitions(1, 2, new IntAVLTreeSet(new int[]{1}))
@@ -98,7 +98,7 @@ public class StripedReadablePartitionsTest
 
     final ReadablePartitions partitions = ReadablePartitions.striped(1, 2, 3);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         partitions,
         mapper.readValue(
             mapper.writeValueAsString(partitions),

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/DataSegmentWithLocationTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/DataSegmentWithLocationTest.java
@@ -41,9 +41,9 @@ import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -56,7 +56,7 @@ public class DataSegmentWithLocationTest
   private static final ObjectMapper MAPPER = new DefaultObjectMapper();
   private static final int TEST_VERSION = 0x9;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     InjectableValues.Std injectableValues = new InjectableValues.Std();
@@ -115,7 +115,7 @@ public class DataSegmentWithLocationTest
         MAPPER.writeValueAsString(segmentWithLocation),
         DataSegmentWithLocation.class
     );
-    Assert.assertEquals(deserialized.toString(), segmentWithLocation.toString());
-    Assert.assertEquals(Set.of(serverMetadata), segmentWithLocation.getServers());
+    Assertions.assertEquals(deserialized.toString(), segmentWithLocation.toString());
+    Assertions.assertEquals(Set.of(serverMetadata), segmentWithLocation.getServers());
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/DataServerRequestDescriptorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/DataServerRequestDescriptorTest.java
@@ -27,8 +27,8 @@ import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.ServerType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DataServerRequestDescriptorTest
 {
@@ -51,7 +51,7 @@ public class DataServerRequestDescriptorTest
     final ObjectMapper mapper = TestHelper.makeJsonMapper()
                                           .registerModules(new MSQIndexingModule().getJacksonModules());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         segment,
         mapper.readValue(mapper.writeValueAsString(segment), DataServerRequestDescriptor.class)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/IndexerTableInputSpecSlicerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/IndexerTableInputSpecSlicerTest.java
@@ -40,9 +40,9 @@ import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.DimensionRangeShardSpec;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -108,7 +108,7 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
   private IndexerTableInputSpecSlicer slicer;
   private TaskActionClient taskActionClient;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     timeline = SegmentTimeline.forSegments(ImmutableList.of(SEGMENT1, SEGMENT2, SEGMENT3));
@@ -149,14 +149,14 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
   @Test
   public void test_canSliceDynamic()
   {
-    Assert.assertTrue(slicer.canSliceDynamic(new TableInputSpec(DATASOURCE, null, null)));
+    Assertions.assertTrue(slicer.canSliceDynamic(new TableInputSpec(DATASOURCE, null, null)));
   }
 
   @Test
   public void test_sliceStatic_noDataSource()
   {
     final TableInputSpec spec = new TableInputSpec("no such datasource", null, null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(NilInputSlice.INSTANCE, NilInputSlice.INSTANCE),
         slicer.sliceStatic(spec, null, 2)
     );
@@ -174,7 +174,7 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singletonList(
             new SegmentsInputSlice(
                 DATASOURCE,
@@ -220,7 +220,7 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(NilInputSlice.INSTANCE, NilInputSlice.INSTANCE),
         slicer.sliceStatic(spec, null, 2)
     );
@@ -245,7 +245,7 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
         SEGMENT1.getVersion(),
         SEGMENT1.getShardSpec().getPartitionNum()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(new SegmentsInputSlice(DATASOURCE, List.of(expectedSegment), List.of())),
         slicer.sliceStatic(spec, null, 1));
   }
@@ -263,7 +263,7 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
         ))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(NilInputSlice.INSTANCE, NilInputSlice.INSTANCE),
         slicer.sliceStatic(spec, null, 2)
     );
@@ -283,7 +283,7 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new SegmentsInputSlice(
                 DATASOURCE,
@@ -317,7 +317,7 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new SegmentsInputSlice(
                 DATASOURCE,
@@ -359,7 +359,7 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new SegmentsInputSlice(
                 DATASOURCE,
@@ -394,7 +394,7 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
   public void test_sliceStatic_oneSlice()
   {
     final TableInputSpec spec = new TableInputSpec(DATASOURCE, null, null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singletonList(
             new SegmentsInputSlice(
                 DATASOURCE,
@@ -423,7 +423,7 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
   public void test_sliceStatic_needTwoSlices()
   {
     final TableInputSpec spec = new TableInputSpec(DATASOURCE, null, null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new SegmentsInputSlice(
                 DATASOURCE,
@@ -458,7 +458,7 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
   public void test_sliceStatic_threeSlices()
   {
     final TableInputSpec spec = new TableInputSpec(DATASOURCE, null, null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new SegmentsInputSlice(
                 DATASOURCE,
@@ -499,7 +499,7 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.emptyList(),
         slicer.sliceDynamic(spec, null, 1, 1, 1)
     );
@@ -514,7 +514,7 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singletonList(
             new SegmentsInputSlice(
                 DATASOURCE,
@@ -548,7 +548,7 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singletonList(
             new SegmentsInputSlice(
                 DATASOURCE,
@@ -582,7 +582,7 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new SegmentsInputSlice(
                 DATASOURCE,
@@ -622,7 +622,7 @@ public class IndexerTableInputSpecSlicerTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new SegmentsInputSlice(
                 DATASOURCE,

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/RichSegmentDescriptorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/RichSegmentDescriptorTest.java
@@ -24,8 +24,8 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.query.SegmentDescriptor;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RichSegmentDescriptorTest
 {
@@ -40,7 +40,7 @@ public class RichSegmentDescriptorTest
         3
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         descriptor,
         mapper.readValue(mapper.writeValueAsString(descriptor), RichSegmentDescriptor.class)
     );
@@ -57,7 +57,7 @@ public class RichSegmentDescriptorTest
         3
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         descriptor,
         mapper.readValue(mapper.writeValueAsString(descriptor), RichSegmentDescriptor.class)
     );
@@ -74,7 +74,7 @@ public class RichSegmentDescriptorTest
         3
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new SegmentDescriptor(Intervals.of("2000/2001"), "2", 3),
         mapper.readValue(mapper.writeValueAsString(descriptor), SegmentDescriptor.class)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/SegmentsInputSliceTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/SegmentsInputSliceTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.msq.input.InputSlice;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.ServerType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SegmentsInputSliceTest
 {
@@ -73,7 +73,7 @@ public class SegmentsInputSliceTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         slice,
         mapper.readValue(mapper.writeValueAsString(slice), InputSlice.class)
     );
@@ -110,7 +110,7 @@ public class SegmentsInputSliceTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedSlice,
         mapper.readValue(sliceString, InputSlice.class)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/TableInputSpecTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/TableInputSpecTest.java
@@ -27,8 +27,8 @@ import org.apache.druid.msq.input.InputSpec;
 import org.apache.druid.query.SegmentDescriptor;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -47,7 +47,7 @@ public class TableInputSpecTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         spec,
         mapper.readValue(mapper.writeValueAsString(spec), InputSpec.class)
     );
@@ -63,7 +63,7 @@ public class TableInputSpecTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         spec,
         mapper.readValue(mapper.writeValueAsString(spec), InputSpec.class)
     );
@@ -78,7 +78,7 @@ public class TableInputSpecTest extends InitializedNullHandlingTest
         Collections.singletonList(new SegmentDescriptor(Intervals.of("2000/P1M"), "version", 0))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         spec,
         mapper.readValue(mapper.writeValueAsString(spec), InputSpec.class)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/QueryDefinitionTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/QueryDefinitionTest.java
@@ -30,8 +30,8 @@ import org.apache.druid.msq.querykit.common.OffsetLimitStageProcessor;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
@@ -63,7 +63,7 @@ public class QueryDefinitionTest
     final ObjectMapper mapper = TestHelper.makeJsonMapper()
                                           .registerModules(new MSQIndexingModule().getJacksonModules());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         queryDef,
         mapper.readValue(mapper.writeValueAsString(queryDef), QueryDefinition.class)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/StageDefinitionTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/StageDefinitionTest.java
@@ -33,8 +33,8 @@ import org.apache.druid.msq.querykit.common.OffsetLimitStageProcessor;
 import org.apache.druid.msq.statistics.ClusterByStatisticsCollectorImpl;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StageDefinitionTest
 {
@@ -61,7 +61,7 @@ public class StageDefinitionTest
         false
     );
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         ISE.class,
         () -> stageDefinition.generatePartitionBoundariesForShuffle(null, Limits.DEFAULT_MAX_PARTITIONS)
     );
@@ -86,7 +86,7 @@ public class StageDefinitionTest
         false
     );
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         ISE.class,
         () -> stageDefinition.generatePartitionBoundariesForShuffle(null, Limits.DEFAULT_MAX_PARTITIONS)
     );
@@ -111,7 +111,7 @@ public class StageDefinitionTest
         false
     );
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         ISE.class,
         () -> stageDefinition.generatePartitionBoundariesForShuffle(
             ClusterByStatisticsCollectorImpl.create(

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/StageIdTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/StageIdTest.java
@@ -24,8 +24,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -44,7 +44,7 @@ public class StageIdTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new StageId("abc", 1),
             new StageId("abc", 2),
@@ -62,7 +62,7 @@ public class StageIdTest
     final ObjectMapper mapper = TestHelper.makeJsonMapper();
     final StageId stageId = new StageId("abc", 1);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         stageId,
         mapper.readValue(mapper.writeValueAsString(stageId), StageId.class)
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/WorkOrderTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/WorkOrderTest.java
@@ -20,7 +20,7 @@
 package org.apache.druid.msq.kernel;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WorkOrderTest
 {

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/controller/BaseControllerQueryKernelTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/controller/BaseControllerQueryKernelTest.java
@@ -45,9 +45,10 @@ import org.apache.druid.msq.statistics.ClusterByStatisticsCollector;
 import org.apache.druid.msq.util.MultiStageQueryContext;
 import org.apache.druid.query.QueryContext;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import javax.annotation.Nonnull;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -465,11 +466,11 @@ public class BaseControllerQueryKernelTest extends InitializedNullHandlingTest
       );
 
       // does not enable the current stage to enable running from start
-      Assert.assertTrue(createAndGetNewStageNumbers().size() == 0);
+      Assertions.assertTrue(createAndGetNewStageNumbers().size() == 0);
       // only work order of failed worker should be there
-      Assert.assertTrue(workOrderList.size() == 1);
-      Assert.assertTrue(workOrderList.get(0).getWorkerNumber() == workeNumber);
-      Assert.assertTrue(workOrderList.get(0).getStageNumber() == retriedStage);
+      Assertions.assertTrue(workOrderList.size() == 1);
+      Assertions.assertTrue(workOrderList.get(0).getWorkerNumber() == workeNumber);
+      Assertions.assertTrue(workOrderList.get(0).getStageNumber() == retriedStage);
 
     }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/controller/ControllerQueryKernelConfigTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/controller/ControllerQueryKernelConfigTest.java
@@ -24,8 +24,8 @@ import com.google.common.collect.ImmutableMap;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.msq.indexing.destination.DurableStorageMSQDestination;
 import org.apache.druid.msq.indexing.destination.MSQDestination;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
@@ -70,7 +70,7 @@ public class ControllerQueryKernelConfigTest
         .workerContextMap(workerContextMap)
         .build();
 
-    Assert.assertEquals(config1, config2);
+    Assertions.assertEquals(config1, config2);
   }
 
   @Test

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/controller/ControllerQueryKernelTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/controller/ControllerQueryKernelTest.java
@@ -27,8 +27,8 @@ import org.apache.druid.msq.exec.OutputChannelMode;
 import org.apache.druid.msq.kernel.QueryDefinition;
 import org.apache.druid.msq.kernel.ShuffleKind;
 import org.apache.druid.msq.kernel.worker.WorkerStagePhase;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
@@ -66,43 +66,43 @@ public class ControllerQueryKernelTest extends BaseControllerQueryKernelTest
 
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(0), newStageNumbers);
-    Assert.assertEquals(ImmutableSet.of(), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(0), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(), effectivelyFinishedStageNumbers);
 
     // Mark 0 as done. Next up will be 1.
     transitionNewToResultsComplete(controllerQueryKernelTester, 0);
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(1), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(1), newStageNumbers);
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(), effectivelyFinishedStageNumbers);
 
     // Mark 1 as done and fetch the new kernels. Next up will be 2.
     transitionNewToResultsComplete(controllerQueryKernelTester, 1);
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(2), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(2), newStageNumbers);
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(), effectivelyFinishedStageNumbers);
 
     // Mark 2 as done and fetch the new kernels. Next up will be 3.
     transitionNewToResultsComplete(controllerQueryKernelTester, 2);
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(3), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(3), newStageNumbers);
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(0), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(0), effectivelyFinishedStageNumbers);
 
     // Mark 3 as done and fetch the new kernels. Next up will be 4.
     transitionNewToResultsComplete(controllerQueryKernelTester, 3);
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(4), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(4), newStageNumbers);
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(0, 1), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(0, 1), effectivelyFinishedStageNumbers);
 
     // Mark 4 as done and fetch new kernels. Next up will be 5.
     transitionNewToResultsComplete(controllerQueryKernelTester, 4);
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(5), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(5), newStageNumbers);
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(0, 1, 2), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(0, 1, 2), effectivelyFinishedStageNumbers);
 
     // Mark 0, 1, 2 finished together.
     effectivelyFinishedStageNumbers.forEach(controllerQueryKernelTester::finishStage);
@@ -110,16 +110,16 @@ public class ControllerQueryKernelTest extends BaseControllerQueryKernelTest
     // Mark 5 as done and fetch new kernels. Next up will be 6, and 3 will be ready to finish.
     transitionNewToResultsComplete(controllerQueryKernelTester, 5);
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(6), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(6), newStageNumbers);
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(3), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(3), effectivelyFinishedStageNumbers);
 
     // Mark 6 as done. No more kernels left, but we can clean up 4, 5, 6 along with 3.
     transitionNewToResultsComplete(controllerQueryKernelTester, 6);
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(), newStageNumbers);
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(3, 4, 5, 6), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(3, 4, 5, 6), effectivelyFinishedStageNumbers);
     effectivelyFinishedStageNumbers.forEach(controllerQueryKernelTester::finishStage);
   }
 
@@ -158,7 +158,7 @@ public class ControllerQueryKernelTest extends BaseControllerQueryKernelTest
     controllerQueryKernelTester.queryDefinition(queryDef);
     controllerQueryKernelTester.init();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             ControllerQueryKernelUtilsTest.makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 0),
             ControllerQueryKernelUtilsTest.makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 1),
@@ -175,45 +175,45 @@ public class ControllerQueryKernelTest extends BaseControllerQueryKernelTest
 
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(0, 1), newStageNumbers);
-    Assert.assertEquals(ImmutableSet.of(), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(0, 1), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(), effectivelyFinishedStageNumbers);
 
 
     transitionNewToResultsComplete(controllerQueryKernelTester, 1);
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(0), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(0), newStageNumbers);
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(), effectivelyFinishedStageNumbers);
 
 
     // Mark 0 as done and fetch the new kernels. 2 should be unblocked along with 4.
     transitionNewToResultsComplete(controllerQueryKernelTester, 0);
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(2, 4), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(2, 4), newStageNumbers);
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(), effectivelyFinishedStageNumbers);
 
 
     // Mark 2 as done and fetch the new kernels. 4 is still ready, 0 can now be cleaned, and 3 can be launched
     transitionNewToResultsComplete(controllerQueryKernelTester, 2);
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(3, 4), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(3, 4), newStageNumbers);
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(0), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(0), effectivelyFinishedStageNumbers);
 
     // Mark 4 as done and fetch the new kernels. 3 is still ready, and 2 becomes cleanable
     transitionNewToResultsComplete(controllerQueryKernelTester, 4);
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(3), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(3), newStageNumbers);
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(0, 2), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(0, 2), effectivelyFinishedStageNumbers);
 
     // Mark 3 as post-reading and fetch new kernels. This makes 1 cleanable, and 5 ready to run
     transitionNewToDoneReadingInput(controllerQueryKernelTester, 3);
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(5), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(5), newStageNumbers);
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(0, 1, 2), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(0, 1, 2), effectivelyFinishedStageNumbers);
 
     // Mark 0, 1, 2 finished together
     effectivelyFinishedStageNumbers.forEach(controllerQueryKernelTester::finishStage);
@@ -222,23 +222,23 @@ public class ControllerQueryKernelTest extends BaseControllerQueryKernelTest
     // However, this does clear up 3 to become cleanable
     transitionNewToDoneReadingInput(controllerQueryKernelTester, 5);
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(), newStageNumbers);
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(3), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(3), effectivelyFinishedStageNumbers);
 
     // Mark 5 as done. This makes 6 ready to go
     transitionDoneReadingInputToResultsComplete(controllerQueryKernelTester, 5);
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(6), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(6), newStageNumbers);
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(3), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(3), effectivelyFinishedStageNumbers);
 
     // Mark 6 as done. No more kernels left, but we can clean up 4 and 5 along with 2
     transitionNewToResultsComplete(controllerQueryKernelTester, 6);
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(), newStageNumbers);
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(3, 4, 5, 6), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(3, 4, 5, 6), effectivelyFinishedStageNumbers);
     effectivelyFinishedStageNumbers.forEach(controllerQueryKernelTester::finishStage);
   }
 
@@ -267,8 +267,8 @@ public class ControllerQueryKernelTest extends BaseControllerQueryKernelTest
 
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(0), newStageNumbers);
-    Assert.assertEquals(ImmutableSet.of(), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(0), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(), effectivelyFinishedStageNumbers);
     controllerQueryKernelTester.startStage(0);
     controllerQueryKernelTester.sendWorkOrdersForWorkers(0, 0);
     controllerQueryKernelTester.addPartialKeyStatsInformation(0, 0);
@@ -284,8 +284,8 @@ public class ControllerQueryKernelTest extends BaseControllerQueryKernelTest
 
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(1), newStageNumbers);
-    Assert.assertEquals(ImmutableSet.of(), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(1), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(), effectivelyFinishedStageNumbers);
     controllerQueryKernelTester.startStage(1);
     controllerQueryKernelTester.sendWorkOrdersForWorkers(1, 0);
     controllerQueryKernelTester.addPartialKeyStatsInformation(1, 0);
@@ -310,8 +310,8 @@ public class ControllerQueryKernelTest extends BaseControllerQueryKernelTest
 
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(2), newStageNumbers);
-    Assert.assertEquals(ImmutableSet.of(0), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(2), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(0), effectivelyFinishedStageNumbers);
     controllerQueryKernelTester.startStage(2);
     controllerQueryKernelTester.assertStagePhase(2, ControllerStagePhase.READING_INPUT);
     controllerQueryKernelTester.sendWorkOrdersForWorkers(2, 0);
@@ -322,8 +322,8 @@ public class ControllerQueryKernelTest extends BaseControllerQueryKernelTest
 
     newStageNumbers = controllerQueryKernelTester.createAndGetNewStageNumbers();
     effectivelyFinishedStageNumbers = controllerQueryKernelTester.getEffectivelyFinishedStageNumbers();
-    Assert.assertEquals(ImmutableSet.of(3), newStageNumbers);
-    Assert.assertEquals(ImmutableSet.of(1), effectivelyFinishedStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(3), newStageNumbers);
+    Assertions.assertEquals(ImmutableSet.of(1), effectivelyFinishedStageNumbers);
     controllerQueryKernelTester.startStage(3);
     controllerQueryKernelTester.assertStagePhase(3, ControllerStagePhase.READING_INPUT);
     controllerQueryKernelTester.startWorkOrder(3);
@@ -415,16 +415,16 @@ public class ControllerQueryKernelTest extends BaseControllerQueryKernelTest
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.READING_INPUT);
 
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
+        ISE.class,
+        () -> controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0),
         StringUtils.format(
             "Worker[%d] for stage[%d] expected to be in state[%s]. Found state[%s]",
             1,
             0,
             WorkerStagePhase.PRESHUFFLE_WAITING_FOR_RESULT_PARTITION_BOUNDARIES,
             WorkerStagePhase.NEW
-        ),
-        ISE.class,
-        () -> controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0)
+        )
     );
 
   }
@@ -455,60 +455,66 @@ public class ControllerQueryKernelTest extends BaseControllerQueryKernelTest
 
     controllerQueryKernelTester.failStage(0);
 
-    Assert.assertTrue(controllerQueryKernelTester.isDone());
-    Assert.assertFalse(controllerQueryKernelTester.isSuccess());
+    Assertions.assertTrue(controllerQueryKernelTester.isDone());
+    Assertions.assertFalse(controllerQueryKernelTester.isSuccess());
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.FAILED);
     controllerQueryKernelTester.assertStagePhase(1, ControllerStagePhase.RESULTS_READY);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testCycleInvalidQueryThrowsException()
   {
-    ControllerQueryKernelTester controllerQueryKernelTester = testControllerQueryKernel();
+    Assertions.assertThrows(IllegalStateException.class, () -> {
+      ControllerQueryKernelTester controllerQueryKernelTester = testControllerQueryKernel();
 
-    // 0 - 1
-    // \  /
-    //   2
-    controllerQueryKernelTester.queryDefinition(
-        new MockQueryDefinitionBuilder(3)
-            .addEdge(0, 1)
-            .addEdge(1, 2)
-            .addEdge(2, 0)
-            .getQueryDefinitionBuilder()
-            .build()
-    );
+      // 0 - 1
+      // \  /
+      //   2
+      controllerQueryKernelTester.queryDefinition(
+          new MockQueryDefinitionBuilder(3)
+              .addEdge(0, 1)
+              .addEdge(1, 2)
+              .addEdge(2, 0)
+              .getQueryDefinitionBuilder()
+              .build()
+      );
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testSelfLoopInvalidQueryThrowsException()
   {
-    ControllerQueryKernelTester controllerQueryKernelTester = testControllerQueryKernel();
+    Assertions.assertThrows(IllegalStateException.class, () -> {
+      ControllerQueryKernelTester controllerQueryKernelTester = testControllerQueryKernel();
 
-    // 0 _
-    // |__|
-    controllerQueryKernelTester.queryDefinition(
-        new MockQueryDefinitionBuilder(1)
-            .addEdge(0, 0)
-            .getQueryDefinitionBuilder()
-            .build()
-    );
+      // 0 _
+      // |__|
+      controllerQueryKernelTester.queryDefinition(
+          new MockQueryDefinitionBuilder(1)
+              .addEdge(0, 0)
+              .getQueryDefinitionBuilder()
+              .build()
+      );
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testLoopInvalidQueryThrowsException()
   {
-    ControllerQueryKernelTester controllerQueryKernelTester = testControllerQueryKernel();
+    Assertions.assertThrows(IllegalStateException.class, () -> {
+      ControllerQueryKernelTester controllerQueryKernelTester = testControllerQueryKernel();
 
-    // 0 - 1
-    // |   |
-    //  ---
-    controllerQueryKernelTester.queryDefinition(
-        new MockQueryDefinitionBuilder(2)
-            .addEdge(0, 1)
-            .addEdge(1, 0)
-            .getQueryDefinitionBuilder()
-            .build()
-    );
+      // 0 - 1
+      // |   |
+      //  ---
+      controllerQueryKernelTester.queryDefinition(
+          new MockQueryDefinitionBuilder(2)
+              .addEdge(0, 1)
+              .addEdge(1, 0)
+              .getQueryDefinitionBuilder()
+              .build()
+      );
+    });
   }
 
   @Test
@@ -533,8 +539,8 @@ public class ControllerQueryKernelTest extends BaseControllerQueryKernelTest
 
     controllerQueryKernelTester.init();
 
-    Assert.assertFalse(controllerQueryKernelTester.isDone());
-    Assert.assertFalse(controllerQueryKernelTester.isSuccess());
+    Assertions.assertFalse(controllerQueryKernelTester.isDone());
+    Assertions.assertFalse(controllerQueryKernelTester.isSuccess());
 
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.FINISHED);
     controllerQueryKernelTester.assertStagePhase(1, ControllerStagePhase.RESULTS_READY);
@@ -569,7 +575,7 @@ public class ControllerQueryKernelTest extends BaseControllerQueryKernelTest
     );
     tester.init();
 
-    Assert.assertEquals(ImmutableSet.of(0), tester.createAndGetNewStageNumbers());
+    Assertions.assertEquals(ImmutableSet.of(0), tester.createAndGetNewStageNumbers());
 
     tester.startStage(0);
     tester.sendWorkOrdersForWorkers(0, 0, 1);
@@ -582,7 +588,7 @@ public class ControllerQueryKernelTest extends BaseControllerQueryKernelTest
 
     // Stage 0 should reach POST_READING; stage 1 should be ready to run
     tester.assertStagePhase(0, ControllerStagePhase.POST_READING);
-    Assert.assertEquals(ImmutableSet.of(1), tester.createAndGetNewStageNumbers());
+    Assertions.assertEquals(ImmutableSet.of(1), tester.createAndGetNewStageNumbers());
   }
 
   private static void transitionNewToResultsComplete(ControllerQueryKernelTester queryKernelTester, int stageNumber)

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/controller/ControllerQueryKernelUtilsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/controller/ControllerQueryKernelUtilsTest.java
@@ -26,8 +26,8 @@ import org.apache.druid.msq.indexing.destination.TaskReportMSQDestination;
 import org.apache.druid.msq.kernel.QueryDefinition;
 import org.apache.druid.msq.kernel.ShuffleKind;
 import org.apache.druid.msq.kernel.StageId;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -39,7 +39,7 @@ public class ControllerQueryKernelUtilsTest
   {
     final QueryDefinition queryDef = makeMultiProngedQueryDefinition();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 0),
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 1),
@@ -68,7 +68,7 @@ public class ControllerQueryKernelUtilsTest
   {
     final QueryDefinition queryDef = makeMultiProngedQueryDefinition();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 0),
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 1),
@@ -95,7 +95,7 @@ public class ControllerQueryKernelUtilsTest
   {
     final QueryDefinition queryDef = makeLinearQueryDefinitionWithoutShuffle();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 0),
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 1),
@@ -121,7 +121,7 @@ public class ControllerQueryKernelUtilsTest
   {
     final QueryDefinition queryDef = makeLinearQueryDefinitionWithShuffle();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 0),
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 1),
@@ -147,7 +147,7 @@ public class ControllerQueryKernelUtilsTest
   {
     final QueryDefinition queryDef = makeLinearQueryDefinitionWithoutShuffle();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.DURABLE_STORAGE_INTERMEDIATE, 0),
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.DURABLE_STORAGE_INTERMEDIATE, 1),
@@ -174,7 +174,7 @@ public class ControllerQueryKernelUtilsTest
   {
     final QueryDefinition queryDef = makeLinearQueryDefinitionWithShuffle();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.DURABLE_STORAGE_INTERMEDIATE, 0),
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.DURABLE_STORAGE_INTERMEDIATE, 1),
@@ -201,7 +201,7 @@ public class ControllerQueryKernelUtilsTest
   {
     final QueryDefinition queryDef = makeLinearQueryDefinitionWithoutShuffle();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.DURABLE_STORAGE_INTERMEDIATE, 0),
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.DURABLE_STORAGE_INTERMEDIATE, 1),
@@ -228,7 +228,7 @@ public class ControllerQueryKernelUtilsTest
   {
     final QueryDefinition queryDef = makeLinearQueryDefinitionWithShuffle();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.DURABLE_STORAGE_INTERMEDIATE, 0),
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.DURABLE_STORAGE_INTERMEDIATE, 1),
@@ -255,7 +255,7 @@ public class ControllerQueryKernelUtilsTest
   {
     final QueryDefinition queryDef = makeLinearQueryDefinitionWithoutShuffle();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         // Without a sort-based shuffle, we can't leapfrog, so we launch two groups broken up by LOCAL_STORAGE
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 0, 1),
@@ -280,7 +280,7 @@ public class ControllerQueryKernelUtilsTest
   {
     final QueryDefinition queryDef = makeLinearQueryDefinitionWithShuffle();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         // With sort-based shuffle, we can leapfrog 4 stages, all of them being in-memory
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.MEMORY, 0),
@@ -312,7 +312,7 @@ public class ControllerQueryKernelUtilsTest
 
     final QueryDefinition queryDef = makeLinearQueryDefinitionWithLeafInput();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.MEMORY, 0, 1, 2)
         ),
@@ -335,7 +335,7 @@ public class ControllerQueryKernelUtilsTest
   {
     final QueryDefinition queryDef = makeFanInQueryDefinition();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 0),
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 1),
@@ -361,7 +361,7 @@ public class ControllerQueryKernelUtilsTest
   {
     final QueryDefinition queryDef = makeFanInQueryDefinitionWithBroadcast();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 0),
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 1),
@@ -387,7 +387,7 @@ public class ControllerQueryKernelUtilsTest
   {
     final QueryDefinition queryDef = makeFanInQueryDefinition();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.DURABLE_STORAGE_INTERMEDIATE, 0),
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.DURABLE_STORAGE_INTERMEDIATE, 1),
@@ -414,7 +414,7 @@ public class ControllerQueryKernelUtilsTest
   {
     final QueryDefinition queryDef = makeFanInQueryDefinition();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.DURABLE_STORAGE_INTERMEDIATE, 0),
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.DURABLE_STORAGE_INTERMEDIATE, 1),
@@ -441,7 +441,7 @@ public class ControllerQueryKernelUtilsTest
   {
     final QueryDefinition queryDef = makeFanInQueryDefinition();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 0),
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 1),
@@ -466,7 +466,7 @@ public class ControllerQueryKernelUtilsTest
   {
     final QueryDefinition queryDef = makeFanInQueryDefinitionWithBroadcast();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         // Output of stage 1 is broadcast, so it must run first; then stages 0 and 2 may be launched together
         ImmutableList.of(
             makeStageGroup(queryDef.getQueryId(), OutputChannelMode.LOCAL_STORAGE, 1),

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/controller/NonShufflingWorkersWithRetryKernelTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/controller/NonShufflingWorkersWithRetryKernelTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.msq.kernel.controller;
 
 
 import org.apache.druid.msq.indexing.destination.DurableStorageMSQDestination;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 
@@ -36,11 +36,11 @@ public class NonShufflingWorkersWithRetryKernelTest extends BaseControllerQueryK
     ControllerQueryKernelTester controllerQueryKernelTester = getSimpleQueryDefinition(2);
     controllerQueryKernelTester.init();
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1
                       && controllerQueryKernelTester.createAndGetNewStageNumbers().contains(0));
-    Assert.assertTrue(controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(0, RETRIABLE_FAULT).size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(0, RETRIABLE_FAULT).size() == 0);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.NEW);
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1
                       && controllerQueryKernelTester.createAndGetNewStageNumbers().contains(0));
   }
 
@@ -113,12 +113,12 @@ public class NonShufflingWorkersWithRetryKernelTest extends BaseControllerQueryK
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 1);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.READING_INPUT);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
 
 
   }
@@ -143,12 +143,12 @@ public class NonShufflingWorkersWithRetryKernelTest extends BaseControllerQueryK
     controllerQueryKernelTester.sendWorkOrdersForWorkers(0, 0);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.READING_INPUT);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
   }
 
   @Test
@@ -158,8 +158,8 @@ public class NonShufflingWorkersWithRetryKernelTest extends BaseControllerQueryK
     controllerQueryKernelTester.setupStage(0, ControllerStagePhase.RESULTS_READY);
     controllerQueryKernelTester.init();
 
-    Assert.assertEquals(0, controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(0, RETRIABLE_FAULT).size());
-    Assert.assertEquals(0, controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(1, RETRIABLE_FAULT).size());
+    Assertions.assertEquals(0, controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(0, RETRIABLE_FAULT).size());
+    Assertions.assertEquals(0, controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(1, RETRIABLE_FAULT).size());
 
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
   }
@@ -172,8 +172,8 @@ public class NonShufflingWorkersWithRetryKernelTest extends BaseControllerQueryK
     controllerQueryKernelTester.setupStage(0, ControllerStagePhase.FINISHED);
     controllerQueryKernelTester.init();
 
-    Assert.assertEquals(0, controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(0, RETRIABLE_FAULT).size());
-    Assert.assertEquals(0, controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(1, RETRIABLE_FAULT).size());
+    Assertions.assertEquals(0, controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(0, RETRIABLE_FAULT).size());
+    Assertions.assertEquals(0, controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(1, RETRIABLE_FAULT).size());
 
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.FINISHED);
 
@@ -186,12 +186,12 @@ public class NonShufflingWorkersWithRetryKernelTest extends BaseControllerQueryK
     ControllerQueryKernelTester controllerQueryKernelTester = getSimpleQueryDefinition(3);
     controllerQueryKernelTester.init();
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1
                       && controllerQueryKernelTester.createAndGetNewStageNumbers().contains(0));
-    Assert.assertTrue(controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(0, RETRIABLE_FAULT).size() == 0);
-    Assert.assertTrue(controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(1, RETRIABLE_FAULT).size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(0, RETRIABLE_FAULT).size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(1, RETRIABLE_FAULT).size() == 0);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.NEW);
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1
                       && controllerQueryKernelTester.createAndGetNewStageNumbers().contains(0));
   }
 
@@ -274,12 +274,12 @@ public class NonShufflingWorkersWithRetryKernelTest extends BaseControllerQueryK
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 1);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.READING_INPUT);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0, 2);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
 
 
   }
@@ -300,19 +300,19 @@ public class NonShufflingWorkersWithRetryKernelTest extends BaseControllerQueryK
     controllerQueryKernelTester.failWorkerAndAssertWorkOrderes(0, 0);
     controllerQueryKernelTester.failWorkerAndAssertWorkOrderes(2, 0);
     // should be no op
-    Assert.assertTrue(controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(1, RETRIABLE_FAULT).size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(1, RETRIABLE_FAULT).size() == 0);
 
 
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RETRYING);
     controllerQueryKernelTester.sendWorkOrdersForWorkers(0, 0, 2);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.READING_INPUT);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0, 2);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
   }
 
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/controller/ShufflingWorkersWithRetryKernelTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/controller/ShufflingWorkersWithRetryKernelTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.msq.kernel.controller;
 
 import org.apache.druid.msq.indexing.destination.DurableStorageMSQDestination;
 import org.apache.druid.msq.kernel.ShuffleKind;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 
@@ -35,11 +35,11 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     ControllerQueryKernelTester controllerQueryKernelTester = getSimpleQueryDefinition(2);
     controllerQueryKernelTester.init();
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1
                       && controllerQueryKernelTester.createAndGetNewStageNumbers().contains(0));
-    Assert.assertTrue(controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(0, RETRIABLE_FAULT).size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(0, RETRIABLE_FAULT).size() == 0);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.NEW);
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1
                       && controllerQueryKernelTester.createAndGetNewStageNumbers().contains(0));
   }
 
@@ -341,12 +341,12 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 1);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.POST_READING);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
 
   }
 
@@ -389,12 +389,12 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 1);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.POST_READING);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
 
   }
 
@@ -428,12 +428,12 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 1);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.POST_READING);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
   }
 
 
@@ -467,12 +467,12 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 1);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.POST_READING);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
   }
 
 
@@ -503,12 +503,12 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
 
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.POST_READING);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
 
 
   }
@@ -542,12 +542,12 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
 
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.POST_READING);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
 
 
   }
@@ -561,8 +561,8 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     controllerQueryKernelTester.setupStage(0, ControllerStagePhase.RESULTS_READY);
     controllerQueryKernelTester.init();
 
-    Assert.assertEquals(0, controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(0, RETRIABLE_FAULT).size());
-    Assert.assertEquals(0, controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(1, RETRIABLE_FAULT).size());
+    Assertions.assertEquals(0, controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(0, RETRIABLE_FAULT).size());
+    Assertions.assertEquals(0, controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(1, RETRIABLE_FAULT).size());
 
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
 
@@ -578,8 +578,8 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     controllerQueryKernelTester.setupStage(0, ControllerStagePhase.FINISHED);
     controllerQueryKernelTester.init();
 
-    Assert.assertEquals(0, controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(0, RETRIABLE_FAULT).size());
-    Assert.assertEquals(0, controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(1, RETRIABLE_FAULT).size());
+    Assertions.assertEquals(0, controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(0, RETRIABLE_FAULT).size());
+    Assertions.assertEquals(0, controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(1, RETRIABLE_FAULT).size());
 
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.FINISHED);
 
@@ -592,12 +592,12 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     ControllerQueryKernelTester controllerQueryKernelTester = getSimpleQueryDefinition(3);
     controllerQueryKernelTester.init();
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1
                       && controllerQueryKernelTester.createAndGetNewStageNumbers().contains(0));
-    Assert.assertTrue(controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(0, RETRIABLE_FAULT).size() == 0);
-    Assert.assertTrue(controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(1, RETRIABLE_FAULT).size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(0, RETRIABLE_FAULT).size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.getRetriableWorkOrdersAndChangeState(1, RETRIABLE_FAULT).size() == 0);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.NEW);
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1
                       && controllerQueryKernelTester.createAndGetNewStageNumbers().contains(0));
 
   }
@@ -711,11 +711,11 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 1);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.POST_READING);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0, 2);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
 
   }
 
@@ -750,11 +750,11 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 1);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.POST_READING);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0, 2);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
 
   }
 
@@ -790,11 +790,11 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 1);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.POST_READING);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0, 2);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
 
   }
 
@@ -830,11 +830,11 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 1);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.POST_READING);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0, 2);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
 
   }
 
@@ -870,11 +870,11 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 1);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.POST_READING);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0, 2);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
 
   }
 
@@ -912,11 +912,11 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 1);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.POST_READING);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0, 2);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
 
   }
 
@@ -949,11 +949,11 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 1);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.POST_READING);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0, 2);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
   }
 
 
@@ -989,11 +989,11 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 1);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.POST_READING);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0, 2);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
   }
 
   @Test
@@ -1023,12 +1023,12 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
 
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.POST_READING);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0, 1, 2);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
   }
 
   @Test
@@ -1061,12 +1061,12 @@ public class ShufflingWorkersWithRetryKernelTest extends BaseControllerQueryKern
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.POST_READING);
 
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 0);
 
     controllerQueryKernelTester.setResultsCompleteForStageAndWorkers(0, 0, 1);
     controllerQueryKernelTester.assertStagePhase(0, ControllerStagePhase.RESULTS_READY);
 
-    Assert.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
+    Assertions.assertTrue(controllerQueryKernelTester.createAndGetNewStageNumbers().size() == 1);
 
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/controller/WorkerInputsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/controller/WorkerInputsTest.java
@@ -46,11 +46,12 @@ import org.apache.druid.msq.kernel.StageDefinition;
 import org.apache.druid.msq.kernel.WorkerAssignmentStrategy;
 import org.apache.druid.msq.querykit.common.OffsetLimitStageProcessor;
 import org.apache.druid.query.filter.SegmentPruner;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -85,7 +86,7 @@ public class WorkerInputsTest
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.<Integer, List<InputSlice>>builder()
                     .put(0, Collections.singletonList(new TestInputSlice(1)))
                     .put(1, Collections.singletonList(new TestInputSlice(2)))
@@ -115,7 +116,7 @@ public class WorkerInputsTest
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.<Integer, List<InputSlice>>builder()
                     .put(1, Collections.singletonList(new TestInputSlice(1)))
                     .put(3, Collections.singletonList(new TestInputSlice(2)))
@@ -145,7 +146,7 @@ public class WorkerInputsTest
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.<Integer, List<InputSlice>>builder()
                     .put(0, Collections.singletonList(new TestInputSlice()))
                     .put(1, Collections.singletonList(new TestInputSlice()))
@@ -175,7 +176,7 @@ public class WorkerInputsTest
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.<Integer, List<InputSlice>>builder()
                     .put(0, Collections.singletonList(NilInputSlice.INSTANCE))
                     .build(),
@@ -202,7 +203,7 @@ public class WorkerInputsTest
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.<Integer, List<InputSlice>>builder()
                     .put(0, Collections.singletonList(NilInputSlice.INSTANCE))
                     .build(),
@@ -230,7 +231,7 @@ public class WorkerInputsTest
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.<Integer, List<InputSlice>>builder()
                     .put(0, Collections.singletonList(new TestInputSlice()))
                     .build(),
@@ -257,7 +258,7 @@ public class WorkerInputsTest
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.<Integer, List<InputSlice>>builder()
                     .put(0, Collections.singletonList(new TestInputSlice(1, 2, 3)))
                     .build(),
@@ -287,7 +288,7 @@ public class WorkerInputsTest
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.<Integer, List<InputSlice>>builder()
                     .put(
                         0,
@@ -336,7 +337,7 @@ public class WorkerInputsTest
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.<Integer, List<InputSlice>>builder()
                     .put(
                         0,
@@ -372,7 +373,7 @@ public class WorkerInputsTest
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.<Integer, List<InputSlice>>builder()
                     .put(0, Collections.singletonList(new TestInputSlice(200_000_000L, 200_000_001L)))
                     .put(1, Collections.singletonList(new TestInputSlice(200_000_002L)))
@@ -400,7 +401,7 @@ public class WorkerInputsTest
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.<Integer, List<InputSlice>>builder()
                     .put(
                         0,
@@ -434,7 +435,7 @@ public class WorkerInputsTest
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.<Integer, List<InputSlice>>builder()
                     .put(
                         0,
@@ -470,7 +471,7 @@ public class WorkerInputsTest
     Mockito.verify(testInputSpecSlicer, times(0)).canSliceDynamic(inputSpecToSplit);
     Mockito.verify(testInputSpecSlicer, times(1)).sliceStatic(any(), any(), anyInt());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.<Integer, List<InputSlice>>builder()
                     .put(
                         0,
@@ -515,7 +516,7 @@ public class WorkerInputsTest
     Mockito.verify(testInputSpecSlicer, times(1)).canSliceDynamic(inputSpecToSplit);
     Mockito.verify(testInputSpecSlicer, times(1)).sliceDynamic(any(), any(), anyInt(), anyInt(), anyLong());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.<Integer, List<InputSlice>>builder()
                     .put(
                         0,
@@ -556,7 +557,7 @@ public class WorkerInputsTest
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.<Integer, List<InputSlice>>builder()
                     .put(
                         0,

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/BroadcastJoinSegmentMapFnProcessorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/BroadcastJoinSegmentMapFnProcessorTest.java
@@ -54,14 +54,14 @@ import org.apache.druid.segment.join.JoinConditionAnalysis;
 import org.apache.druid.segment.join.JoinType;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.easymock.EasyMock;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.io.IOException;
@@ -72,8 +72,8 @@ import java.util.stream.Collectors;
 
 public class BroadcastJoinSegmentMapFnProcessorTest extends InitializedNullHandlingTest
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   private CursorFactory cursorFactory;
   private File testDataFile1;
@@ -81,7 +81,7 @@ public class BroadcastJoinSegmentMapFnProcessorTest extends InitializedNullHandl
   private FrameReader frameReader1;
   private FrameReader frameReader2;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
     final ArenaMemoryAllocator allocator = ArenaMemoryAllocator.createOnHeap(10_000);
@@ -137,7 +137,7 @@ public class BroadcastJoinSegmentMapFnProcessorTest extends InitializedNullHandl
         25_000_000L // High enough memory limit that we won't hit it
     );
 
-    Assert.assertEquals(ImmutableSet.of(1, 2), broadcastJoinReader.getSideChannelNumbers());
+    Assertions.assertEquals(ImmutableSet.of(1, 2), broadcastJoinReader.getSideChannelNumbers());
 
     boolean doneReading = false;
     while (!doneReading) {
@@ -148,27 +148,27 @@ public class BroadcastJoinSegmentMapFnProcessorTest extends InitializedNullHandl
       doneReading = broadcastJoinReader.buildBroadcastTablesIncrementally(readableInputs);
     }
 
-    Assert.assertTrue(channels.get(1).isFinished());
-    Assert.assertTrue(channels.get(2).isFinished());
+    Assertions.assertTrue(channels.get(1).isFinished());
+    Assertions.assertTrue(channels.get(2).isFinished());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new InputNumberDataSource(0),
         broadcastJoinReader.inlineChannelData(new InputNumberDataSource(0))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new InputNumberDataSource(1),
         broadcastJoinReader.inlineChannelData(new InputNumberDataSource(1))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new InputNumberDataSource(2),
         broadcastJoinReader.inlineChannelData(new InputNumberDataSource(2))
     );
 
     final List<Object[]> rowsFromStage3 =
         ((InlineDataSource) broadcastJoinReader.inlineChannelData(new InputNumberDataSource(3))).getRowsAsList();
-    Assert.assertEquals(1209, rowsFromStage3.size());
+    Assertions.assertEquals(1209, rowsFromStage3.size());
 
     FrameTestUtil.assertRowsEqual(
         FrameTestUtil.readRowsFromCursorFactory(cursorFactory),
@@ -177,7 +177,7 @@ public class BroadcastJoinSegmentMapFnProcessorTest extends InitializedNullHandl
 
     final List<Object[]> rowsFromStage4 =
         ((InlineDataSource) broadcastJoinReader.inlineChannelData(new InputNumberDataSource(4))).getRowsAsList();
-    Assert.assertEquals(2, rowsFromStage4.size());
+    Assertions.assertEquals(2, rowsFromStage4.size());
 
     FrameTestUtil.assertRowsEqual(
         FrameTestUtil.readRowsFromCursorFactory(cursorFactory).limit(2),
@@ -202,7 +202,7 @@ public class BroadcastJoinSegmentMapFnProcessorTest extends InitializedNullHandl
         CoreMatchers.instanceOf(InlineDataSource.class)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2,
         ((InlineDataSource) ((JoinDataSource) inlinedJoinDataSource).getRight()).getRowsAsList().size()
     );
@@ -229,9 +229,9 @@ public class BroadcastJoinSegmentMapFnProcessorTest extends InitializedNullHandl
         100_000 // Low memory limit; we will hit this
     );
 
-    Assert.assertEquals(ImmutableSet.of(0), broadcastJoinHelper.getSideChannelNumbers());
+    Assertions.assertEquals(ImmutableSet.of(0), broadcastJoinHelper.getSideChannelNumbers());
 
-    final MSQException e = Assert.assertThrows(
+    final MSQException e = Assertions.assertThrows(
         MSQException.class,
         () -> {
           boolean doneReading = false;
@@ -242,7 +242,7 @@ public class BroadcastJoinSegmentMapFnProcessorTest extends InitializedNullHandl
         }
     );
 
-    Assert.assertEquals(new BroadcastTablesTooLargeFault(100_000, null), e.getFault());
+    Assertions.assertEquals(new BroadcastTablesTooLargeFault(100_000, null), e.getFault());
   }
 
   /**
@@ -281,9 +281,9 @@ public class BroadcastJoinSegmentMapFnProcessorTest extends InitializedNullHandl
         100_000 // Low memory limit; we will hit this
     );
 
-    Assert.assertEquals(ImmutableSet.of(0), broadcastJoinHelper.getSideChannelNumbers());
+    Assertions.assertEquals(ImmutableSet.of(0), broadcastJoinHelper.getSideChannelNumbers());
 
-    final MSQException e = Assert.assertThrows(
+    final MSQException e = Assertions.assertThrows(
         MSQException.class,
         () -> {
           boolean doneReading = false;
@@ -294,7 +294,7 @@ public class BroadcastJoinSegmentMapFnProcessorTest extends InitializedNullHandl
         }
     );
 
-    Assert.assertEquals(new BroadcastTablesTooLargeFault(100_000, JoinAlgorithm.SORT_MERGE), e.getFault());
+    Assertions.assertEquals(new BroadcastTablesTooLargeFault(100_000, JoinAlgorithm.SORT_MERGE), e.getFault());
     EasyMock.verify(mockQuery);
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/BroadcastJoinSegmentMapFnProcessorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/BroadcastJoinSegmentMapFnProcessorTest.java
@@ -56,8 +56,6 @@ import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.testing.TemporaryFolderExtension;
 import org.easymock.EasyMock;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -197,10 +195,7 @@ public class BroadcastJoinSegmentMapFnProcessorTest extends InitializedNullHandl
         )
     );
 
-    MatcherAssert.assertThat(
-        ((JoinDataSource) inlinedJoinDataSource).getRight(),
-        CoreMatchers.instanceOf(InlineDataSource.class)
-    );
+    Assertions.assertInstanceOf(InlineDataSource.class, ((JoinDataSource) inlinedJoinDataSource).getRight());
 
     Assertions.assertEquals(
         2,

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/ChainedProcessorManagerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/ChainedProcessorManagerTest.java
@@ -46,10 +46,12 @@ import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -67,11 +69,13 @@ import java.util.stream.LongStream;
 /**
  * Unit tests for {@link ChainedProcessorManager}.
  */
-@RunWith(Parameterized.class)
+
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class ChainedProcessorManagerTest extends FrameProcessorExecutorTest.BaseFrameProcessorExecutorTestSuite
 {
-  private final Bouncer bouncer;
-  private final int maxOutstandingProcessors;
+  private Bouncer bouncer;
+  private int maxOutstandingProcessors;
 
   private static final RowSignature ROW_SIGNATURE = RowSignature.builder()
                                                                .addTimeColumn()
@@ -85,7 +89,20 @@ public class ChainedProcessorManagerTest extends FrameProcessorExecutorTest.Base
     this.maxOutstandingProcessors = maxOutstandingProcessors;
   }
 
-  @Parameterized.Parameters(name = "numThreads = {0}, bouncerPoolSize = {1}, maxOutstandingProcessors = {2}")
+  @BeforeEach
+  @Override
+  public void setUp() throws Exception
+  {
+    super.setUp();
+  }
+
+  @AfterEach
+  @Override
+  public void tearDown() throws Exception
+  {
+    super.tearDown();
+  }
+
   public static Collection<Object[]> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -132,7 +149,7 @@ public class ChainedProcessorManagerTest extends FrameProcessorExecutorTest.Base
         actualValues.add(extractColumnValue(readable.readFrame(), 1));
       }
     }
-    Assert.assertEquals(new HashSet<>(expectedValues), actualValues);
+    Assertions.assertEquals(new HashSet<>(expectedValues), actualValues);
   }
 
   /**
@@ -171,7 +188,7 @@ public class ChainedProcessorManagerTest extends FrameProcessorExecutorTest.Base
         actualValues.add(extractColumnValue(readable.readFrame(), 1));
       }
     }
-    Assert.assertEquals(expectedValues, actualValues);
+    Assertions.assertEquals(expectedValues, actualValues);
   }
 
   @Test
@@ -200,7 +217,7 @@ public class ChainedProcessorManagerTest extends FrameProcessorExecutorTest.Base
         null
     );
 
-    Assert.assertThrows(ExecutionException.class, future::get);
+    Assertions.assertThrows(ExecutionException.class, future::get);
 
     final HashSet<Long> actualValues = new HashSet<>();
     try (ReadableFrameChannel readable = outputChannel.readable()) {
@@ -208,7 +225,7 @@ public class ChainedProcessorManagerTest extends FrameProcessorExecutorTest.Base
         actualValues.add(extractColumnValue(readable.readFrame(), 1));
       }
     }
-    Assert.assertEquals(expectedValues, actualValues);
+    Assertions.assertEquals(expectedValues, actualValues);
   }
 
   @Test
@@ -255,7 +272,7 @@ public class ChainedProcessorManagerTest extends FrameProcessorExecutorTest.Base
         actualValues.add(extractColumnValue(readable.readFrame(), 1));
       }
     }
-    Assert.assertEquals(expectedValues, actualValues);
+    Assertions.assertEquals(expectedValues, actualValues);
   }
 
   @SuppressWarnings("rawtypes")

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/FrameProcessorTestBase.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/FrameProcessorTestBase.java
@@ -34,8 +34,8 @@ import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.segment.CursorFactory;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.util.List;
@@ -49,14 +49,14 @@ public class FrameProcessorTestBase extends InitializedNullHandlingTest
   private ListeningExecutorService innerExec;
   protected FrameProcessorExecutor exec;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     innerExec = MoreExecutors.listeningDecorator(Execs.singleThreaded("test-exec"));
     exec = new FrameProcessorExecutor(innerExec);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception
   {
     innerExec.shutdownNow();

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/RestrictedInputNumberDataSourceTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/RestrictedInputNumberDataSourceTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.query.policy.NoRestrictionPolicy;
 import org.apache.druid.query.policy.RowFilterPolicy;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.VirtualColumns;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RestrictedInputNumberDataSourceTest
 {
@@ -48,54 +48,54 @@ public class RestrictedInputNumberDataSourceTest
   @Test
   public void test_creation_failWithNullPolicy()
   {
-    Exception e = Assert.assertThrows(Exception.class, () -> new RestrictedInputNumberDataSource(1, null));
-    Assert.assertEquals(e.getMessage(), "Policy can't be null");
+    Exception e = Assertions.assertThrows(Exception.class, () -> new RestrictedInputNumberDataSource(1, null));
+    Assertions.assertEquals(e.getMessage(), "Policy can't be null");
   }
 
   @Test
   public void test_getTableNames()
   {
-    Assert.assertTrue(restrictedFooDataSource.getTableNames().isEmpty());
-    Assert.assertTrue(restrictedBarDataSource.getTableNames().isEmpty());
+    Assertions.assertTrue(restrictedFooDataSource.getTableNames().isEmpty());
+    Assertions.assertTrue(restrictedBarDataSource.getTableNames().isEmpty());
   }
 
   @Test
   public void test_getChildren()
   {
-    Assert.assertTrue(restrictedFooDataSource.getChildren().isEmpty());
-    Assert.assertTrue(restrictedBarDataSource.getChildren().isEmpty());
+    Assertions.assertTrue(restrictedFooDataSource.getChildren().isEmpty());
+    Assertions.assertTrue(restrictedBarDataSource.getChildren().isEmpty());
   }
 
   @Test
   public void test_isCacheable()
   {
-    Assert.assertFalse(restrictedFooDataSource.isCacheable(true));
+    Assertions.assertFalse(restrictedFooDataSource.isCacheable(true));
   }
 
   @Test
   public void test_isGlobal()
   {
-    Assert.assertFalse(restrictedFooDataSource.isGlobal());
+    Assertions.assertFalse(restrictedFooDataSource.isGlobal());
   }
 
   @Test
   public void test_isConcrete()
   {
-    Assert.assertTrue(restrictedFooDataSource.isProcessable());
+    Assertions.assertTrue(restrictedFooDataSource.isProcessable());
   }
 
   @Test
   public void test_withChildren()
   {
-    IllegalArgumentException exception = Assert.assertThrows(
+    IllegalArgumentException exception = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> restrictedFooDataSource.withChildren(ImmutableList.of(new TableDataSource("foo")))
     );
-    Assert.assertEquals(exception.getMessage(), "Cannot accept children");
+    Assertions.assertEquals(exception.getMessage(), "Cannot accept children");
 
     RestrictedInputNumberDataSource newRestrictedDataSource = (RestrictedInputNumberDataSource) restrictedFooDataSource.withChildren(
         ImmutableList.of());
-    Assert.assertTrue(newRestrictedDataSource.getChildren().isEmpty());
+    Assertions.assertTrue(newRestrictedDataSource.getChildren().isEmpty());
   }
 
   @Test
@@ -116,7 +116,7 @@ public class RestrictedInputNumberDataSourceTest
         RestrictedInputNumberDataSource.class
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         deserializedRestrictedDataSource,
         restrictedBarDataSource
     );
@@ -128,7 +128,7 @@ public class RestrictedInputNumberDataSourceTest
     final ObjectMapper jsonMapper = TestHelper.makeJsonMapper();
     final String s = jsonMapper.writeValueAsString(restrictedFooDataSource);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "{\"type\":\"restrictedInputNumber\",\"inputNumber\":0,\"policy\":{\"type\":\"row\",\"rowFilter\":{\"type\":\"true\"}}}",
         s
     );
@@ -137,7 +137,7 @@ public class RestrictedInputNumberDataSourceTest
   @Test
   public void testStringRep()
   {
-    Assert.assertNotEquals(restrictedFooDataSource.toString(), restrictedBarDataSource.toString());
+    Assertions.assertNotEquals(restrictedFooDataSource.toString(), restrictedBarDataSource.toString());
   }
 
   @Test
@@ -151,7 +151,7 @@ public class RestrictedInputNumberDataSourceTest
         RowFilterPolicy.from(TrueDimFilter.instance())
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         dataSource,
         mapper.readValue(mapper.writeValueAsString(dataSource), DataSource.class)
     );
@@ -160,7 +160,7 @@ public class RestrictedInputNumberDataSourceTest
   @Test
   public void test_createSegmentPruner_withRowFilterPolicy()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new FilterSegmentPruner(TrueDimFilter.instance(), null, VirtualColumns.EMPTY),
         restrictedFooDataSource.createSegmentPruner()
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessorTest.java
@@ -53,8 +53,8 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -144,15 +144,15 @@ public class WindowOperatorQueryFrameProcessorTest extends FrameProcessorTestBas
     );
 
     List<List<Object>> outputRows = rowsFromProcessor.toList();
-    Assert.assertEquals(INPUT_ROWS.size(), outputRows.size());
+    Assertions.assertEquals(INPUT_ROWS.size(), outputRows.size());
 
     for (int i = 0; i < INPUT_ROWS.size(); i++) {
       Map<String, Object> inputRow = INPUT_ROWS.get(i);
       List<Object> outputRow = outputRows.get(i);
 
-      Assert.assertEquals("cityName should match", inputRow.get("cityName"), outputRow.get(0));
-      Assert.assertEquals("added should match", inputRow.get("added"), outputRow.get(1));
-      Assert.assertEquals("row_number() should be correct", (long) i + 1, outputRow.get(2));
+      Assertions.assertEquals(inputRow.get("cityName"), outputRow.get(0), "cityName should match");
+      Assertions.assertEquals(inputRow.get("added"), outputRow.get(1), "added should match");
+      Assertions.assertEquals((long) i + 1, outputRow.get(2), "row_number() should be correct");
     }
   }
 
@@ -229,15 +229,15 @@ public class WindowOperatorQueryFrameProcessorTest extends FrameProcessorTestBas
     );
 
     List<List<Object>> outputRows = rowsFromProcessor.toList();
-    Assert.assertEquals(INPUT_ROWS.size(), outputRows.size());
+    Assertions.assertEquals(INPUT_ROWS.size(), outputRows.size());
 
     for (int i = 0; i < INPUT_ROWS.size(); i++) {
       Map<String, Object> inputRow = INPUT_ROWS.get(i);
       List<Object> outputRow = outputRows.get(i);
 
-      Assert.assertEquals("cityName should match", inputRow.get("cityName"), outputRow.get(0));
-      Assert.assertEquals("added should match", inputRow.get("added"), outputRow.get(1));
-      Assert.assertEquals("row_number() should be correct", (long) i + 1, outputRow.get(2));
+      Assertions.assertEquals(inputRow.get("cityName"), outputRow.get(0), "cityName should match");
+      Assertions.assertEquals(inputRow.get("added"), outputRow.get(1), "added should match");
+      Assertions.assertEquals((long) i + 1, outputRow.get(2), "row_number() should be correct");
     }
   }
 
@@ -250,7 +250,7 @@ public class WindowOperatorQueryFrameProcessorTest extends FrameProcessorTestBas
   @Test
   public void testMaxRowsMaterializedConstraint()
   {
-    final RuntimeException e = Assert.assertThrows(
+    final RuntimeException e = Assertions.assertThrows(
         RuntimeException.class,
         () -> runProcessor(2, 3)
     );
@@ -258,7 +258,7 @@ public class WindowOperatorQueryFrameProcessorTest extends FrameProcessorTestBas
         ((MSQException) e.getCause().getCause()).getFault(),
         CoreMatchers.instanceOf(TooManyRowsInAWindowFault.class)
     );
-    Assert.assertTrue(e.getMessage().contains("TooManyRowsInAWindow: Too many rows in a window (requested = 7, max = 2)"));
+    Assertions.assertTrue(e.getMessage().contains("TooManyRowsInAWindow: Too many rows in a window (requested = 7, max = 2)"));
   }
 
   public void runProcessor(int maxRowsMaterialized, int expectedNumFramesWritten) throws Exception
@@ -339,8 +339,8 @@ public class WindowOperatorQueryFrameProcessorTest extends FrameProcessorTestBas
     final List<List<Object>> rows = rowsFromProcessor.toList();
 
     long actualNumFrames = Arrays.stream(channelCounters.snapshot().getFrames()).findFirst().getAsLong();
-    Assert.assertEquals(expectedNumFramesWritten, actualNumFrames);
-    Assert.assertEquals(7, rows.size());
+    Assertions.assertEquals(expectedNumFramesWritten, actualNumFrames);
+    Assertions.assertEquals(7, rows.size());
   }
 
   private ReadableInput buildWindowTestInputChannel() throws IOException

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessorTest.java
@@ -51,8 +51,6 @@ import org.apache.druid.segment.CursorFactory;
 import org.apache.druid.segment.RowBasedSegment;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -254,10 +252,8 @@ public class WindowOperatorQueryFrameProcessorTest extends FrameProcessorTestBas
         RuntimeException.class,
         () -> runProcessor(2, 3)
     );
-    MatcherAssert.assertThat(
-        ((MSQException) e.getCause().getCause()).getFault(),
-        CoreMatchers.instanceOf(TooManyRowsInAWindowFault.class)
-    );
+    final MSQException msqException = Assertions.assertInstanceOf(MSQException.class, e.getCause().getCause());
+    Assertions.assertInstanceOf(TooManyRowsInAWindowFault.class, msqException.getFault());
     Assertions.assertTrue(e.getMessage().contains("TooManyRowsInAWindow: Too many rows in a window (requested = 7, max = 2)"));
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/WindowOperatorQueryStageProcessorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/WindowOperatorQueryStageProcessorTest.java
@@ -20,7 +20,7 @@
 package org.apache.druid.msq.querykit;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WindowOperatorQueryStageProcessorTest
 {

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/common/SortMergeJoinFrameProcessorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/common/SortMergeJoinFrameProcessorTest.java
@@ -51,16 +51,14 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.join.JoinTestHelper;
 import org.apache.druid.segment.join.JoinType;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -69,24 +67,22 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-@RunWith(Parameterized.class)
 public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
 {
   private static final long MAX_BUFFERED_BYTES = 10_000_000;
 
-  private final int rowsPerInputFrame;
-  private final int rowsPerOutputFrame;
+  private int rowsPerInputFrame;
+  private int rowsPerOutputFrame;
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
-  public SortMergeJoinFrameProcessorTest(int rowsPerInputFrame, int rowsPerOutputFrame)
+  public void initSortMergeJoinFrameProcessorTest(int rowsPerInputFrame, int rowsPerOutputFrame)
   {
     this.rowsPerInputFrame = rowsPerInputFrame;
     this.rowsPerOutputFrame = rowsPerOutputFrame;
   }
 
-  @Parameterized.Parameters(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
   public static Iterable<Object[]> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -100,9 +96,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     return constructors;
   }
 
-  @Test
-  public void testLeftJoinEmptyLeftSide() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testLeftJoinEmptyLeftSide(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = ReadableInput.channel(
         ReadableNilFrameChannel.INSTANCE,
         FrameReader.create(JoinTestHelper.FACT_SIGNATURE),
@@ -142,9 +140,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, Collections.emptyList());
   }
 
-  @Test
-  public void testLeftJoinEmptyRightSide() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testLeftJoinEmptyRightSide(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryIsoCode", KeyOrder.ASCENDING),
@@ -221,9 +221,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @Test
-  public void testInnerJoinEmptyRightSide() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testInnerJoinEmptyRightSide(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryIsoCode", KeyOrder.ASCENDING),
@@ -266,9 +268,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, Collections.emptyList());
   }
 
-  @Test
-  public void testLeftJoinCountryIsoCode() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testLeftJoinCountryIsoCode(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryIsoCode", KeyOrder.ASCENDING),
@@ -340,9 +344,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @Test
-  public void testCrossJoin() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testCrossJoin(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryIsoCode", KeyOrder.ASCENDING),
@@ -441,9 +447,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @Test
-  public void testLeftJoinRegions() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testLeftJoinRegions(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel =
         buildFactInput(
             ImmutableList.of(
@@ -526,9 +534,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @Test
-  public void testRightJoinRegionCodeOnly() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testRightJoinRegionCodeOnly(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     // This join generates duplicates.
 
     final ReadableInput factChannel =
@@ -609,9 +619,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @Test
-  public void testFullOuterJoinRegionCodeOnly() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testFullOuterJoinRegionCodeOnly(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     // This join generates duplicates.
 
     final ReadableInput factChannel =
@@ -695,9 +707,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @Test
-  public void testInnerJoinRegionCodeOnly() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testInnerJoinRegionCodeOnly(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     // This join generates duplicates.
 
     final ReadableInput factChannel =
@@ -772,9 +786,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @Test
-  public void testInnerJoinRegionCodeOnlyIsNotDistinctFrom() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testInnerJoinRegionCodeOnlyIsNotDistinctFrom(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     // This join generates duplicates.
 
     final ReadableInput factChannel =
@@ -854,9 +870,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @Test
-  public void testLeftJoinCountryNumber() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testLeftJoinCountryNumber(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryNumber", KeyOrder.ASCENDING),
@@ -936,9 +954,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @Test
-  public void testRightJoinCountryNumber() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testRightJoinCountryNumber(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryNumber", KeyOrder.ASCENDING),
@@ -1018,9 +1038,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @Test
-  public void testInnerJoinCountryIsoCode() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testInnerJoinCountryIsoCode(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryIsoCode", KeyOrder.ASCENDING),
@@ -1086,9 +1108,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @Test
-  public void testInnerJoinCountryIsoCodeNotDistinctFrom() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testInnerJoinCountryIsoCodeNotDistinctFrom(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryIsoCode", KeyOrder.ASCENDING),
@@ -1154,9 +1178,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @Test
-  public void testInnerJoinCountryIsoCode_withMaxBufferedBytesLimit_succeeds() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testInnerJoinCountryIsoCode_withMaxBufferedBytesLimit_succeeds(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryIsoCode", KeyOrder.ASCENDING),
@@ -1222,9 +1248,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @Test
-  public void testInnerJoinCountryIsoCode_backwards_withMaxBufferedBytesLimit_succeeds() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testInnerJoinCountryIsoCode_backwards_withMaxBufferedBytesLimit_succeeds(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryIsoCode", KeyOrder.ASCENDING),
@@ -1290,9 +1318,11 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @Test
-  public void testCountrySelfJoin() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testCountrySelfJoin(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel1 = buildFactInput(ImmutableList.of(new KeyColumn("channel", KeyOrder.ASCENDING)));
     final ReadableInput factChannel2 = buildFactInput(ImmutableList.of(new KeyColumn("channel", KeyOrder.ASCENDING)));
 
@@ -1342,11 +1372,13 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @Test
-  public void testCountrySelfJoin_withMaxBufferedBytesLimit_fails() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
+  public void testCountrySelfJoin_withMaxBufferedBytesLimit_fails(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
   {
+    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     // Test is only valid when rowsPerInputFrame is low enough that we get multiple frames.
-    Assume.assumeThat(rowsPerInputFrame, Matchers.lessThanOrEqualTo(7));
+    Assumptions.assumeTrue(rowsPerInputFrame <= 7);
 
     final ReadableInput factChannel1 = buildFactInput(ImmutableList.of(new KeyColumn("channel", KeyOrder.ASCENDING)));
     final ReadableInput factChannel2 = buildFactInput(ImmutableList.of(new KeyColumn("channel", KeyOrder.ASCENDING)));
@@ -1373,7 +1405,7 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
         1
     );
 
-    final RuntimeException e = Assert.assertThrows(
+    final RuntimeException e = Assertions.assertThrows(
         RuntimeException.class,
         () -> run(processor, outputChannel.readable(), joinSignature)
     );
@@ -1410,7 +1442,7 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     );
 
     final List<List<Object>> rows = rowsFromProcessor.toList();
-    Assert.assertEquals(Unit.instance(), FutureUtils.getUnchecked(retValFromProcessor, true));
+    Assertions.assertEquals(Unit.instance(), FutureUtils.getUnchecked(retValFromProcessor, true));
     return rows;
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/common/SortMergeJoinFrameProcessorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/common/SortMergeJoinFrameProcessorTest.java
@@ -52,12 +52,11 @@ import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.join.JoinTestHelper;
 import org.apache.druid.segment.join.JoinType;
 import org.apache.druid.testing.TemporaryFolderExtension;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
@@ -67,17 +66,19 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
 {
   private static final long MAX_BUFFERED_BYTES = 10_000_000;
 
-  private int rowsPerInputFrame;
-  private int rowsPerOutputFrame;
+  private final int rowsPerInputFrame;
+  private final int rowsPerOutputFrame;
 
   @RegisterExtension
   public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
-  public void initSortMergeJoinFrameProcessorTest(int rowsPerInputFrame, int rowsPerOutputFrame)
+  public SortMergeJoinFrameProcessorTest(int rowsPerInputFrame, int rowsPerOutputFrame)
   {
     this.rowsPerInputFrame = rowsPerInputFrame;
     this.rowsPerOutputFrame = rowsPerOutputFrame;
@@ -96,11 +97,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     return constructors;
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testLeftJoinEmptyLeftSide(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testLeftJoinEmptyLeftSide() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = ReadableInput.channel(
         ReadableNilFrameChannel.INSTANCE,
         FrameReader.create(JoinTestHelper.FACT_SIGNATURE),
@@ -140,11 +139,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, Collections.emptyList());
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testLeftJoinEmptyRightSide(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testLeftJoinEmptyRightSide() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryIsoCode", KeyOrder.ASCENDING),
@@ -221,11 +218,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testInnerJoinEmptyRightSide(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testInnerJoinEmptyRightSide() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryIsoCode", KeyOrder.ASCENDING),
@@ -268,11 +263,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, Collections.emptyList());
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testLeftJoinCountryIsoCode(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testLeftJoinCountryIsoCode() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryIsoCode", KeyOrder.ASCENDING),
@@ -344,11 +337,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testCrossJoin(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testCrossJoin() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryIsoCode", KeyOrder.ASCENDING),
@@ -447,11 +438,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testLeftJoinRegions(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testLeftJoinRegions() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel =
         buildFactInput(
             ImmutableList.of(
@@ -534,11 +523,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testRightJoinRegionCodeOnly(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testRightJoinRegionCodeOnly() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     // This join generates duplicates.
 
     final ReadableInput factChannel =
@@ -619,11 +606,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testFullOuterJoinRegionCodeOnly(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testFullOuterJoinRegionCodeOnly() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     // This join generates duplicates.
 
     final ReadableInput factChannel =
@@ -707,11 +692,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testInnerJoinRegionCodeOnly(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testInnerJoinRegionCodeOnly() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     // This join generates duplicates.
 
     final ReadableInput factChannel =
@@ -786,11 +769,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testInnerJoinRegionCodeOnlyIsNotDistinctFrom(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testInnerJoinRegionCodeOnlyIsNotDistinctFrom() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     // This join generates duplicates.
 
     final ReadableInput factChannel =
@@ -870,11 +851,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testLeftJoinCountryNumber(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testLeftJoinCountryNumber() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryNumber", KeyOrder.ASCENDING),
@@ -954,11 +933,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testRightJoinCountryNumber(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testRightJoinCountryNumber() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryNumber", KeyOrder.ASCENDING),
@@ -1038,11 +1015,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testInnerJoinCountryIsoCode(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testInnerJoinCountryIsoCode() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryIsoCode", KeyOrder.ASCENDING),
@@ -1108,11 +1083,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testInnerJoinCountryIsoCodeNotDistinctFrom(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testInnerJoinCountryIsoCodeNotDistinctFrom() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryIsoCode", KeyOrder.ASCENDING),
@@ -1178,11 +1151,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testInnerJoinCountryIsoCode_withMaxBufferedBytesLimit_succeeds(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testInnerJoinCountryIsoCode_withMaxBufferedBytesLimit_succeeds() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryIsoCode", KeyOrder.ASCENDING),
@@ -1248,11 +1219,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testInnerJoinCountryIsoCode_backwards_withMaxBufferedBytesLimit_succeeds(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testInnerJoinCountryIsoCode_backwards_withMaxBufferedBytesLimit_succeeds() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel = buildFactInput(
         ImmutableList.of(
             new KeyColumn("countryIsoCode", KeyOrder.ASCENDING),
@@ -1318,11 +1287,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testCountrySelfJoin(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testCountrySelfJoin() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     final ReadableInput factChannel1 = buildFactInput(ImmutableList.of(new KeyColumn("channel", KeyOrder.ASCENDING)));
     final ReadableInput factChannel2 = buildFactInput(ImmutableList.of(new KeyColumn("channel", KeyOrder.ASCENDING)));
 
@@ -1372,11 +1339,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
     assertResult(processor, outputChannel.readable(), joinSignature, expectedRows);
   }
 
-  @MethodSource("constructorFeeder")
-  @ParameterizedTest(name = "rowsPerInputFrame = {0}, rowsPerOutputFrame = {1}")
-  public void testCountrySelfJoin_withMaxBufferedBytesLimit_fails(int rowsPerInputFrame, int rowsPerOutputFrame) throws Exception
+  @Test
+  public void testCountrySelfJoin_withMaxBufferedBytesLimit_fails() throws Exception
   {
-    initSortMergeJoinFrameProcessorTest(rowsPerInputFrame, rowsPerOutputFrame);
     // Test is only valid when rowsPerInputFrame is low enough that we get multiple frames.
     Assumptions.assumeTrue(rowsPerInputFrame <= 7);
 
@@ -1410,12 +1375,9 @@ public class SortMergeJoinFrameProcessorTest extends FrameProcessorTestBase
         () -> run(processor, outputChannel.readable(), joinSignature)
     );
 
-    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(RuntimeException.class));
-    MatcherAssert.assertThat(e.getCause().getCause(), CoreMatchers.instanceOf(MSQException.class));
-    MatcherAssert.assertThat(
-        ((MSQException) e.getCause().getCause()).getFault(),
-        CoreMatchers.instanceOf(TooManyRowsWithSameKeyFault.class)
-    );
+    final RuntimeException cause = Assertions.assertInstanceOf(RuntimeException.class, e.getCause());
+    final MSQException msqException = Assertions.assertInstanceOf(MSQException.class, cause.getCause());
+    Assertions.assertInstanceOf(TooManyRowsWithSameKeyFault.class, msqException.getFault());
   }
 
   private void assertResult(

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/common/SortMergeJoinStageProcessorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/common/SortMergeJoinStageProcessorTest.java
@@ -24,39 +24,39 @@ import org.apache.druid.frame.key.KeyColumn;
 import org.apache.druid.frame.key.KeyOrder;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.join.JoinConditionAnalysis;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SortMergeJoinStageProcessorTest
 {
   @Test
   public void test_validateCondition()
   {
-    Assert.assertNotNull(
+    Assertions.assertNotNull(
         SortMergeJoinStageProcessor.validateCondition(
             JoinConditionAnalysis.forExpression("1", "j.", ExprMacroTable.nil())
         )
     );
 
-    Assert.assertNotNull(
+    Assertions.assertNotNull(
         SortMergeJoinStageProcessor.validateCondition(
             JoinConditionAnalysis.forExpression("x == \"j.y\"", "j.", ExprMacroTable.nil())
         )
     );
 
-    Assert.assertNotNull(
+    Assertions.assertNotNull(
         SortMergeJoinStageProcessor.validateCondition(
             JoinConditionAnalysis.forExpression("1", "j.", ExprMacroTable.nil())
         )
     );
 
-    Assert.assertNotNull(
+    Assertions.assertNotNull(
         SortMergeJoinStageProcessor.validateCondition(
             JoinConditionAnalysis.forExpression("x == \"j.y\" && a == \"j.b\"", "j.", ExprMacroTable.nil())
         )
     );
 
-    Assert.assertNotNull(
+    Assertions.assertNotNull(
         SortMergeJoinStageProcessor.validateCondition(
             JoinConditionAnalysis.forExpression(
                 "notdistinctfrom(x, \"j.y\") && a == \"j.b\"",
@@ -66,14 +66,14 @@ public class SortMergeJoinStageProcessorTest
         )
     );
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> SortMergeJoinStageProcessor.validateCondition(
             JoinConditionAnalysis.forExpression("x == y", "j.", ExprMacroTable.nil())
         )
     );
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> SortMergeJoinStageProcessor.validateCondition(
             JoinConditionAnalysis.forExpression("x + 1 == \"j.y\"", "j.", ExprMacroTable.nil())
@@ -84,7 +84,7 @@ public class SortMergeJoinStageProcessorTest
   @Test
   public void test_toKeyColumns()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             ImmutableList.of(new KeyColumn("x", KeyOrder.ASCENDING)),
             ImmutableList.of(new KeyColumn("y", KeyOrder.ASCENDING))
@@ -98,7 +98,7 @@ public class SortMergeJoinStageProcessorTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             ImmutableList.of(),
             ImmutableList.of()
@@ -112,7 +112,7 @@ public class SortMergeJoinStageProcessorTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             ImmutableList.of(new KeyColumn("x", KeyOrder.ASCENDING), new KeyColumn("a", KeyOrder.ASCENDING)),
             ImmutableList.of(new KeyColumn("y", KeyOrder.ASCENDING), new KeyColumn("b", KeyOrder.ASCENDING))
@@ -126,7 +126,7 @@ public class SortMergeJoinStageProcessorTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             ImmutableList.of(new KeyColumn("x", KeyOrder.ASCENDING), new KeyColumn("a", KeyOrder.ASCENDING)),
             ImmutableList.of(new KeyColumn("y", KeyOrder.ASCENDING), new KeyColumn("b", KeyOrder.ASCENDING))
@@ -140,7 +140,7 @@ public class SortMergeJoinStageProcessorTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             ImmutableList.of(new KeyColumn("x", KeyOrder.ASCENDING), new KeyColumn("a", KeyOrder.ASCENDING)),
             ImmutableList.of(new KeyColumn("y", KeyOrder.ASCENDING), new KeyColumn("b", KeyOrder.ASCENDING))
@@ -154,7 +154,7 @@ public class SortMergeJoinStageProcessorTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             ImmutableList.of(new KeyColumn("x", KeyOrder.ASCENDING), new KeyColumn("a", KeyOrder.ASCENDING)),
             ImmutableList.of(new KeyColumn("y", KeyOrder.ASCENDING), new KeyColumn("b", KeyOrder.ASCENDING))
@@ -172,7 +172,7 @@ public class SortMergeJoinStageProcessorTest
   @Test
   public void test_toRequiredNonNullKeyParts()
   {
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new int[0],
         SortMergeJoinStageProcessor.toRequiredNonNullKeyParts(
             JoinConditionAnalysis.forExpression(
@@ -183,7 +183,7 @@ public class SortMergeJoinStageProcessorTest
         )
     );
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new int[]{0},
         SortMergeJoinStageProcessor.toRequiredNonNullKeyParts(
             JoinConditionAnalysis.forExpression(
@@ -194,7 +194,7 @@ public class SortMergeJoinStageProcessorTest
         )
     );
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new int[]{0, 1},
         SortMergeJoinStageProcessor.toRequiredNonNullKeyParts(
             JoinConditionAnalysis.forExpression(
@@ -205,7 +205,7 @@ public class SortMergeJoinStageProcessorTest
         )
     );
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new int[]{0},
         SortMergeJoinStageProcessor.toRequiredNonNullKeyParts(
             JoinConditionAnalysis.forExpression(
@@ -216,7 +216,7 @@ public class SortMergeJoinStageProcessorTest
         )
     );
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new int[]{1},
         SortMergeJoinStageProcessor.toRequiredNonNullKeyParts(
             JoinConditionAnalysis.forExpression(
@@ -227,7 +227,7 @@ public class SortMergeJoinStageProcessorTest
         )
     );
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new int[0],
         SortMergeJoinStageProcessor.toRequiredNonNullKeyParts(
             JoinConditionAnalysis.forExpression(

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/groupby/GroupByFrameCombinerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/groupby/GroupByFrameCombinerTest.java
@@ -46,8 +46,8 @@ import org.apache.druid.segment.RowBasedCursorFactory;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -93,7 +93,7 @@ public class GroupByFrameCombinerTest extends InitializedNullHandlingTest
         1 // one row per frame
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             ImmutableList.of("a", 100L, 11L),
             ImmutableList.of("b", 200L, 22L),
@@ -123,11 +123,11 @@ public class GroupByFrameCombinerTest extends InitializedNullHandlingTest
 
     final List<List<Object>> rows = runMergerWithCombiner(channelData, 1);
 
-    Assert.assertEquals(numKeys, rows.size());
+    Assertions.assertEquals(numKeys, rows.size());
     for (int k = 0; k < numKeys; k++) {
-      Assert.assertEquals(StringUtils.format("key_%02d", k), rows.get(k).get(0));
-      Assert.assertEquals((long) k, rows.get(k).get(1));
-      Assert.assertEquals((long) numChannels, rows.get(k).get(2));
+      Assertions.assertEquals(StringUtils.format("key_%02d", k), rows.get(k).get(0));
+      Assertions.assertEquals((long) k, rows.get(k).get(1));
+      Assertions.assertEquals((long) numChannels, rows.get(k).get(2));
     }
   }
 
@@ -157,7 +157,7 @@ public class GroupByFrameCombinerTest extends InitializedNullHandlingTest
         3 // multiple rows per frame
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             ImmutableList.of("a", 1L, 130L),
             ImmutableList.of("b", 2L, 530L),

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/results/ExportResultsStageProcessorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/results/ExportResultsStageProcessorTest.java
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.storage.StorageConfig;
 import org.apache.druid.storage.StorageConnectorModule;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -47,7 +47,7 @@ public class ExportResultsStageProcessorTest
         exportFactoryString,
         ExportResultsStageProcessor.class
     );
-    Assert.assertNull(exportResultsFrameProcessor.getColumnMappings());
-    Assert.assertNull(exportResultsFrameProcessor.getResultsContext());
+    Assertions.assertNull(exportResultsFrameProcessor.getColumnMappings());
+    Assertions.assertNull(exportResultsFrameProcessor.getResultsContext());
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/results/QueryResultsFrameProcessorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/results/QueryResultsFrameProcessorTest.java
@@ -35,8 +35,8 @@ import org.apache.druid.msq.querykit.ReadableInput;
 import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.incremental.IncrementalIndexCursorFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
@@ -88,7 +88,7 @@ public class QueryResultsFrameProcessorTest extends FrameProcessorTestBase
         FrameTestUtil.readRowsFromCursorFactory(cursorFactory, signature, false),
         rowsFromProcessor
     );
-    Assert.assertEquals(Unit.instance(), retVal.get());
+    Assertions.assertEquals(Unit.instance(), retVal.get());
   }
 
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessorTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.collections.ReferenceCountingResourceHolder;
 import org.apache.druid.collections.ResourceHolder;
+import org.apache.druid.error.ThrowableMatcher;
 import org.apache.druid.frame.Frame;
 import org.apache.druid.frame.FrameType;
 import org.apache.druid.frame.allocation.ArenaMemoryAllocator;
@@ -64,16 +65,13 @@ import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.incremental.IncrementalIndexCursorFactory;
 import org.apache.druid.timeline.SegmentId;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -171,7 +169,7 @@ public class ScanQueryFrameProcessorTest extends FrameProcessorTestBase
         rowsFromProcessor
     );
 
-    Assert.assertEquals(Unit.instance(), retVal.get());
+    Assertions.assertEquals(Unit.instance(), retVal.get());
     Assertions.assertEquals(0, segmentReferenceProvider.getNumReferences()); // Segment reference was closed
   }
 
@@ -260,17 +258,17 @@ public class ScanQueryFrameProcessorTest extends FrameProcessorTestBase
         FrameReader.create(signature)
     );
 
-    final RuntimeException e = Assert.assertThrows(
+    final RuntimeException e = Assertions.assertThrows(
         RuntimeException.class,
         rowsFromProcessor::toList
     );
 
-    MatcherAssert.assertThat(
-        e,
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
-            "Expected eternity intervals, but got[[2001-01-01T00:00:00.000Z/2011-01-01T00:00:00.000Z, "
-            + "2011-01-02T00:00:00.000Z/2021-01-01T00:00:00.000Z]]"))
-    );
+    ThrowableMatcher.of(RuntimeException.class)
+                   .expectMessageContains(
+                       "Expected eternity intervals, but got[[2001-01-01T00:00:00.000Z/2011-01-01T00:00:00.000Z, "
+                       + "2011-01-02T00:00:00.000Z/2021-01-01T00:00:00.000Z]]"
+                   )
+                   .assertThat(e);
   }
 
   /**
@@ -441,6 +439,6 @@ public class ScanQueryFrameProcessorTest extends FrameProcessorTestBase
         rowsFromProcessor
     );
 
-    Assert.assertEquals(Unit.instance(), retVal.get(30, TimeUnit.SECONDS));
+    Assertions.assertEquals(Unit.instance(), retVal.get(30, TimeUnit.SECONDS));
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/rpc/BaseWorkerClientImplTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/rpc/BaseWorkerClientImplTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import it.unimi.dsi.fastutil.bytes.ByteArrays;
 import org.apache.druid.common.guava.FutureUtils;
+import org.apache.druid.error.ThrowableMatcher;
 import org.apache.druid.frame.Frame;
 import org.apache.druid.frame.FrameType;
 import org.apache.druid.frame.channel.ByteTracker;
@@ -54,16 +55,16 @@ import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
@@ -93,7 +94,7 @@ public class BaseWorkerClientImplTest extends InitializedNullHandlingTest
   private WorkerClient workerClient;
   private ExecutorService exec;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass()
   {
     final QueryableIndexCursorFactory cursorFactory = new QueryableIndexCursorFactory(TestIndex.getMMappedTestIndex());
@@ -108,7 +109,7 @@ public class BaseWorkerClientImplTest extends InitializedNullHandlingTest
     FRAME_READER = FrameReader.create(cursorFactory.getRowSignature());
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass()
   {
     NIL_FILE_BYTES = null;
@@ -116,7 +117,7 @@ public class BaseWorkerClientImplTest extends InitializedNullHandlingTest
     FRAME_READER = null;
   }
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     jsonMapper = new DefaultObjectMapper();
@@ -125,7 +126,7 @@ public class BaseWorkerClientImplTest extends InitializedNullHandlingTest
     exec = Execs.singleThreaded(StringUtils.encodeForFormat("exec-for-" + getClass().getName()) + "-%s");
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws InterruptedException
   {
     workerServiceClient.verify();
@@ -157,11 +158,11 @@ public class BaseWorkerClientImplTest extends InitializedNullHandlingTest
     final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("testChannel", false, null);
     final Future<List<List<Object>>> framesFuture = readChannelAsync(channel);
 
-    Assert.assertFalse(workerClient.fetchChannelData(WORKER_ID, stageId, 2, 0, channel).get());
-    Assert.assertTrue(workerClient.fetchChannelData(WORKER_ID, stageId, 2, NIL_FILE_BYTES.length, channel).get());
+    Assertions.assertFalse(workerClient.fetchChannelData(WORKER_ID, stageId, 2, 0, channel).get());
+    Assertions.assertTrue(workerClient.fetchChannelData(WORKER_ID, stageId, 2, NIL_FILE_BYTES.length, channel).get());
     channel.doneWriting(); // Caller is expected to call doneWriting after fetchChannelData returns true.
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         framesFuture.get().size()
     );
@@ -183,7 +184,7 @@ public class BaseWorkerClientImplTest extends InitializedNullHandlingTest
     final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("testChannel", false, null);
     channel.close(); // ReadableFrameChannel's close() method.
 
-    final ExecutionException e = Assert.assertThrows(
+    final ExecutionException e = Assertions.assertThrows(
         ExecutionException.class,
         () -> workerClient.fetchChannelData(WORKER_ID, stageId, 2, 0, channel).get()
     );
@@ -222,12 +223,12 @@ public class BaseWorkerClientImplTest extends InitializedNullHandlingTest
     final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("testChannel", false, null);
     final Future<List<List<Object>>> framesFuture = readChannelAsync(channel);
 
-    Assert.assertFalse(workerClient.fetchChannelData(WORKER_ID, stageId, 2, 0, channel).get());
-    Assert.assertFalse(workerClient.fetchChannelData(WORKER_ID, stageId, 2, 0, channel).get());
-    Assert.assertTrue(workerClient.fetchChannelData(WORKER_ID, stageId, 2, NIL_FILE_BYTES.length, channel).get());
+    Assertions.assertFalse(workerClient.fetchChannelData(WORKER_ID, stageId, 2, 0, channel).get());
+    Assertions.assertFalse(workerClient.fetchChannelData(WORKER_ID, stageId, 2, 0, channel).get());
+    Assertions.assertTrue(workerClient.fetchChannelData(WORKER_ID, stageId, 2, NIL_FILE_BYTES.length, channel).get());
     channel.doneWriting(); // Caller is expected to call doneWriting after fetchChannelData returns true.
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         framesFuture.get().size()
     );
@@ -246,18 +247,14 @@ public class BaseWorkerClientImplTest extends InitializedNullHandlingTest
     final StageId stageId = new StageId("xyz", 1);
     final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("testChannel", false, null);
 
-    final ExecutionException e = Assert.assertThrows(
+    final ExecutionException e = Assertions.assertThrows(
         ExecutionException.class,
         () -> workerClient.fetchChannelData(WORKER_ID, stageId, 2, 0, channel).get()
     );
 
-    MatcherAssert.assertThat(
-        e.getCause(),
-        CoreMatchers.allOf(
-            CoreMatchers.instanceOf(IOException.class),
-            ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("Some error"))
-        )
-    );
+    ThrowableMatcher.of(IOException.class)
+                   .expectMessageIs("Some error")
+                   .assertThat(e.getCause());
 
     channel.close();
   }
@@ -284,8 +281,8 @@ public class BaseWorkerClientImplTest extends InitializedNullHandlingTest
     final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("testChannel", false, null);
     final Future<List<List<Object>>> framesFuture = readChannelAsync(channel);
 
-    Assert.assertFalse(workerClient.fetchChannelData(WORKER_ID, stageId, 2, 0, channel).get());
-    Assert.assertTrue(workerClient.fetchChannelData(WORKER_ID, stageId, 2, FILE_BYTES.length, channel).get());
+    Assertions.assertFalse(workerClient.fetchChannelData(WORKER_ID, stageId, 2, 0, channel).get());
+    Assertions.assertTrue(workerClient.fetchChannelData(WORKER_ID, stageId, 2, FILE_BYTES.length, channel).get());
     channel.doneWriting(); // Caller is expected to call doneWriting after fetchChannelData returns true.
 
     FrameTestUtil.assertRowsEqual(

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/rpc/BaseWorkerClientImplTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/rpc/BaseWorkerClientImplTest.java
@@ -51,8 +51,6 @@ import org.apache.druid.segment.QueryableIndexCursorFactory;
 import org.apache.druid.segment.TestIndex;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.utils.CloseableUtils;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.jupiter.api.AfterAll;
@@ -189,10 +187,7 @@ public class BaseWorkerClientImplTest extends InitializedNullHandlingTest
         () -> workerClient.fetchChannelData(WORKER_ID, stageId, 2, 0, channel).get()
     );
 
-    MatcherAssert.assertThat(
-        e.getCause(),
-        CoreMatchers.instanceOf(ChannelClosedForWritesException.class)
-    );
+    Assertions.assertInstanceOf(ChannelClosedForWritesException.class, e.getCause());
   }
 
   @Test

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/shuffle/output/ByteChunksInputStreamTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/shuffle/output/ByteChunksInputStreamTest.java
@@ -44,7 +44,6 @@ public class ByteChunksInputStreamTest
 
       int c;
       while ((c = in.read()) != -1) {
-        Assertions.assertTrue(c >= 0, "InputStream#read contract");
         baos.write(c);
       }
 
@@ -60,7 +59,6 @@ public class ByteChunksInputStreamTest
 
       int c;
       while ((c = in.read()) != -1) {
-        Assertions.assertTrue(c >= 0, "InputStream#read contract");
         baos.write(c);
       }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/shuffle/output/ByteChunksInputStreamTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/shuffle/output/ByteChunksInputStreamTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.msq.shuffle.output;
 import com.google.common.collect.ImmutableList;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -50,7 +50,7 @@ public class ByteChunksInputStreamTest
         baos.write(c);
       }
 
-      Assert.assertArrayEquals(chunksSubset(0), baos.toByteArray());
+      Assertions.assertArrayEquals(chunksSubset(0), baos.toByteArray());
     }
   }
 
@@ -66,7 +66,7 @@ public class ByteChunksInputStreamTest
         baos.write(c);
       }
 
-      Assert.assertArrayEquals(chunksSubset(1), baos.toByteArray());
+      Assertions.assertArrayEquals(chunksSubset(1), baos.toByteArray());
     }
   }
 
@@ -79,11 +79,11 @@ public class ByteChunksInputStreamTest
 
       int r;
       while ((r = in.read(buf, 1, 1)) != -1) {
-        Assert.assertEquals("InputStream#read bytes read", 1, r);
+        Assertions.assertEquals(1, r, "InputStream#read bytes read");
         baos.write(buf, 1, 1);
       }
 
-      Assert.assertArrayEquals(chunksSubset(0), baos.toByteArray());
+      Assertions.assertArrayEquals(chunksSubset(0), baos.toByteArray());
     }
   }
 
@@ -96,11 +96,11 @@ public class ByteChunksInputStreamTest
 
       int r;
       while ((r = in.read(buf, 1, 1)) != -1) {
-        Assert.assertEquals("InputStream#read bytes read", 1, r);
+        Assertions.assertEquals(1, r, "InputStream#read bytes read");
         baos.write(buf, 1, 1);
       }
 
-      Assert.assertArrayEquals(chunksSubset(1), baos.toByteArray());
+      Assertions.assertArrayEquals(chunksSubset(1), baos.toByteArray());
     }
   }
 
@@ -116,7 +116,7 @@ public class ByteChunksInputStreamTest
         baos.write(buf, 2, r);
       }
 
-      Assert.assertArrayEquals(chunksSubset(0), baos.toByteArray());
+      Assertions.assertArrayEquals(chunksSubset(0), baos.toByteArray());
     }
   }
 
@@ -132,7 +132,7 @@ public class ByteChunksInputStreamTest
         baos.write(buf, 2, r);
       }
 
-      Assert.assertArrayEquals(chunksSubset(1), baos.toByteArray());
+      Assertions.assertArrayEquals(chunksSubset(1), baos.toByteArray());
     }
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/shuffle/output/ByteChunksInputStreamTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/shuffle/output/ByteChunksInputStreamTest.java
@@ -20,8 +20,6 @@
 package org.apache.druid.msq.shuffle.output;
 
 import com.google.common.collect.ImmutableList;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -46,7 +44,7 @@ public class ByteChunksInputStreamTest
 
       int c;
       while ((c = in.read()) != -1) {
-        MatcherAssert.assertThat("InputStream#read contract", c, Matchers.greaterThanOrEqualTo(0));
+        Assertions.assertTrue(c >= 0, "InputStream#read contract");
         baos.write(c);
       }
 
@@ -62,7 +60,7 @@ public class ByteChunksInputStreamTest
 
       int c;
       while ((c = in.read()) != -1) {
-        MatcherAssert.assertThat("InputStream#read contract", c, Matchers.greaterThanOrEqualTo(0));
+        Assertions.assertTrue(c >= 0, "InputStream#read contract");
         baos.write(c);
       }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/shuffle/output/ChannelStageOutputReaderTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/shuffle/output/ChannelStageOutputReaderTest.java
@@ -40,8 +40,6 @@ import org.apache.druid.segment.incremental.IncrementalIndexCursorFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.utils.CloseableUtils;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -381,7 +379,7 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
           }
         }
 
-        MatcherAssert.assertThat(numReads, Matchers.greaterThan(1));
+        Assertions.assertTrue(numReads > 1);
       }
 
       final FrameFile frameFile = FrameFile.open(tmpFile, null);
@@ -452,7 +450,7 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
       // Read remotely from offset = 1.
       final InputStream in = FutureUtils.getUnchecked(reader.readRemotelyFrom(1), true);
       final int offset = ByteStreams.toByteArray(in).length;
-      MatcherAssert.assertThat(offset, Matchers.greaterThan(0));
+      Assertions.assertTrue(offset > 0);
 
       // Then read again from offset = 0; should get an error.
       final RuntimeException e = Assertions.assertThrows(

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/shuffle/output/ChannelStageOutputReaderTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/shuffle/output/ChannelStageOutputReaderTest.java
@@ -24,6 +24,7 @@ import com.google.common.io.ByteStreams;
 import com.google.common.math.IntMath;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.common.guava.FutureUtils;
+import org.apache.druid.error.ThrowableMatcher;
 import org.apache.druid.frame.Frame;
 import org.apache.druid.frame.FrameType;
 import org.apache.druid.frame.channel.BlockingQueueFrameChannel;
@@ -37,18 +38,16 @@ import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCursorFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.utils.CloseableUtils;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableCauseMatcher;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -64,7 +63,8 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
   /**
    * Tests that use {@link BlockingQueueFrameChannel#minimal()}.
    */
-  public static class WithMinimalBuffering extends InitializedNullHandlingTest
+  @Nested
+  public class WithMinimalBuffering extends InitializedNullHandlingTest
   {
     private final Frame frame = Iterables.getOnlyElement(
         FrameSequenceBuilder
@@ -74,8 +74,8 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
             .toList()
     );
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @RegisterExtension
+    public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
     private BlockingQueueFrameChannel channel;
     private ChannelStageOutputReader channelReader;
@@ -87,7 +87,7 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
     private long offset;
     private ListenableFuture<InputStream> nextRead;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception
     {
       channel = BlockingQueueFrameChannel.minimal();
@@ -96,7 +96,7 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
       tmpOut = Files.newOutputStream(tmpFile.toPath());
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception
     {
       CloseableUtils.closeAll(tmpOut, tmpFrameFile);
@@ -112,7 +112,7 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
         // Do nothing, just keep reading.
       }
 
-      Assert.assertEquals(0, tmpFrameFile.numFrames());
+      Assertions.assertEquals(0, tmpFrameFile.numFrames());
     }
 
     @Test
@@ -126,14 +126,14 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
         // Do nothing, just keep reading.
       }
 
-      Assert.assertEquals(1, tmpFrameFile.numFrames());
-      Assert.assertEquals(frame.numBytes(), tmpFrameFile.rac(0, null).as(Frame.class).numBytes());
+      Assertions.assertEquals(1, tmpFrameFile.numFrames());
+      Assertions.assertEquals(frame.numBytes(), tmpFrameFile.rac(0, null).as(Frame.class).numBytes());
     }
 
     @Test
     public void test_remote_oneFrame_writeAfterFirstRead() throws Exception
     {
-      Assert.assertTrue(doRead(-1));
+      Assertions.assertTrue(doRead(-1));
 
       // Close after writing one frame.
       channel.writable().write(frame);
@@ -143,8 +143,8 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
         // Do nothing, just keep reading.
       }
 
-      Assert.assertEquals(1, tmpFrameFile.numFrames());
-      Assert.assertEquals(frame.numBytes(), tmpFrameFile.rac(0, null).as(Frame.class).numBytes());
+      Assertions.assertEquals(1, tmpFrameFile.numFrames());
+      Assertions.assertEquals(frame.numBytes(), tmpFrameFile.rac(0, null).as(Frame.class).numBytes());
     }
 
     @Test
@@ -158,8 +158,8 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
         // Do nothing, just keep reading.
       }
 
-      Assert.assertEquals(1, tmpFrameFile.numFrames());
-      Assert.assertEquals(frame.numBytes(), tmpFrameFile.rac(0, null).as(Frame.class).numBytes());
+      Assertions.assertEquals(1, tmpFrameFile.numFrames());
+      Assertions.assertEquals(frame.numBytes(), tmpFrameFile.rac(0, null).as(Frame.class).numBytes());
     }
 
     @Test
@@ -169,45 +169,43 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
       channel.writable().write(frame);
 
       // See that we can't write another frame.
-      final IllegalStateException e = Assert.assertThrows(
+      final IllegalStateException e = Assertions.assertThrows(
           IllegalStateException.class,
           () -> channel.writable().write(frame)
       );
 
-      MatcherAssert.assertThat(
-          e,
-          ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Channel has no capacity"))
-      );
+      ThrowableMatcher.of(IllegalStateException.class)
+                     .expectMessage(message -> message.startsWith("Channel has no capacity"))
+                     .assertThat(e);
 
       // Read the first frame until we start blocking.
       while (nextRead == null) {
-        Assert.assertTrue(doRead(1));
+        Assertions.assertTrue(doRead(1));
       }
 
       // Write the next frame.
-      Assert.assertFalse(nextRead.isDone());
+      Assertions.assertFalse(nextRead.isDone());
       channel.writable().write(frame);
 
       // This write would have unblocked nextRead, which will now be done.
-      Assert.assertTrue(nextRead.isDone());
+      Assertions.assertTrue(nextRead.isDone());
 
       // Write a third frame.
       channel.writable().write(frame);
 
       // See that we can't write a fourth frame.
-      final IllegalStateException e2 = Assert.assertThrows(
+      final IllegalStateException e2 = Assertions.assertThrows(
           IllegalStateException.class,
           () -> channel.writable().write(frame)
       );
 
-      MatcherAssert.assertThat(
-          e2,
-          ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Channel has no capacity"))
-      );
+      ThrowableMatcher.of(IllegalStateException.class)
+                     .expectMessage(message -> message.startsWith("Channel has no capacity"))
+                     .assertThat(e2);
 
       // And read until we start blocking.
       while (nextRead == null) {
-        Assert.assertTrue(doRead(1));
+        Assertions.assertTrue(doRead(1));
       }
 
       // Close.
@@ -218,10 +216,10 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
         // Just keep looping.
       }
 
-      Assert.assertEquals(3, tmpFrameFile.numFrames());
-      Assert.assertEquals(frame.numBytes(), tmpFrameFile.rac(0, null).as(Frame.class).numBytes());
-      Assert.assertEquals(frame.numBytes(), tmpFrameFile.rac(1, null).as(Frame.class).numBytes());
-      Assert.assertEquals(frame.numBytes(), tmpFrameFile.rac(2, null).as(Frame.class).numBytes());
+      Assertions.assertEquals(3, tmpFrameFile.numFrames());
+      Assertions.assertEquals(frame.numBytes(), tmpFrameFile.rac(0, null).as(Frame.class).numBytes());
+      Assertions.assertEquals(frame.numBytes(), tmpFrameFile.rac(1, null).as(Frame.class).numBytes());
+      Assertions.assertEquals(frame.numBytes(), tmpFrameFile.rac(2, null).as(Frame.class).numBytes());
     }
 
     /**
@@ -274,7 +272,8 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
   /**
    * Tests that use {@link BlockingQueueFrameChannel} that is fully buffered.
    */
-  public static class WithMaximalBuffering extends InitializedNullHandlingTest
+  @Nested
+  public class WithMaximalBuffering extends InitializedNullHandlingTest
   {
     private static final int MAX_FRAMES = 10;
     private static final int EXPECTED_NUM_ROWS = 1209;
@@ -282,13 +281,13 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
     private final BlockingQueueFrameChannel channel = new BlockingQueueFrameChannel(MAX_FRAMES);
     private final ChannelStageOutputReader reader = new ChannelStageOutputReader(channel.readable(), FrameTestUtil.WT_CONTEXT_LEGACY);
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @RegisterExtension
+    public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
     private FrameReader frameReader;
     private List<Frame> frameList;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
       final IncrementalIndex index = TestIndex.getIncrementalTestIndex();
@@ -307,7 +306,7 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
                                       .toList();
     }
 
-    @After
+    @AfterEach
     public void tearDown()
     {
       reader.close();
@@ -318,11 +317,11 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
     {
       writeAllFramesToChannel();
 
-      Assert.assertSame(channel.readable(), reader.readLocally());
+      Assertions.assertSame(channel.readable(), reader.readLocally());
       reader.close(); // Won't close the channel, because it's already been returned by readLocally
 
       final int numRows = FrameTestUtil.readRowsFromFrameChannel(channel.readable(), frameReader).toList().size();
-      Assert.assertEquals(EXPECTED_NUM_ROWS, numRows);
+      Assertions.assertEquals(EXPECTED_NUM_ROWS, numRows);
     }
 
     @Test
@@ -333,7 +332,7 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
       reader.close();
 
       // Can't read the channel after closing the reader
-      Assert.assertThrows(
+      Assertions.assertThrows(
           IllegalStateException.class,
           reader::readLocally
       );
@@ -344,17 +343,17 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
     {
       writeAllFramesToChannel();
 
-      Assert.assertSame(channel.readable(), reader.readLocally());
+      Assertions.assertSame(channel.readable(), reader.readLocally());
 
       // Can't read remotely after reading locally
-      Assert.assertThrows(
+      Assertions.assertThrows(
           IllegalStateException.class,
           () -> reader.readRemotelyFrom(0)
       );
 
       // Can still read locally after this error
       final int numRows = FrameTestUtil.readRowsFromFrameChannel(channel.readable(), frameReader).toList().size();
-      Assert.assertEquals(EXPECTED_NUM_ROWS, numRows);
+      Assertions.assertEquals(EXPECTED_NUM_ROWS, numRows);
     }
 
     @Test
@@ -389,7 +388,7 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
       final int numRows =
           FrameTestUtil.readRowsFromFrameChannel(new ReadableFileFrameChannel(frameFile, null), frameReader).toList().size();
 
-      Assert.assertEquals(EXPECTED_NUM_ROWS, numRows);
+      Assertions.assertEquals(EXPECTED_NUM_ROWS, numRows);
     }
 
     @Test
@@ -420,14 +419,14 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
           }
         }
 
-        Assert.assertEquals(numReads, offset + 1);
+        Assertions.assertEquals(numReads, offset + 1);
       }
 
       final FrameFile frameFile = FrameFile.open(tmpFile, null);
       final int numRows =
           FrameTestUtil.readRowsFromFrameChannel(new ReadableFileFrameChannel(frameFile, null), frameReader).toList().size();
 
-      Assert.assertEquals(EXPECTED_NUM_ROWS, numRows);
+      Assertions.assertEquals(EXPECTED_NUM_ROWS, numRows);
     }
 
     @Test
@@ -439,7 +438,7 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
       FutureUtils.getUnchecked(reader.readRemotelyFrom(0), true);
 
       // Then read locally
-      Assert.assertThrows(
+      Assertions.assertThrows(
           IllegalStateException.class,
           reader::readLocally
       );
@@ -456,20 +455,18 @@ public class ChannelStageOutputReaderTest extends InitializedNullHandlingTest
       MatcherAssert.assertThat(offset, Matchers.greaterThan(0));
 
       // Then read again from offset = 0; should get an error.
-      final RuntimeException e = Assert.assertThrows(
+      final RuntimeException e = Assertions.assertThrows(
           RuntimeException.class,
           () -> FutureUtils.getUnchecked(reader.readRemotelyFrom(0), true)
       );
 
-      MatcherAssert.assertThat(
-          e,
-          ThrowableCauseMatcher.hasCause(
-              Matchers.allOf(
-                  CoreMatchers.instanceOf(IllegalStateException.class),
-                  ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Offset[0] no longer available"))
-              )
-          )
-      );
+      ThrowableMatcher.of(RuntimeException.class)
+                     .expectCause(
+                         cause -> cause instanceof IllegalStateException
+                                  && cause.getMessage() != null
+                                  && cause.getMessage().startsWith("Offset[0] no longer available")
+                     )
+                     .assertThat(e);
     }
 
     private void writeAllFramesToChannel() throws IOException

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/shuffle/output/NilStageOutputReaderTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/shuffle/output/NilStageOutputReaderTest.java
@@ -26,8 +26,6 @@ import org.apache.druid.frame.channel.ReadableNilFrameChannel;
 import org.apache.druid.frame.file.FrameFile;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.testing.TemporaryFolderExtension;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -74,7 +72,7 @@ public class NilStageOutputReaderTest extends InitializedNullHandlingTest
       try (final InputStream in = reader.readRemotelyFrom(0).get()) {
         for (int i = 0; i < offset; i++) {
           final int r = in.read();
-          MatcherAssert.assertThat(r, Matchers.greaterThanOrEqualTo(0));
+          Assertions.assertTrue(r >= 0);
           out.write(r);
         }
       }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/shuffle/output/NilStageOutputReaderTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/shuffle/output/NilStageOutputReaderTest.java
@@ -25,12 +25,12 @@ import org.apache.druid.frame.channel.ReadableFrameChannel;
 import org.apache.druid.frame.channel.ReadableNilFrameChannel;
 import org.apache.druid.frame.file.FrameFile;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -43,8 +43,8 @@ import java.util.concurrent.ExecutionException;
 
 public class NilStageOutputReaderTest extends InitializedNullHandlingTest
 {
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   private final NilStageOutputReader reader = NilStageOutputReader.INSTANCE;
 
@@ -59,7 +59,7 @@ public class NilStageOutputReaderTest extends InitializedNullHandlingTest
     }
 
     try (final FrameFile frameFile = FrameFile.open(tmpFile, null)) {
-      Assert.assertEquals(0, frameFile.numFrames());
+      Assertions.assertEquals(0, frameFile.numFrames());
     }
   }
 
@@ -87,7 +87,7 @@ public class NilStageOutputReaderTest extends InitializedNullHandlingTest
 
     // Verify written file
     try (final FrameFile frameFile = FrameFile.open(tmpFile, null)) {
-      Assert.assertEquals(0, frameFile.numFrames());
+      Assertions.assertEquals(0, frameFile.numFrames());
     }
   }
 
@@ -97,7 +97,7 @@ public class NilStageOutputReaderTest extends InitializedNullHandlingTest
     final ListenableFuture<InputStream> future = reader.readRemotelyFrom(1000L);
 
     try (final InputStream inputStream = future.get()) {
-      Assert.assertEquals(-1, inputStream.read()); // expect EOF
+      Assertions.assertEquals(-1, inputStream.read()); // expect EOF
     }
   }
 
@@ -105,6 +105,6 @@ public class NilStageOutputReaderTest extends InitializedNullHandlingTest
   public void test_readLocally()
   {
     final ReadableFrameChannel channel = reader.readLocally();
-    Assert.assertSame(ReadableNilFrameChannel.INSTANCE, channel);
+    Assertions.assertSame(ReadableNilFrameChannel.INSTANCE, channel);
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/sql/MSQModeTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/sql/MSQModeTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.msq.sql;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.msq.indexing.error.MSQWarnings;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,7 +35,7 @@ public class MSQModeTest
   {
     Map<String, Object> originalQueryContext = new HashMap<>();
     MSQMode.populateDefaultQueryContext("strict", originalQueryContext);
-    Assert.assertEquals(ImmutableMap.of(MSQWarnings.CTX_MAX_PARSE_EXCEPTIONS_ALLOWED, 0), originalQueryContext);
+    Assertions.assertEquals(ImmutableMap.of(MSQWarnings.CTX_MAX_PARSE_EXCEPTIONS_ALLOWED, 0), originalQueryContext);
   }
 
   @Test
@@ -44,7 +44,7 @@ public class MSQModeTest
     Map<String, Object> originalQueryContext = new HashMap<>();
     originalQueryContext.put(MSQWarnings.CTX_MAX_PARSE_EXCEPTIONS_ALLOWED, 10);
     MSQMode.populateDefaultQueryContext("strict", originalQueryContext);
-    Assert.assertEquals(ImmutableMap.of(MSQWarnings.CTX_MAX_PARSE_EXCEPTIONS_ALLOWED, 10), originalQueryContext);
+    Assertions.assertEquals(ImmutableMap.of(MSQWarnings.CTX_MAX_PARSE_EXCEPTIONS_ALLOWED, 10), originalQueryContext);
 
   }
 
@@ -52,8 +52,7 @@ public class MSQModeTest
   public void testPopulateQueryContextWhenInvalidMode()
   {
     Map<String, Object> originalQueryContext = new HashMap<>();
-    Assert.assertThrows(ISE.class, () -> {
-      MSQMode.populateDefaultQueryContext("fake_mode", originalQueryContext);
-    });
+    Assertions.assertThrows(ISE.class, () ->
+      MSQMode.populateDefaultQueryContext("fake_mode", originalQueryContext));
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/sql/MSQTaskQueryMakerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/sql/MSQTaskQueryMakerTest.java
@@ -108,16 +108,18 @@ import org.apache.druid.sql.calcite.util.TestDataBuilder;
 import org.apache.druid.sql.destination.IngestDestination;
 import org.apache.druid.test.utils.TestSegmentManager;
 import org.apache.druid.timeline.DataSegment;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -131,13 +133,12 @@ import static org.apache.druid.sql.calcite.BaseCalciteQueryTest.expressionVirtua
 import static org.apache.druid.sql.calcite.table.RowSignatures.toRelDataType;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class MSQTaskQueryMakerTest
 {
   private static final Closer CLOSER = Closer.create();
   private static final JavaTypeFactoryImpl JAVA_TYPE_FACTORY = new JavaTypeFactoryImpl();
-
-  @Rule
-  public MockitoRule mockitoRule = MockitoJUnit.rule();
 
   @Bind
   private SpecificSegmentsQuerySegmentWalker walker;
@@ -176,7 +177,7 @@ public class MSQTaskQueryMakerTest
 
   private MSQTaskQueryMaker msqTaskQueryMaker;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     objectMapper = TestHelper.makeJsonMapper();
@@ -270,7 +271,7 @@ public class MSQTaskQueryMakerTest
                                                                             .get()
                                                                             .get(MSQTaskReport.REPORT_KEY)
                                                                             .getPayload();
-    Assert.assertTrue(payload.getStatus().getStatus().isSuccess());
+    Assertions.assertTrue(payload.getStatus().getStatus().isSuccess());
     ImmutableList<Object[]> expectedResults = ImmutableList.of(
         new Object[]{1L, ""},
         new Object[]{1L, "10.1"},
@@ -308,9 +309,9 @@ public class MSQTaskQueryMakerTest
                                                                             .get()
                                                                             .get(MSQTaskReport.REPORT_KEY)
                                                                             .getPayload();
-    Assert.assertTrue(payload.getStatus().getStatus().isFailure());
+    Assertions.assertTrue(payload.getStatus().getStatus().isFailure());
     MSQErrorReport errorReport = payload.getStatus().getErrorReport();
-    Assert.assertTrue(errorReport.getFault().getErrorMessage().contains("Failed security validation with segment"));
+    Assertions.assertTrue(errorReport.getFault().getErrorMessage().contains("Failed security validation with segment"));
   }
 
   @Test
@@ -348,7 +349,7 @@ public class MSQTaskQueryMakerTest
                                                                             .get()
                                                                             .get(MSQTaskReport.REPORT_KEY)
                                                                             .getPayload();
-    Assert.assertTrue(payload.getStatus().getStatus().isSuccess());
+    Assertions.assertTrue(payload.getStatus().getStatus().isSuccess());
     ImmutableList<Object[]> expectedResults = ImmutableList.of(new Object[]{1L, "abc"});
     assertResultsEquals(
         "select cnt, dim1 from foo (with restriction)",
@@ -396,7 +397,7 @@ public class MSQTaskQueryMakerTest
                                                                             .get()
                                                                             .get(MSQTaskReport.REPORT_KEY)
                                                                             .getPayload();
-    Assert.assertTrue(payload.getStatus().getStatus().isSuccess());
+    Assertions.assertTrue(payload.getStatus().getStatus().isSuccess());
     ImmutableList<Object[]> expectedResults = ImmutableList.of(new Object[]{"10.1", "b"}, new Object[]{"10.1", "c"});
     assertResultsEquals(
         "SELECT dim1 FROM foo, UNNEST(MV_TO_ARRAY(dim3)) as unnested (d3) (with restriction)",
@@ -435,7 +436,7 @@ public class MSQTaskQueryMakerTest
                                                                             .get()
                                                                             .get(MSQTaskReport.REPORT_KEY)
                                                                             .getPayload();
-    Assert.assertTrue(payload.getStatus().getStatus().isSuccess());
+    Assertions.assertTrue(payload.getStatus().getStatus().isSuccess());
     ImmutableList<Object[]> expectedResults = ImmutableList.of(new Object[]{2L});
     assertResultsEquals("select 1 + 1", expectedResults, payload.getResults().getResults());
   }
@@ -465,7 +466,7 @@ public class MSQTaskQueryMakerTest
                                                                             .get(MSQTaskReport.REPORT_KEY)
                                                                             .getPayload();
     // Assert
-    Assert.assertTrue(payload.getStatus().getStatus().isSuccess());
+    Assertions.assertTrue(payload.getStatus().getStatus().isSuccess());
     ImmutableList<Object[]> expectedResults = ImmutableList.of(
         new Object[]{"mysteryvalue"},
         new Object[]{"x6"},
@@ -530,9 +531,9 @@ public class MSQTaskQueryMakerTest
                                                                             .get()
                                                                             .get(MSQTaskReport.REPORT_KEY)
                                                                             .getPayload();
-    Assert.assertTrue(payload.getStatus().getStatus().isFailure());
+    Assertions.assertTrue(payload.getStatus().getStatus().isFailure());
     MSQErrorReport errorReport = payload.getStatus().getErrorReport();
-    Assert.assertTrue(errorReport.getFault().getErrorMessage().contains("Failed security validation with segment"));
+    Assertions.assertTrue(errorReport.getFault().getErrorMessage().contains("Failed security validation with segment"));
   }
 
   @Test
@@ -591,9 +592,9 @@ public class MSQTaskQueryMakerTest
                                                                             .get()
                                                                             .get(MSQTaskReport.REPORT_KEY)
                                                                             .getPayload();
-    Assert.assertTrue(payload.getStatus().getStatus().isFailure());
+    Assertions.assertTrue(payload.getStatus().getStatus().isFailure());
     MSQErrorReport errorReport = payload.getStatus().getErrorReport();
-    Assert.assertTrue(errorReport.getFault().getErrorMessage().contains("Failed security validation with segment"));
+    Assertions.assertTrue(errorReport.getFault().getErrorMessage().contains("Failed security validation with segment"));
   }
 
   @Test
@@ -651,7 +652,7 @@ public class MSQTaskQueryMakerTest
                                                                             .get()
                                                                             .get(MSQTaskReport.REPORT_KEY)
                                                                             .getPayload();
-    Assert.assertTrue(payload.getStatus().getStatus().isSuccess());
+    Assertions.assertTrue(payload.getStatus().getStatus().isSuccess());
     ImmutableList<Object[]> expectedResults = ImmutableList.of(new Object[]{"abc", 1L});
     assertResultsEquals(
         "select dim1, q.c from foo, (select count(*) c from foo) q",

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/sql/entity/ColumnNameAndTypesTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/sql/entity/ColumnNameAndTypesTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.msq.sql.entity;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ColumnNameAndTypesTest
 {
@@ -34,18 +34,18 @@ public class ColumnNameAndTypesTest
   @Test
   public void sanityTest() throws JsonProcessingException
   {
-    Assert.assertEquals(JSON_STRING, MAPPER.writeValueAsString(COLUMN_NAME_AND_TYPES));
-    Assert.assertEquals(
+    Assertions.assertEquals(JSON_STRING, MAPPER.writeValueAsString(COLUMN_NAME_AND_TYPES));
+    Assertions.assertEquals(
         COLUMN_NAME_AND_TYPES,
         MAPPER.readValue(MAPPER.writeValueAsString(COLUMN_NAME_AND_TYPES), ColumnNameAndTypes.class)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         COLUMN_NAME_AND_TYPES.hashCode(),
         MAPPER.readValue(MAPPER.writeValueAsString(COLUMN_NAME_AND_TYPES), ColumnNameAndTypes.class)
               .hashCode()
     );
-    Assert.assertEquals("ColumnNameAndTypes{colName='test', sqlTypeName='test1', nativeTypeName='test2'}",
+    Assertions.assertEquals("ColumnNameAndTypes{colName='test', sqlTypeName='test1', nativeTypeName='test2'}",
                         COLUMN_NAME_AND_TYPES.toString());
 
   }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/sql/entity/ResultSetInformationTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/sql/entity/ResultSetInformationTest.java
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.sql.http.ResultFormat;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ResultSetInformationTest
 {
@@ -59,13 +59,13 @@ public class ResultSetInformationTest
   @Test
   public void sanityTest() throws JsonProcessingException
   {
-    Assert.assertEquals(JSON_STRING, MAPPER.writeValueAsString(RESULTS));
-    Assert.assertEquals(RESULTS, MAPPER.readValue(MAPPER.writeValueAsString(RESULTS), ResultSetInformation.class));
-    Assert.assertEquals(
+    Assertions.assertEquals(JSON_STRING, MAPPER.writeValueAsString(RESULTS));
+    Assertions.assertEquals(RESULTS, MAPPER.readValue(MAPPER.writeValueAsString(RESULTS), ResultSetInformation.class));
+    Assertions.assertEquals(
         RESULTS.hashCode(),
         MAPPER.readValue(MAPPER.writeValueAsString(RESULTS), ResultSetInformation.class).hashCode()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "ResultSetInformation{numTotalRows=1, totalSizeInBytes=1, resultFormat=object, records=null, dataSource='ds', pages=[PageInformation{id=0, numRows=null, sizeInBytes=1, worker=null, partition=null}]}",
         RESULTS.toString()
     );
@@ -75,7 +75,7 @@ public class ResultSetInformationTest
   public void resultsSanityTest() throws JsonProcessingException
   {
     // Since we have a List<Object[]> as a field, we cannot call equals method after deserialization.
-    Assert.assertEquals(JSON_STRING_1, MAPPER.writeValueAsString(RESULTS_1));
+    Assertions.assertEquals(JSON_STRING_1, MAPPER.writeValueAsString(RESULTS_1));
   }
 
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/sql/entity/SqlStatementResultTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/sql/entity/SqlStatementResultTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.msq.indexing.error.MSQException;
 import org.apache.druid.msq.indexing.error.QueryNotSupportedFault;
 import org.apache.druid.msq.sql.SqlStatementState;
 import org.apache.druid.msq.sql.resources.SqlStatementResourceTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SqlStatementResultTest
 {
@@ -70,8 +70,8 @@ public class SqlStatementResultTest
   public void sanityTest() throws JsonProcessingException
   {
 
-    Assert.assertEquals(JSON_STRING, MAPPER.writeValueAsString(SQL_STATEMENT_RESULT));
-    Assert.assertEquals(
+    Assertions.assertEquals(JSON_STRING, MAPPER.writeValueAsString(SQL_STATEMENT_RESULT));
+    Assertions.assertEquals(
         "SqlStatementResult{"
         + "queryId='q1',"
         + " state=RUNNING,"

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
@@ -49,12 +49,13 @@ import org.apache.druid.sql.calcite.util.CalciteTests;
 import org.apache.druid.sql.http.ResultFormat;
 import org.apache.druid.sql.http.SqlQuery;
 import org.apache.druid.storage.NilStorageConnector;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -110,7 +111,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     ), SqlStatementResourceTest.makeOkRequest());
 
 
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
     String taskId = ((SqlStatementResult) response.getEntity()).getQueryId();
 
@@ -141,7 +142,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
                                null
         );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         objectMapper.writeValueAsString(expected),
         objectMapper.writeValueAsString(response.getEntity())
     );
@@ -196,7 +197,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
                     .build(),
         null
     ), SqlStatementResourceTest.makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
     SqlStatementResult actual = (SqlStatementResult) response.getEntity();
 
@@ -226,7 +227,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
                     .build(),
         null
     ), SqlStatementResourceTest.makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
     SqlStatementResult actual = (SqlStatementResult) response.getEntity();
 
@@ -257,7 +258,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
                     .build(),
         null
     ), SqlStatementResourceTest.makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
     SqlStatementResult actual = (SqlStatementResult) response.getEntity();
 
@@ -303,7 +304,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         null
     ), SqlStatementResourceTest.makeOkRequest());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "{PLAN=[{\"query\":{\"queryType\":\"scan\",\"dataSource\":{\"type\":\"table\",\"name\":\"foo\"},\"intervals\":{\"type\":\"intervals\",\"intervals\":[\"-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z\"]},\"resultFormat\":\"compactedList\",\"columns\":[\"__time\",\"dim1\",\"dim2\",\"dim3\",\"cnt\",\"m1\",\"m2\",\"unique_dim1\"],\"context\":{\"__resultFormat\":\"object\",\"debug\":\"false\",\"executionMode\":\"ASYNC\",\"sqlQueryId\":\"queryId\"},\"columnTypes\":[\"LONG\",\"STRING\",\"STRING\",\"STRING\",\"LONG\",\"FLOAT\",\"DOUBLE\",\"COMPLEX<hyperUnique>\"],\"granularity\":{\"type\":\"all\"},\"legacy\":false},\"signature\":[{\"name\":\"__time\",\"type\":\"LONG\"},{\"name\":\"dim1\",\"type\":\"STRING\"},{\"name\":\"dim2\",\"type\":\"STRING\"},{\"name\":\"dim3\",\"type\":\"STRING\"},{\"name\":\"cnt\",\"type\":\"LONG\"},{\"name\":\"m1\",\"type\":\"FLOAT\"},{\"name\":\"m2\",\"type\":\"DOUBLE\"},{\"name\":\"unique_dim1\",\"type\":\"COMPLEX<hyperUnique>\"}],\"columnMappings\":[{\"queryColumn\":\"__time\",\"outputColumn\":\"__time\"},{\"queryColumn\":\"dim1\",\"outputColumn\":\"dim1\"},{\"queryColumn\":\"dim2\",\"outputColumn\":\"dim2\"},{\"queryColumn\":\"dim3\",\"outputColumn\":\"dim3\"},{\"queryColumn\":\"cnt\",\"outputColumn\":\"cnt\"},{\"queryColumn\":\"m1\",\"outputColumn\":\"m1\"},{\"queryColumn\":\"m2\",\"outputColumn\":\"m2\"},{\"queryColumn\":\"unique_dim1\",\"outputColumn\":\"unique_dim1\"}]}], RESOURCES=[{\"name\":\"foo\",\"type\":\"DATASOURCE\"}], ATTRIBUTES={\"statementType\":\"SELECT\"}}",
         String.valueOf(SqlStatementResourceTest.getResultRowsFromResponse(response).get(0))
     );
@@ -312,7 +313,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
   @Test
   public void forbiddenTest()
   {
-    Assert.assertEquals(Response.Status.FORBIDDEN.getStatusCode(), resource.doPost(
+    Assertions.assertEquals(Response.Status.FORBIDDEN.getStatusCode(), resource.doPost(
         new SqlQuery(
             StringUtils.format("select * from %s", CalciteTests.FORBIDDEN_DATASOURCE),
             null,
@@ -383,7 +384,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         SqlStatementResourceTest.makeOkRequest()
     ).getEntity();
 
-    Assert.assertEquals(ImmutableList.of(
+    Assertions.assertEquals(ImmutableList.of(
         new PageInformation(0, 2L, 120L, 0, 0),
         new PageInformation(1, 2L, 118L, 0, 1),
         new PageInformation(2, 2L, 122L, 0, 2)
@@ -471,7 +472,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         SqlStatementResourceTest.makeOkRequest()
     ).getEntity();
 
-    Assert.assertEquals(ImmutableList.of(
+    Assertions.assertEquals(ImmutableList.of(
         new PageInformation(0, 2L, 128L, 0, 0),
         new PageInformation(1, 2L, 132L, 1, 1),
         new PageInformation(2, 2L, 128L, 0, 2),
@@ -492,7 +493,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     rows.add(ImmutableList.of(1466985600000L, "GiftBot"));
     rows.add(ImmutableList.of(1466985600000L, "GiftBot"));
 
-    Assert.assertEquals(rows, SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
+    Assertions.assertEquals(rows, SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
         sqlStatementResult.getQueryId(),
         null,
         ResultFormat.ARRAY.name(),
@@ -500,7 +501,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         SqlStatementResourceTest.makeOkRequest()
     )));
 
-    Assert.assertEquals(rows.subList(0, 2), SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
+    Assertions.assertEquals(rows.subList(0, 2), SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
         sqlStatementResult.getQueryId(),
         0L,
         ResultFormat.ARRAY.name(),
@@ -508,7 +509,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         SqlStatementResourceTest.makeOkRequest()
     )));
 
-    Assert.assertEquals(rows.subList(2, 4), SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
+    Assertions.assertEquals(rows.subList(2, 4), SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
         sqlStatementResult.getQueryId(),
         1L,
         ResultFormat.ARRAY.name(),
@@ -516,7 +517,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         SqlStatementResourceTest.makeOkRequest()
     )));
 
-    Assert.assertEquals(rows.subList(4, 6), SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
+    Assertions.assertEquals(rows.subList(4, 6), SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
         sqlStatementResult.getQueryId(),
         2L,
         ResultFormat.ARRAY.name(),
@@ -524,7 +525,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         SqlStatementResourceTest.makeOkRequest()
     )));
 
-    Assert.assertEquals(rows.subList(6, 8), SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
+    Assertions.assertEquals(rows.subList(6, 8), SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
         sqlStatementResult.getQueryId(),
         3L,
         ResultFormat.ARRAY.name(),
@@ -532,7 +533,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         SqlStatementResourceTest.makeOkRequest()
     )));
 
-    Assert.assertEquals(rows.subList(8, 10), SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
+    Assertions.assertEquals(rows.subList(8, 10), SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
         sqlStatementResult.getQueryId(),
         4L,
         ResultFormat.ARRAY.name(),
@@ -575,7 +576,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     );
 
     for (ResultFormat resultFormat : ResultFormat.values()) {
-      Assert.assertArrayEquals(
+      Assertions.assertArrayEquals(
           createExpectedResultsInFormat(resultFormat, expectedRows, columnNameAndTypes, objectMapper),
           responseToByteArray(
               resource.doGetResults(
@@ -588,7 +589,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
           )
       );
 
-      Assert.assertArrayEquals(
+      Assertions.assertArrayEquals(
           createExpectedResultsInFormat(resultFormat, expectedRows, columnNameAndTypes, objectMapper),
           responseToByteArray(
               resource.doGetResults(
@@ -631,7 +632,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     rows.add(ImmutableList.of(1, "def"));
     rows.add(ImmutableList.of(1, "abc"));
 
-    Assert.assertEquals(rows, SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
+    Assertions.assertEquals(rows, SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
         sqlStatementResult.getQueryId(),
         null,
         ResultFormat.ARRAY.name(),
@@ -639,7 +640,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         SqlStatementResourceTest.makeOkRequest()
     )));
 
-    Assert.assertEquals(rows, SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
+    Assertions.assertEquals(rows, SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
         sqlStatementResult.getQueryId(),
         0L,
         ResultFormat.ARRAY.name(),
@@ -666,7 +667,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
       throws IOException
   {
     byte[] bytes = responseToByteArray(resultsResponse, objectMapper);
-    Assert.assertEquals(expectedResult, new String(bytes, StandardCharsets.UTF_8));
+    Assertions.assertEquals(expectedResult, new String(bytes, StandardCharsets.UTF_8));
   }
 
   public static byte[] responseToByteArray(Response resp, ObjectMapper objectMapper) throws IOException
@@ -692,7 +693,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         defaultAsyncContext(),
         null
     ), SqlStatementResourceTest.makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
     SqlStatementResult actual = (SqlStatementResult) response.getEntity();
 
@@ -709,7 +710,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     assertSqlStatementResult(expected, actual);
 
     Response getResponse = resource.doGetStatus(actual.getQueryId(), false, SqlStatementResourceTest.makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), getResponse.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), getResponse.getStatus());
     assertSqlStatementResult(expected, (SqlStatementResult) getResponse.getEntity());
 
     Response resultsResponse = resource.doGetResults(
@@ -719,8 +720,8 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         null,
         SqlStatementResourceTest.makeOkRequest()
     );
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), resultsResponse.getStatus());
-    Assert.assertNull(resultsResponse.getEntity());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resultsResponse.getStatus());
+    Assertions.assertNull(resultsResponse.getEntity());
   }
 
 
@@ -736,7 +737,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         defaultAsyncContext(),
         null
     ), SqlStatementResourceTest.makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
     SqlStatementResult actual = (SqlStatementResult) response.getEntity();
 
@@ -753,7 +754,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     assertSqlStatementResult(expected, actual);
 
     Response getResponse = resource.doGetStatus(actual.getQueryId(), false, SqlStatementResourceTest.makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), getResponse.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), getResponse.getStatus());
     assertSqlStatementResult(expected, (SqlStatementResult) getResponse.getEntity());
 
     Response resultsResponse = resource.doGetResults(
@@ -763,8 +764,8 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         null,
         SqlStatementResourceTest.makeOkRequest()
     );
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), resultsResponse.getStatus());
-    Assert.assertNull(resultsResponse.getEntity());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resultsResponse.getStatus());
+    Assertions.assertNull(resultsResponse.getEntity());
   }
 
 
@@ -777,25 +778,25 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
 
   private void assertSqlStatementResult(SqlStatementResult expected, SqlStatementResult actual)
   {
-    Assert.assertEquals(expected.getQueryId(), actual.getQueryId());
-    Assert.assertEquals(expected.getCreatedAt(), actual.getCreatedAt());
-    Assert.assertEquals(expected.getSqlRowSignature(), actual.getSqlRowSignature());
-    Assert.assertEquals(expected.getDurationMs(), actual.getDurationMs());
-    Assert.assertEquals(expected.getStages(), actual.getStages());
-    Assert.assertEquals(expected.getState(), actual.getState());
-    Assert.assertEquals(expected.getWarnings(), actual.getWarnings());
-    Assert.assertEquals(expected.getResultSetInformation(), actual.getResultSetInformation());
+    Assertions.assertEquals(expected.getQueryId(), actual.getQueryId());
+    Assertions.assertEquals(expected.getCreatedAt(), actual.getCreatedAt());
+    Assertions.assertEquals(expected.getSqlRowSignature(), actual.getSqlRowSignature());
+    Assertions.assertEquals(expected.getDurationMs(), actual.getDurationMs());
+    Assertions.assertEquals(expected.getStages(), actual.getStages());
+    Assertions.assertEquals(expected.getState(), actual.getState());
+    Assertions.assertEquals(expected.getWarnings(), actual.getWarnings());
+    Assertions.assertEquals(expected.getResultSetInformation(), actual.getResultSetInformation());
 
     if (actual.getCounters() == null || expected.getCounters() == null) {
-      Assert.assertEquals(expected.getCounters(), actual.getCounters());
+      Assertions.assertEquals(expected.getCounters(), actual.getCounters());
     } else {
-      Assert.assertEquals(expected.getCounters().toString(), actual.getCounters().toString());
+      Assertions.assertEquals(expected.getCounters().toString(), actual.getCounters().toString());
     }
 
     if (actual.getErrorResponse() == null || expected.getErrorResponse() == null) {
-      Assert.assertEquals(expected.getErrorResponse(), actual.getErrorResponse());
+      Assertions.assertEquals(expected.getErrorResponse(), actual.getErrorResponse());
     } else {
-      Assert.assertEquals(expected.getErrorResponse().getAsMap(), actual.getErrorResponse().getAsMap());
+      Assertions.assertEquals(expected.getErrorResponse().getAsMap(), actual.getErrorResponse().getAsMap());
     }
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
@@ -91,7 +91,7 @@ import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.joda.time.DateTime;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -100,6 +100,7 @@ import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
 import javax.ws.rs.core.Response;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
@@ -640,8 +641,8 @@ public class SqlStatementResourceTest extends MSQTestBase
       Response.Status expectectedStatus
   )
   {
-    Assert.assertEquals(expectectedStatus.getStatusCode(), response.getStatus());
-    Assert.assertEquals(exceptionMessage, getQueryExceptionFromResponse(response));
+    Assertions.assertEquals(expectectedStatus.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(exceptionMessage, getQueryExceptionFromResponse(response));
   }
 
   public static List getResultRowsFromResponse(Response resultsResponse) throws IOException
@@ -716,7 +717,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   public void testMSQSelectAcceptedQuery()
   {
     Response response = resource.doGetStatus(ACCEPTED_SELECT_MSQ_QUERY, false, makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     assertSqlStatementResult(
         new SqlStatementResult(
             ACCEPTED_SELECT_MSQ_QUERY,
@@ -739,7 +740,7 @@ public class SqlStatementResourceTest extends MSQTestBase
         ),
         Response.Status.BAD_REQUEST
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.ACCEPTED.getStatusCode(),
         resource.deleteQuery(ACCEPTED_SELECT_MSQ_QUERY, makeOkRequest()).getStatus()
     );
@@ -750,7 +751,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   {
 
     Response response = resource.doGetStatus(RUNNING_SELECT_MSQ_QUERY, false, makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     assertSqlStatementResult(
         new SqlStatementResult(
             RUNNING_SELECT_MSQ_QUERY,
@@ -773,7 +774,7 @@ public class SqlStatementResourceTest extends MSQTestBase
         ),
         Response.Status.BAD_REQUEST
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.ACCEPTED.getStatusCode(),
         resource.deleteQuery(RUNNING_SELECT_MSQ_QUERY, makeOkRequest()).getStatus()
     );
@@ -783,7 +784,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   public void testMSQSelectRunningQueryWithDetail()
   {
     Response response = resource.doGetStatus(RUNNING_SELECT_MSQ_QUERY, true, makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
     SqlStatementResult expectedSqlStatementResult = new SqlStatementResult(
         RUNNING_SELECT_MSQ_QUERY,
@@ -803,7 +804,7 @@ public class SqlStatementResourceTest extends MSQTestBase
         (SqlStatementResult) response.getEntity()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.ACCEPTED.getStatusCode(),
         resource.deleteQuery(RUNNING_SELECT_MSQ_QUERY, makeOkRequest()).getStatus()
     );
@@ -813,8 +814,8 @@ public class SqlStatementResourceTest extends MSQTestBase
   public void testFinishedSelectMSQQuery() throws Exception
   {
     Response response = resource.doGetStatus(FINISHED_SELECT_MSQ_QUERY, false, makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    Assert.assertEquals(objectMapper.writeValueAsString(new SqlStatementResult(
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(objectMapper.writeValueAsString(new SqlStatementResult(
         FINISHED_SELECT_MSQ_QUERY,
         SqlStatementState.SUCCESS,
         CREATED_TIME,
@@ -832,16 +833,16 @@ public class SqlStatementResourceTest extends MSQTestBase
     )), objectMapper.writeValueAsString(response.getEntity()));
 
     Response resultsResponse = resource.doGetResults(FINISHED_SELECT_MSQ_QUERY, 0L, ResultFormat.OBJECTLINES.name(), null, makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), resultsResponse.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resultsResponse.getStatus());
 
     String expectedResult = "{\"_time\":123,\"alias\":\"foo\",\"market\":\"bar\"}\n"
                             + "{\"_time\":234,\"alias\":\"foo1\",\"market\":\"bar1\"}\n\n";
 
     assertExpectedResults(expectedResult, resultsResponse);
 
-    Assert.assertNull(getHeader(resultsResponse, SqlStatementResource.CONTENT_DISPOSITION_RESPONSE_HEADER));
+    Assertions.assertNull(getHeader(resultsResponse, SqlStatementResource.CONTENT_DISPOSITION_RESPONSE_HEADER));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.OK.getStatusCode(),
         resource.deleteQuery(FINISHED_SELECT_MSQ_QUERY, makeOkRequest()).getStatus()
     );
@@ -868,12 +869,12 @@ public class SqlStatementResourceTest extends MSQTestBase
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.BAD_REQUEST.getStatusCode(),
         resource.doGetResults(FINISHED_SELECT_MSQ_QUERY, -1L, null, null, makeOkRequest()).getStatus()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "attachment; filename=\"my-file.ndjson\"",
         getHeader(
             resource.doGetResults(FINISHED_SELECT_MSQ_QUERY, 0L, ResultFormat.OBJECTLINES.name(), "my-file.ndjson", makeOkRequest()),
@@ -889,30 +890,30 @@ public class SqlStatementResourceTest extends MSQTestBase
                                   + "{\"_time\":234,\"alias\":\"foo1\",\"market\":\"bar1\"}\n\n";
 
     Response resultsResponse1 = resource.doGetResults(FINISHED_SELECT_MSQ_QUERY, 0L, ResultFormat.OBJECTLINES.name(), "results.txt", makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), resultsResponse1.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resultsResponse1.getStatus());
+    Assertions.assertEquals(
         "attachment; filename=\"results.txt\"",
         getHeader(resultsResponse1, "Content-Disposition")
     );
     assertExpectedResults(expectedResult, resultsResponse1);
 
     Response resultsResponse2 = resource.doGetResults(FINISHED_SELECT_MSQ_QUERY, 0L, ResultFormat.OBJECTLINES.name(), "final results.txt", makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), resultsResponse2.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resultsResponse2.getStatus());
+    Assertions.assertEquals(
         "attachment; filename=\"final results.txt\"",
         getHeader(resultsResponse2, "Content-Disposition")
     );
     assertExpectedResults(expectedResult, resultsResponse2);
 
     Response resultsResponse3 = resource.doGetResults(FINISHED_SELECT_MSQ_QUERY, 0L, ResultFormat.OBJECTLINES.name(), "/Users/Name/final.txt", makeOkRequest());
-    Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resultsResponse3.getStatus());
-    Assert.assertNull(resultsResponse3.getMetadata().get("Content-Disposition"));
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resultsResponse3.getStatus());
+    Assertions.assertNull(resultsResponse3.getMetadata().get("Content-Disposition"));
   }
 
   private void assertExpectedResults(String expectedResult, Response resultsResponse) throws IOException
   {
     byte[] bytes = SqlResourceTest.responseToByteArray(resultsResponse);
-    Assert.assertEquals(expectedResult, new String(bytes, StandardCharsets.UTF_8));
+    Assertions.assertEquals(expectedResult, new String(bytes, StandardCharsets.UTF_8));
   }
 
   @Test
@@ -929,7 +930,7 @@ public class SqlStatementResourceTest extends MSQTestBase
           Response.Status.BAD_REQUEST
       );
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           Response.Status.OK.getStatusCode(),
           resource.deleteQuery(queryID, makeOkRequest()).getStatus()
       );
@@ -940,7 +941,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   public void testFinishedInsertMSQQuery()
   {
     Response response = resource.doGetStatus(FINISHED_INSERT_MSQ_QUERY, false, makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     assertSqlStatementResult(new SqlStatementResult(
         FINISHED_INSERT_MSQ_QUERY,
         SqlStatementState.SUCCESS,
@@ -953,22 +954,22 @@ public class SqlStatementResourceTest extends MSQTestBase
 
     final Response resultResponse = resource.doGetResults(FINISHED_INSERT_MSQ_QUERY, 0L, null, null, makeOkRequest());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.OK.getStatusCode(),
         resultResponse.getStatus()
     );
-    Assert.assertNull(getHeader(resultResponse, SqlStatementResource.CONTENT_DISPOSITION_RESPONSE_HEADER));
-    Assert.assertEquals(
+    Assertions.assertNull(getHeader(resultResponse, SqlStatementResource.CONTENT_DISPOSITION_RESPONSE_HEADER));
+    Assertions.assertEquals(
         Response.Status.OK.getStatusCode(),
         resource.doGetResults(FINISHED_INSERT_MSQ_QUERY, null, null, null, makeOkRequest()).getStatus()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.BAD_REQUEST.getStatusCode(),
         resource.doGetResults(FINISHED_INSERT_MSQ_QUERY, -1L, null, null, makeOkRequest()).getStatus()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "attachment; filename=\"my-file.ndjson\"",
         getHeader(
             resource.doGetResults(FINISHED_INSERT_MSQ_QUERY, 0L, null, "my-file.ndjson", makeOkRequest()),
@@ -991,7 +992,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   public void testMSQInsertAcceptedQuery()
   {
     Response response = resource.doGetStatus(ACCEPTED_INSERT_MSQ_TASK, false, makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     assertSqlStatementResult(
         new SqlStatementResult(
             ACCEPTED_INSERT_MSQ_TASK,
@@ -1014,7 +1015,7 @@ public class SqlStatementResourceTest extends MSQTestBase
         ),
         Response.Status.BAD_REQUEST
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.ACCEPTED.getStatusCode(),
         resource.deleteQuery(ACCEPTED_INSERT_MSQ_TASK, makeOkRequest()).getStatus()
     );
@@ -1024,7 +1025,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   public void testMSQInsertRunningQuery()
   {
     Response response = resource.doGetStatus(RUNNING_INSERT_MSQ_QUERY, false, makeOkRequest());
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     assertSqlStatementResult(
         new SqlStatementResult(
             RUNNING_INSERT_MSQ_QUERY,
@@ -1047,7 +1048,7 @@ public class SqlStatementResourceTest extends MSQTestBase
         ),
         Response.Status.BAD_REQUEST
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.ACCEPTED.getStatusCode(),
         resource.deleteQuery(RUNNING_INSERT_MSQ_QUERY, makeOkRequest()).getStatus()
     );
@@ -1056,7 +1057,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   @Test
   public void testAPIBehaviourWithSuperUsers()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.OK.getStatusCode(),
         resource.doGetStatus(
             RUNNING_SELECT_MSQ_QUERY,
@@ -1064,7 +1065,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             makeExpectedReq(makeAuthResultForUser(SUPERUSER))
         ).getStatus()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.BAD_REQUEST.getStatusCode(),
         resource.doGetResults(
             RUNNING_SELECT_MSQ_QUERY,
@@ -1074,7 +1075,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             makeExpectedReq(makeAuthResultForUser(SUPERUSER))
         ).getStatus()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.ACCEPTED.getStatusCode(),
         resource.deleteQuery(
             RUNNING_SELECT_MSQ_QUERY,
@@ -1087,7 +1088,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   public void testAPIBehaviourWithDifferentUserAndNoStatePermission()
   {
     AuthenticationResult differentUserAuthResult = makeAuthResultForUser("differentUser");
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.FORBIDDEN.getStatusCode(),
         resource.doGetStatus(
             RUNNING_SELECT_MSQ_QUERY,
@@ -1095,7 +1096,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             makeExpectedReq(differentUserAuthResult)
         ).getStatus()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.FORBIDDEN.getStatusCode(),
         resource.doGetResults(
             RUNNING_SELECT_MSQ_QUERY,
@@ -1105,7 +1106,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             makeExpectedReq(differentUserAuthResult)
         ).getStatus()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.FORBIDDEN.getStatusCode(),
         resource.deleteQuery(
             RUNNING_SELECT_MSQ_QUERY,
@@ -1118,7 +1119,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   public void testAPIBehaviourWithDifferentUserAndStateRPermission()
   {
     AuthenticationResult differentUserAuthResult = makeAuthResultForUser(STATE_R_USER);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.OK.getStatusCode(),
         resource.doGetStatus(
             RUNNING_SELECT_MSQ_QUERY,
@@ -1126,7 +1127,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             makeExpectedReq(differentUserAuthResult)
         ).getStatus()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.BAD_REQUEST.getStatusCode(),
         resource.doGetResults(
             RUNNING_SELECT_MSQ_QUERY,
@@ -1136,7 +1137,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             makeExpectedReq(differentUserAuthResult)
         ).getStatus()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.FORBIDDEN.getStatusCode(),
         resource.deleteQuery(
             RUNNING_SELECT_MSQ_QUERY,
@@ -1149,7 +1150,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   public void testAPIBehaviourWithDifferentUserAndStateWPermission()
   {
     AuthenticationResult differentUserAuthResult = makeAuthResultForUser(STATE_W_USER);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.FORBIDDEN.getStatusCode(),
         resource.doGetStatus(
             RUNNING_SELECT_MSQ_QUERY,
@@ -1157,7 +1158,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             makeExpectedReq(differentUserAuthResult)
         ).getStatus()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.FORBIDDEN.getStatusCode(),
         resource.doGetResults(
             RUNNING_SELECT_MSQ_QUERY,
@@ -1167,7 +1168,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             makeExpectedReq(differentUserAuthResult)
         ).getStatus()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.ACCEPTED.getStatusCode(),
         resource.deleteQuery(
             RUNNING_SELECT_MSQ_QUERY,
@@ -1180,7 +1181,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   public void testAPIBehaviourWithDifferentUserAndStateRWPermission()
   {
     AuthenticationResult differentUserAuthResult = makeAuthResultForUser(STATE_RW_USER);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.OK.getStatusCode(),
         resource.doGetStatus(
             RUNNING_SELECT_MSQ_QUERY,
@@ -1188,7 +1189,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             makeExpectedReq(differentUserAuthResult)
         ).getStatus()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.BAD_REQUEST.getStatusCode(),
         resource.doGetResults(
             RUNNING_SELECT_MSQ_QUERY,
@@ -1198,7 +1199,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             makeExpectedReq(differentUserAuthResult)
         ).getStatus()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.ACCEPTED.getStatusCode(),
         resource.deleteQuery(
             RUNNING_SELECT_MSQ_QUERY,
@@ -1220,15 +1221,15 @@ public class SqlStatementResourceTest extends MSQTestBase
     )));
     Mockito.when(overlordClient.taskStatus(taskIdNotFound)).thenReturn(settableFuture);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.NOT_FOUND.getStatusCode(),
         resource.doGetStatus(taskIdNotFound, false, makeOkRequest()).getStatus()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.NOT_FOUND.getStatusCode(),
         resource.doGetResults(taskIdNotFound, null, null, null, makeOkRequest()).getStatus()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Response.Status.NOT_FOUND.getStatusCode(),
         resource.deleteQuery(taskIdNotFound, makeOkRequest()).getStatus()
     );
@@ -1237,30 +1238,30 @@ public class SqlStatementResourceTest extends MSQTestBase
   @Test
   public void testIsEnabled()
   {
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), resource.isEnabled(makeOkRequest()).getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), resource.isEnabled(makeOkRequest()).getStatus());
   }
 
   private void assertSqlStatementResult(SqlStatementResult expected, SqlStatementResult actual)
   {
-    Assert.assertEquals(expected.getQueryId(), actual.getQueryId());
-    Assert.assertEquals(expected.getCreatedAt(), actual.getCreatedAt());
-    Assert.assertEquals(expected.getSqlRowSignature(), actual.getSqlRowSignature());
-    Assert.assertEquals(expected.getDurationMs(), actual.getDurationMs());
-    Assert.assertEquals(expected.getStages(), actual.getStages());
-    Assert.assertEquals(expected.getState(), actual.getState());
-    Assert.assertEquals(expected.getWarnings(), actual.getWarnings());
-    Assert.assertEquals(expected.getResultSetInformation(), actual.getResultSetInformation());
+    Assertions.assertEquals(expected.getQueryId(), actual.getQueryId());
+    Assertions.assertEquals(expected.getCreatedAt(), actual.getCreatedAt());
+    Assertions.assertEquals(expected.getSqlRowSignature(), actual.getSqlRowSignature());
+    Assertions.assertEquals(expected.getDurationMs(), actual.getDurationMs());
+    Assertions.assertEquals(expected.getStages(), actual.getStages());
+    Assertions.assertEquals(expected.getState(), actual.getState());
+    Assertions.assertEquals(expected.getWarnings(), actual.getWarnings());
+    Assertions.assertEquals(expected.getResultSetInformation(), actual.getResultSetInformation());
 
     if (actual.getCounters() == null || expected.getCounters() == null) {
-      Assert.assertEquals(expected.getCounters(), actual.getCounters());
+      Assertions.assertEquals(expected.getCounters(), actual.getCounters());
     } else {
-      Assert.assertEquals(expected.getCounters().toString(), actual.getCounters().toString());
+      Assertions.assertEquals(expected.getCounters().toString(), actual.getCounters().toString());
     }
 
     if (actual.getErrorResponse() == null || expected.getErrorResponse() == null) {
-      Assert.assertEquals(expected.getErrorResponse(), actual.getErrorResponse());
+      Assertions.assertEquals(expected.getErrorResponse(), actual.getErrorResponse());
     } else {
-      Assert.assertEquals(expected.getErrorResponse().getAsMap(), actual.getErrorResponse().getAsMap());
+      Assertions.assertEquals(expected.getErrorResponse().getAsMap(), actual.getErrorResponse().getAsMap());
     }
   }
 
@@ -1299,7 +1300,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   private void assertInvalidFileName(String filename, String errorMessage)
   {
     DruidExceptionMatcher.assertThat(
-        Assert.assertThrows(DruidException.class, () -> SqlStatementResource.validateFilename(filename)),
+        Assertions.assertThrows(DruidException.class, () -> SqlStatementResource.validateFilename(filename)),
         DruidExceptionMatcher.invalidInput().expectMessageIs(errorMessage)
     );
   }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/ByteRowKeySerdeTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/ByteRowKeySerdeTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.frame.key.KeyTestUtils;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ByteRowKeySerdeTest extends InitializedNullHandlingTest
 {
@@ -61,24 +61,24 @@ public class ByteRowKeySerdeTest extends InitializedNullHandlingTest
   private void testSerde(byte[] byteRowKey)
   {
     byte[] bytes = serde.serializeToByteArray(byteRowKey);
-    Assert.assertEquals(serde.sizeOf(byteRowKey), bytes.length);
+    Assertions.assertEquals(serde.sizeOf(byteRowKey), bytes.length);
 
     Memory wrappedMemory = Memory.wrap(bytes);
-    Assert.assertEquals(serde.sizeOf(wrappedMemory, 0, 1), bytes.length);
+    Assertions.assertEquals(serde.sizeOf(wrappedMemory, 0, 1), bytes.length);
 
     byte[][] deserialized = serde.deserializeFromMemory(wrappedMemory, 1);
-    Assert.assertArrayEquals(new byte[][]{byteRowKey}, deserialized);
+    Assertions.assertArrayEquals(new byte[][]{byteRowKey}, deserialized);
   }
 
   private void testSerde(byte[][] inputArray)
   {
     byte[] bytes = serde.serializeToByteArray(inputArray);
-    Assert.assertEquals(serde.sizeOf(inputArray), bytes.length);
+    Assertions.assertEquals(serde.sizeOf(inputArray), bytes.length);
 
     Memory wrappedMemory = Memory.wrap(bytes);
-    Assert.assertEquals(serde.sizeOf(wrappedMemory, 0, inputArray.length), bytes.length);
+    Assertions.assertEquals(serde.sizeOf(wrappedMemory, 0, inputArray.length), bytes.length);
 
     byte[][] deserialized = serde.deserializeFromMemory(wrappedMemory, inputArray.length);
-    Assert.assertArrayEquals(inputArray, deserialized);
+    Assertions.assertArrayEquals(inputArray, deserialized);
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/ClusterByStatisticsCollectorImplTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/ClusterByStatisticsCollectorImplTest.java
@@ -43,8 +43,6 @@ import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -750,10 +748,9 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
         )
     );
 
-    MatcherAssert.assertThat(
-        StringUtils.format("%s: number of partitions ≤ max", testName),
-        partitions.size(),
-        Matchers.lessThanOrEqualTo(maxPartitionCount)
+    Assertions.assertTrue(
+        partitions.size() <= maxPartitionCount,
+        StringUtils.format("%s: number of partitions ≤ max", testName)
     );
   }
 
@@ -828,10 +825,9 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
 
       // Check that the ends are all after the starts.
       if (partition.getStart() != null && partition.getEnd() != null) {
-        MatcherAssert.assertThat(
-            StringUtils.format("%s: partition %d: start compareTo end", testName, i),
-            comparator.compare(partition.getStart(), partition.getEnd()),
-            Matchers.lessThan(0)
+        Assertions.assertTrue(
+            comparator.compare(partition.getStart(), partition.getEnd()) < 0,
+            StringUtils.format("%s: partition %d: start compareTo end", testName, i)
         );
       }
     }
@@ -900,10 +896,9 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
       final long actualNumberOfRows = rowsPerPartition.get(partition.getStart());
 
       // Reasonable maximum number of rows per partition.
-      MatcherAssert.assertThat(
-          StringUtils.format("%s: partition #%d: number of rows", testName, i),
-          actualNumberOfRows,
-          Matchers.lessThanOrEqualTo((long) ((1 + PARTITION_SIZE_LEEWAY) * expectedPartitionSize))
+      Assertions.assertTrue(
+          actualNumberOfRows <= (long) ((1 + PARTITION_SIZE_LEEWAY) * expectedPartitionSize),
+          StringUtils.format("%s: partition #%d: number of rows", testName, i)
       );
 
       // Reasonable minimum number of rows per partition, for all partitions except the last in a bucket.
@@ -913,10 +908,9 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
           || !keyReader.trim(partitions.get(i + 1).getStart(), clusterBy.getBucketByCount()).equals(bucketKey);
 
       if (!isLastInBucket) {
-        MatcherAssert.assertThat(
-            StringUtils.format("%s: partition #%d: number of rows", testName, i),
-            actualNumberOfRows,
-            Matchers.greaterThanOrEqualTo((long) ((1 - PARTITION_SIZE_LEEWAY) * expectedPartitionSize))
+        Assertions.assertTrue(
+            actualNumberOfRows >= (long) ((1 - PARTITION_SIZE_LEEWAY) * expectedPartitionSize),
+            StringUtils.format("%s: partition #%d: number of rows", testName, i)
         );
       }
     }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/ClusterByStatisticsCollectorImplTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/ClusterByStatisticsCollectorImplTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.math.LongMath;
+import org.apache.druid.error.ThrowableMatcher;
 import org.apache.druid.frame.FrameType;
 import org.apache.druid.frame.key.ClusterBy;
 import org.apache.druid.frame.key.ClusterByPartition;
@@ -42,12 +43,10 @@ import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -119,8 +118,8 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
         aggregate,
         keys,
         (testName, collector) -> {
-          Assert.assertEquals(StringUtils.format("%s: tracked bucket count", testName), 1, trackedBuckets(collector));
-          Assert.assertEquals(StringUtils.format("%s: tracked row count", testName), numRows, trackedRows(collector));
+          Assertions.assertEquals(1, trackedBuckets(collector), StringUtils.format("%s: tracked bucket count", testName));
+          Assertions.assertEquals(numRows, trackedRows(collector), StringUtils.format("%s: tracked row count", testName));
 
           for (int targetPartitionWeight : new int[]{5111, 6543, (int) numRows + 10}) {
             verifyPartitionsWithTargetWeight(
@@ -168,8 +167,8 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
         aggregate,
         keys,
         (testName, collector) -> {
-          Assert.assertEquals(StringUtils.format("%s: tracked bucket count", testName), 1, trackedBuckets(collector));
-          Assert.assertEquals(StringUtils.format("%s: tracked row count", testName), numRows, trackedRows(collector));
+          Assertions.assertEquals(1, trackedBuckets(collector), StringUtils.format("%s: tracked bucket count", testName));
+          Assertions.assertEquals(numRows, trackedRows(collector), StringUtils.format("%s: tracked row count", testName));
 
           for (int targetPartitionWeight : new int[]{5111, 6543, (int) numRows + 10}) {
             verifyPartitionsWithTargetWeight(
@@ -219,14 +218,14 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
         aggregate,
         keys,
         (testName, collector) -> {
-          Assert.assertEquals(StringUtils.format("%s: tracked bucket count", testName), 1, trackedBuckets(collector));
+          Assertions.assertEquals(1, trackedBuckets(collector), StringUtils.format("%s: tracked bucket count", testName));
 
           final double expectedNumRows = (double) numRows / duplicationFactor;
-          Assert.assertEquals(
-              StringUtils.format("%s: tracked row count", testName),
+          Assertions.assertEquals(
               expectedNumRows,
               (double) trackedRows(collector),
-              expectedNumRows * .05 // Acceptable estimation error
+              expectedNumRows * .05, // Acceptable estimation error
+              StringUtils.format("%s: tracked row count", testName)
           );
 
           for (int targetPartitionWeight : new int[]{5111, 6543, (int) numRows + 10}) {
@@ -278,8 +277,8 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
         aggregate,
         keys,
         (testName, collector) -> {
-          Assert.assertEquals(StringUtils.format("%s: bucket count", testName), numBuckets, trackedBuckets(collector));
-          Assert.assertEquals(StringUtils.format("%s: row count", testName), numRows, trackedRows(collector));
+          Assertions.assertEquals(numBuckets, trackedBuckets(collector), StringUtils.format("%s: bucket count", testName));
+          Assertions.assertEquals(numRows, trackedRows(collector), StringUtils.format("%s: row count", testName));
 
           for (int targetPartitionWeight : new int[]{5111, 6543}) {
             verifyPartitionsWithTargetWeight(
@@ -293,15 +292,14 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
 
           for (int maxPartitionCount : new int[]{1, 2, 3, 10, 50}) {
             if (maxPartitionCount < numBuckets) {
-              final IllegalStateException e = Assert.assertThrows(
+              final IllegalStateException e = Assertions.assertThrows(
                   IllegalStateException.class,
                   () -> collector.generatePartitionsWithMaxCount(maxPartitionCount)
               );
 
-              MatcherAssert.assertThat(
-                  e,
-                  ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Unable to compute partition ranges"))
-              );
+              ThrowableMatcher.of(IllegalStateException.class)
+                             .expectMessage(message -> message.startsWith("Unable to compute partition ranges"))
+                             .assertThat(e);
             } else {
               verifyPartitionsWithMaxCount(
                   StringUtils.format("%s: generatePartitionsWithMaxCount(%d)", testName, maxPartitionCount),
@@ -342,7 +340,7 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
         aggregate,
         keys,
         (testName, collector) -> {
-          Assert.assertEquals(StringUtils.format("%s: bucket count", testName), numBuckets, trackedBuckets(collector));
+          Assertions.assertEquals(numBuckets, trackedBuckets(collector), StringUtils.format("%s: bucket count", testName));
 
           for (int targetPartitionWeight : new int[]{1701, 2301}) {
             verifyPartitionsWithTargetWeight(
@@ -358,7 +356,7 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
             if (maxPartitionCount < numBuckets) {
               // Cannot compute partitions ranges when maxPartitionCount < numBuckets, because there must be at
               // least one partition per bucket.
-              final IllegalStateException e = Assert.assertThrows(
+              final IllegalStateException e = Assertions.assertThrows(
                   IllegalStateException.class,
                   () -> verifyPartitionsWithMaxCount(
                       StringUtils.format("%s: generatePartitionsWithMaxCount(%d)", testName, maxPartitionCount),
@@ -369,10 +367,9 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
                   )
               );
 
-              MatcherAssert.assertThat(
-                  e,
-                  ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Unable to compute partition ranges"))
-              );
+              ThrowableMatcher.of(IllegalStateException.class)
+                             .expectMessage(message -> message.startsWith("Unable to compute partition ranges"))
+                             .assertThat(e);
             } else {
               verifyPartitionsWithMaxCount(
                   StringUtils.format("%s: generatePartitionsWithMaxCount(%d)", testName, maxPartitionCount),
@@ -413,10 +410,10 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
         aggregate,
         keys,
         (testName, collector) -> {
-          Assert.assertEquals(StringUtils.format("%s: bucket count", testName), numBuckets, trackedBuckets(collector));
+          Assertions.assertEquals(numBuckets, trackedBuckets(collector), StringUtils.format("%s: bucket count", testName));
 
           // trackedRows will equal numBuckets, because the collectors have been downsampled so much
-          Assert.assertEquals(StringUtils.format("%s: row count", testName), numBuckets, trackedRows(collector));
+          Assertions.assertEquals(numBuckets, trackedRows(collector), StringUtils.format("%s: row count", testName));
 
           for (int targetPartitionWeight : new int[]{1701, 2301}) {
             verifyPartitionsWithTargetWeight(
@@ -430,15 +427,14 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
 
           for (int maxPartitionCount : new int[]{1, 10, numBuckets, numBuckets + 1}) {
             if (maxPartitionCount < numBuckets) {
-              final IllegalStateException e = Assert.assertThrows(
+              final IllegalStateException e = Assertions.assertThrows(
                   IllegalStateException.class,
                   () -> collector.generatePartitionsWithMaxCount(maxPartitionCount)
               );
 
-              MatcherAssert.assertThat(
-                  e,
-                  ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Unable to compute partition ranges"))
-              );
+              ThrowableMatcher.of(IllegalStateException.class)
+                             .expectMessage(message -> message.startsWith("Unable to compute partition ranges"))
+                             .assertThat(e);
             } else {
               verifyPartitionsWithMaxCount(
                   StringUtils.format("%s: generatePartitionsWithMaxCount(%d)", testName, maxPartitionCount),
@@ -473,7 +469,7 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
     clusterByStatisticsCollector.add(createKey(CLUSTER_BY_XYZ_BUCKET_BY_X, 2, 3, "value2"), 1);
     clusterByStatisticsCollector.add(createKey(CLUSTER_BY_XYZ_BUCKET_BY_X, 1, 1, "Extremely long key string for unit test; Extremely long key string for unit test;"), 500);
 
-    Assert.assertTrue(clusterByStatisticsCollector.getTotalRetainedBytes() <= 35000);
+    Assertions.assertTrue(clusterByStatisticsCollector.getTotalRetainedBytes() <= 35000);
   }
 
   @Test
@@ -487,29 +483,32 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
     clusterByStatisticsCollector.downSample();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testMoreBucketsThanKeysThrowsException()
   {
-    ClusterByStatisticsCollectorImpl.create(ClusterBy.none(),
-                                            RowSignature.empty(),
-                                            FrameType.latestRowBased(),
-                                            0,
-                                            5,
-                                            false,
-                                            false);
+    Assertions.assertThrows(IllegalArgumentException.class, () ->
+      ClusterByStatisticsCollectorImpl.create(ClusterBy.none(),
+          RowSignature.empty(),
+          FrameType.latestRowBased(),
+          0,
+          5,
+          false,
+          false));
   }
 
-  @Test(expected = TooManyBucketsException.class)
+  @Test
   public void testTooManyBuckets()
   {
-    ClusterByStatisticsCollector clusterByStatisticsCollector = ClusterByStatisticsCollectorImpl.create(ClusterBy.none(),
-                                                                                                        RowSignature.empty(),
-                                                                                                        FrameType.latestRowBased(),
-                                                                                                        5,
-                                                                                                        0,
-                                                                                                        false,
-                                                                                                        false);
-    clusterByStatisticsCollector.add(RowKey.empty(), 1);
+    Assertions.assertThrows(TooManyBucketsException.class, () -> {
+      ClusterByStatisticsCollector clusterByStatisticsCollector = ClusterByStatisticsCollectorImpl.create(ClusterBy.none(),
+          RowSignature.empty(),
+          FrameType.latestRowBased(),
+          5,
+          0,
+          false,
+          false);
+      clusterByStatisticsCollector.add(RowKey.empty(), 1);
+    });
   }
 
   @Test
@@ -522,58 +521,66 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
                                                                                                         0,
                                                                                                         false,
                                                                                                         false);
-    Assert.assertEquals(ClusterByPartitions.oneUniversalPartition(), clusterByStatisticsCollector.generatePartitionsWithTargetWeight(10));
+    Assertions.assertEquals(ClusterByPartitions.oneUniversalPartition(), clusterByStatisticsCollector.generatePartitionsWithTargetWeight(10));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGeneratePartitionWithZeroTargetWeightThrowsException()
   {
-    ClusterByStatisticsCollector clusterByStatisticsCollector = ClusterByStatisticsCollectorImpl.create(ClusterBy.none(),
-                                                                                                        RowSignature.empty(),
-                                                                                                        FrameType.latestRowBased(),
-                                                                                                        5,
-                                                                                                        0,
-                                                                                                        false, false);
-    clusterByStatisticsCollector.generatePartitionsWithTargetWeight(0);
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      ClusterByStatisticsCollector clusterByStatisticsCollector = ClusterByStatisticsCollectorImpl.create(ClusterBy.none(),
+          RowSignature.empty(),
+          FrameType.latestRowBased(),
+          5,
+          0,
+          false, false);
+      clusterByStatisticsCollector.generatePartitionsWithTargetWeight(0);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGeneratePartitionWithZeroCountThrowsException()
   {
-    ClusterByStatisticsCollector clusterByStatisticsCollector = ClusterByStatisticsCollectorImpl.create(ClusterBy.none(),
-                                                                                                        RowSignature.empty(),
-                                                                                                        FrameType.latestRowBased(),
-                                                                                                        5,
-                                                                                                        0,
-                                                                                                        false,
-                                                                                                        false);
-    clusterByStatisticsCollector.generatePartitionsWithMaxCount(0);
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      ClusterByStatisticsCollector clusterByStatisticsCollector = ClusterByStatisticsCollectorImpl.create(ClusterBy.none(),
+          RowSignature.empty(),
+          FrameType.latestRowBased(),
+          5,
+          0,
+          false,
+          false);
+      clusterByStatisticsCollector.generatePartitionsWithMaxCount(0);
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testHasMultipleValuesFalseThrowsException()
   {
-    ClusterByStatisticsCollector clusterByStatisticsCollector = ClusterByStatisticsCollectorImpl.create(ClusterBy.none(),
-                                                                                                        RowSignature.empty(),
-                                                                                                        FrameType.latestRowBased(),
-                                                                                                        5,
-                                                                                                        0,
-                                                                                                        false,
-                                                                                                        false);
-    clusterByStatisticsCollector.hasMultipleValues(0);
+    Assertions.assertThrows(IllegalStateException.class, () -> {
+      ClusterByStatisticsCollector clusterByStatisticsCollector = ClusterByStatisticsCollectorImpl.create(ClusterBy.none(),
+          RowSignature.empty(),
+          FrameType.latestRowBased(),
+          5,
+          0,
+          false,
+          false);
+      clusterByStatisticsCollector.hasMultipleValues(0);
+    });
   }
 
-  @Test(expected = ISE.class)
+  @Test
   public void testHasMultipleValuesInvalidKeyThrowsException()
   {
-    ClusterByStatisticsCollector clusterByStatisticsCollector = ClusterByStatisticsCollectorImpl.create(ClusterBy.none(),
-                                                                                                        RowSignature.empty(),
-                                                                                                        FrameType.latestRowBased(),
-                                                                                                        5,
-                                                                                                        0,
-                                                                                                        false,
-                                                                                                        false);
-    clusterByStatisticsCollector.hasMultipleValues(-1);
+    Assertions.assertThrows(ISE.class, () -> {
+      ClusterByStatisticsCollector clusterByStatisticsCollector = ClusterByStatisticsCollectorImpl.create(ClusterBy.none(),
+          RowSignature.empty(),
+          FrameType.latestRowBased(),
+          5,
+          0,
+          false,
+          false);
+      clusterByStatisticsCollector.hasMultipleValues(-1);
+    });
   }
 
   private void doTest(
@@ -759,14 +766,14 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
   {
     final RowKeyReader keyReader = clusterBy.keyReader(SIGNATURE, FrameType.latestRowBased());
 
-    Assert.assertEquals(
-        StringUtils.format("%s: number of buckets", testName),
+    Assertions.assertEquals(
         expectedNumberOfBuckets,
         partitions.ranges()
                   .stream()
                   .map(partition -> keyReader.trim(partition.getStart(), clusterBy.getBucketByCount()))
                   .distinct()
-                  .count()
+                  .count(),
+        StringUtils.format("%s: number of buckets", testName)
     );
   }
 
@@ -785,7 +792,7 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
       final Comparator<RowKey> comparator
   )
   {
-    Assert.assertTrue(StringUtils.format("%s: partitions abutting", testName), partitions.allAbutting());
+    Assertions.assertTrue(partitions.allAbutting(), StringUtils.format("%s: partitions abutting", testName));
 
     final List<ClusterByPartition> ranges = partitions.ranges();
 
@@ -794,28 +801,28 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
 
       // Check expected nullness of the start key.
       if (i == 0) {
-        Assert.assertEquals(
-            StringUtils.format("%s: partition %d: start is min key", testName, i),
+        Assertions.assertEquals(
             expectedMinKey,
-            partition.getStart()
+            partition.getStart(),
+            StringUtils.format("%s: partition %d: start is min key", testName, i)
         );
       } else {
-        Assert.assertNotNull(
-            StringUtils.format("%s: partition %d: start is nonnull", testName, i),
-            partition.getStart()
+        Assertions.assertNotNull(
+            partition.getStart(),
+            StringUtils.format("%s: partition %d: start is nonnull", testName, i)
         );
       }
 
       // Check expected nullness of the end key.
       if (i == ranges.size() - 1) {
-        Assert.assertNull(
-            StringUtils.format("%s: partition %d (final): end is null", testName, i),
-            partition.getEnd()
+        Assertions.assertNull(
+            partition.getEnd(),
+            StringUtils.format("%s: partition %d (final): end is null", testName, i)
         );
       } else {
-        Assert.assertNotNull(
-            StringUtils.format("%s: partition %d: end is nonnull", testName, i),
-            partition.getEnd()
+        Assertions.assertNotNull(
+            partition.getEnd(),
+            StringUtils.format("%s: partition %d: end is nonnull", testName, i)
         );
       }
 
@@ -853,10 +860,10 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
           clusterBy.getBucketByCount()
       );
 
-      Assert.assertEquals(
-          StringUtils.format("%s: partition %d: first, last bucket key are equal", testName, i),
+      Assertions.assertEquals(
           firstBucketKey,
-          lastBucketKey
+          lastBucketKey,
+          StringUtils.format("%s: partition %d: first, last bucket key are equal", testName, i)
       );
     }
   }
@@ -997,14 +1004,14 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
           ClusterByStatisticsSnapshot.class
       );
 
-      Assert.assertEquals(StringUtils.format("%s: snapshot is serializable", testName), snapshot, snapshot2);
+      Assertions.assertEquals(snapshot, snapshot2, StringUtils.format("%s: snapshot is serializable", testName));
 
       // Verify octet stream serialization
       ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
       ClusterByStatisticsSnapshotSerde.serialize(byteArrayOutputStream, snapshot);
 
       final ClusterByStatisticsSnapshot snapshot3 = ClusterByStatisticsSnapshotSerde.deserialize(ByteBuffer.wrap(byteArrayOutputStream.toByteArray()));
-      Assert.assertEquals(StringUtils.format("%s: snapshot is serializable", testName), snapshot, snapshot3);
+      Assertions.assertEquals(snapshot, snapshot3, StringUtils.format("%s: snapshot is serializable", testName));
     }
     catch (IOException e) {
       throw new RuntimeException(e);

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/DelegateOrMinKeyCollectorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/DelegateOrMinKeyCollectorTest.java
@@ -29,8 +29,6 @@ import org.apache.druid.frame.key.RowKey;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -57,7 +55,7 @@ public class DelegateOrMinKeyCollectorTest
     Assertions.assertThrows(NoSuchElementException.class, collector::minKey);
     Assertions.assertEquals(0, collector.estimatedRetainedBytes(), 0);
     Assertions.assertEquals(0, collector.estimatedTotalWeight());
-    MatcherAssert.assertThat(collector.getDelegate().get(), CoreMatchers.instanceOf(QuantilesSketchKeyCollector.class));
+    Assertions.assertInstanceOf(QuantilesSketchKeyCollector.class, collector.getDelegate().get());
   }
 
   @Test

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/DelegateOrMinKeyCollectorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/DelegateOrMinKeyCollectorTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
 import java.util.NoSuchElementException;
@@ -52,23 +52,25 @@ public class DelegateOrMinKeyCollectorTest
             QuantilesSketchKeyCollectorFactory.create(clusterBy, signature)
         ).newKeyCollector();
 
-    Assert.assertTrue(collector.getDelegate().isPresent());
-    Assert.assertTrue(collector.isEmpty());
-    Assert.assertThrows(NoSuchElementException.class, collector::minKey);
-    Assert.assertEquals(0, collector.estimatedRetainedBytes(), 0);
-    Assert.assertEquals(0, collector.estimatedTotalWeight());
+    Assertions.assertTrue(collector.getDelegate().isPresent());
+    Assertions.assertTrue(collector.isEmpty());
+    Assertions.assertThrows(NoSuchElementException.class, collector::minKey);
+    Assertions.assertEquals(0, collector.estimatedRetainedBytes(), 0);
+    Assertions.assertEquals(0, collector.estimatedTotalWeight());
     MatcherAssert.assertThat(collector.getDelegate().get(), CoreMatchers.instanceOf(QuantilesSketchKeyCollector.class));
   }
 
-  @Test(expected = ISE.class)
+  @Test
   public void testDelegateAndMinKeyNotNullThrowsException()
   {
-    ClusterBy clusterBy = ClusterBy.none();
-    new DelegateOrMinKeyCollector<>(
-        clusterBy.keyComparator(RowSignature.empty()),
-        QuantilesSketchKeyCollectorFactory.create(clusterBy, RowSignature.empty()).newKeyCollector(),
-        RowKey.empty()
-    );
+    Assertions.assertThrows(ISE.class, () -> {
+      ClusterBy clusterBy = ClusterBy.none();
+      new DelegateOrMinKeyCollector<>(
+          clusterBy.keyComparator(RowSignature.empty()),
+          QuantilesSketchKeyCollectorFactory.create(clusterBy, RowSignature.empty()).newKeyCollector(),
+          RowKey.empty()
+      );
+    });
   }
 
   @Test
@@ -83,11 +85,11 @@ public class DelegateOrMinKeyCollectorTest
     RowKey key = createKey(1L);
     collector.add(key, 1);
 
-    Assert.assertTrue(collector.getDelegate().isPresent());
-    Assert.assertFalse(collector.isEmpty());
-    Assert.assertEquals(key, collector.minKey());
-    Assert.assertEquals(key.estimatedObjectSizeBytes(), collector.estimatedRetainedBytes(), 0);
-    Assert.assertEquals(1, collector.estimatedTotalWeight());
+    Assertions.assertTrue(collector.getDelegate().isPresent());
+    Assertions.assertFalse(collector.isEmpty());
+    Assertions.assertEquals(key, collector.minKey());
+    Assertions.assertEquals(key.estimatedObjectSizeBytes(), collector.estimatedRetainedBytes(), 0);
+    Assertions.assertEquals(1, collector.estimatedTotalWeight());
   }
 
   @Test
@@ -102,17 +104,17 @@ public class DelegateOrMinKeyCollectorTest
     RowKey key = createKey(1L);
 
     collector.add(key, 1);
-    Assert.assertTrue(collector.downSample());
+    Assertions.assertTrue(collector.downSample());
 
-    Assert.assertTrue(collector.getDelegate().isPresent());
-    Assert.assertFalse(collector.isEmpty());
-    Assert.assertEquals(key, collector.minKey());
-    Assert.assertEquals(key.estimatedObjectSizeBytes(), collector.estimatedRetainedBytes(), 0);
-    Assert.assertEquals(1, collector.estimatedTotalWeight());
+    Assertions.assertTrue(collector.getDelegate().isPresent());
+    Assertions.assertFalse(collector.isEmpty());
+    Assertions.assertEquals(key, collector.minKey());
+    Assertions.assertEquals(key.estimatedObjectSizeBytes(), collector.estimatedRetainedBytes(), 0);
+    Assertions.assertEquals(1, collector.estimatedTotalWeight());
 
     // Should not have actually downsampled, because the quantiles-based collector does nothing when
     // downsampling on a single key.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         QuantilesSketchKeyCollectorFactory.SKETCH_INITIAL_K,
         collector.getDelegate().get().getSketch().getK()
     );
@@ -132,22 +134,22 @@ public class DelegateOrMinKeyCollectorTest
     collector.add(key, 1);
     int expectedRetainedBytes = 2 * key.estimatedObjectSizeBytes();
 
-    Assert.assertTrue(collector.getDelegate().isPresent());
-    Assert.assertFalse(collector.isEmpty());
-    Assert.assertEquals(createKey(1L), collector.minKey());
-    Assert.assertEquals(expectedRetainedBytes, collector.estimatedRetainedBytes(), 0);
-    Assert.assertEquals(2, collector.estimatedTotalWeight());
+    Assertions.assertTrue(collector.getDelegate().isPresent());
+    Assertions.assertFalse(collector.isEmpty());
+    Assertions.assertEquals(createKey(1L), collector.minKey());
+    Assertions.assertEquals(expectedRetainedBytes, collector.estimatedRetainedBytes(), 0);
+    Assertions.assertEquals(2, collector.estimatedTotalWeight());
 
     while (collector.getDelegate().isPresent()) {
-      Assert.assertTrue(collector.downSample());
+      Assertions.assertTrue(collector.downSample());
     }
     expectedRetainedBytes = key.estimatedObjectSizeBytes();
 
-    Assert.assertFalse(collector.getDelegate().isPresent());
-    Assert.assertFalse(collector.isEmpty());
-    Assert.assertEquals(createKey(1L), collector.minKey());
-    Assert.assertEquals(expectedRetainedBytes, collector.estimatedRetainedBytes(), 0);
-    Assert.assertEquals(1, collector.estimatedTotalWeight());
+    Assertions.assertFalse(collector.getDelegate().isPresent());
+    Assertions.assertFalse(collector.isEmpty());
+    Assertions.assertEquals(createKey(1L), collector.minKey());
+    Assertions.assertEquals(expectedRetainedBytes, collector.estimatedRetainedBytes(), 0);
+    Assertions.assertEquals(1, collector.estimatedTotalWeight());
   }
 
   private RowKey createKey(final Object... objects)

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/DistinctKeyCollectorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/DistinctKeyCollectorTest.java
@@ -30,8 +30,6 @@ import org.apache.druid.frame.key.RowKey;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -150,10 +148,9 @@ public class DistinctKeyCollectorTest
           }
 
           Assertions.assertTrue(DistinctKeyCollector.SMALLEST_MAX_BYTES >= collector.getMaxBytes());
-          MatcherAssert.assertThat(
-              testName,
-              (int) collector.estimatedRetainedBytes(),
-              Matchers.lessThanOrEqualTo(DistinctKeyCollector.SMALLEST_MAX_BYTES)
+          Assertions.assertTrue(
+              (int) collector.estimatedRetainedBytes() <= DistinctKeyCollector.SMALLEST_MAX_BYTES,
+              testName
           );
 
           // Don't use verifyCollector, since this collector is downsampled so aggressively that it can't possibly
@@ -252,7 +249,7 @@ public class DistinctKeyCollectorTest
       final NavigableMap<RowKey, List<Integer>> sortedKeyWeights
   )
   {
-    MatcherAssert.assertThat((int) collector.estimatedRetainedBytes(), Matchers.lessThan(collector.getMaxBytes()));
+    Assertions.assertTrue((int) collector.estimatedRetainedBytes() < collector.getMaxBytes());
 
     KeyCollectorTestUtils.verifyCollector(
         collector,

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/DistinctKeyCollectorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/DistinctKeyCollectorTest.java
@@ -32,8 +32,8 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -56,10 +56,10 @@ public class DistinctKeyCollectorTest
         Collections.emptyList(),
         comparator,
         (testName, collector) -> {
-          Assert.assertTrue(collector.isEmpty());
-          Assert.assertThrows(NoSuchElementException.class, collector::minKey);
-          Assert.assertEquals(testName, 0, collector.estimatedTotalWeight());
-          Assert.assertEquals(
+          Assertions.assertTrue(collector.isEmpty());
+          Assertions.assertThrows(NoSuchElementException.class, collector::minKey);
+          Assertions.assertEquals(0, collector.estimatedTotalWeight(), testName);
+          Assertions.assertEquals(
               ClusterByPartitions.oneUniversalPartition(),
               collector.generatePartitionsWithTargetWeight(1000)
           );
@@ -80,7 +80,7 @@ public class DistinctKeyCollectorTest
         keyWeights,
         comparator,
         (testName, collector) -> {
-          Assert.assertEquals(numKeys, collector.estimatedTotalWeight(), numKeys * 0.05);
+          Assertions.assertEquals(numKeys, collector.estimatedTotalWeight(), numKeys * 0.05);
           verifyCollector(collector, clusterBy, comparator, sortedKeyWeights);
         }
     );
@@ -113,22 +113,24 @@ public class DistinctKeyCollectorTest
         keyWeights,
         comparator,
         (testName, collector) -> {
-          Assert.assertEquals(
-              testName,
+          Assertions.assertEquals(
               sortedKeyWeights.size(),
               collector.estimatedTotalWeight(),
-              sortedKeyWeights.size() * 0.05
+              sortedKeyWeights.size() * 0.05,
+              testName
           );
           verifyCollector(collector, clusterBy, comparator, sortedKeyWeights);
         }
     );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void test_generateWithNegativeTargetWeight_throwsException()
   {
-    DistinctKeyCollector distinctKeyCollector = DistinctKeyCollectorFactory.create(clusterBy, signature).newKeyCollector();
-    distinctKeyCollector.generatePartitionsWithTargetWeight(-1);
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      DistinctKeyCollector distinctKeyCollector = DistinctKeyCollectorFactory.create(clusterBy, signature).newKeyCollector();
+      distinctKeyCollector.generatePartitionsWithTargetWeight(-1);
+    });
   }
 
   @Test
@@ -147,7 +149,7 @@ public class DistinctKeyCollectorTest
             // Intentionally empty loop body.
           }
 
-          Assert.assertTrue(DistinctKeyCollector.SMALLEST_MAX_BYTES >= collector.getMaxBytes());
+          Assertions.assertTrue(DistinctKeyCollector.SMALLEST_MAX_BYTES >= collector.getMaxBytes());
           MatcherAssert.assertThat(
               testName,
               (int) collector.estimatedRetainedBytes(),
@@ -179,7 +181,7 @@ public class DistinctKeyCollectorTest
         keyWeights,
         comparator,
         (testName, collector) -> {
-          Assert.assertEquals(
+          Assertions.assertEquals(
               sortedKeyWeights.size(),
               collector.estimatedTotalWeight(),
               sortedKeyWeights.size() * 0.05
@@ -202,7 +204,7 @@ public class DistinctKeyCollectorTest
         keyWeights,
         comparator,
         (testName, collector) -> {
-          Assert.assertEquals(
+          Assertions.assertEquals(
               ClusterByStatisticsCollectorImplTest.totalWeight(
                   sortedKeyWeights,
                   new ClusterByPartition(null, null),
@@ -229,7 +231,7 @@ public class DistinctKeyCollectorTest
         keyWeights,
         comparator,
         (testName, collector) -> {
-          Assert.assertEquals(
+          Assertions.assertEquals(
               ClusterByStatisticsCollectorImplTest.totalWeight(
                   sortedKeyWeights,
                   new ClusterByPartition(null, null),

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/KeyCollectorTestUtils.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/KeyCollectorTestUtils.java
@@ -32,7 +32,7 @@ import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -147,7 +147,7 @@ public class KeyCollectorTestUtils
       final NavigableMap<RowKey, List<Integer>> sortedKeyWeights
   )
   {
-    Assert.assertEquals(sortedKeyWeights.isEmpty() ? null : sortedKeyWeights.firstKey(), collector.minKey());
+    Assertions.assertEquals(sortedKeyWeights.isEmpty() ? null : sortedKeyWeights.firstKey(), collector.minKey());
 
     for (int targetWeight : new int[]{10_000, 50_000, 300_000}) {
       final ClusterByPartitions partitions = collector.generatePartitionsWithTargetWeight(targetWeight);

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/PartialKeyStatisticsInformationSerdeTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/PartialKeyStatisticsInformationSerdeTest.java
@@ -25,15 +25,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class PartialKeyStatisticsInformationSerdeTest
 {
   private ObjectMapper objectMapper;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     objectMapper = TestHelper.makeJsonMapper();
@@ -55,8 +55,8 @@ public class PartialKeyStatisticsInformationSerdeTest
         json,
         PartialKeyStatisticsInformation.class
     );
-    Assert.assertEquals(json, partialInformation.getTimeSegments(), deserializedKeyStatistics.getTimeSegments());
-    Assert.assertEquals(json, partialInformation.hasMultipleValues(), deserializedKeyStatistics.hasMultipleValues());
-    Assert.assertEquals(json, partialInformation.getBytesRetained(), deserializedKeyStatistics.getBytesRetained(), 0);
+    Assertions.assertEquals(partialInformation.getTimeSegments(), deserializedKeyStatistics.getTimeSegments(), json);
+    Assertions.assertEquals(partialInformation.hasMultipleValues(), deserializedKeyStatistics.hasMultipleValues(), json);
+    Assertions.assertEquals(partialInformation.getBytesRetained(), deserializedKeyStatistics.getBytesRetained(), 0, json);
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/QuantilesSketchKeyCollectorSnapshotTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/QuantilesSketchKeyCollectorSnapshotTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.msq.statistics;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class QuantilesSketchKeyCollectorSnapshotTest
 {
@@ -34,6 +34,6 @@ public class QuantilesSketchKeyCollectorSnapshotTest
   {
     QuantilesSketchKeyCollectorSnapshot snapshot = new QuantilesSketchKeyCollectorSnapshot("sketchString", 100);
     String jsonStr = jsonMapper.writeValueAsString(snapshot);
-    Assert.assertEquals(snapshot, jsonMapper.readValue(jsonStr, QuantilesSketchKeyCollectorSnapshot.class));
+    Assertions.assertEquals(snapshot, jsonMapper.readValue(jsonStr, QuantilesSketchKeyCollectorSnapshot.class));
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/QuantilesSketchKeyCollectorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/QuantilesSketchKeyCollectorTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.frame.key.RowKey;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -55,10 +55,10 @@ public class QuantilesSketchKeyCollectorTest
         Collections.emptyList(),
         comparator,
         (testName, collector) -> {
-          Assert.assertTrue(collector.isEmpty());
-          Assert.assertThrows(NoSuchElementException.class, collector::minKey);
-          Assert.assertEquals(testName, 0, collector.estimatedTotalWeight());
-          Assert.assertEquals(
+          Assertions.assertTrue(collector.isEmpty());
+          Assertions.assertThrows(NoSuchElementException.class, collector::minKey);
+          Assertions.assertEquals(0, collector.estimatedTotalWeight(), testName);
+          Assertions.assertEquals(
               ClusterByPartitions.oneUniversalPartition(),
               collector.generatePartitionsWithTargetWeight(1000)
           );
@@ -79,7 +79,7 @@ public class QuantilesSketchKeyCollectorTest
         keyWeights,
         comparator,
         (testName, collector) -> {
-          Assert.assertEquals(testName, numKeys, collector.estimatedTotalWeight());
+          Assertions.assertEquals(numKeys, collector.estimatedTotalWeight(), testName);
           verifyCollector(collector, clusterBy, comparator, sortedKeyWeights);
         }
     );
@@ -97,7 +97,7 @@ public class QuantilesSketchKeyCollectorTest
         keyWeights,
         comparator,
         (testName, collector) -> {
-          Assert.assertEquals(testName, numKeys, collector.estimatedTotalWeight());
+          Assertions.assertEquals(numKeys, collector.estimatedTotalWeight(), testName);
           verifyCollector(collector, clusterBy, comparator, sortedKeyWeights);
         }
     );
@@ -119,8 +119,8 @@ public class QuantilesSketchKeyCollectorTest
             // Intentionally empty loop body.
           }
 
-          Assert.assertEquals(testName, 2, collector.getSketch().getK());
-          Assert.assertEquals(testName, 12, collector.estimatedRetainedKeys());
+          Assertions.assertEquals(2, collector.getSketch().getK(), testName);
+          Assertions.assertEquals(12, collector.estimatedRetainedKeys(), testName);
 
           // Don't use verifyCollector, since this collector is downsampled so aggressively that it can't possibly
           // hope to pass those tests. Grade on a curve.
@@ -148,14 +148,14 @@ public class QuantilesSketchKeyCollectorTest
         keyWeights,
         comparator,
         (testName, collector) -> {
-          Assert.assertEquals(
-              testName,
+          Assertions.assertEquals(
               ClusterByStatisticsCollectorImplTest.totalWeight(
                   sortedKeyWeights,
                   new ClusterByPartition(null, null),
                   false
               ),
-              collector.estimatedTotalWeight()
+              collector.estimatedTotalWeight(),
+              testName
           );
           verifyCollector(collector, clusterBy, comparator, sortedKeyWeights);
         }
@@ -194,13 +194,13 @@ public class QuantilesSketchKeyCollectorTest
 
 
     collector.add(smallKey, 3);
-    Assert.assertEquals(smallKey.estimatedObjectSizeBytes(), collector.getAverageKeyLength(), 0);
+    Assertions.assertEquals(smallKey.estimatedObjectSizeBytes(), collector.getAverageKeyLength(), 0);
 
     other.add(largeKey, 5);
-    Assert.assertEquals(largeKey.estimatedObjectSizeBytes(), other.getAverageKeyLength(), 0);
+    Assertions.assertEquals(largeKey.estimatedObjectSizeBytes(), other.getAverageKeyLength(), 0);
 
     collector.addAll(other);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         (smallKey.estimatedObjectSizeBytes() * 3 + largeKey.estimatedObjectSizeBytes() * 5) / 8.0,
         collector.getAverageKeyLength(),
         0
@@ -220,14 +220,14 @@ public class QuantilesSketchKeyCollectorTest
         keyWeights,
         comparator,
         (testName, collector) -> {
-          Assert.assertEquals(
-              testName,
+          Assertions.assertEquals(
               ClusterByStatisticsCollectorImplTest.totalWeight(
                   sortedKeyWeights,
                   new ClusterByPartition(null, null),
                   false
               ),
-              collector.estimatedTotalWeight()
+              collector.estimatedTotalWeight(),
+              testName
           );
           verifyCollector(collector, clusterBy, comparator, sortedKeyWeights);
         }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/SendPartialKeyStatisticsInformationSerdeTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/SendPartialKeyStatisticsInformationSerdeTest.java
@@ -25,15 +25,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SendPartialKeyStatisticsInformationSerdeTest
 {
   private ObjectMapper objectMapper;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     objectMapper = TestHelper.makeJsonMapper();
@@ -55,8 +55,8 @@ public class SendPartialKeyStatisticsInformationSerdeTest
         json,
         PartialKeyStatisticsInformation.class
     );
-    Assert.assertEquals(json, partialInformation.getTimeSegments(), deserializedKeyStatistics.getTimeSegments());
-    Assert.assertEquals(json, partialInformation.hasMultipleValues(), deserializedKeyStatistics.hasMultipleValues());
-    Assert.assertEquals(json, partialInformation.getBytesRetained(), deserializedKeyStatistics.getBytesRetained(), 0);
+    Assertions.assertEquals(partialInformation.getTimeSegments(), deserializedKeyStatistics.getTimeSegments(), json);
+    Assertions.assertEquals(partialInformation.hasMultipleValues(), deserializedKeyStatistics.hasMultipleValues(), json);
+    Assertions.assertEquals(partialInformation.getBytesRetained(), deserializedKeyStatistics.getBytesRetained(), 0, json);
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/serde/KeyCollectorSnapshotSerializerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/serde/KeyCollectorSnapshotSerializerTest.java
@@ -29,8 +29,8 @@ import org.apache.druid.msq.statistics.ClusterByStatisticsSnapshot;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -68,7 +68,7 @@ public class KeyCollectorSnapshotSerializerTest extends InitializedNullHandlingT
 
     final ClusterByStatisticsSnapshot deserializedSnapshot = ClusterByStatisticsSnapshotSerde.deserialize(serializedSnapshot);
 
-    Assert.assertEquals(snapshot, deserializedSnapshot);
+    Assertions.assertEquals(snapshot, deserializedSnapshot);
   }
 
   @Test
@@ -83,7 +83,7 @@ public class KeyCollectorSnapshotSerializerTest extends InitializedNullHandlingT
 
     final ClusterByStatisticsSnapshot deserializedSnapshot = ClusterByStatisticsSnapshotSerde.deserialize(serializedSnapshot);
 
-    Assert.assertEquals(snapshot, deserializedSnapshot);
+    Assertions.assertEquals(snapshot, deserializedSnapshot);
   }
 
   private ClusterByStatisticsCollectorImpl makeCollector(final boolean aggregate)

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteSelectQueryMSQTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteSelectQueryMSQTest.java
@@ -26,7 +26,7 @@ import org.apache.druid.msq.sql.MSQTaskSqlEngine;
 import org.apache.druid.sql.calcite.CalciteQueryTest;
 import org.apache.druid.sql.calcite.QueryTestBuilder;
 import org.apache.druid.sql.calcite.SqlTestFrameworkConfig;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -136,10 +136,10 @@ public class CalciteSelectQueryMSQTest extends CalciteQueryTest
   {
     try {
       testQuery("SELECT ARRAY_AGG(unique_dim1) FROM druid.foo", ImmutableList.of(), ImmutableList.of());
-      Assert.fail("query execution should fail");
+      Assertions.fail("query execution should fail");
     }
     catch (ISE e) {
-      Assert.assertTrue(
+      Assertions.assertTrue(
           e.getMessage().contains("Cannot handle column [a0] with type [ARRAY<COMPLEX<hyperUnique>>]")
       );
     }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/CounterSnapshotMatcher.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/CounterSnapshotMatcher.java
@@ -22,7 +22,7 @@ package org.apache.druid.msq.test;
 import org.apache.druid.msq.counters.ChannelCounters;
 import org.apache.druid.msq.counters.QueryCounterSnapshot;
 import org.apache.druid.msq.counters.SegmentGenerationProgressCounter;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Utility class to build instances of {@link QueryCounterSnapshot} used in tests.
@@ -111,34 +111,34 @@ public class CounterSnapshotMatcher
   public void matchQuerySnapshot(String errorMessageFormat, QueryCounterSnapshot queryCounterSnapshot)
   {
     if (rows != null) {
-      Assert.assertArrayEquals(errorMessageFormat, rows, ((ChannelCounters.Snapshot) queryCounterSnapshot).getRows());
+      Assertions.assertArrayEquals(rows, ((ChannelCounters.Snapshot) queryCounterSnapshot).getRows(), errorMessageFormat);
     }
     if (bytes != null) {
-      Assert.assertArrayEquals(errorMessageFormat, bytes, ((ChannelCounters.Snapshot) queryCounterSnapshot).getBytes());
+      Assertions.assertArrayEquals(bytes, ((ChannelCounters.Snapshot) queryCounterSnapshot).getBytes(), errorMessageFormat);
     }
     if (frames != null) {
-      Assert.assertArrayEquals(errorMessageFormat, frames, ((ChannelCounters.Snapshot) queryCounterSnapshot).getFrames());
+      Assertions.assertArrayEquals(frames, ((ChannelCounters.Snapshot) queryCounterSnapshot).getFrames(), errorMessageFormat);
     }
     if (files != null) {
-      Assert.assertArrayEquals(errorMessageFormat, files, ((ChannelCounters.Snapshot) queryCounterSnapshot).getFiles());
+      Assertions.assertArrayEquals(files, ((ChannelCounters.Snapshot) queryCounterSnapshot).getFiles(), errorMessageFormat);
     }
     if (totalFiles != null) {
-      Assert.assertArrayEquals(errorMessageFormat, totalFiles, ((ChannelCounters.Snapshot) queryCounterSnapshot).getTotalFiles());
+      Assertions.assertArrayEquals(totalFiles, ((ChannelCounters.Snapshot) queryCounterSnapshot).getTotalFiles(), errorMessageFormat);
     }
     if (loadBytes != null) {
-      Assert.assertArrayEquals(errorMessageFormat, loadBytes, ((ChannelCounters.Snapshot) queryCounterSnapshot).getLoadBytes());
+      Assertions.assertArrayEquals(loadBytes, ((ChannelCounters.Snapshot) queryCounterSnapshot).getLoadBytes(), errorMessageFormat);
     }
     if (loadTime != null) {
-      Assert.assertArrayEquals(errorMessageFormat, loadTime, ((ChannelCounters.Snapshot) queryCounterSnapshot).getLoadTime());
+      Assertions.assertArrayEquals(loadTime, ((ChannelCounters.Snapshot) queryCounterSnapshot).getLoadTime(), errorMessageFormat);
     }
     if (loadWait != null) {
-      Assert.assertArrayEquals(errorMessageFormat, loadWait, ((ChannelCounters.Snapshot) queryCounterSnapshot).getLoadWait());
+      Assertions.assertArrayEquals(loadWait, ((ChannelCounters.Snapshot) queryCounterSnapshot).getLoadWait(), errorMessageFormat);
     }
     if (loadFiles != null) {
-      Assert.assertArrayEquals(errorMessageFormat, loadFiles, ((ChannelCounters.Snapshot) queryCounterSnapshot).getLoadFiles());
+      Assertions.assertArrayEquals(loadFiles, ((ChannelCounters.Snapshot) queryCounterSnapshot).getLoadFiles(), errorMessageFormat);
     }
     if (segmentRowsProcessed != null) {
-      Assert.assertEquals(errorMessageFormat, segmentRowsProcessed.longValue(), ((SegmentGenerationProgressCounter.Snapshot) queryCounterSnapshot).getRowsProcessed());
+      Assertions.assertEquals(segmentRowsProcessed.longValue(), ((SegmentGenerationProgressCounter.Snapshot) queryCounterSnapshot).getRowsProcessed(), errorMessageFormat);
     }
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledDartCalciteArraysQueryTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledDartCalciteArraysQueryTest.java
@@ -26,8 +26,8 @@ import org.apache.druid.sql.calcite.NotYetSupported;
 import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
 import org.apache.druid.sql.calcite.QueryTestBuilder;
 import org.apache.druid.sql.calcite.SqlTestFrameworkConfig;
-import org.junit.AssumptionViolatedException;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.opentest4j.TestAbortedException;
 
 @SqlTestFrameworkConfig.ComponentSupplier(DartComponentSupplier.class)
 public class DecoupledDartCalciteArraysQueryTest extends CalciteArraysQueryTest
@@ -64,6 +64,6 @@ public class DecoupledDartCalciteArraysQueryTest extends CalciteArraysQueryTest
   @Override
   protected void msqIncompatible()
   {
-    throw new AssumptionViolatedException("Case marked as msqIncompatible; not trying dart right now");
+    throw new TestAbortedException("Case marked as msqIncompatible; not trying dart right now");
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledDartCalciteArraysQueryTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledDartCalciteArraysQueryTest.java
@@ -26,8 +26,8 @@ import org.apache.druid.sql.calcite.NotYetSupported;
 import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
 import org.apache.druid.sql.calcite.QueryTestBuilder;
 import org.apache.druid.sql.calcite.SqlTestFrameworkConfig;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.opentest4j.TestAbortedException;
 
 @SqlTestFrameworkConfig.ComponentSupplier(DartComponentSupplier.class)
 public class DecoupledDartCalciteArraysQueryTest extends CalciteArraysQueryTest
@@ -64,6 +64,6 @@ public class DecoupledDartCalciteArraysQueryTest extends CalciteArraysQueryTest
   @Override
   protected void msqIncompatible()
   {
-    throw new TestAbortedException("Case marked as msqIncompatible; not trying dart right now");
+    Assumptions.assumeFalse(true, "Case marked as msqIncompatible; not trying dart right now");
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledDartCalciteJoinQueryTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledDartCalciteJoinQueryTest.java
@@ -29,10 +29,10 @@ import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
 import org.apache.druid.sql.calcite.QueryTestBuilder;
 import org.apache.druid.sql.calcite.SqlTestFrameworkConfig;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
-import org.junit.AssumptionViolatedException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.opentest4j.TestAbortedException;
 
 @SqlTestFrameworkConfig.ComponentSupplier(DartComponentSupplier.class)
 public abstract class DecoupledDartCalciteJoinQueryTest extends CalciteJoinQueryTest
@@ -107,7 +107,7 @@ public abstract class DecoupledDartCalciteJoinQueryTest extends CalciteJoinQuery
   @Override
   protected void msqIncompatible()
   {
-    throw new AssumptionViolatedException("Case marked as msqIncompatible; not trying dart right now");
+    throw new TestAbortedException("Case marked as msqIncompatible; not trying dart right now");
   }
 
   @Override

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledDartCalciteJoinQueryTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledDartCalciteJoinQueryTest.java
@@ -29,10 +29,10 @@ import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
 import org.apache.druid.sql.calcite.QueryTestBuilder;
 import org.apache.druid.sql.calcite.SqlTestFrameworkConfig;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.opentest4j.TestAbortedException;
 
 @SqlTestFrameworkConfig.ComponentSupplier(DartComponentSupplier.class)
 public abstract class DecoupledDartCalciteJoinQueryTest extends CalciteJoinQueryTest
@@ -107,7 +107,7 @@ public abstract class DecoupledDartCalciteJoinQueryTest extends CalciteJoinQuery
   @Override
   protected void msqIncompatible()
   {
-    throw new TestAbortedException("Case marked as msqIncompatible; not trying dart right now");
+    Assumptions.assumeFalse(true, "Case marked as msqIncompatible; not trying dart right now");
   }
 
   @Override

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledDartCalciteNestedDataQueryTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledDartCalciteNestedDataQueryTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
 import org.apache.druid.sql.calcite.QueryTestBuilder;
 import org.apache.druid.sql.calcite.SqlTestFrameworkConfig;
 import org.apache.druid.sql.calcite.TempDirProducer;
-import org.junit.AssumptionViolatedException;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.opentest4j.TestAbortedException;
 
 @SqlTestFrameworkConfig.ComponentSupplier(DecoupledDartCalciteNestedDataQueryTest.NestedDataQueryMSQComponentSupplier.class)
 public class DecoupledDartCalciteNestedDataQueryTest extends CalciteNestedDataQueryTest
@@ -55,6 +55,6 @@ public class DecoupledDartCalciteNestedDataQueryTest extends CalciteNestedDataQu
   @Override
   protected void msqIncompatible()
   {
-    throw new AssumptionViolatedException("Case marked as msqIncompatible; not trying dart right now");
+    throw new TestAbortedException("Case marked as msqIncompatible; not trying dart right now");
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledDartCalciteNestedDataQueryTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledDartCalciteNestedDataQueryTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
 import org.apache.druid.sql.calcite.QueryTestBuilder;
 import org.apache.druid.sql.calcite.SqlTestFrameworkConfig;
 import org.apache.druid.sql.calcite.TempDirProducer;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.opentest4j.TestAbortedException;
 
 @SqlTestFrameworkConfig.ComponentSupplier(DecoupledDartCalciteNestedDataQueryTest.NestedDataQueryMSQComponentSupplier.class)
 public class DecoupledDartCalciteNestedDataQueryTest extends CalciteNestedDataQueryTest
@@ -55,6 +55,6 @@ public class DecoupledDartCalciteNestedDataQueryTest extends CalciteNestedDataQu
   @Override
   protected void msqIncompatible()
   {
-    throw new TestAbortedException("Case marked as msqIncompatible; not trying dart right now");
+    Assumptions.assumeFalse(true, "Case marked as msqIncompatible; not trying dart right now");
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledDartCalciteQueryTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledDartCalciteQueryTest.java
@@ -24,8 +24,8 @@ import org.apache.druid.sql.calcite.NotYetSupported;
 import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
 import org.apache.druid.sql.calcite.QueryTestBuilder;
 import org.apache.druid.sql.calcite.SqlTestFrameworkConfig;
-import org.junit.AssumptionViolatedException;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.opentest4j.TestAbortedException;
 
 @SqlTestFrameworkConfig.ComponentSupplier(DartComponentSupplier.class)
 public class DecoupledDartCalciteQueryTest extends CalciteQueryTest
@@ -45,6 +45,6 @@ public class DecoupledDartCalciteQueryTest extends CalciteQueryTest
   @Override
   protected void msqIncompatible()
   {
-    throw new AssumptionViolatedException("Case marked as msqIncompatible; not trying dart right now");
+    throw new TestAbortedException("Case marked as msqIncompatible; not trying dart right now");
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledDartCalciteQueryTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledDartCalciteQueryTest.java
@@ -24,8 +24,8 @@ import org.apache.druid.sql.calcite.NotYetSupported;
 import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
 import org.apache.druid.sql.calcite.QueryTestBuilder;
 import org.apache.druid.sql.calcite.SqlTestFrameworkConfig;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.opentest4j.TestAbortedException;
 
 @SqlTestFrameworkConfig.ComponentSupplier(DartComponentSupplier.class)
 public class DecoupledDartCalciteQueryTest extends CalciteQueryTest
@@ -45,6 +45,6 @@ public class DecoupledDartCalciteQueryTest extends CalciteQueryTest
   @Override
   protected void msqIncompatible()
   {
-    throw new TestAbortedException("Case marked as msqIncompatible; not trying dart right now");
+    Assumptions.assumeFalse(true, "Case marked as msqIncompatible; not trying dart right now");
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/ExtractResultsFactory.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/ExtractResultsFactory.java
@@ -25,7 +25,7 @@ import org.apache.druid.msq.indexing.report.MSQTaskReport;
 import org.apache.druid.msq.indexing.report.MSQTaskReportPayload;
 import org.apache.druid.sql.calcite.QueryTestBuilder;
 import org.apache.druid.sql.calcite.QueryTestRunner;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -70,16 +70,16 @@ public class ExtractResultsFactory implements QueryTestRunner.QueryRunStepFactor
           }
           // For a single run, only a single query results containing a single row must be fetched, since UNION is not
           // currently supported by MSQ
-          Assert.assertEquals(
-              "Found multiple rows, cannot extract the actual results from the reports",
+          Assertions.assertEquals(
               1,
-              queryResults.size()
+              queryResults.size(),
+              "Found multiple rows, cannot extract the actual results from the reports"
           );
           Object[] row = queryResults.get(0);
-          Assert.assertEquals(
-              "Found multiple taskIds, cannot extract the actual results from the reports",
+          Assertions.assertEquals(
               1,
-              row.length
+              row.length,
+              "Found multiple taskIds, cannot extract the actual results from the reports"
           );
           String taskId = row[0].toString();
           MSQTaskReportPayload payload = (MSQTaskReportPayload) overlordClient.getReportForTask(taskId)

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -229,13 +229,14 @@ import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -949,10 +950,10 @@ public class MSQTestBase extends BaseCalciteQueryTest
       }
     }
 
-    Assert.assertEquals(expectedMSQSpec.getQuery().withOverriddenContext(ignoredContext), querySpecForTask.getQuery());
-    Assert.assertEquals(expectedMSQSpec.getAssignmentStrategy(), querySpecForTask.getAssignmentStrategy());
-    Assert.assertEquals(expectedMSQSpec.getColumnMappings(), querySpecForTask.getColumnMappings());
-    Assert.assertEquals(expectedMSQSpec.getDestination(), querySpecForTask.getDestination());
+    Assertions.assertEquals(expectedMSQSpec.getQuery().withOverriddenContext(ignoredContext), querySpecForTask.getQuery());
+    Assertions.assertEquals(expectedMSQSpec.getAssignmentStrategy(), querySpecForTask.getAssignmentStrategy());
+    Assertions.assertEquals(expectedMSQSpec.getColumnMappings(), querySpecForTask.getColumnMappings());
+    Assertions.assertEquals(expectedMSQSpec.getDestination(), querySpecForTask.getDestination());
 
   }
 
@@ -961,19 +962,19 @@ public class MSQTestBase extends BaseCalciteQueryTest
       MSQTuningConfig tuningConfig
   )
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedTuningConfig.getMaxNumWorkers(),
         tuningConfig.getMaxRowsInMemory()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedTuningConfig.getMaxRowsInMemory(),
         tuningConfig.getMaxRowsInMemory()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedTuningConfig.getRowsPerSegment(),
         tuningConfig.getRowsPerSegment()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedTuningConfig.getMaxNumSegments(),
         tuningConfig.getMaxNumSegments()
     );
@@ -1205,7 +1206,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
       Preconditions.checkArgument(sql != null, "Sql cannot be null");
       readyToRun();
 
-      final Throwable e = Assert.assertThrows(
+      final Throwable e = Assertions.assertThrows(
           Throwable.class,
           () -> runMultiStageQuery(sql, queryContext, authenticationResult, dynamicParameters)
       );
@@ -1225,47 +1226,47 @@ public class MSQTestBase extends BaseCalciteQueryTest
         // Since the time could vary, it can't be asserted, but the dimensions are asserted by using them as a filter.
         // The value should be greater than 0 as a basic sanity check.
         List<Number> metric = getEmittedMetrics("query/time", controllerDims);
-        Assert.assertEquals(1, metric.size());
-        Assert.assertTrue(metric.get(0).longValue() > 0);
+        Assertions.assertEquals(1, metric.size());
+        Assertions.assertTrue(metric.get(0).longValue() > 0);
 
         metric = getEmittedMetrics("query/time", workerDims);
-        Assert.assertEquals(1, metric.size());
-        Assert.assertTrue(metric.get(0).longValue() > 0);
+        Assertions.assertEquals(1, metric.size());
+        Assertions.assertTrue(metric.get(0).longValue() > 0);
 
         metric = getEmittedMetrics("query/cpu/time", workerDims);
-        Assert.assertEquals(1, metric.size());
-        Assert.assertTrue(metric.get(0).longValue() > 0);
+        Assertions.assertEquals(1, metric.size());
+        Assertions.assertTrue(metric.get(0).longValue() > 0);
       }
     }
 
     protected void verifyLookupLoadingInfoInTaskContext(Map<String, Object> context)
     {
       LookupLoadingSpec specFromContext = LookupLoadingSpec.createFromContext(context, LookupLoadingSpec.ALL);
-      Assert.assertEquals(expectedLookupLoadingSpec, specFromContext);
+      Assertions.assertEquals(expectedLookupLoadingSpec, specFromContext);
     }
 
     protected void verifyWorkerCount(CounterSnapshotsTree counterSnapshotsTree)
     {
       Map<Integer, Map<Integer, CounterSnapshots>> counterMap = counterSnapshotsTree.copyMap();
       for (Map.Entry<Integer, Integer> stageWorkerCount : expectedStageVsWorkerCount.entrySet()) {
-        Assert.assertEquals(stageWorkerCount.getValue().intValue(), counterMap.get(stageWorkerCount.getKey()).size());
+        Assertions.assertEquals(stageWorkerCount.getValue().intValue(), counterMap.get(stageWorkerCount.getKey()).size());
       }
     }
 
     protected void verifyCounters(CounterSnapshotsTree counterSnapshotsTree)
     {
-      Assert.assertNotNull(counterSnapshotsTree);
+      Assertions.assertNotNull(counterSnapshotsTree);
 
       final Map<Integer, Map<Integer, CounterSnapshots>> stageWorkerToSnapshots = counterSnapshotsTree.copyMap();
       expectedStageWorkerChannelToCounters.forEach((stage, expectedWorkerChannelToCounters) -> {
         final Map<Integer, CounterSnapshots> workerToCounters = stageWorkerToSnapshots.get(stage);
-        Assert.assertNotNull("No counters for stage " + stage, workerToCounters);
+        Assertions.assertNotNull(workerToCounters, "No counters for stage " + stage);
 
         expectedWorkerChannelToCounters.forEach((worker, expectedChannelToCounters) -> {
           CounterSnapshots counters = workerToCounters.get(worker);
-          Assert.assertNotNull(
-              StringUtils.format("No counters for stage [%d], worker [%d]", stage, worker),
-              counters
+          Assertions.assertNotNull(
+              counters,
+              StringUtils.format("No counters for stage [%d], worker [%d]", stage, worker)
           );
 
           final Map<String, QueryCounterSnapshot> channelToCounters = counters.getMap();
@@ -1277,12 +1278,15 @@ public class MSQTestBase extends BaseCalciteQueryTest
                     worker,
                     channel
                 );
-                Assert.assertTrue(StringUtils.format(
+                Assertions.assertTrue(
+                    channelToCounters.containsKey(channel),
+                    StringUtils.format(
                     "Counters not found for stage [%d], worker [%d], channel [%s]",
                     stage,
                     worker,
                     channel
-                ), channelToCounters.containsKey(channel));
+                    )
+                );
                 counter.matchQuerySnapshot(errorMessageFormat, channelToCounters.get(channel));
               }
           );
@@ -1412,13 +1416,13 @@ public class MSQTestBase extends BaseCalciteQueryTest
             String errorMessage = msqErrorReport.getFault() instanceof TooManyAttemptsForWorker
                                   ? ((TooManyAttemptsForWorker) msqErrorReport.getFault()).getRootErrorMessage()
                                   : MSQFaultUtils.generateMessageWithErrorCode(msqErrorReport.getFault());
-            Assert.assertEquals(
+            Assertions.assertEquals(
                 MSQFaultUtils.generateMessageWithErrorCode(expectedMSQFault),
                 errorMessage
             );
           }
           if (expectedMSQFaultClass != null) {
-            Assert.assertEquals(
+            Assertions.assertEquals(
                 expectedMSQFaultClass,
                 msqErrorReport.getFault().getClass()
             );
@@ -1441,7 +1445,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
         );
         // check if segments are created
         if (!expectedResultRows.isEmpty()) {
-          Assert.assertNotEquals(0, testSegmentManager.getGeneratedSegments().size());
+          Assertions.assertNotEquals(0, testSegmentManager.getGeneratedSegments().size());
         }
 
         String foundDataSource = null;
@@ -1449,7 +1453,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
         for (DataSegment dataSegment : testSegmentManager.getGeneratedSegments()) {
 
           //Assert shard spec class
-          Assert.assertEquals(expectedShardSpec, dataSegment.getShardSpec().getClass());
+          Assertions.assertEquals(expectedShardSpec, dataSegment.getShardSpec().getClass());
           if (foundDataSource == null) {
             foundDataSource = dataSegment.getDataSource();
 
@@ -1468,17 +1472,17 @@ public class MSQTestBase extends BaseCalciteQueryTest
           final CursorFactory cursorFactory = new QueryableIndexCursorFactory(queryableIndex);
 
           // assert rowSignature
-          Assert.assertEquals(expectedRowSignature, resultSignatureFromRowSignature(cursorFactory.getRowSignature()));
+          Assertions.assertEquals(expectedRowSignature, resultSignatureFromRowSignature(cursorFactory.getRowSignature()));
 
           // assert rollup
-          Assert.assertEquals(expectedRollUp, queryableIndex.getMetadata().isRollup());
+          Assertions.assertEquals(expectedRollUp, queryableIndex.getMetadata().isRollup());
 
           // assert query granularity
-          Assert.assertEquals(expectedQueryGranularity, queryableIndex.getMetadata().getQueryGranularity());
+          Assertions.assertEquals(expectedQueryGranularity, queryableIndex.getMetadata().getQueryGranularity());
 
           // assert aggregator factories; clustered base table segments have no aggregator metadata (never rollup),
           // so treat null as empty
-          Assert.assertArrayEquals(
+          Assertions.assertArrayEquals(
               expectedAggregatorFactories.toArray(new AggregatorFactory[0]),
               queryableIndex.getMetadata().getAggregators() == null
               ? new AggregatorFactory[0]
@@ -1486,12 +1490,12 @@ public class MSQTestBase extends BaseCalciteQueryTest
           );
 
           if (expectedProjections != null) {
-            Assert.assertEquals(expectedProjections, queryableIndex.getMetadata().getProjections());
+            Assertions.assertEquals(expectedProjections, queryableIndex.getMetadata().getProjections());
           }
 
           if (expectedClusterGroups != null) {
-            Assert.assertEquals(expectedClusterGroups, dataSegment.getClusterGroups());
-            Assert.assertNotNull(queryableIndex.getMetadata().getClusteredBaseTable());
+            Assertions.assertEquals(expectedClusterGroups, dataSegment.getClusterGroups());
+            Assertions.assertNotNull(queryableIndex.getMetadata().getClusteredBaseTable());
           }
 
           for (List<Object> row : FrameTestUtil.readRowsFromCursorFactory(cursorFactory).toList()) {
@@ -1518,7 +1522,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
 
         // assert data source name when result rows is non-empty
         if (!expectedResultRows.isEmpty()) {
-          Assert.assertEquals(expectedDataSource, foundDataSource);
+          Assertions.assertEquals(expectedDataSource, foundDataSource);
         }
         // assert spec
         if (expectedMSQSpec != null) {
@@ -1528,18 +1532,18 @@ public class MSQTestBase extends BaseCalciteQueryTest
           assertTuningConfig(expectedTuningConfig, foundSpec.getTuningConfig());
         }
         if (expectedSegmentReport != null) {
-          Assert.assertEquals(expectedSegmentReport, reportPayload.getStatus().getSegmentReport());
+          Assertions.assertEquals(expectedSegmentReport, reportPayload.getStatus().getSegmentReport());
         }
         if (expectedDestinationIntervals != null) {
-          Assert.assertNotNull(foundSpec);
+          Assertions.assertNotNull(foundSpec);
           DataSourceMSQDestination destination = (DataSourceMSQDestination) foundSpec.getDestination();
-          Assert.assertEquals(expectedDestinationIntervals, destination.getReplaceTimeChunks());
+          Assertions.assertEquals(expectedDestinationIntervals, destination.getReplaceTimeChunks());
         }
         if (expectedSegments != null) {
           final int timeIndex =
               MSQResultsReport.ColumnAndType.toRowSignature(expectedRowSignature)
                                             .indexOf(ColumnHolder.TIME_COLUMN_NAME);
-          Assert.assertEquals(expectedSegments, segmentIdVsOutputRowsMap.keySet());
+          Assertions.assertEquals(expectedSegments, segmentIdVsOutputRowsMap.keySet());
           for (Object[] row : transformedOutputRows) {
             List<SegmentId> diskSegmentList = segmentIdVsOutputRowsMap
                 .keySet()
@@ -1555,7 +1559,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
             }
             SegmentId diskSegment = diskSegmentList.get(0);
             // Checking if the row belongs to the correct segment interval
-            Assert.assertTrue(segmentIdVsOutputRowsMap.get(diskSegment).contains(Arrays.asList(row)));
+            Assertions.assertTrue(segmentIdVsOutputRowsMap.get(diskSegment).contains(Arrays.asList(row)));
           }
         }
 
@@ -1567,7 +1571,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
           if (expectedLastCompactionState != null) {
             CompactionState compactionState = testTaskActionClient.getPublishedSegments().stream().findFirst().get()
                                                                   .getLastCompactionState();
-            Assert.assertEquals(expectedLastCompactionState, compactionState);
+            Assertions.assertEquals(expectedLastCompactionState, compactionState);
 
           }
           Set<SegmentId> publishedSegmentIds = testTaskActionClient.getPublishedSegments()
@@ -1597,11 +1601,11 @@ public class MSQTestBase extends BaseCalciteQueryTest
                                           .collect(Collectors.toSet())
             );
           }
-          Assert.assertEquals(expectedTombstoneSegmentIds, tombstoneSegmentIds);
+          Assertions.assertEquals(expectedTombstoneSegmentIds, tombstoneSegmentIds);
         }
 
         for (Pair<Predicate<MSQTaskReportPayload>, String> adhocReportAssertionAndReason : adhocReportAssertionAndReasons) {
-          Assert.assertTrue(adhocReportAssertionAndReason.rhs, adhocReportAssertionAndReason.lhs.test(reportPayload));
+          Assertions.assertTrue(adhocReportAssertionAndReason.lhs.test(reportPayload), adhocReportAssertionAndReason.rhs);
         }
 
         // assert results
@@ -1635,7 +1639,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
           indexingServiceClient.runTask(controllerId, taskSpec);
         }
         getPayloadOrThrow(controllerId);
-        Assert.fail(StringUtils.format("Query did not throw an exception (sql = [%s])", sql));
+        Assertions.fail(StringUtils.format("Query did not throw an exception (sql = [%s])", sql));
       }
       catch (Exception e) {
         assertExpectedExecutionError(
@@ -1702,13 +1706,13 @@ public class MSQTestBase extends BaseCalciteQueryTest
             String errorMessage = msqErrorReport.getFault() instanceof TooManyAttemptsForWorker
                                   ? ((TooManyAttemptsForWorker) msqErrorReport.getFault()).getRootErrorMessage()
                                   : MSQFaultUtils.generateMessageWithErrorCode(msqErrorReport.getFault());
-            Assert.assertEquals(
+            Assertions.assertEquals(
                 MSQFaultUtils.generateMessageWithErrorCode(expectedMSQFault),
                 errorMessage
             );
           }
           if (expectedMSQFaultClass != null) {
-            Assert.assertEquals(
+            Assertions.assertEquals(
                 expectedMSQFaultClass,
                 msqErrorReport.getFault().getClass()
             );
@@ -1772,7 +1776,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
           log.info(rows.stream().map(Arrays::toString).collect(Collectors.joining("\n")));
 
           for (Pair<Predicate<MSQTaskReportPayload>, String> adhocReportAssertionAndReason : adhocReportAssertionAndReasons) {
-            Assert.assertTrue(adhocReportAssertionAndReason.rhs, adhocReportAssertionAndReason.lhs.test(payload));
+            Assertions.assertTrue(adhocReportAssertionAndReason.lhs.test(payload), adhocReportAssertionAndReason.rhs);
           }
 
           log.info("Found spec: %s", objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(spec));
@@ -1808,7 +1812,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
         return;
       }
 
-      Assert.assertEquals(expectedRowSignature, specAndResults.rhs.lhs);
+      Assertions.assertEquals(expectedRowSignature, specAndResults.rhs.lhs);
       assertResultsEquals(sql != null ? sql : taskSpec.toString(), expectedResultRows, specAndResults.rhs.rhs);
       assertMSQSpec(expectedMSQSpec, specAndResults.lhs);
       verifyMetrics();

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -454,7 +454,6 @@ public class MSQTestBase extends BaseCalciteQueryTest
   @AfterEach
   public void tearDown2()
   {
-    Mockito.framework().clearInlineMocks();
     groupByBuffers.close();
 
     // Wait for workers to exit, so we don't pollute the shared executor for the next test.

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/util/DimensionSchemaUtilsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/util/DimensionSchemaUtilsTest.java
@@ -29,14 +29,14 @@ import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.segment.AutoTypeColumnSchema;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DimensionSchemaUtilsTest
 {
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     EmittingLogger.registerEmitter(new NoopServiceEmitter());
@@ -53,7 +53,7 @@ public class DimensionSchemaUtilsTest
           mode
       );
       DimensionSchema expected = new LongDimensionSchema("x");
-      Assert.assertEquals(expected, dimensionSchema);
+      Assertions.assertEquals(expected, dimensionSchema);
 
       dimensionSchema = DimensionSchemaUtils.createDimensionSchema(
           "x",
@@ -62,7 +62,7 @@ public class DimensionSchemaUtilsTest
           mode
       );
       expected = new DoubleDimensionSchema("x");
-      Assert.assertEquals(expected, dimensionSchema);
+      Assertions.assertEquals(expected, dimensionSchema);
 
       dimensionSchema = DimensionSchemaUtils.createDimensionSchema(
           "x",
@@ -71,7 +71,7 @@ public class DimensionSchemaUtilsTest
           mode
       );
       expected = new FloatDimensionSchema("x");
-      Assert.assertEquals(expected, dimensionSchema);
+      Assertions.assertEquals(expected, dimensionSchema);
 
       dimensionSchema = DimensionSchemaUtils.createDimensionSchema(
           "x",
@@ -80,7 +80,7 @@ public class DimensionSchemaUtilsTest
           mode
       );
       expected = new StringDimensionSchema("x");
-      Assert.assertEquals(expected, dimensionSchema);
+      Assertions.assertEquals(expected, dimensionSchema);
     }
   }
 
@@ -95,7 +95,7 @@ public class DimensionSchemaUtilsTest
           mode
       );
       DimensionSchema expected = new AutoTypeColumnSchema("x", ColumnType.LONG, null);
-      Assert.assertEquals(expected, dimensionSchema);
+      Assertions.assertEquals(expected, dimensionSchema);
 
       dimensionSchema = DimensionSchemaUtils.createDimensionSchema(
           "x",
@@ -104,7 +104,7 @@ public class DimensionSchemaUtilsTest
           mode
       );
       expected = new AutoTypeColumnSchema("x", ColumnType.DOUBLE, null);
-      Assert.assertEquals(expected, dimensionSchema);
+      Assertions.assertEquals(expected, dimensionSchema);
 
       dimensionSchema = DimensionSchemaUtils.createDimensionSchema(
           "x",
@@ -113,7 +113,7 @@ public class DimensionSchemaUtilsTest
           mode
       );
       expected = new AutoTypeColumnSchema("x", ColumnType.FLOAT, null);
-      Assert.assertEquals(expected, dimensionSchema);
+      Assertions.assertEquals(expected, dimensionSchema);
 
       dimensionSchema = DimensionSchemaUtils.createDimensionSchema(
           "x",
@@ -122,7 +122,7 @@ public class DimensionSchemaUtilsTest
           mode
       );
       expected = new AutoTypeColumnSchema("x", ColumnType.STRING, null);
-      Assert.assertEquals(expected, dimensionSchema);
+      Assertions.assertEquals(expected, dimensionSchema);
 
 
       dimensionSchema = DimensionSchemaUtils.createDimensionSchema(
@@ -132,7 +132,7 @@ public class DimensionSchemaUtilsTest
           mode
       );
       expected = new AutoTypeColumnSchema("x", ColumnType.LONG_ARRAY, null);
-      Assert.assertEquals(expected, dimensionSchema);
+      Assertions.assertEquals(expected, dimensionSchema);
 
       dimensionSchema = DimensionSchemaUtils.createDimensionSchema(
           "x",
@@ -141,7 +141,7 @@ public class DimensionSchemaUtilsTest
           mode
       );
       expected = new AutoTypeColumnSchema("x", ColumnType.DOUBLE_ARRAY, null);
-      Assert.assertEquals(expected, dimensionSchema);
+      Assertions.assertEquals(expected, dimensionSchema);
 
       dimensionSchema = DimensionSchemaUtils.createDimensionSchema(
           "x",
@@ -150,7 +150,7 @@ public class DimensionSchemaUtilsTest
           mode
       );
       expected = new AutoTypeColumnSchema("x", ColumnType.FLOAT_ARRAY, null);
-      Assert.assertEquals(expected, dimensionSchema);
+      Assertions.assertEquals(expected, dimensionSchema);
 
       dimensionSchema = DimensionSchemaUtils.createDimensionSchema(
           "x",
@@ -159,7 +159,7 @@ public class DimensionSchemaUtilsTest
           mode
       );
       expected = new AutoTypeColumnSchema("x", ColumnType.STRING_ARRAY, null);
-      Assert.assertEquals(expected, dimensionSchema);
+      Assertions.assertEquals(expected, dimensionSchema);
 
       dimensionSchema = DimensionSchemaUtils.createDimensionSchema(
           "x",
@@ -168,7 +168,7 @@ public class DimensionSchemaUtilsTest
           mode
       );
       expected = AutoTypeColumnSchema.of("x");
-      Assert.assertEquals(expected, dimensionSchema);
+      Assertions.assertEquals(expected, dimensionSchema);
     }
   }
 
@@ -182,31 +182,31 @@ public class DimensionSchemaUtilsTest
         ArrayIngestMode.MVD
     );
     DimensionSchema expected = new StringDimensionSchema("x", DimensionSchema.MultiValueHandling.ARRAY, null);
-    Assert.assertEquals(expected, dimensionSchema);
+    Assertions.assertEquals(expected, dimensionSchema);
 
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () -> DimensionSchemaUtils.createDimensionSchema("x", ColumnType.LONG_ARRAY, false, ArrayIngestMode.MVD)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Numeric arrays can only be ingested when 'arrayIngestMode' is set to 'array'. Current value of the parameter is[mvd]",
         t.getMessage()
     );
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         DruidException.class,
         () -> DimensionSchemaUtils.createDimensionSchema("x", ColumnType.DOUBLE_ARRAY, false, ArrayIngestMode.MVD)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Numeric arrays can only be ingested when 'arrayIngestMode' is set to 'array'. Current value of the parameter is[mvd]",
         t.getMessage()
     );
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         DruidException.class,
         () -> DimensionSchemaUtils.createDimensionSchema("x", ColumnType.FLOAT_ARRAY, false, ArrayIngestMode.MVD)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Numeric arrays can only be ingested when 'arrayIngestMode' is set to 'array'. Current value of the parameter is[mvd]",
         t.getMessage()
     );
@@ -222,7 +222,7 @@ public class DimensionSchemaUtilsTest
         ArrayIngestMode.ARRAY
     );
     DimensionSchema expected = new AutoTypeColumnSchema("x", ColumnType.STRING_ARRAY, null);
-    Assert.assertEquals(expected, dimensionSchema);
+    Assertions.assertEquals(expected, dimensionSchema);
 
     dimensionSchema = DimensionSchemaUtils.createDimensionSchema(
         "x",
@@ -231,7 +231,7 @@ public class DimensionSchemaUtilsTest
         ArrayIngestMode.ARRAY
     );
     expected = new AutoTypeColumnSchema("x", ColumnType.LONG_ARRAY, null);
-    Assert.assertEquals(expected, dimensionSchema);
+    Assertions.assertEquals(expected, dimensionSchema);
 
     dimensionSchema = DimensionSchemaUtils.createDimensionSchema(
         "x",
@@ -240,7 +240,7 @@ public class DimensionSchemaUtilsTest
         ArrayIngestMode.ARRAY
     );
     expected = new AutoTypeColumnSchema("x", ColumnType.DOUBLE_ARRAY, null);
-    Assert.assertEquals(expected, dimensionSchema);
+    Assertions.assertEquals(expected, dimensionSchema);
 
     dimensionSchema = DimensionSchemaUtils.createDimensionSchema(
         "x",
@@ -249,6 +249,6 @@ public class DimensionSchemaUtilsTest
         ArrayIngestMode.ARRAY
     );
     expected = new AutoTypeColumnSchema("x", ColumnType.FLOAT_ARRAY, null);
-    Assert.assertEquals(expected, dimensionSchema);
+    Assertions.assertEquals(expected, dimensionSchema);
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/util/IntervalUtilsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/util/IntervalUtilsTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.PeriodGranularity;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -37,52 +37,52 @@ public class IntervalUtilsTest
   @Test
   public void test_difference()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         intervals(),
         IntervalUtils.difference(intervals(), intervals("2000/P1D"))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         intervals("2000/P1D"),
         IntervalUtils.difference(intervals("2000/P1D"), intervals())
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         intervals("2000/2001"),
         IntervalUtils.difference(intervals("2000/2001"), intervals("2003/2004"))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         intervals("2000-01-02/2001"),
         IntervalUtils.difference(intervals("2000/2001"), intervals("2000/P1D"))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         intervals("2000/2000-02-01", "2000-02-02/2001"),
         IntervalUtils.difference(intervals("2000/2001"), intervals("2000-02-01/P1D"))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         intervals(),
         IntervalUtils.difference(intervals("2000/2001"), intervals("1999/2001"))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         intervals("2000-01-14/2000-02-01", "2000-02-02/2001"),
         IntervalUtils.difference(intervals("2000/P1D", "2000-01-14/2001"), intervals("2000/P1D", "2000-02-01/P1D"))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         intervals("2000-01-01/2000-07-01", "2000-07-02/2001-01-01", "2002-01-01/2002-07-01", "2002-07-02/2003-01-01"),
         IntervalUtils.difference(intervals("2000/P1Y", "2002/P1Y"), intervals("2000-07-01/P1D", "2002-07-01/P1D"))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         intervals(),
         IntervalUtils.difference(intervals("2000-01-12/2000-01-15"), intervals("2000-01-12/2000-01-13", "2000-01-13/2000-01-16"))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         intervals("2000-07-14/2000-07-15"),
         IntervalUtils.difference(intervals("2000/2001"), intervals("2000-01-01/2000-07-14", "2000-07-15/2001"))
     );
@@ -92,73 +92,73 @@ public class IntervalUtilsTest
   public void test_doesIntervalMatchesGranularity_withStandardGranularities()
   {
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         IntervalUtils.isAligned(Intervals.ETERNITY, Granularities.ALL)
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         IntervalUtils.isAligned(
             Intervals.of("2000-01-01/2001-01-01"), Granularities.YEAR
         )
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         IntervalUtils.isAligned(
             Intervals.of("2000-01-01/2000-04-01"), Granularities.QUARTER
         )
     );
 
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         IntervalUtils.isAligned(
             Intervals.of("2000-01-01/2000-02-01"), Granularities.MONTH
         )
     );
 
     // With the way WEEK granularities work, this needs to be aligned to an actual week
-    Assert.assertTrue(
+    Assertions.assertTrue(
         IntervalUtils.isAligned(
             Intervals.of("1999-12-27/2000-01-03"), Granularities.WEEK
         )
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         IntervalUtils.isAligned(
             Intervals.of("2000-01-01/2000-01-02"), Granularities.DAY
         )
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         IntervalUtils.isAligned(
             Intervals.of("2000-01-01T00:00:00.000/2000-01-01T08:00:00.000"), Granularities.EIGHT_HOUR
         )
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         IntervalUtils.isAligned(
             Intervals.of("2000-01-01T00:00:00.000/2000-01-01T01:00:00.000"), Granularities.HOUR
         )
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         IntervalUtils.isAligned(
             Intervals.of("2000-01-01T00:00:00.000/2000-01-01T00:01:00.000"), Granularities.MINUTE
         )
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         IntervalUtils.isAligned(
             Intervals.of("2000-01-01T00:00:00.000/2000-01-01T00:00:01.000"), Granularities.SECOND
         )
     );
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         IntervalUtils.isAligned(
             Intervals.of("2000-01-01/2002-01-01"), Granularities.YEAR
         )
     );
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         IntervalUtils.isAligned(
             Intervals.of("2000-01-01/2002-01-08"), Granularities.YEAR
         )
@@ -168,14 +168,14 @@ public class IntervalUtilsTest
   @Test
   public void test_doesIntervalMatchesGranularity_withPeriodGranularity()
   {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         IntervalUtils.isAligned(
             Intervals.of("2000-01-01/2000-01-04"),
             new PeriodGranularity(new Period("P3D"), DateTimes.of("2000-01-01"), null)
         )
     );
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         IntervalUtils.isAligned(
             Intervals.of("2000-01-01/2000-01-04"),
             new PeriodGranularity(new Period("P3D"), DateTimes.of("2000-01-02"), null)

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/util/MSQFaultUtilsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/util/MSQFaultUtilsTest.java
@@ -23,8 +23,8 @@ import org.apache.druid.indexing.overlord.TaskQueue;
 import org.apache.druid.msq.indexing.error.MSQFaultUtils;
 import org.apache.druid.msq.indexing.error.UnknownFault;
 import org.apache.druid.msq.indexing.error.WorkerFailedFault;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class MSQFaultUtilsTest
 {
@@ -33,19 +33,19 @@ public class MSQFaultUtilsTest
   @Test
   public void testGetErrorCodeFromMessage()
   {
-    Assert.assertEquals(UnknownFault.CODE, MSQFaultUtils.getErrorCodeFromMessage(
+    Assertions.assertEquals(UnknownFault.CODE, MSQFaultUtils.getErrorCodeFromMessage(
         "Task execution process exited unsuccessfully with code[137]. See middleManager logs for more details..."));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         UnknownFault.CODE,
         MSQFaultUtils.getErrorCodeFromMessage(TaskQueue.FAILED_TO_RUN_TASK_SEE_OVERLORD_MSG)
     );
 
-    Assert.assertEquals(UnknownFault.CODE, MSQFaultUtils.getErrorCodeFromMessage(""));
-    Assert.assertEquals(UnknownFault.CODE, MSQFaultUtils.getErrorCodeFromMessage(null));
+    Assertions.assertEquals(UnknownFault.CODE, MSQFaultUtils.getErrorCodeFromMessage(""));
+    Assertions.assertEquals(UnknownFault.CODE, MSQFaultUtils.getErrorCodeFromMessage(null));
 
-    Assert.assertEquals("ABC", MSQFaultUtils.getErrorCodeFromMessage("ABC: xyz xyz : xyz"));
+    Assertions.assertEquals("ABC", MSQFaultUtils.getErrorCodeFromMessage("ABC: xyz xyz : xyz"));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         WorkerFailedFault.CODE,
         MSQFaultUtils.getErrorCodeFromMessage(MSQFaultUtils.generateMessageWithErrorCode(new WorkerFailedFault(
             "123",

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/util/MSQTaskQueryMakerUtilsTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/util/MSQTaskQueryMakerUtilsTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.msq.util;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.error.DruidException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -40,7 +40,7 @@ public class MSQTaskQueryMakerUtilsTest
     MSQTaskQueryMakerUtils.validateContextSortOrderColumnsExist(ImmutableList.of("b", "__time"), ImmutableSet.of("__time", "a", "b"));
 
     // These are not OK.
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> MSQTaskQueryMakerUtils.validateContextSortOrderColumnsExist(
             ImmutableList.of("c"),
@@ -108,7 +108,7 @@ public class MSQTaskQueryMakerUtilsTest
                   + "FROM ext\\n"
                   + "PARTITIONED BY DAY\"";
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "\"REPLACE INTO table "
         + "OVERWRITE ALL\\n"
         + "WITH ext AS "
@@ -122,7 +122,7 @@ public class MSQTaskQueryMakerUtilsTest
         MSQTaskQueryMakerUtils.maskSensitiveJsonKeys(sql1)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "\"REPLACE INTO table "
         + "OVERWRITE ALL\\n"
         + "WITH ext AS "
@@ -136,7 +136,7 @@ public class MSQTaskQueryMakerUtilsTest
         MSQTaskQueryMakerUtils.maskSensitiveJsonKeys(sql2)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "\"REPLACE INTO table "
         + "OVERWRITE ALL\\n"
         + "WITH ext AS "
@@ -150,7 +150,7 @@ public class MSQTaskQueryMakerUtilsTest
         MSQTaskQueryMakerUtils.maskSensitiveJsonKeys(sql3)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "\"REPLACE INTO table "
         + "OVERWRITE ALL\\n"
         + "WITH ext AS "
@@ -164,7 +164,7 @@ public class MSQTaskQueryMakerUtilsTest
         MSQTaskQueryMakerUtils.maskSensitiveJsonKeys(sql4)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "\"REPLACE INTO table "
         + "OVERWRITE ALL\\n"
         + "WITH ext AS "

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.error.DruidException;
+import org.apache.druid.error.ThrowableMatcher;
 import org.apache.druid.indexing.common.TaskLockType;
 import org.apache.druid.indexing.common.task.Tasks;
 import org.apache.druid.java.util.common.DateTimes;
@@ -35,14 +36,12 @@ import org.apache.druid.query.QueryContext;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.segment.IndexSpec;
 import org.apache.druid.segment.column.StringEncodingStrategy;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -69,46 +68,46 @@ public class MultiStageQueryContextTest
   @Test
   public void isDurableShuffleStorageEnabled_unset_returnsDefaultValue()
   {
-    Assert.assertFalse(MultiStageQueryContext.isDurableStorageEnabled(QueryContext.empty()));
+    Assertions.assertFalse(MultiStageQueryContext.isDurableStorageEnabled(QueryContext.empty()));
   }
 
   @Test
   public void isDurableShuffleStorageEnabled_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_DURABLE_SHUFFLE_STORAGE, "true");
-    Assert.assertTrue(MultiStageQueryContext.isDurableStorageEnabled(QueryContext.of(propertyMap)));
+    Assertions.assertTrue(MultiStageQueryContext.isDurableStorageEnabled(QueryContext.of(propertyMap)));
   }
 
   @Test
   public void isFaultToleranceEnabled_unset_returnsDefaultValue()
   {
-    Assert.assertFalse(MultiStageQueryContext.isFaultToleranceEnabled(QueryContext.empty()));
+    Assertions.assertFalse(MultiStageQueryContext.isFaultToleranceEnabled(QueryContext.empty()));
   }
 
   @Test
   public void isFaultToleranceEnabled_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_FAULT_TOLERANCE, "true");
-    Assert.assertTrue(MultiStageQueryContext.isFaultToleranceEnabled(QueryContext.of(propertyMap)));
+    Assertions.assertTrue(MultiStageQueryContext.isFaultToleranceEnabled(QueryContext.of(propertyMap)));
   }
 
   @Test
   public void isFinalizeAggregations_unset_returnsDefaultValue()
   {
-    Assert.assertTrue(MultiStageQueryContext.isFinalizeAggregations(QueryContext.empty()));
+    Assertions.assertTrue(MultiStageQueryContext.isFinalizeAggregations(QueryContext.empty()));
   }
 
   @Test
   public void isFinalizeAggregations_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_FINALIZE_AGGREGATIONS, "false");
-    Assert.assertFalse(MultiStageQueryContext.isFinalizeAggregations(QueryContext.of(propertyMap)));
+    Assertions.assertFalse(MultiStageQueryContext.isFinalizeAggregations(QueryContext.of(propertyMap)));
   }
 
   @Test
   public void getAssignmentStrategy_unset_returnsDefaultValue()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         WorkerAssignmentStrategy.MAX,
         MultiStageQueryContext.getAssignmentStrategy(QueryContext.empty())
     );
@@ -119,7 +118,7 @@ public class MultiStageQueryContextTest
   {
     Map<String, Object> propertyMap = ImmutableMap.of(MultiStageQueryContext.CTX_MAX_INPUT_BYTES_PER_WORKER, 1024);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1024,
         MultiStageQueryContext.getMaxInputBytesPerWorker(QueryContext.of(propertyMap))
     );
@@ -128,7 +127,7 @@ public class MultiStageQueryContextTest
   @Test
   public void getMaxInputFilesPerWorker_unset_returnsDefaultValue()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Limits.DEFAULT_MAX_INPUT_FILES_PER_WORKER,
         MultiStageQueryContext.getMaxInputFilesPerWorker(QueryContext.empty())
     );
@@ -138,14 +137,14 @@ public class MultiStageQueryContextTest
   public void getMaxInputFilesPerWorker_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(MultiStageQueryContext.CTX_MAX_INPUT_FILES_PER_WORKER, 5000);
-    Assert.assertEquals(5000, MultiStageQueryContext.getMaxInputFilesPerWorker(QueryContext.of(propertyMap)));
+    Assertions.assertEquals(5000, MultiStageQueryContext.getMaxInputFilesPerWorker(QueryContext.of(propertyMap)));
   }
 
   @Test
   public void getMaxInputFilesPerWorker_zero_throwsException()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(MultiStageQueryContext.CTX_MAX_INPUT_FILES_PER_WORKER, 0);
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> MultiStageQueryContext.getMaxInputFilesPerWorker(QueryContext.of(propertyMap))
     );
@@ -155,7 +154,7 @@ public class MultiStageQueryContextTest
   public void getMaxInputFilesPerWorker_negative_throwsException()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(MultiStageQueryContext.CTX_MAX_INPUT_FILES_PER_WORKER, -1);
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> MultiStageQueryContext.getMaxInputFilesPerWorker(QueryContext.of(propertyMap))
     );
@@ -164,7 +163,7 @@ public class MultiStageQueryContextTest
   @Test
   public void getMaxPartitions_unset_returnsDefaultValue()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Limits.DEFAULT_MAX_PARTITIONS,
         MultiStageQueryContext.getMaxPartitions(QueryContext.empty())
     );
@@ -174,14 +173,14 @@ public class MultiStageQueryContextTest
   public void getMaxPartitions_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(MultiStageQueryContext.CTX_MAX_PARTITIONS, 50000);
-    Assert.assertEquals(50000, MultiStageQueryContext.getMaxPartitions(QueryContext.of(propertyMap)));
+    Assertions.assertEquals(50000, MultiStageQueryContext.getMaxPartitions(QueryContext.of(propertyMap)));
   }
 
   @Test
   public void getMaxPartitions_zero_throwsException()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(MultiStageQueryContext.CTX_MAX_PARTITIONS, 0);
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> MultiStageQueryContext.getMaxPartitions(QueryContext.of(propertyMap))
     );
@@ -191,7 +190,7 @@ public class MultiStageQueryContextTest
   public void getMaxPartitions_negative_throwsException()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(MultiStageQueryContext.CTX_MAX_PARTITIONS, -1);
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> MultiStageQueryContext.getMaxPartitions(QueryContext.of(propertyMap))
     );
@@ -201,7 +200,7 @@ public class MultiStageQueryContextTest
   public void getAssignmentStrategy_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_TASK_ASSIGNMENT_STRATEGY, "AUTO");
-    Assert.assertEquals(
+    Assertions.assertEquals(
         WorkerAssignmentStrategy.AUTO,
         MultiStageQueryContext.getAssignmentStrategy(QueryContext.of(propertyMap))
     );
@@ -210,20 +209,20 @@ public class MultiStageQueryContextTest
   @Test
   public void getMaxNumTasks_unset_returnsDefaultValue()
   {
-    Assert.assertEquals(DEFAULT_MAX_NUM_TASKS, MultiStageQueryContext.getMaxNumTasks(QueryContext.empty()));
+    Assertions.assertEquals(DEFAULT_MAX_NUM_TASKS, MultiStageQueryContext.getMaxNumTasks(QueryContext.empty()));
   }
 
   @Test
   public void getMaxNumTasks_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_MAX_NUM_TASKS, 101);
-    Assert.assertEquals(101, MultiStageQueryContext.getMaxNumTasks(QueryContext.of(propertyMap)));
+    Assertions.assertEquals(101, MultiStageQueryContext.getMaxNumTasks(QueryContext.of(propertyMap)));
   }
 
   @Test
   public void getRowsPerSegment_unset_returnsDefaultValue()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         MultiStageQueryContext.DEFAULT_ROWS_PER_SEGMENT,
         MultiStageQueryContext.getRowsPerSegment(QueryContext.empty())
     );
@@ -233,13 +232,13 @@ public class MultiStageQueryContextTest
   public void getRowsPerSegment_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_ROWS_PER_SEGMENT, 10);
-    Assert.assertEquals(10, MultiStageQueryContext.getRowsPerSegment(QueryContext.of(propertyMap)));
+    Assertions.assertEquals(10, MultiStageQueryContext.getRowsPerSegment(QueryContext.of(propertyMap)));
   }
 
   @Test
   public void getMaxRowsInMemory_unset_returnsDefaultValue()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         MultiStageQueryContext.DEFAULT_MAX_ROWS_IN_MEMORY,
         MultiStageQueryContext.getMaxRowsInMemory(QueryContext.empty())
     );
@@ -249,34 +248,34 @@ public class MultiStageQueryContextTest
   public void getMaxRowsInMemory_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_MAX_ROWS_IN_MEMORY, 10);
-    Assert.assertEquals(10, MultiStageQueryContext.getMaxRowsInMemory(QueryContext.of(propertyMap)));
+    Assertions.assertEquals(10, MultiStageQueryContext.getMaxRowsInMemory(QueryContext.of(propertyMap)));
   }
 
   @Test
   public void getMaxRowsInMemory_altSet_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_ROWS_IN_MEMORY, 20);
-    Assert.assertEquals(20, MultiStageQueryContext.getMaxRowsInMemory(QueryContext.of(propertyMap)));
+    Assertions.assertEquals(20, MultiStageQueryContext.getMaxRowsInMemory(QueryContext.of(propertyMap)));
   }
 
   @Test
   public void getMaxRowsInMemory_bothSet_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_ROWS_IN_MEMORY, 20, CTX_MAX_ROWS_IN_MEMORY, 10);
-    Assert.assertEquals(10, MultiStageQueryContext.getMaxRowsInMemory(QueryContext.of(propertyMap)));
+    Assertions.assertEquals(10, MultiStageQueryContext.getMaxRowsInMemory(QueryContext.of(propertyMap)));
   }
 
   @Test
   public void getSortOrder_unset_returnsDefaultValue()
   {
-    Assert.assertEquals(Collections.emptyList(), MultiStageQueryContext.getSortOrder(QueryContext.empty()));
+    Assertions.assertEquals(Collections.emptyList(), MultiStageQueryContext.getSortOrder(QueryContext.empty()));
   }
 
   @Test
   public void getSortOrder_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_SORT_ORDER, "a, b,\"c,d\"");
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("a", "b", "c,d"),
         MultiStageQueryContext.getSortOrder(QueryContext.of(propertyMap))
     );
@@ -285,20 +284,20 @@ public class MultiStageQueryContextTest
   @Test
   public void getMSQMode_unset_returnsDefaultValue()
   {
-    Assert.assertEquals("strict", MultiStageQueryContext.getMSQMode(QueryContext.empty()));
+    Assertions.assertEquals("strict", MultiStageQueryContext.getMSQMode(QueryContext.empty()));
   }
 
   @Test
   public void getMSQMode_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_MSQ_MODE, "nonStrict");
-    Assert.assertEquals("nonStrict", MultiStageQueryContext.getMSQMode(QueryContext.of(propertyMap)));
+    Assertions.assertEquals("nonStrict", MultiStageQueryContext.getMSQMode(QueryContext.of(propertyMap)));
   }
 
   @Test
   public void getSelectDestination_unset_returnsDefaultValue()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         MSQSelectDestination.TASKREPORT,
         MultiStageQueryContext.getSelectDestination(QueryContext.empty())
     );
@@ -307,36 +306,36 @@ public class MultiStageQueryContextTest
   @Test
   public void useAutoColumnSchemes_unset_returnsDefaultValue()
   {
-    Assert.assertFalse(MultiStageQueryContext.useAutoColumnSchemas(QueryContext.empty()));
+    Assertions.assertFalse(MultiStageQueryContext.useAutoColumnSchemas(QueryContext.empty()));
   }
 
   @Test
   public void useAutoColumnSchemes_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_USE_AUTO_SCHEMAS, true);
-    Assert.assertTrue(MultiStageQueryContext.useAutoColumnSchemas(QueryContext.of(propertyMap)));
+    Assertions.assertTrue(MultiStageQueryContext.useAutoColumnSchemas(QueryContext.of(propertyMap)));
   }
 
   @Test
   public void arrayIngestMode_unset_returnsDefaultValue()
   {
-    Assert.assertEquals(ArrayIngestMode.ARRAY, MultiStageQueryContext.getArrayIngestMode(QueryContext.empty()));
+    Assertions.assertEquals(ArrayIngestMode.ARRAY, MultiStageQueryContext.getArrayIngestMode(QueryContext.empty()));
   }
 
   @Test
   public void arrayIngestMode_set_returnsCorrectValue()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ArrayIngestMode.MVD,
         MultiStageQueryContext.getArrayIngestMode(QueryContext.of(ImmutableMap.of(CTX_ARRAY_INGEST_MODE, "mvd")))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ArrayIngestMode.ARRAY,
         MultiStageQueryContext.getArrayIngestMode(QueryContext.of(ImmutableMap.of(CTX_ARRAY_INGEST_MODE, "array")))
     );
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         BadQueryContextException.class,
         () ->
             MultiStageQueryContext.getArrayIngestMode(QueryContext.of(ImmutableMap.of(CTX_ARRAY_INGEST_MODE, "dummy")))
@@ -346,17 +345,17 @@ public class MultiStageQueryContextTest
   @Test
   public void removeNullBytes_unset_returnsDefaultValue()
   {
-    Assert.assertFalse(MultiStageQueryContext.removeNullBytes(QueryContext.empty()));
+    Assertions.assertFalse(MultiStageQueryContext.removeNullBytes(QueryContext.empty()));
   }
 
   @Test
   public void removeNullBytes_set_returnsCorrectValue()
   {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         MultiStageQueryContext.removeNullBytes(QueryContext.of(ImmutableMap.of(CTX_REMOVE_NULL_BYTES, true)))
     );
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         MultiStageQueryContext.removeNullBytes(QueryContext.of(ImmutableMap.of(CTX_REMOVE_NULL_BYTES, false)))
     );
   }
@@ -364,49 +363,47 @@ public class MultiStageQueryContextTest
   @Test
   public void testDecodeSortOrder()
   {
-    Assert.assertEquals(ImmutableList.of("a", "b", "c,d"), decodeSortOrder("a, b,\"c,d\""));
-    Assert.assertEquals(ImmutableList.of("a", "b", "c,d"), decodeSortOrder(" a, b,\"c,d\""));
-    Assert.assertEquals(ImmutableList.of("a", "b", "c,d"), decodeSortOrder("[\"a\", \"b\", \"c,d\"]"));
-    Assert.assertEquals(ImmutableList.of("a", "b", "c,d"), decodeSortOrder(" [\"a\", \"b\", \"c,d\"] "));
-    Assert.assertEquals(ImmutableList.of(), decodeSortOrder("[]"));
-    Assert.assertEquals(ImmutableList.of(), decodeSortOrder(""));
-    Assert.assertEquals(ImmutableList.of(), decodeSortOrder(null));
+    Assertions.assertEquals(ImmutableList.of("a", "b", "c,d"), decodeSortOrder("a, b,\"c,d\""));
+    Assertions.assertEquals(ImmutableList.of("a", "b", "c,d"), decodeSortOrder(" a, b,\"c,d\""));
+    Assertions.assertEquals(ImmutableList.of("a", "b", "c,d"), decodeSortOrder("[\"a\", \"b\", \"c,d\"]"));
+    Assertions.assertEquals(ImmutableList.of("a", "b", "c,d"), decodeSortOrder(" [\"a\", \"b\", \"c,d\"] "));
+    Assertions.assertEquals(ImmutableList.of(), decodeSortOrder("[]"));
+    Assertions.assertEquals(ImmutableList.of(), decodeSortOrder(""));
+    Assertions.assertEquals(ImmutableList.of(), decodeSortOrder(null));
 
-    Assert.assertThrows(BadQueryContextException.class, () -> decodeSortOrder("[["));
+    Assertions.assertThrows(BadQueryContextException.class, () -> decodeSortOrder("[["));
   }
 
   @Test
   public void testGetIndexSpec()
   {
-    Assert.assertNull(decodeIndexSpec(null));
+    Assertions.assertNull(decodeIndexSpec(null));
 
-    Assert.assertEquals(IndexSpec.getDefault(), decodeIndexSpec("{}"));
-    Assert.assertEquals(IndexSpec.getDefault(), decodeIndexSpec(Collections.emptyMap()));
+    Assertions.assertEquals(IndexSpec.getDefault(), decodeIndexSpec("{}"));
+    Assertions.assertEquals(IndexSpec.getDefault(), decodeIndexSpec(Collections.emptyMap()));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         IndexSpec.builder()
                  .withStringDictionaryEncoding(new StringEncodingStrategy.FrontCoded(null, null))
                  .build(),
         decodeIndexSpec("{\"stringDictionaryEncoding\":{\"type\":\"frontCoded\"}}")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         IndexSpec.builder()
                  .withStringDictionaryEncoding(new StringEncodingStrategy.FrontCoded(null))
                  .build(),
         decodeIndexSpec(ImmutableMap.of("stringDictionaryEncoding", ImmutableMap.of("type", "frontCoded")))
     );
 
-    final BadQueryContextException e = Assert.assertThrows(
+    final BadQueryContextException e = Assertions.assertThrows(
         BadQueryContextException.class,
         () -> decodeIndexSpec("{")
     );
 
-    MatcherAssert.assertThat(
-        e,
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo(
-            "Expected key [indexSpec] to be an indexSpec, but got [{]"))
-    );
+    ThrowableMatcher.of(BadQueryContextException.class)
+                   .expectMessageIs("Expected key [indexSpec] to be an indexSpec, but got [{]")
+                   .assertThat(e);
   }
 
   @Test
@@ -414,12 +411,12 @@ public class MultiStageQueryContextTest
   {
     final QueryContext context = QueryContext.of(ImmutableMap.of(Tasks.USE_CONCURRENT_LOCKS, true));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TaskLockType.REPLACE,
         MultiStageQueryContext.validateAndGetTaskLockType(context, true)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TaskLockType.APPEND,
         MultiStageQueryContext.validateAndGetTaskLockType(context, false)
     );
@@ -435,7 +432,7 @@ public class MultiStageQueryContextTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         MSQSelectDestination.TASKREPORT,
         MultiStageQueryContext.getSelectDestination(context)
     );
@@ -444,7 +441,7 @@ public class MultiStageQueryContextTest
   @Test
   public void getFrameSize_unset_returnsDefaultValue()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         WorkerMemoryParameters.DEFAULT_FRAME_SIZE,
         MultiStageQueryContext.getFrameSize(QueryContext.empty())
     );
@@ -454,39 +451,39 @@ public class MultiStageQueryContextTest
   public void getFrameSize_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_MAX_FRAME_SIZE, 500000);
-    Assert.assertEquals(500000, MultiStageQueryContext.getFrameSize(QueryContext.of(propertyMap)));
+    Assertions.assertEquals(500000, MultiStageQueryContext.getFrameSize(QueryContext.of(propertyMap)));
   }
 
   @Test
   public void getMaxThreads_unset_returnsNull()
   {
-    Assert.assertNull(MultiStageQueryContext.getMaxThreads(QueryContext.empty()));
+    Assertions.assertNull(MultiStageQueryContext.getMaxThreads(QueryContext.empty()));
   }
 
   @Test
   public void getMaxThreads_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_MAX_THREADS, 4);
-    Assert.assertEquals(Integer.valueOf(4), MultiStageQueryContext.getMaxThreads(QueryContext.of(propertyMap)));
+    Assertions.assertEquals(Integer.valueOf(4), MultiStageQueryContext.getMaxThreads(QueryContext.of(propertyMap)));
   }
 
   @Test
   public void getVirtualStoragePartialDownloadsEnabled_unset_returnsDefault()
   {
-    Assert.assertFalse(MultiStageQueryContext.getVirtualStoragePartialDownloadsEnabled(QueryContext.empty(), false));
-    Assert.assertTrue(MultiStageQueryContext.getVirtualStoragePartialDownloadsEnabled(QueryContext.empty(), true));
+    Assertions.assertFalse(MultiStageQueryContext.getVirtualStoragePartialDownloadsEnabled(QueryContext.empty(), false));
+    Assertions.assertTrue(MultiStageQueryContext.getVirtualStoragePartialDownloadsEnabled(QueryContext.empty(), true));
   }
 
   @Test
   public void getVirtualStoragePartialDownloadsEnabled_set_overridesDefault()
   {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         MultiStageQueryContext.getVirtualStoragePartialDownloadsEnabled(
             QueryContext.of(ImmutableMap.of(MultiStageQueryContext.CTX_VIRTUAL_STORAGE_PARTIAL_DOWNLOADS, true)),
             false
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         MultiStageQueryContext.getVirtualStoragePartialDownloadsEnabled(
             QueryContext.of(ImmutableMap.of(MultiStageQueryContext.CTX_VIRTUAL_STORAGE_PARTIAL_DOWNLOADS, false)),
             true
@@ -498,11 +495,11 @@ public class MultiStageQueryContextTest
   public void withCommonContext_noTimeout_setsStartTimeOnly()
   {
     final QueryContext context = MultiStageQueryContext.withCommonContext(QueryContext.empty());
-    Assert.assertTrue(context.containsKey(MultiStageQueryContext.CTX_START_TIME));
-    Assert.assertFalse(context.containsKey(MultiStageQueryContext.CTX_QUERY_DEADLINE));
-    Assert.assertEquals(true, context.get(QueryContexts.FINALIZE_KEY));
-    Assert.assertEquals(true, context.get(MultiStageQueryContext.WINDOW_FUNCTION_OPERATOR_TRANSFORMATION));
-    Assert.assertTrue(context.containsKey(MultiStageQueryContext.CTX_ROW_BASED_FRAME_TYPE));
+    Assertions.assertTrue(context.containsKey(MultiStageQueryContext.CTX_START_TIME));
+    Assertions.assertFalse(context.containsKey(MultiStageQueryContext.CTX_QUERY_DEADLINE));
+    Assertions.assertEquals(true, context.get(QueryContexts.FINALIZE_KEY));
+    Assertions.assertEquals(true, context.get(MultiStageQueryContext.WINDOW_FUNCTION_OPERATOR_TRANSFORMATION));
+    Assertions.assertTrue(context.containsKey(MultiStageQueryContext.CTX_ROW_BASED_FRAME_TYPE));
   }
 
   @Test
@@ -513,12 +510,12 @@ public class MultiStageQueryContextTest
         QueryContext.of(ImmutableMap.of(QueryContexts.TIMEOUT_KEY, timeoutMs))
     );
 
-    Assert.assertTrue(context.containsKey(MultiStageQueryContext.CTX_START_TIME));
-    Assert.assertTrue(context.containsKey(MultiStageQueryContext.CTX_QUERY_DEADLINE));
+    Assertions.assertTrue(context.containsKey(MultiStageQueryContext.CTX_START_TIME));
+    Assertions.assertTrue(context.containsKey(MultiStageQueryContext.CTX_QUERY_DEADLINE));
 
     final DateTime startTime = DateTimes.of((String) context.get(MultiStageQueryContext.CTX_START_TIME));
     final DateTime deadline = DateTimes.of((String) context.get(MultiStageQueryContext.CTX_QUERY_DEADLINE));
-    Assert.assertEquals(timeoutMs, deadline.getMillis() - startTime.getMillis());
+    Assertions.assertEquals(timeoutMs, deadline.getMillis() - startTime.getMillis());
   }
 
   @Test
@@ -528,7 +525,7 @@ public class MultiStageQueryContextTest
         QueryContext.of(ImmutableMap.of("customKey", "customValue"))
     );
 
-    Assert.assertEquals("customValue", context.get("customKey"));
+    Assertions.assertEquals("customValue", context.get("customKey"));
   }
 
   private static List<String> decodeSortOrder(@Nullable final String input)

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/util/PassthroughAggregatorFactoryTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/util/PassthroughAggregatorFactoryTest.java
@@ -26,8 +26,8 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.AggregatorFactoryNotMergeableException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PassthroughAggregatorFactoryTest
 {
@@ -39,17 +39,17 @@ public class PassthroughAggregatorFactoryTest
     objectMapper.registerSubtypes(PassthroughAggregatorFactory.class);
     AggregatorFactory aggregatorFactory = new PassthroughAggregatorFactory("x", "y");
     String serializedvalue = objectMapper.writeValueAsString(aggregatorFactory);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "{\"type\":\"passthrough\",\"columnName\":\"x\",\"complexTypeName\":\"y\"}",
         serializedvalue
     );
-    Assert.assertEquals(aggregatorFactory, objectMapper.readValue(serializedvalue, AggregatorFactory.class));
+    Assertions.assertEquals(aggregatorFactory, objectMapper.readValue(serializedvalue, AggregatorFactory.class));
   }
 
   @Test
   public void testRequiredFields()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("x"),
         new PassthroughAggregatorFactory("x", "y").requiredFields()
     );
@@ -58,7 +58,7 @@ public class PassthroughAggregatorFactoryTest
   @Test
   public void testGetCombiningFactory()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new PassthroughAggregatorFactory("x", "y"),
         new PassthroughAggregatorFactory("x", "y").getCombiningFactory()
     );
@@ -70,18 +70,18 @@ public class PassthroughAggregatorFactoryTest
     final AggregatorFactory mergingFactory =
         new PassthroughAggregatorFactory("x", "y").getMergingFactory(new PassthroughAggregatorFactory("x", "y"));
 
-    Assert.assertEquals(new PassthroughAggregatorFactory("x", "y"), mergingFactory);
+    Assertions.assertEquals(new PassthroughAggregatorFactory("x", "y"), mergingFactory);
   }
 
   @Test
   public void testGetMergingFactoryNotOk()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         AggregatorFactoryNotMergeableException.class,
         () -> new PassthroughAggregatorFactory("x", "y").getMergingFactory(new PassthroughAggregatorFactory("x", "z"))
     );
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         AggregatorFactoryNotMergeableException.class,
         () -> new PassthroughAggregatorFactory("x", "y").getMergingFactory(new PassthroughAggregatorFactory("z", "y"))
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/util/SqlStatementResourceHelperTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/util/SqlStatementResourceHelperTest.java
@@ -38,8 +38,8 @@ import org.apache.druid.msq.indexing.report.MSQTaskReportTest;
 import org.apache.druid.msq.sql.entity.PageInformation;
 import org.apache.druid.query.rowsandcols.concrete.FrameRowsAndColumns;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -334,9 +334,9 @@ public class SqlStatementResourceHelperTest
         payload,
         TaskReportMSQDestination.instance()
     );
-    Assert.assertTrue(pages.isPresent());
-    Assert.assertEquals(1, pages.get().size());
-    Assert.assertEquals(new PageInformation(0, 0L, 0L), pages.get().get(0));
+    Assertions.assertTrue(pages.isPresent());
+    Assertions.assertEquals(1, pages.get().size());
+    Assertions.assertEquals(new PageInformation(0, 0L, 0L), pages.get().get(0));
   }
 
   @Test
@@ -382,15 +382,15 @@ public class SqlStatementResourceHelperTest
             null
         )
     );
-    Assert.assertTrue(pages.isPresent());
-    Assert.assertEquals(1, pages.get().size());
-    Assert.assertEquals(new PageInformation(0, 0L, null), pages.get().get(0));
+    Assertions.assertTrue(pages.isPresent());
+    Assertions.assertEquals(1, pages.get().size());
+    Assertions.assertEquals(new PageInformation(0, 0L, null), pages.get().get(0));
   }
 
   private void validatePages(List<PageInformation> actualPageList, List<PageInformation> expectedPageList)
   {
-    Assert.assertEquals(expectedPageList.size(), actualPageList.size());
-    Assert.assertEquals(expectedPageList, actualPageList);
+    Assertions.assertEquals(expectedPageList.size(), actualPageList.size());
+    Assertions.assertEquals(expectedPageList, actualPageList);
   }
 
   private List<PageInformation> getExpectedPageInformationList(ChannelCounters... workerCounters)

--- a/multi-stage-query/src/test/java/org/apache/druid/sql/calcite/NotYetSupportedUsageTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/sql/calcite/NotYetSupportedUsageTest.java
@@ -21,7 +21,8 @@ package org.apache.druid.sql.calcite;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.sql.calcite.NotYetSupported.Modes;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.reflections.Reflections;
 import org.reflections.scanners.MethodAnnotationsScanner;
 
@@ -35,8 +36,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
 
 public class NotYetSupportedUsageTest
 {
@@ -53,7 +52,7 @@ public class NotYetSupportedUsageTest
       }
     }
 
-    assertEquals("There are unused modes which should be removed", Collections.emptySet(), modes);
+    Assertions.assertEquals(Collections.emptySet(), modes, "There are unused modes which should be removed");
   }
 
   private Set<Method> getAnnotatedMethods()

--- a/server/src/test/java/org/apache/druid/metadata/TestDerbyConnector.java
+++ b/server/src/test/java/org/apache/druid/metadata/TestDerbyConnector.java
@@ -29,7 +29,7 @@ import org.apache.druid.segment.metadata.CentralizedDatasourceSchemaConfig;
 import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -117,10 +117,10 @@ public class TestDerbyConnector extends DerbyConnector
     catch (UnableToObtainConnectionException e) {
       SQLException cause = (SQLException) e.getCause();
       // error code "08006" indicates proper shutdown
-      Assert.assertEquals(
-          StringUtils.format("Derby not shutdown: [%s]", cause.toString()),
+      Assertions.assertEquals(
           "08006",
-          cause.getSQLState()
+          cause.getSQLState(),
+          StringUtils.format("Derby not shutdown: [%s]", cause.toString())
       );
     }
   }

--- a/server/src/test/java/org/apache/druid/rpc/MockServiceClient.java
+++ b/server/src/test/java/org/apache/druid/rpc/MockServiceClient.java
@@ -30,7 +30,7 @@ import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.ArrayDeque;
 import java.util.Map;
@@ -53,10 +53,10 @@ public class MockServiceClient implements ServiceClient
     final Expectation expectation = expectations.poll();
 
     requestNumber++;
-    Assert.assertEquals(
-        "request[" + requestNumber + "]",
+    Assertions.assertEquals(
         expectation == null ? null : expectation.request,
-        requestBuilder
+        requestBuilder,
+        "request[" + requestNumber + "]"
     );
 
     if (expectation.response.isValue()) {
@@ -105,7 +105,7 @@ public class MockServiceClient implements ServiceClient
 
   public void verify()
   {
-    Assert.assertTrue("all requests were made", expectations.isEmpty());
+    Assertions.assertTrue(expectations.isEmpty(), "all requests were made");
   }
 
   private static class Expectation

--- a/sql/src/test/java/org/apache/druid/sql/calcite/NotYetSupported.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/NotYetSupported.java
@@ -21,7 +21,6 @@ package org.apache.druid.sql.calcite;
 
 import com.google.common.base.Throwables;
 import org.apache.druid.error.DruidException;
-import org.junit.AssumptionViolatedException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
@@ -188,7 +187,7 @@ public @interface NotYetSupported
           }
           // If the base test case is supposed to be ignored already, just skip
           // the further evaluation
-          if (e instanceof AssumptionViolatedException || e instanceof TestAbortedException) {
+          if (e instanceof TestAbortedException) {
             throw e;
           }
           if (e instanceof IncompleteExecutionException) {


### PR DESCRIPTION
Part of #13948.

### Description

Migrate the `multi-stage-query` test suite from JUnit 4 to JUnit 5 following `dev/junit5-migration-guidance.md`.

- Convert JUnit 4 tests, lifecycle annotations, assertions, parameterized tests, and Mockito setup to Jupiter APIs.
- Reuse `TemporaryFolderExtension` for instance-scoped Druid temporary directories and the shared `ThrowableMatcher`/Druid assertion helpers.
- Remove the local JUnit assertion and matcher copies that were only needed by the JUnit 4 suite.
- Remove `junit:junit`, Vintage, migration-support, and JUnitParams dependencies from `multi-stage-query`; exclude JUnit 4 from Guice testlib's transitive test dependency and add Mockito's Jupiter integration.
- Update shared test fixtures used by the MSQ tests (`TaskActionTestKit`, `MockServiceClient`, and `TestDerbyConnector`) so the migrated tests do not load JUnit 4 classes at runtime.
- Remove the JUnit 4 `AssumptionViolatedException` reference from SQL's `NotYetSupported` test extension, which was required after the MSQ test runtime stopped providing JUnit 4.

Generic Hamcrest remains in the module because a small set of tests still use its generic matchers; no JUnit 4 matcher or engine remains in the module's resolved test dependency tree.

The remaining JUnit 5 `@TempDir` usages are lifecycle-constrained: one is used by a static `@BeforeAll` setup and one is a static directory required by a superclass constructor. Other migrated instance-scoped temporary directories use `TemporaryFolderExtension`.

### Validation

- `mvn -ntp -pl multi-stage-query -am test -Dtest='org.apache.druid.msq.**,org.apache.druid.sql.avatica.MSQDruidMeta' -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks -Dweb.console.skip=true -T1C`
  - 7,685 tests, 0 failures, 0 errors, 698 skips; one transient `DartWorkerRunnerTest` failure passed Surefire's retry.
- `mvn -ntp -pl multi-stage-query,server,indexing-service,sql -am checkstyle:check -Dweb.console.skip=true -T1C`
- `mvn -ntp -pl multi-stage-query,server,indexing-service -am spotbugs:check -Dweb.console.skip=true -T1C`
- `mvn -ntp -pl multi-stage-query dependency:tree -Dscope=test -Dincludes=junit:junit,org.junit.vintage:junit-vintage-engine -Dweb.console.skip=true`
- `git diff --check`
