### PR TITLE
perf(embedded-tests): reduce auto compaction scheduler wait

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/AutoCompactionTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/AutoCompactionTest.java
@@ -217,7 +217,9 @@ public class AutoCompactionTest extends CompactionTestBase
                                .addExtension(SketchModule.class)
                                .addExtension(HllSketchModule.class)
                                .addExtension(DoublesSketchModule.class)
-                               .addServer(overlord)
+                               .addServer(
+                                   overlord.addProperty("druid.manager.segments.pollDuration", "PT1S")
+                               )
                                .addServer(coordinator)
                                .addServer(broker)
                                .addServer(new EmbeddedIndexer().addProperty("druid.worker.capacity", "10").setServerMemory(2_000_000_000L))


### PR DESCRIPTION
## Summary
- Set the embedded Overlord segment poll period to PT1S for AutoCompactionTest.
- Preserve the test data, compaction policies, task execution, ordering, and assertions; this only removes the default 60-second scheduler polling delay.

## Evidence
- CI run #20087 shard I*,A*,U*: AutoCompactionTest took 506.69s. The four slow supervisor configurations consumed 462.885s (91.35% of the class), with 459.756s (99.32% of that time) spent waiting for the Overlord compaction scheduler.
- Local unmodified filter method: 3/3 passed, 245.171s Surefire / 272.79s Maven wall.
- Local optimized filter method: run 1 = 13.831s Surefire / 39.81s Maven wall; run 2 = 13.895s / 39.58s.
- Local optimized full class: 31 tests, 3 skips, 0 failures/errors, 57.57s Surefire / 82.79s Maven wall.

## Validation
- `mvn -ntp verify -pl embedded-tests -am -DskipTests -Dweb.console.skip=true -T1C` passed.
- Explicit SpotBugs check passed; embedded-tests has no production classes to analyze.
- `git diff --check` passed.

The CI run link used for the baseline is https://github.com/apache/druid/actions/runs/32339940988?pr=20087.