### PR TITLE
fix: convert anonymous classes to named inner classes for Jackson serialization

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/aggregation/firstlast/first/DoubleFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/firstlast/first/DoubleFirstAggregatorFactory.java
@@ -59,32 +59,37 @@ public class DoubleFirstAggregatorFactory extends AggregatorFactory
 {
   public static final ColumnType TYPE = ColumnType.ofComplex(SerializablePairLongDoubleComplexMetricSerde.TYPE_NAME);
 
-  private static final Aggregator NIL_AGGREGATOR = new DoubleFirstAggregator(
-      NilColumnValueSelector.instance(),
-      NilColumnValueSelector.instance(),
-      false
-  )
+  private static final Aggregator NIL_AGGREGATOR = new NilDoubleFirstAggregator();
+
+  private static class NilDoubleFirstAggregator extends DoubleFirstAggregator
   {
+    NilDoubleFirstAggregator()
+    {
+      super(NilColumnValueSelector.instance(), NilColumnValueSelector.instance(), false);
+    }
+
     @Override
     public void aggregate()
     {
       // no-op
     }
-  };
+  }
 
-  private static final BufferAggregator NIL_BUFFER_AGGREGATOR = new DoubleFirstBufferAggregator(
-      NilColumnValueSelector.instance(),
-      NilColumnValueSelector.instance(),
-      false
+  private static final BufferAggregator NIL_BUFFER_AGGREGATOR = new NilDoubleFirstBufferAggregator();
 
-  )
+  private static class NilDoubleFirstBufferAggregator extends DoubleFirstBufferAggregator
   {
+    NilDoubleFirstBufferAggregator()
+    {
+      super(NilColumnValueSelector.instance(), NilColumnValueSelector.instance(), false);
+    }
+
     @Override
     public void aggregate(ByteBuffer buf, int position)
     {
       // no-op
     }
-  };
+  }
 
   public static final Comparator<SerializablePair<Long, Double>> VALUE_COMPARATOR =
       SerializablePair.createNullHandlingComparator(Double::compare, true);

--- a/processing/src/main/java/org/apache/druid/query/aggregation/firstlast/first/FloatFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/firstlast/first/FloatFirstAggregatorFactory.java
@@ -59,31 +59,37 @@ public class FloatFirstAggregatorFactory extends AggregatorFactory
 {
   public static final ColumnType TYPE = ColumnType.ofComplex(SerializablePairLongFloatComplexMetricSerde.TYPE_NAME);
 
-  private static final Aggregator NIL_AGGREGATOR = new FloatFirstAggregator(
-      NilColumnValueSelector.instance(),
-      NilColumnValueSelector.instance(),
-      false
-  )
+  private static final Aggregator NIL_AGGREGATOR = new NilFloatFirstAggregator();
+
+  private static class NilFloatFirstAggregator extends FloatFirstAggregator
   {
+    NilFloatFirstAggregator()
+    {
+      super(NilColumnValueSelector.instance(), NilColumnValueSelector.instance(), false);
+    }
+
     @Override
     public void aggregate()
     {
       // no-op
     }
-  };
+  }
 
-  private static final BufferAggregator NIL_BUFFER_AGGREGATOR = new FloatFirstBufferAggregator(
-      NilColumnValueSelector.instance(),
-      NilColumnValueSelector.instance(),
-      false
-  )
+  private static final BufferAggregator NIL_BUFFER_AGGREGATOR = new NilFloatFirstBufferAggregator();
+
+  private static class NilFloatFirstBufferAggregator extends FloatFirstBufferAggregator
   {
+    NilFloatFirstBufferAggregator()
+    {
+      super(NilColumnValueSelector.instance(), NilColumnValueSelector.instance(), false);
+    }
+
     @Override
     public void aggregate(ByteBuffer buf, int position)
     {
       // no-op
     }
-  };
+  }
 
   public static final Comparator<SerializablePair<Long, Float>> VALUE_COMPARATOR =
       SerializablePair.createNullHandlingComparator(Float::compare, true);

--- a/processing/src/main/java/org/apache/druid/query/aggregation/firstlast/first/LongFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/firstlast/first/LongFirstAggregatorFactory.java
@@ -58,31 +58,37 @@ public class LongFirstAggregatorFactory extends AggregatorFactory
 {
   public static final ColumnType TYPE = ColumnType.ofComplex(SerializablePairLongLongComplexMetricSerde.TYPE_NAME);
 
-  private static final Aggregator NIL_AGGREGATOR = new LongFirstAggregator(
-      NilColumnValueSelector.instance(),
-      NilColumnValueSelector.instance(),
-      false
-  )
+  private static final Aggregator NIL_AGGREGATOR = new NilLongFirstAggregator();
+
+  private static class NilLongFirstAggregator extends LongFirstAggregator
   {
+    NilLongFirstAggregator()
+    {
+      super(NilColumnValueSelector.instance(), NilColumnValueSelector.instance(), false);
+    }
+
     @Override
     public void aggregate()
     {
       // no-op
     }
-  };
+  }
 
-  private static final BufferAggregator NIL_BUFFER_AGGREGATOR = new LongFirstBufferAggregator(
-      NilColumnValueSelector.instance(),
-      NilColumnValueSelector.instance(),
-      false
-  )
+  private static final BufferAggregator NIL_BUFFER_AGGREGATOR = new NilLongFirstBufferAggregator();
+
+  private static class NilLongFirstBufferAggregator extends LongFirstBufferAggregator
   {
+    NilLongFirstBufferAggregator()
+    {
+      super(NilColumnValueSelector.instance(), NilColumnValueSelector.instance(), false);
+    }
+
     @Override
     public void aggregate(ByteBuffer buf, int position)
     {
       // no-op
     }
-  };
+  }
 
   public static final Comparator<SerializablePair<Long, Long>> VALUE_COMPARATOR =
       SerializablePair.createNullHandlingComparator(Long::compare, true);

--- a/processing/src/main/java/org/apache/druid/query/aggregation/firstlast/last/DoubleLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/firstlast/last/DoubleLastAggregatorFactory.java
@@ -59,31 +59,37 @@ import java.util.Objects;
 public class DoubleLastAggregatorFactory extends AggregatorFactory
 {
   public static final ColumnType TYPE = ColumnType.ofComplex(SerializablePairLongDoubleComplexMetricSerde.TYPE_NAME);
-  private static final Aggregator NIL_AGGREGATOR = new DoubleLastAggregator(
-      NilColumnValueSelector.instance(),
-      NilColumnValueSelector.instance(),
-      false
-  )
+  private static final Aggregator NIL_AGGREGATOR = new NilDoubleLastAggregator();
+
+  private static class NilDoubleLastAggregator extends DoubleLastAggregator
   {
+    NilDoubleLastAggregator()
+    {
+      super(NilColumnValueSelector.instance(), NilColumnValueSelector.instance(), false);
+    }
+
     @Override
     public void aggregate()
     {
       // no-op
     }
-  };
+  }
 
-  private static final BufferAggregator NIL_BUFFER_AGGREGATOR = new DoubleLastBufferAggregator(
-      NilColumnValueSelector.instance(),
-      NilColumnValueSelector.instance(),
-      false
-  )
+  private static final BufferAggregator NIL_BUFFER_AGGREGATOR = new NilDoubleLastBufferAggregator();
+
+  private static class NilDoubleLastBufferAggregator extends DoubleLastBufferAggregator
   {
+    NilDoubleLastBufferAggregator()
+    {
+      super(NilColumnValueSelector.instance(), NilColumnValueSelector.instance(), false);
+    }
+
     @Override
     public void aggregate(ByteBuffer buf, int position)
     {
       // no-op
     }
-  };
+  }
 
   private final String fieldName;
   private final String timeColumn;

--- a/processing/src/main/java/org/apache/druid/query/aggregation/firstlast/last/FloatLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/firstlast/last/FloatLastAggregatorFactory.java
@@ -59,31 +59,37 @@ import java.util.Objects;
 public class FloatLastAggregatorFactory extends AggregatorFactory
 {
   public static final ColumnType TYPE = ColumnType.ofComplex(SerializablePairLongFloatComplexMetricSerde.TYPE_NAME);
-  private static final Aggregator NIL_AGGREGATOR = new FloatLastAggregator(
-      NilColumnValueSelector.instance(),
-      NilColumnValueSelector.instance(),
-      false
-  )
+  private static final Aggregator NIL_AGGREGATOR = new NilFloatLastAggregator();
+
+  private static class NilFloatLastAggregator extends FloatLastAggregator
   {
+    NilFloatLastAggregator()
+    {
+      super(NilColumnValueSelector.instance(), NilColumnValueSelector.instance(), false);
+    }
+
     @Override
     public void aggregate()
     {
       // no-op
     }
-  };
+  }
 
-  private static final BufferAggregator NIL_BUFFER_AGGREGATOR = new FloatLastBufferAggregator(
-      NilColumnValueSelector.instance(),
-      NilColumnValueSelector.instance(),
-      false
-  )
+  private static final BufferAggregator NIL_BUFFER_AGGREGATOR = new NilFloatLastBufferAggregator();
+
+  private static class NilFloatLastBufferAggregator extends FloatLastBufferAggregator
   {
+    NilFloatLastBufferAggregator()
+    {
+      super(NilColumnValueSelector.instance(), NilColumnValueSelector.instance(), false);
+    }
+
     @Override
     public void aggregate(ByteBuffer buf, int position)
     {
       // no-op
     }
-  };
+  }
 
   private final String fieldName;
   private final String timeColumn;

--- a/processing/src/main/java/org/apache/druid/query/aggregation/firstlast/last/LongLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/firstlast/last/LongLastAggregatorFactory.java
@@ -60,31 +60,37 @@ public class LongLastAggregatorFactory extends AggregatorFactory
 {
   public static final ColumnType TYPE = ColumnType.ofComplex(SerializablePairLongLongComplexMetricSerde.TYPE_NAME);
 
-  private static final Aggregator NIL_AGGREGATOR = new LongLastAggregator(
-      NilColumnValueSelector.instance(),
-      NilColumnValueSelector.instance(),
-      false
-  )
+  private static final Aggregator NIL_AGGREGATOR = new NilLongLastAggregator();
+
+  private static class NilLongLastAggregator extends LongLastAggregator
   {
+    NilLongLastAggregator()
+    {
+      super(NilColumnValueSelector.instance(), NilColumnValueSelector.instance(), false);
+    }
+
     @Override
     public void aggregate()
     {
       // no-op
     }
-  };
+  }
 
-  private static final BufferAggregator NIL_BUFFER_AGGREGATOR = new LongLastBufferAggregator(
-      NilColumnValueSelector.instance(),
-      NilColumnValueSelector.instance(),
-      false
-  )
+  private static final BufferAggregator NIL_BUFFER_AGGREGATOR = new NilLongLastBufferAggregator();
+
+  private static class NilLongLastBufferAggregator extends LongLastBufferAggregator
   {
+    NilLongLastBufferAggregator()
+    {
+      super(NilColumnValueSelector.instance(), NilColumnValueSelector.instance(), false);
+    }
+
     @Override
     public void aggregate(ByteBuffer buf, int position)
     {
       // no-op
     }
-  };
+  }
 
   private final String fieldName;
   private final String timeColumn;


### PR DESCRIPTION
## Purpose

Fix Jackson serialization failure for Long/Double/Float First/Last aggregator factories.

Anonymous inner classes used as `NIL_AGGREGATOR` and `NIL_BUFFER_AGGREGATOR` were being serialized
as `LongLastAggregatorFactory$1` instead of the registered `@JsonTypeName`. This caused the error:

```
Could not resolve type id 'LongLastAggregatorFactory$1' into a subtype of AggregatorFactory
```

## Changes

Converted all anonymous subclasses of `Aggregator` and `BufferAggregator` in the following 6 factory
classes to private static named inner classes:

- `LongLastAggregatorFactory`
- `DoubleLastAggregatorFactory`
- `FloatLastAggregatorFactory`
- `LongFirstAggregatorFactory`
- `DoubleFirstAggregatorFactory`
- `FloatFirstAggregatorFactory`

Each factory previously had two anonymous classes (`NIL_AGGREGATOR` and `NIL_BUFFER_AGGREGATOR`)
that overrode `aggregate()` to be no-ops. These are now named inner classes (e.g.,
`NilLongLastAggregator`, `NilLongLastBufferAggregator`) that correctly extend their parent classes
with explicit constructors.

Closes #7599