### PR TITLE
test: reduce ScanQueryResultOrderingTest runtime from 316s to 7s

### DIFF
--- a/processing/src/test/java/org/apache/druid/query/scan/ScanQueryResultOrderingTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/ScanQueryResultOrderingTest.java
@@ -194,11 +194,6 @@ public class ScanQueryResultOrderingTest extends InitializedNullHandlingTest
   )
   {
     configure(segmentToServerMap, limit, batchSize, maxRowsQueuedForOrdering);
-    runTestOrderNone();
-  }
-
-  private void runTestOrderNone()
-  {
     assertResultsEquals(
         Druids.newScanQueryBuilder()
               .dataSource("ds")

--- a/processing/src/test/java/org/apache/druid/query/scan/ScanQueryResultOrderingTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/ScanQueryResultOrderingTest.java
@@ -240,11 +240,6 @@ public class ScanQueryResultOrderingTest extends InitializedNullHandlingTest
   )
   {
     configure(segmentToServerMap, limit, batchSize, maxRowsQueuedForOrdering);
-    runTestOrderTimeAscending();
-  }
-
-  private void runTestOrderTimeAscending()
-  {
     assertResultsEquals(
         Druids.newScanQueryBuilder()
               .dataSource("ds")
@@ -286,11 +281,6 @@ public class ScanQueryResultOrderingTest extends InitializedNullHandlingTest
   )
   {
     configure(segmentToServerMap, limit, batchSize, maxRowsQueuedForOrdering);
-    runTestOrderTimeDescending();
-  }
-
-  private void runTestOrderTimeDescending()
-  {
     assertResultsEquals(
         Druids.newScanQueryBuilder()
               .dataSource("ds")

--- a/processing/src/test/java/org/apache/druid/query/scan/ScanQueryResultOrderingTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/ScanQueryResultOrderingTest.java
@@ -48,8 +48,7 @@ import org.apache.druid.timeline.SegmentId;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
@@ -66,8 +65,6 @@ import java.util.stream.IntStream;
  * <p>
  * Ensures that we have run-to-run stability of result order, which is important for offset-based pagination.
  */
-@ParameterizedClass
-@MethodSource("constructorFeeder")
 public class ScanQueryResultOrderingTest extends InitializedNullHandlingTest
 {
   private static final String DATASOURCE = "datasource";
@@ -137,10 +134,10 @@ public class ScanQueryResultOrderingTest extends InitializedNullHandlingTest
       )
   );
 
-  private final List<Integer> segmentToServerMap;
-  private final int limit;
-  private final int batchSize;
-  private final int maxRowsQueuedForOrdering;
+  private List<Integer> segmentToServerMap;
+  private int limit;
+  private int batchSize;
+  private int maxRowsQueuedForOrdering;
 
   private ScanQueryRunnerFactory queryRunnerFactory;
   private List<QueryRunner<ScanResultValue>> segmentRunners;
@@ -175,19 +172,6 @@ public class ScanQueryResultOrderingTest extends InitializedNullHandlingTest
     ).stream().map(args -> args.toArray(new Object[0])).collect(Collectors.toList());
   }
 
-  public ScanQueryResultOrderingTest(
-      final List<Integer> segmentToServerMap,
-      final int limit,
-      final int batchSize,
-      final int maxRowsQueuedForOrdering
-  )
-  {
-    this.segmentToServerMap = segmentToServerMap;
-    this.limit = limit;
-    this.batchSize = batchSize;
-    this.maxRowsQueuedForOrdering = maxRowsQueuedForOrdering;
-  }
-
   @BeforeEach
   public void setUp()
   {
@@ -200,8 +184,20 @@ public class ScanQueryResultOrderingTest extends InitializedNullHandlingTest
     segmentRunners = SEGMENTS.stream().map(queryRunnerFactory::createRunner).collect(Collectors.toList());
   }
 
-  @Test
-  public void testOrderNone()
+  @ParameterizedTest
+  @MethodSource("constructorFeeder")
+  public void testOrderNone(
+      final List<Integer> segmentToServerMap,
+      final int limit,
+      final int batchSize,
+      final int maxRowsQueuedForOrdering
+  )
+  {
+    configure(segmentToServerMap, limit, batchSize, maxRowsQueuedForOrdering);
+    runTestOrderNone();
+  }
+
+  private void runTestOrderNone()
   {
     assertResultsEquals(
         Druids.newScanQueryBuilder()
@@ -234,8 +230,20 @@ public class ScanQueryResultOrderingTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  public void testOrderTimeAscending()
+  @ParameterizedTest
+  @MethodSource("constructorFeeder")
+  public void testOrderTimeAscending(
+      final List<Integer> segmentToServerMap,
+      final int limit,
+      final int batchSize,
+      final int maxRowsQueuedForOrdering
+  )
+  {
+    configure(segmentToServerMap, limit, batchSize, maxRowsQueuedForOrdering);
+    runTestOrderTimeAscending();
+  }
+
+  private void runTestOrderTimeAscending()
   {
     assertResultsEquals(
         Druids.newScanQueryBuilder()
@@ -268,8 +276,20 @@ public class ScanQueryResultOrderingTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  public void testOrderTimeDescending()
+  @ParameterizedTest
+  @MethodSource("constructorFeeder")
+  public void testOrderTimeDescending(
+      final List<Integer> segmentToServerMap,
+      final int limit,
+      final int batchSize,
+      final int maxRowsQueuedForOrdering
+  )
+  {
+    configure(segmentToServerMap, limit, batchSize, maxRowsQueuedForOrdering);
+    runTestOrderTimeDescending();
+  }
+
+  private void runTestOrderTimeDescending()
   {
     assertResultsEquals(
         Druids.newScanQueryBuilder()
@@ -300,6 +320,19 @@ public class ScanQueryResultOrderingTest extends InitializedNullHandlingTest
             101
         )
     );
+  }
+
+  private void configure(
+      final List<Integer> segmentToServerMap,
+      final int limit,
+      final int batchSize,
+      final int maxRowsQueuedForOrdering
+  )
+  {
+    this.segmentToServerMap = segmentToServerMap;
+    this.limit = limit;
+    this.batchSize = batchSize;
+    this.maxRowsQueuedForOrdering = maxRowsQueuedForOrdering;
   }
 
   private void assertResultsEquals(final ScanQuery query, final List<Integer> expectedResults)


### PR DESCRIPTION
### Description

Convert `ScanQueryResultOrderingTest` from JUnit 5 `@ParameterizedClass` to method-level `@ParameterizedTest` methods.

The parameter matrix and the three ordering assertions are unchanged. Each method still receives every tuple from `constructorFeeder`; the change removes the cost of creating and reporting thousands of parameterized test-class containers.

This follows the similar `@ParameterizedClass` to method-level `@ParameterizedTest` conversion in [PR #19859](https://github.com/apache/druid/pull/19859).

### Performance benchmark

Measured locally with JDK 25 using the same focused Maven command before and after the change:

```text
env JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-25.jdk/Contents/Home \
  /usr/bin/time -p mvn -B -q -pl processing \
  -Dtest=ScanQueryResultOrderingTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Dweb.console.skip=true -Pskip-static-checks test
```

| Measurement | `master` | This PR |
| --- | ---: | ---: |
| Wall time | 316.02 s | 7.33 s |
| Improvement |  | 97.68% faster |

### Test-count evidence

The converted run executed all 15,309 test cases. The Surefire report contains the following evidence:

```text
$ grep -c '<testcase' processing/target/surefire-reports/TEST-org.apache.druid.query.scan.ScanQueryResultOrderingTest.xml
15309

<testsuite ... tests="15309" errors="0" skipped="0" failures="0" ...>
```

This matches the unchanged matrix of 5,103 parameter tuples across three test methods (`5,103 x 3 = 15,309`).

### Key changed/added classes

* `processing/src/test/java/org/apache/druid/query/scan/ScanQueryResultOrderingTest.java`

### Test plan

- [x] Focused `ScanQueryResultOrderingTest` run under JDK 25
- [x] Verified 15,309 testcases executed
- [x] Verified zero failures and errors

This PR has:

- [x] been self-reviewed.
- [x] added or modified existing tests or test infrastructure to cover the changed path.
