### PR TITLE
perf(embedded-tests): reduce MSQ fault tolerance test delay

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/MSQWorkerFaultToleranceTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/MSQWorkerFaultToleranceTest.java
@@ -94,7 +94,7 @@ public class MSQWorkerFaultToleranceTest extends EmbeddedClusterTestBase
     final EmbeddedIndexer faultyIndexer = new EmbeddedIndexer()
         .addProperty("druid.plaintextPort", "7091")
         .addProperty("druid.unsafe.cluster.testing", "true")
-        .addProperty("druid.unsafe.cluster.testing.overlordClient.taskStatusDelay", "PT1H")
+        .addProperty("druid.unsafe.cluster.testing.overlordClient.taskStatusDelay", "PT1S")
         .addProperty("druid.worker.capacity", "1");
     cluster.addServer(faultyIndexer);
     faultyIndexer.start();


### PR DESCRIPTION
## Summary

- Reduce the faulty worker's Overlord task-status delay in `MSQWorkerFaultToleranceTest` from `PT1H` to `PT1S`.
- The test still uses the faulty Indexer, worker capacity of one, explicit worker cancellation, failed-task metric, fault-tolerant relaunch, segment availability, and final SQL result assertion.

## Evidence

The `M*,P*,O*` CI shard in run [#20087](https://github.com/apache/druid/actions/runs/32339940988?pr=20087) reported this test as the shard's slowest test:

- `MSQWorkerFaultToleranceTest#test_cancelledWorker_isRetried_ifFaultToleranceIsEnabled`: 301.197s
- Next slowest test: `MergingRowIteratorTest#testAllPossible5ElementSequences`: 69.853s
- The 301.197s test accounts for 25.5% of the shard's 1,179.924 recorded testcase-seconds.

`FaultyOverlordClient` sleeps for the configured delay on every `taskStatus`/`taskStatuses` call. The test only needs to hold the faulty worker long enough to observe `ingest/count` and cancel it; the one-hour delay was a blocking-wait bottleneck.

## Local measurements

Command used for each isolated run:

```text
mvn -ntp test -pl embedded-tests -am \
  -Dtest=org.apache.druid.testing.embedded.msq.MSQWorkerFaultToleranceTest#test_cancelledWorker_isRetried_ifFaultToleranceIsEnabled \
  -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks -Dweb.console.skip=true -T1C
```

| Variant | Passing runs | Surefire | Maven wall |
| --- | ---: | ---: | ---: |
| Unmodified `PT1H` | 1 | 312.00s | 353.09s |
| `PT1S` | 1 | 13.07s | 38.71s |
| `PT1S` | 2 | 12.62s | 37.96s |

Optimized average: 12.845s Surefire and 38.335s Maven wall.

- Surefire saving: 299.155s (95.88%).
- Maven wall saving: 314.755s (89.14%).
- Optimized Surefire range: 12.62–13.07s (0.45s spread).

The complete affected test class passed in 12.57s.

## Validation

- `mvn -ntp verify -pl embedded-tests -am -DskipTests -Dweb.console.skip=true -T1C`
- `mvn -ntp com.github.spotbugs:spotbugs-maven-plugin:4.10.2.0:check -pl embedded-tests -DskipTests -Dweb.console.skip=true`
- `git diff --check`

All passed. This is part of #13948.
