### PR TITLE
perf(indexing-service): reduce serial task polling latency

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -265,6 +265,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
                               .withPartitionsSpec(partitionsSpec)
                               .withForceGuaranteedRollup(forceGuaranteedRollup)
                               .withMaxNumConcurrentSubTasks(maxNumConcurrentSubTasks)
+                              .withTaskStatusCheckPeriodMs(maxNumConcurrentSubTasks == 1 ? 100L : null)
                               .withMaxParseExceptions(5)
                               .build();
   }


### PR DESCRIPTION
## Summary

- Reduce the test-only parallel-index task status polling interval from the production default of 1 second to 100 ms when a test deliberately runs with one concurrent subtask.
- This removes scheduler polling latency from serial multi-phase test cases without changing the input payloads, task ordering, partitioning, transaction boundaries, retry injection, or assertions.

## Evidence

The baseline JDK 25 unit-shard artifact from run [#20087](https://github.com/apache/druid/actions/runs/32339940988) (`unit-test-reports-jdk25-f7b3ee25`) ranked these tests among the slowest entries in the selected shard:

| Test | Baseline Surefire time |
| --- | ---: |
| `RangePartitionMultiPhaseParallelIndexingTest[4]#createsCorrectRangePartitions` | 47.820 s |
| `RangePartitionMultiPhaseParallelIndexingTest[4]#testAppendLinearlyPartitionedSegmentsToHashPartitionedDatasourceSuccessfullyAppend` | 33.028 s |
| `RangePartitionAdjustingCorePartitionSizeTest[2]#testEqualNumberOfPartitionsToBuckets` | 25.864 s |
| `QueryVirtualStorageTest#testQueryPartials` | 21.267 s |

The first three parameterizations use one concurrent subtask. Local baseline logs showed ten serialized subtasks being submitted approximately one second apart in each of three phases. The same logs showed transient task kills and retries, confirming that the optimization must retain the failure-injection path rather than disable it.

## Local measurements

The unmodified fourth parameterization passed in isolation with 56.77 s Surefire time and 68.13 s Maven wall time.

With the 100 ms test-harness polling interval, the same test passed twice:

| Run | Surefire | Maven wall |
| --- | ---: | ---: |
| 1 | 12.03 s | 23.46 s |
| 2 | 12.34 s | 19.97 s |
| Average | 12.185 s | 21.715 s |

Compared with the baseline, the average savings are 44.585 s (78.5%) in Surefire time and 46.415 s (68.1%) in Maven wall time. The optimized Surefire range was 0.31 s. Both optimized runs retained transient task failures and retries and passed all assertions.

The complete affected `RangePartitionMultiPhaseParallelIndexingTest` passed 10 tests with 0 failures, errors, or skips. The shared-harness consumer `RangePartitionAdjustingCorePartitionSizeTest` passed 6 tests with 0 failures, errors, or skips.

## Validation

- Maven test compilation passed for `indexing-service` and dependencies.
- Checkstyle passed with 0 violations.
- SpotBugs passed with 0 bugs and 0 errors.
- Focused and complete affected classes passed.
- `git diff --check` passed.

Part of #13948.
