### PR TITLE
test: harden bounded Kafka supervisor timeouts

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
@@ -44,10 +44,6 @@ public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
   // This is a maximum wait, not a fixed delay; successful waits return as soon as the metric is emitted.
   private static final long BOUNDED_SUPERVISOR_INGESTION_TIMEOUT_MILLIS = 120_000L;
 
-  // Use up to 100 rows per segment instead of the shared fixture's one-row segments. The test assertions
-  // cover bounded offsets, row counts, and supervisor state, so they do not depend on segment count.
-  private static final int BOUNDED_SUPERVISOR_MAX_ROWS_PER_SEGMENT = 100;
-
   private final KafkaResource kafkaServer = new KafkaResource();
 
   @Override
@@ -59,10 +55,11 @@ public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
   @Override
   protected KafkaSupervisorSpecBuilder createKafkaSupervisor(KafkaResource kafkaServer)
   {
+    // Use a moderate segment size to avoid the shared fixture's one-row segment rollover overhead while
+    // retaining normal segment publication behavior. These tests assert offsets, row counts, and supervisor
+    // state, not segment count, so 100 does not change their semantics.
     return super.createKafkaSupervisor(kafkaServer)
-        .withTuningConfig(
-            tuningConfig -> tuningConfig.withMaxRowsPerSegment(BOUNDED_SUPERVISOR_MAX_ROWS_PER_SEGMENT)
-        );
+        .withTuningConfig(tuningConfig -> tuningConfig.withMaxRowsPerSegment(100));
   }
 
   @Override

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
@@ -40,7 +40,12 @@ import java.util.Map;
  */
 public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
 {
+  // Allow two minutes for bounded-supervisor cold start, ingestion, and segment publication on CI.
+  // This is a maximum wait, not a fixed delay; successful waits return as soon as the metric is emitted.
   private static final long BOUNDED_SUPERVISOR_INGESTION_TIMEOUT_MILLIS = 120_000L;
+
+  // Use up to 100 rows per segment instead of the shared fixture's one-row segments. The test assertions
+  // cover bounded offsets, row counts, and supervisor state, so they do not depend on segment count.
   private static final int BOUNDED_SUPERVISOR_MAX_ROWS_PER_SEGMENT = 100;
 
   private final KafkaResource kafkaServer = new KafkaResource();

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
@@ -39,6 +39,8 @@ import java.util.Map;
  */
 public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
 {
+  private static final long BOUNDED_SUPERVISOR_INGESTION_TIMEOUT_MILLIS = 120_000L;
+
   private final KafkaResource kafkaServer = new KafkaResource();
 
   @Override
@@ -89,7 +91,7 @@ public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
 
     // Bounded supervisor cold start (post supervisor -> schedule task -> consume -> publish) can exceed
     // the cluster default wait on CI; give it a generous ceiling.
-    waitUntilPublishedRecordsAreIngested(totalRecords, 120_000L);
+    waitUntilPublishedRecordsAreIngested(totalRecords, BOUNDED_SUPERVISOR_INGESTION_TIMEOUT_MILLIS);
 
     // Wait for supervisor to transition to COMPLETED state
     waitForSupervisorToComplete(supervisor.getId());
@@ -203,7 +205,7 @@ public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
     cluster.callApi().postSupervisor(supervisor1);
 
     // Wait for records to be ingested (approximately 200 records total from both partitions)
-    waitUntilPublishedRecordsAreIngested(200);
+    waitUntilPublishedRecordsAreIngested(200, BOUNDED_SUPERVISOR_INGESTION_TIMEOUT_MILLIS);
 
     // Wait for supervisor to transition to COMPLETED state
     waitForSupervisorToComplete(supervisor1.getId());
@@ -265,7 +267,7 @@ public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
     final KafkaSupervisorSpec supervisor1 = createBoundedKafkaSupervisor(kafkaServer, topic, boundedConfig1);
 
     cluster.callApi().postSupervisor(supervisor1);
-    waitUntilPublishedRecordsAreIngested(250);
+    waitUntilPublishedRecordsAreIngested(250, BOUNDED_SUPERVISOR_INGESTION_TIMEOUT_MILLIS);
     waitForSupervisorToComplete(supervisor1.getId());
 
     final SupervisorStatus status1 = cluster.callApi().getSupervisorStatus(supervisor1.getId());

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
@@ -40,6 +40,7 @@ import java.util.Map;
 public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
 {
   private static final long BOUNDED_SUPERVISOR_INGESTION_TIMEOUT_MILLIS = 120_000L;
+  private static final int BOUNDED_SUPERVISOR_MAX_ROWS_PER_SEGMENT = 100;
 
   private final KafkaResource kafkaServer = new KafkaResource();
 
@@ -166,6 +167,9 @@ public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
   )
   {
     return createKafkaSupervisor(kafkaServer)
+        .withTuningConfig(
+            tuningConfig -> tuningConfig.withMaxRowsPerSegment(BOUNDED_SUPERVISOR_MAX_ROWS_PER_SEGMENT)
+        )
         .withIoConfig(io -> io
             .withKafkaInputFormat(new JsonInputFormat(null, null, null, null, null))
             .withBoundedStreamConfig(boundedConfig)

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
@@ -23,6 +23,7 @@ import org.apache.druid.common.utils.IdUtils;
 import org.apache.druid.data.input.impl.JsonInputFormat;
 import org.apache.druid.indexing.kafka.simulate.KafkaResource;
 import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorSpec;
+import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorSpecBuilder;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorStatus;
 import org.apache.druid.indexing.seekablestream.supervisor.BoundedStreamConfig;
 import org.apache.druid.query.DruidMetrics;
@@ -48,6 +49,15 @@ public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
   protected StreamIngestResource<?> getStreamIngestResource()
   {
     return kafkaServer;
+  }
+
+  @Override
+  protected KafkaSupervisorSpecBuilder createKafkaSupervisor(KafkaResource kafkaServer)
+  {
+    return super.createKafkaSupervisor(kafkaServer)
+        .withTuningConfig(
+            tuningConfig -> tuningConfig.withMaxRowsPerSegment(BOUNDED_SUPERVISOR_MAX_ROWS_PER_SEGMENT)
+        );
   }
 
   @Override
@@ -167,9 +177,6 @@ public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
   )
   {
     return createKafkaSupervisor(kafkaServer)
-        .withTuningConfig(
-            tuningConfig -> tuningConfig.withMaxRowsPerSegment(BOUNDED_SUPERVISOR_MAX_ROWS_PER_SEGMENT)
-        )
         .withIoConfig(io -> io
             .withKafkaInputFormat(new JsonInputFormat(null, null, null, null, null))
             .withBoundedStreamConfig(boundedConfig)


### PR DESCRIPTION
### Description

`KafkaBoundedSupervisorTest` can exceed the embedded cluster's default 60-second latch timeout while a bounded supervisor starts tasks, consumes records, and publishes segments.

The post-merge CI run for PR [#20106](https://github.com/apache/druid/pull/20106) provides the evidence:

- The `Unit & Integration tests CI` run [32516481844](https://github.com/apache/druid/actions/runs/32516481844) failed in job [96879148560](https://github.com/apache/druid/actions/runs/32516481844/job/96879148560).
- The failed JDK 25 shard timed out in `KafkaBoundedSupervisorTest.test_boundedSupervisor_doesNotSilentlyCompleteWhenStaleOffsetExceedsNewEnd` while waiting for 250 published records.
- The same shard passed before merge in PR #20106.
- PR [#19543](https://github.com/apache/druid/pull/19543) previously addressed the same cold-start timing issue by using a 120-second wait for one bounded-supervisor ingestion path.

This change:

- Applies a 120-second maximum wait to the bounded-supervisor ingestion waits. The timeout is a ceiling, not a fixed delay.
- Uses `maxRowsPerSegment = 100` for this test class instead of the shared fixture's one-row segments. This reduces segment rollover and publication overhead while preserving the test's offset, row-count, and supervisor-state assertions.

There is no user-facing behavior change.

#### Release note

No user-facing behavior change.

<hr>

##### Key changed/added classes in this PR

 * `KafkaBoundedSupervisorTest`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] modified an existing test to cover the affected CI timing path.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description (test-only change).
- [ ] added or updated version, license, or notice information in `licenses.yaml`.

Local verification:

```text
mvn test -pl embedded-tests -am -Dtest=org.apache.druid.testing.embedded.indexing.KafkaBoundedSupervisorTest -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks -Dweb.console.skip=true -T1
```

Result: 6 tests passed; Maven reactor `BUILD SUCCESS`.
