### PR TITLE
fix(server): master branch CI failure

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -324,11 +324,6 @@
 
         <!-- Tests -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
@@ -340,17 +335,7 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-migrationsupport</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -423,11 +408,6 @@
                     <artifactId>javax.servlet-api</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>pl.pragmatists</groupId>
-            <artifactId>JUnitParams</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -324,6 +324,11 @@
 
         <!-- Tests -->
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/server/src/test/java/org/apache/druid/metadata/TestDerbyConnector.java
+++ b/server/src/test/java/org/apache/druid/metadata/TestDerbyConnector.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.rules.ExternalResource;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.PreparedBatch;
 import org.skife.jdbi.v2.exceptions.UnableToObtainConnectionException;
@@ -141,7 +142,7 @@ public class TestDerbyConnector extends DerbyConnector
     this.getDBI().open().close();
   }
 
-  public static class DerbyConnectorRule implements BeforeEachCallback, AfterEachCallback
+  public static class DerbyConnectorRule extends ExternalResource implements BeforeEachCallback, AfterEachCallback
   {
     private TestDerbyConnector connector;
     private final MetadataStorageTablesConfig tablesConfig;
@@ -188,6 +189,7 @@ public class TestDerbyConnector extends DerbyConnector
       this.centralizedDatasourceSchemaConfig = centralizedDatasourceSchemaConfig;
     }
 
+    @Override
     public void before()
     {
       connector = new TestDerbyConnector(
@@ -198,6 +200,7 @@ public class TestDerbyConnector extends DerbyConnector
       connector.createDatabase(); // create db
     }
 
+    @Override
     public void after()
     {
       connector.tearDown();

--- a/server/src/test/java/org/apache/druid/metadata/TestDerbyConnector.java
+++ b/server/src/test/java/org/apache/druid/metadata/TestDerbyConnector.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.rules.ExternalResource;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.PreparedBatch;
 import org.skife.jdbi.v2.exceptions.UnableToObtainConnectionException;
@@ -142,7 +141,7 @@ public class TestDerbyConnector extends DerbyConnector
     this.getDBI().open().close();
   }
 
-  public static class DerbyConnectorRule extends ExternalResource implements BeforeEachCallback, AfterEachCallback
+  public static class DerbyConnectorRule implements BeforeEachCallback, AfterEachCallback
   {
     private TestDerbyConnector connector;
     private final MetadataStorageTablesConfig tablesConfig;
@@ -189,7 +188,6 @@ public class TestDerbyConnector extends DerbyConnector
       this.centralizedDatasourceSchemaConfig = centralizedDatasourceSchemaConfig;
     }
 
-    @Override
     public void before()
     {
       connector = new TestDerbyConnector(
@@ -200,7 +198,6 @@ public class TestDerbyConnector extends DerbyConnector
       connector.createDatabase(); // create db
     }
 
-    @Override
     public void after()
     {
       connector.tearDown();

--- a/server/src/test/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIteratorTest.java
@@ -177,11 +177,11 @@ public class DataSourceCompactibleSegmentIteratorTest
     );
 
     // The DAY bucket overlaps the skip interval, so none of its segments should be picked up for compaction.
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
     final List<CompactionCandidate> skipped = iterator.getSkippedSegments();
-    Assert.assertEquals(1, skipped.size());
-    Assert.assertEquals(Intervals.of("2018-01-01/2018-01-02"), skipped.getFirst().getUmbrellaInterval());
-    Assert.assertEquals(24, skipped.getFirst().getSegments().size());
+    Assertions.assertEquals(1, skipped.size());
+    Assertions.assertEquals(Intervals.of("2018-01-01/2018-01-02"), skipped.getFirst().getUmbrellaInterval());
+    Assertions.assertEquals(24, skipped.getFirst().getSegments().size());
   }
 
   @Test
@@ -212,11 +212,11 @@ public class DataSourceCompactibleSegmentIteratorTest
         FINGERPRINT_MAPPER
     );
 
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
     final List<CompactionCandidate> skipped = iterator.getSkippedSegments();
-    Assert.assertEquals(1, skipped.size());
-    Assert.assertEquals(24, skipped.getFirst().getSegments().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, skipped.size());
+    Assertions.assertEquals(24, skipped.getFirst().getSegments().size());
+    Assertions.assertEquals(
         StringUtils.format("Interval[%s] skipped by compaction config", Intervals.ETERNITY),
         skipped.getFirst().getCurrentStatus().getReason()
     );


### PR DESCRIPTION
### Description

CI of PR #20027 and PR #20059 are green, but they changes the SAME file but changes does not overlap so no merge conflict is shown.

after both of them are merged, 'import' used in one PR it not found because another removes it.

Such problem can only be fixed if the [merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue?apiVersion=2022-11-28) is enabled. It's not realistic for us to rebase every PR to the latest before merging it.


### Changes

Replace the eight remaining `Assert` calls with `Assertions`.

### Testing

- `mvn test -pl server -am -Dtest="org.apache.druid.server.compaction.DataSourceCompactibleSegmentIteratorTest" -Dsurefire.failIfNoSpecifiedTests=false -DforkCount=0 -Pskip-static-checks -Dweb.console.skip=true -T1`
- Result: 5 tests passed, 0 failures, 0 errors.

No release note is needed; this is a test-only build fix.

This PR has:

- [x] been self-reviewed.
- [x] added or updated tests or test assertions for the affected code path.