### PR TITLE
fix: wrap CountDownLatch.await() in assertTrue() in tests

### DIFF
--- a/processing/src/test/java/org/apache/druid/segment/join/PostJoinCursorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/PostJoinCursorTest.java
@@ -237,7 +237,7 @@ public class PostJoinCursorTest extends BaseHashJoinSegmentCursorFactoryTest
     joinCursorThread.setUncaughtExceptionHandler(exceptionHandler);
     joinCursorThread.start();
 
-    countDownLatch.await(1, TimeUnit.SECONDS);
+    assertTrue(countDownLatch.await(1, TimeUnit.SECONDS));
     joinCursorThread.interrupt();
 
     // Wait for a max of 1 sec for the exception to be set.

--- a/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCacheTest.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCacheTest.java
@@ -2198,7 +2198,7 @@ public class CoordinatorSegmentMetadataCacheTest extends CoordinatorSegmentMetad
     schema.onLeaderStart();
     schema.awaitInitialization();
 
-    latch.await(1, TimeUnit.SECONDS);
+    Assert.assertTrue(latch.await(1, TimeUnit.SECONDS));
     Assert.assertEquals(0, latch.getCount());
   }
 

--- a/server/src/test/java/org/apache/druid/server/coordination/ServerManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/ServerManagerTest.java
@@ -318,7 +318,7 @@ public class ServerManagerTest
         )
     );
 
-    factory.notifyLatch.await(1000, TimeUnit.MILLISECONDS);
+    Assert.assertTrue(factory.notifyLatch.await(1000, TimeUnit.MILLISECONDS));
 
     Assert.assertEquals(1, factory.getReferenceProviders().size());
 
@@ -357,7 +357,7 @@ public class ServerManagerTest
         )
     );
 
-    factory.notifyLatch.await(1000, TimeUnit.MILLISECONDS);
+    Assert.assertTrue(factory.notifyLatch.await(1000, TimeUnit.MILLISECONDS));
 
     Assert.assertEquals(1, factory.getReferenceProviders().size());
 
@@ -400,7 +400,7 @@ public class ServerManagerTest
         )
     );
 
-    factory.notifyLatch.await(1000, TimeUnit.MILLISECONDS);
+    Assert.assertTrue(factory.notifyLatch.await(1000, TimeUnit.MILLISECONDS));
 
     Assert.assertEquals(1, factory.getReferenceProviders().size());
 
@@ -667,7 +667,7 @@ public class ServerManagerTest
   private void waitForTestVerificationAndCleanup(Future future)
   {
     try {
-      factory.notifyLatch.await(1000, TimeUnit.MILLISECONDS);
+      Assert.assertTrue(factory.notifyLatch.await(1000, TimeUnit.MILLISECONDS));
       factory.waitLatch.countDown();
       future.get();
       factory.clearSegments();

--- a/server/src/test/java/org/apache/druid/server/initialization/JettyTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/JettyTest.java
@@ -377,7 +377,7 @@ public class JettyTest extends BaseJettyTest
         }
     );
 
-    latch.await(5, TimeUnit.SECONDS);
+    Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
   }
 
   @Test


### PR DESCRIPTION
## Purpose

Wrap `CountDownLatch.await(timeout, unit)` calls in `assertTrue()` to prevent silent test timeouts. When the boolean return value of `await()` is ignored, a timeout causes the test to silently pass instead of failing.

## Changes

- `PostJoinCursorTest.java`: wrap `countDownLatch.await(1, TimeUnit.SECONDS)` in `assertTrue()`
- `CoordinatorSegmentMetadataCacheTest.java`: wrap `latch.await(1, TimeUnit.SECONDS)` in `Assert.assertTrue()`
- `ServerManagerTest.java`: wrap 4 occurrences of `factory.notifyLatch.await(1000, TimeUnit.MILLISECONDS)` in `Assert.assertTrue()`
- `JettyTest.java`: wrap `latch.await(5, TimeUnit.SECONDS)` in `Assert.assertTrue()`

Closes #9285