### PR TITLE
fix: handle byte[] complex types from realtime segments in MSQ scans (#18340)

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/data/ObjectStrategy.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/ObjectStrategy.java
@@ -53,6 +53,25 @@ public interface ObjectStrategy<T> extends Comparator<T>
   byte[] toBytes(@Nullable T val);
 
   /**
+   * Converts an Object to bytes, handling the case where the input is already a byte[].
+   * This is needed when complex types are read from realtime segments, where
+   * {@link org.apache.druid.segment.ColumnValueSelector#getObject()} returns the already-serialized byte[] form
+   * rather than the deserialized object form. In that case, we can return the byte[] directly instead of
+   * trying to cast it to {@code T} and re-serialize it, which would cause a {@link ClassCastException}.
+   *
+   * @see <a href="https://github.com/apache/druid/issues/18340">GitHub issue #18340</a>
+   */
+  @Nullable
+  default byte[] objectToBytes(@Nullable Object val)
+  {
+    if (val instanceof byte[]) {
+      return (byte[]) val;
+    } else {
+      return toBytes((T) val);
+    }
+  }
+
+  /**
    * Whether {@link #compare} is valid or not.
    */
   default boolean canCompare()

--- a/processing/src/main/java/org/apache/druid/segment/serde/ComplexMetricSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/ComplexMetricSerde.java
@@ -94,7 +94,7 @@ public abstract class ComplexMetricSerde
   public byte[] toBytes(@Nullable Object val)
   {
     if (val != null) {
-      byte[] bytes = getObjectStrategy().toBytes(val);
+      byte[] bytes = getObjectStrategy().objectToBytes(val);
       return bytes != null ? bytes : ByteArrays.EMPTY_ARRAY;
     } else {
       return ByteArrays.EMPTY_ARRAY;


### PR DESCRIPTION
### Description

When MSQ scans realtime segments containing complex types, `ColumnValueSelector.getObject()` returns the already-serialized `byte[]` form rather than the deserialized object. `ComplexMetricSerde.toBytes()` calls `ObjectStrategy.toBytes(val)` which expects the deserialized object type `T`, causing a `ClassCastException` when the value is actually `byte[]`.

This fix adds a new `objectToBytes(Object val)` default method to `ObjectStrategy` that checks if the value is already a `byte[]` and returns it directly, otherwise delegates to the existing `toBytes(T val)` method. `ComplexMetricSerde.toBytes()` is updated to use `objectToBytes()` instead of `toBytes()`.

### Changes

- **ObjectStrategy.java**: Added `objectToBytes(Object val)` default method that handles `byte[]` input directly
- **ComplexMetricSerde.java**: Changed `toBytes(val)` to `objectToBytes(val)` in the serde

Fixes #18340.