### PR TITLE
ci: enable incremental dependency-check updates

### DIFF
--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Update Dependency-Check data
         id: dependency-check-update
         env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY || secrets.NIST_NVD_API_KEY }}
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: |
           if [ -n "$NVD_API_KEY" ]; then
             echo "NVD API key is available to the update"
@@ -79,22 +79,21 @@ jobs:
           fi
           mvn -B dependency-check:update-only \
             -DdataDirectory="$HOME/.cache/dependency-check" \
-            -DnvdValidForHours=24 \
-            -DnvdApiKey="$NVD_API_KEY"
+            -DnvdValidForHours=24
 
       - name: security vulnerabilities check
-        if: always()
+        if: steps.dependency-check-update.outcome == 'success'
         env:
           OSS_INDEX_USERNAME: ${{ secrets.OSS_INDEX_USERNAME }}
           OSS_INDEX_PASSWORD: ${{ secrets.OSS_INDEX_PASSWORD }}
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY || secrets.NIST_NVD_API_KEY }}
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: |
           if [ -n "$NVD_API_KEY" ]; then
             echo "NVD API key is available to the scan"
           else
             echo "NVD API key is unavailable to the scan"
           fi
-          mvn -B --fail-at-end dependency-check:check -DautoUpdate=false -DdataDirectory="$HOME/.cache/dependency-check" -DnvdApiKey="$NVD_API_KEY" -DossIndexUsername="$OSS_INDEX_USERNAME" -DossIndexPassword="$OSS_INDEX_PASSWORD" || { echo "
+          mvn -B --fail-at-end dependency-check:check -DautoUpdate=false -DdataDirectory="$HOME/.cache/dependency-check" -DossIndexUsername="$OSS_INDEX_USERNAME" -DossIndexPassword="$OSS_INDEX_PASSWORD" || { echo "
           The OWASP dependency check has found security vulnerabilities. Please use a newer version
           of the dependency that does not have vulnerabilities. To see a report run
           `mvn dependency-check:check`

--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -21,6 +21,7 @@ on:
   pull_request:
     paths:
       - 'owasp-dependency-check-suppressions.xml'
+      - '.github/workflows/cron-job-its.yml'
     branches:
       - master
       - '[0-9]+.[0-9]+.[0-9]+' # release branches
@@ -35,6 +36,9 @@ jobs:
     if: github.repository == 'apache/druid'
     name: security vulnerabilities
     runs-on: ubuntu-latest
+    env:
+      # Keep this in sync with dependency-check-maven in pom.xml.
+      DEPENDENCY_CHECK_CACHE_VERSION: 12.2.2
     steps:
       - name: Checkout branch
         uses: actions/checkout@v6
@@ -50,9 +54,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/dependency-check
-          key: dependency-check-data-${{ runner.os }}-${{ hashFiles('pom.xml') }}-${{ github.run_id }}
+          key: dependency-check-data-${{ runner.os }}-odc-${{ env.DEPENDENCY_CHECK_CACHE_VERSION }}-${{ github.run_id }}
           restore-keys: |
-            dependency-check-data-${{ runner.os }}-${{ hashFiles('pom.xml') }}-
+            dependency-check-data-${{ runner.os }}-odc-${{ env.DEPENDENCY_CHECK_CACHE_VERSION }}-
 
       - name: maven build # needed to rebuild in case of maven snapshot resolution fails
         run: mvn clean install -P dist -P skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dweb.console.skip=true
@@ -63,7 +67,7 @@ jobs:
           OSS_INDEX_PASSWORD: ${{ secrets.OSS_INDEX_PASSWORD }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: |
-          mvn -B dependency-check:check -DdataDirectory="$HOME/.cache/dependency-check" -DnvdValidForHours=24 -DnvdApiKey="$NVD_API_KEY" -DossIndexUsername="$OSS_INDEX_USERNAME" -DossIndexPassword="$OSS_INDEX_PASSWORD" || { echo "
+          mvn -B --fail-at-end dependency-check:check -DdataDirectory="$HOME/.cache/dependency-check" -DnvdValidForHours=24 -DnvdApiKey="$NVD_API_KEY" -DossIndexUsername="$OSS_INDEX_USERNAME" -DossIndexPassword="$OSS_INDEX_PASSWORD" || { echo "
           The OWASP dependency check has found security vulnerabilities. Please use a newer version
           of the dependency that does not have vulnerabilities. To see a report run
           `mvn dependency-check:check`
@@ -77,4 +81,4 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ~/.cache/dependency-check
-          key: dependency-check-data-${{ runner.os }}-${{ hashFiles('pom.xml') }}-${{ github.run_id }}
+          key: dependency-check-data-${{ runner.os }}-odc-${{ env.DEPENDENCY_CHECK_CACHE_VERSION }}-${{ github.run_id }}

--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -17,6 +17,7 @@ name: "Cron Job ITs"
 on:
   schedule: # Runs by default on master branch
     - cron: '0 3 * * *' # Runs every day at 3:00 AM UTC
+  workflow_dispatch:
   pull_request:
     paths:
       - 'owasp-dependency-check-suppressions.xml'
@@ -45,6 +46,14 @@ jobs:
           distribution: 'zulu'
           cache: maven
 
+      - name: Restore Dependency-Check data
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/dependency-check
+          key: dependency-check-data-${{ runner.os }}-${{ hashFiles('pom.xml') }}-${{ github.run_id }}
+          restore-keys: |
+            dependency-check-data-${{ runner.os }}-${{ hashFiles('pom.xml') }}-
+
       - name: maven build # needed to rebuild in case of maven snapshot resolution fails
         run: mvn clean install -P dist -P skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dweb.console.skip=true
 
@@ -54,7 +63,7 @@ jobs:
           OSS_INDEX_PASSWORD: ${{ secrets.OSS_INDEX_PASSWORD }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: |
-          mvn -B dependency-check:purge dependency-check:check -DnvdApiKey=$NVD_API_KEY -DossIndexUsername=$OSS_INDEX_USERNAME -DossIndexPassword=$OSS_INDEX_PASSWORD || { echo "
+          mvn -B dependency-check:check -DdataDirectory="$HOME/.cache/dependency-check" -DnvdValidForHours=24 -DnvdApiKey="$NVD_API_KEY" -DossIndexUsername="$OSS_INDEX_USERNAME" -DossIndexPassword="$OSS_INDEX_PASSWORD" || { echo "
           The OWASP dependency check has found security vulnerabilities. Please use a newer version
           of the dependency that does not have vulnerabilities. To see a report run
           `mvn dependency-check:check`
@@ -62,3 +71,10 @@ jobs:
           they can be suppressed by adding entries to owasp-dependency-check-suppressions.xml (for more
           information, see https://jeremylong.github.io/DependencyCheck/general/suppression.html).
           " && false; }
+
+      - name: Save Dependency-Check data
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/dependency-check
+          key: dependency-check-data-${{ runner.os }}-${{ hashFiles('pom.xml') }}-${{ github.run_id }}

--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -71,8 +71,13 @@ jobs:
         env:
           OSS_INDEX_USERNAME: ${{ secrets.OSS_INDEX_USERNAME }}
           OSS_INDEX_PASSWORD: ${{ secrets.OSS_INDEX_PASSWORD }}
-          NVD_API_KEY: ${{ secrets.NIST_NVD_API_KEY }}
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY || secrets.NIST_NVD_API_KEY }}
         run: |
+          if [ -n "$NVD_API_KEY" ]; then
+            echo "NVD API key is available to the scan"
+          else
+            echo "NVD API key is unavailable to the scan"
+          fi
           mvn -B --fail-at-end dependency-check:check -DdataDirectory="$HOME/.cache/dependency-check" -DnvdValidForHours=24 -DnvdApiKey="$NVD_API_KEY" -DossIndexUsername="$OSS_INDEX_USERNAME" -DossIndexPassword="$OSS_INDEX_PASSWORD" || { echo "
           The OWASP dependency check has found security vulnerabilities. Please use a newer version
           of the dependency that does not have vulnerabilities. To see a report run

--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -93,14 +93,27 @@ jobs:
           else
             echo "NVD API key is unavailable to the scan"
           fi
-          mvn -B --fail-at-end dependency-check:check -DautoUpdate=false -DdataDirectory="$HOME/.cache/dependency-check" -DossIndexUsername="$OSS_INDEX_USERNAME" -DossIndexPassword="$OSS_INDEX_PASSWORD" || { echo "
-          The OWASP dependency check has found security vulnerabilities. Please use a newer version
-          of the dependency that does not have vulnerabilities. To see a report run
-          `mvn dependency-check:check`
-          If the analysis has false positives,
-          they can be suppressed by adding entries to owasp-dependency-check-suppressions.xml (for more
-          information, see https://jeremylong.github.io/DependencyCheck/general/suppression.html).
-          " && false; }
+          # --fail-at-end skips modules that depend on a failed module. Continue through the
+          # entire reactor, then aggregate the module results so CI still fails when findings exist.
+          dependency_check_log="$RUNNER_TEMP/dependency-check.log"
+          set +e
+          mvn -B --fail-never dependency-check:check -DautoUpdate=false -DdataDirectory="$HOME/.cache/dependency-check" -DossIndexUsername="$OSS_INDEX_USERNAME" -DossIndexPassword="$OSS_INDEX_PASSWORD" 2>&1 | tee "$dependency_check_log"
+          pipeline_status=("${PIPESTATUS[@]}")
+          set -e
+          maven_status=${pipeline_status[0]}
+          tee_status=${pipeline_status[1]}
+          if [ "$maven_status" -ne 0 ] || [ "$tee_status" -ne 0 ] \
+             || grep -Eq '^\[INFO\] BUILD FAILURE$|^\[ERROR\] Failed to execute goal org\.owasp:dependency-check-maven:' "$dependency_check_log"; then
+            echo "
+            The OWASP dependency check has found security vulnerabilities or failed in one or more modules. Please use a newer version
+            of the dependency that does not have vulnerabilities. To see a report run
+            `mvn dependency-check:check`
+            If the analysis has false positives,
+            they can be suppressed by adding entries to owasp-dependency-check-suppressions.xml (for more
+            information, see https://jeremylong.github.io/DependencyCheck/general/suppression.html).
+            "
+            exit 1
+          fi
 
       - name: Save Dependency-Check data
         # A pull_request run uses an isolated merge-ref cache that cannot be

--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Keep this in sync with dependency-check-maven in pom.xml.
-      DEPENDENCY_CHECK_CACHE_VERSION: 12.2.2
+      DEPENDENCY_CHECK_CACHE_VERSION: 13.0.0
     steps:
       - name: Checkout branch
         uses: actions/checkout@v6
@@ -67,7 +67,23 @@ jobs:
       - name: maven build # needed to rebuild in case of maven snapshot resolution fails
         run: mvn clean install -P dist -P skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dweb.console.skip=true
 
+      - name: Update Dependency-Check data
+        id: dependency-check-update
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY || secrets.NIST_NVD_API_KEY }}
+        run: |
+          if [ -n "$NVD_API_KEY" ]; then
+            echo "NVD API key is available to the update"
+          else
+            echo "NVD API key is unavailable to the update"
+          fi
+          mvn -B dependency-check:update-only \
+            -DdataDirectory="$HOME/.cache/dependency-check" \
+            -DnvdValidForHours=24 \
+            -DnvdApiKey="$NVD_API_KEY"
+
       - name: security vulnerabilities check
+        if: always()
         env:
           OSS_INDEX_USERNAME: ${{ secrets.OSS_INDEX_USERNAME }}
           OSS_INDEX_PASSWORD: ${{ secrets.OSS_INDEX_PASSWORD }}
@@ -78,7 +94,7 @@ jobs:
           else
             echo "NVD API key is unavailable to the scan"
           fi
-          mvn -B --fail-at-end dependency-check:check -DdataDirectory="$HOME/.cache/dependency-check" -DnvdValidForHours=24 -DnvdApiKey="$NVD_API_KEY" -DossIndexUsername="$OSS_INDEX_USERNAME" -DossIndexPassword="$OSS_INDEX_PASSWORD" || { echo "
+          mvn -B --fail-at-end dependency-check:check -DautoUpdate=false -DdataDirectory="$HOME/.cache/dependency-check" -DnvdApiKey="$NVD_API_KEY" -DossIndexUsername="$OSS_INDEX_USERNAME" -DossIndexPassword="$OSS_INDEX_PASSWORD" || { echo "
           The OWASP dependency check has found security vulnerabilities. Please use a newer version
           of the dependency that does not have vulnerabilities. To see a report run
           `mvn dependency-check:check`
@@ -90,7 +106,7 @@ jobs:
       - name: Save Dependency-Check data
         # A pull_request run uses an isolated merge-ref cache that cannot be
         # reused by branch, scheduled, or workflow_dispatch runs.
-        if: always() && github.event_name != 'pull_request'
+        if: steps.dependency-check-update.outcome == 'success' && github.event_name != 'pull_request'
         uses: actions/cache/save@v4
         with:
           path: ~/.cache/dependency-check

--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -107,7 +107,7 @@ jobs:
             echo "
             The OWASP dependency check has found security vulnerabilities or failed in one or more modules. Please use a newer version
             of the dependency that does not have vulnerabilities. To see a report run
-            `mvn dependency-check:check`
+            mvn dependency-check:check
             If the analysis has false positives,
             they can be suppressed by adding entries to owasp-dependency-check-suppressions.xml (for more
             information, see https://jeremylong.github.io/DependencyCheck/general/suppression.html).

--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -51,12 +51,16 @@ jobs:
           cache: maven
 
       - name: Restore Dependency-Check data
+        id: dependency-check-cache
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/dependency-check
           key: dependency-check-data-${{ runner.os }}-odc-${{ env.DEPENDENCY_CHECK_CACHE_VERSION }}-${{ github.run_id }}
           restore-keys: |
             dependency-check-data-${{ runner.os }}-odc-${{ env.DEPENDENCY_CHECK_CACHE_VERSION }}-
+
+      - name: Report Dependency-Check cache status
+        run: echo "Dependency-Check cache-hit=${{ steps.dependency-check-cache.outputs.cache-hit }}"
 
       - name: maven build # needed to rebuild in case of maven snapshot resolution fails
         run: mvn clean install -P dist -P skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dweb.console.skip=true
@@ -77,7 +81,9 @@ jobs:
           " && false; }
 
       - name: Save Dependency-Check data
-        if: always()
+        # A pull_request run uses an isolated merge-ref cache that cannot be
+        # reused by branch, scheduled, or workflow_dispatch runs.
+        if: always() && github.event_name != 'pull_request'
         uses: actions/cache/save@v4
         with:
           path: ~/.cache/dependency-check

--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -71,7 +71,7 @@ jobs:
         env:
           OSS_INDEX_USERNAME: ${{ secrets.OSS_INDEX_USERNAME }}
           OSS_INDEX_PASSWORD: ${{ secrets.OSS_INDEX_PASSWORD }}
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+          NVD_API_KEY: ${{ secrets.NIST_NVD_API_KEY }}
         run: |
           mvn -B --fail-at-end dependency-check:check -DdataDirectory="$HOME/.cache/dependency-check" -DnvdValidForHours=24 -DnvdApiKey="$NVD_API_KEY" -DossIndexUsername="$OSS_INDEX_USERNAME" -DossIndexPassword="$OSS_INDEX_PASSWORD" || { echo "
           The OWASP dependency check has found security vulnerabilities. Please use a newer version

--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -60,7 +60,9 @@ jobs:
             dependency-check-data-${{ runner.os }}-odc-${{ env.DEPENDENCY_CHECK_CACHE_VERSION }}-
 
       - name: Report Dependency-Check cache status
-        run: echo "Dependency-Check cache-hit=${{ steps.dependency-check-cache.outputs.cache-hit }}"
+        run: |
+          echo "Dependency-Check cache-hit=${{ steps.dependency-check-cache.outputs.cache-hit }}"
+          echo "Dependency-Check cache-matched-key=${{ steps.dependency-check-cache.outputs.cache-matched-key }}"
 
       - name: maven build # needed to rebuild in case of maven snapshot resolution fails
         run: mvn clean install -P dist -P skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dweb.console.skip=true

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -269,11 +269,61 @@
     <cve>CVE-2022-24823</cve> <!-- We don't decode user HTTP requests nor forward them to remote systems, we also don't support for java 6 or lower - https://github.com/advisories/GHSA-269q-hmxg-m83q -->
     <cve>CVE-2022-41881</cve>
     <cve>CVE-2023-34462</cve>	<!-- Suppressed since netty requests in Druid are internal, and not user-facing -->
+    <!--
+      Dependency-Check maps the generic netty:netty CPE to advisories published for Netty 4 module artifacts.
+      Druid uses this Netty 3 artifact only for internal HTTP client requests; the affected Netty 4 modules and
+      APIs are not used by Druid.
+    -->
+    <cve>CVE-2024-29025</cve>
+    <cve>CVE-2024-47535</cve>
+    <cve>CVE-2025-25193</cve>
     <cve>CVE-2025-55163</cve> <!-- Netty 3.x not affected; HTTP/2 issues only in 4.x -->
     <cve>CVE-2025-58056</cve>
     <cve>CVE-2025-58057</cve> <!-- Netty 3.x not affected; compression issue only in 4.x -->
+    <cve>CVE-2025-67735</cve>
     <cve>CVE-2026-33870</cve> <!-- We don't use HttpPostRequestDecoder -->
     <cve>CVE-2026-33871</cve> <!-- Netty 3.x not affected; HTTP/2 issues only in 4.x -->
+    <cve>CVE-2026-41417</cve>
+    <cve>CVE-2026-42578</cve>
+    <cve>CVE-2026-42579</cve>
+    <cve>CVE-2026-42580</cve>
+    <cve>CVE-2026-42581</cve>
+    <cve>CVE-2026-42583</cve>
+    <cve>CVE-2026-42584</cve>
+    <cve>CVE-2026-42585</cve>
+    <cve>CVE-2026-42586</cve>
+    <cve>CVE-2026-42587</cve>
+    <cve>CVE-2026-44248</cve>
+    <cve>CVE-2026-44249</cve>
+    <cve>CVE-2026-44250</cve>
+    <cve>CVE-2026-44890</cve>
+    <cve>CVE-2026-44891</cve>
+    <cve>CVE-2026-44893</cve>
+    <cve>CVE-2026-45416</cve>
+    <cve>CVE-2026-45536</cve>
+    <cve>CVE-2026-45673</cve>
+    <cve>CVE-2026-45674</cve>
+    <cve>CVE-2026-46340</cve>
+    <cve>CVE-2026-47244</cve>
+    <cve>CVE-2026-47691</cve>
+    <cve>CVE-2026-48006</cve>
+    <cve>CVE-2026-48043</cve>
+    <cve>CVE-2026-48059</cve>
+    <cve>CVE-2026-50010</cve>
+    <cve>CVE-2026-50011</cve>
+    <cve>CVE-2026-50020</cve>
+    <cve>CVE-2026-50560</cve>
+    <cve>CVE-2026-56820</cve>
+    <cve>CVE-2026-56821</cve>
+    <cve>CVE-2026-56822</cve>
+    <cve>CVE-2026-59898</cve>
+    <cve>CVE-2026-59899</cve>
+    <cve>CVE-2026-59900</cve>
+    <cve>CVE-2026-59901</cve>
+    <cve>CVE-2026-59919</cve>
+    <cve>CVE-2026-59920</cve>
+    <cve>CVE-2026-59921</cve>
+    <cve>CVE-2026-62380</cve>
   </suppress>
 
   <suppress>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -843,7 +843,7 @@
       file name: hadoop-client-runtime-3.5.0.jar (shaded jetty-http/jetty-io 9.4.58.v20250814)
     ]]></notes>
     <filePath regex="true">.*hadoop-client-runtime-3\.5\.0\.jar.*</filePath>
-    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty-(http|io)@9\.4\.58.*$</packageUrl>
+    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty(\.[^/]+)?/.*@9\.4\.58.*$</packageUrl>
     <cve>CVE-2026-2332</cve>
     <cve>CVE-2026-10050</cve>
   </suppress>
@@ -855,7 +855,7 @@
       file name: hadoop-client-runtime-3.5.0.jar (shaded jline 3.9.0)
     ]]></notes>
     <filePath regex="true">.*hadoop-client-runtime-3\.5\.0\.jar.*</filePath>
-    <packageUrl regex="true">^pkg:maven/org\.jline/jline@3\.9\.0$</packageUrl>
+    <packageUrl regex="true">^pkg:maven/org\.jline/jline.*@.*$</packageUrl>
     <cve>CVE-2026-56741</cve>
     <cve>CVE-2026-56740</cve>
   </suppress>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -818,4 +818,74 @@
     <packageUrl regex="true">^pkg:maven/io\.grpc/grpc-.*@.*$</packageUrl>
     <cve>CVE-2026-33186</cve> <!-- Only applicable to gRPC Go (google.golang.org/grpc < 1.79.3), not gRPC Java - https://nvd.nist.gov/vuln/detail/CVE-2026-33186 -->
   </suppress>
+
+  <suppress>
+    <!-- These findings come from Jackson versions embedded in third-party shaded JARs.
+         Druid's normal Jackson dependency management cannot replace those copies. The
+         selectors are restricted to the two affected embedded JARs. Revisit when Hadoop
+         or Parquet ships a build containing the fixed Jackson version. -->
+    <notes><![CDATA[
+      file name: hadoop-client-runtime-3.5.0.jar (shaded jackson-databind 2.18.6)
+                 parquet-jackson-1.18.0.jar (shaded jackson-databind 2.22.1)
+    ]]></notes>
+    <filePath regex="true">.*(hadoop-client-runtime-3\.5\.0|parquet-jackson-1\.18\.0)\.jar.*</filePath>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@(2\.18\.6|2\.22\.1)$</packageUrl>
+    <cve>CVE-2026-54512</cve>
+    <cve>CVE-2026-54513</cve>
+    <cve>CVE-2026-68497</cve>
+  </suppress>
+
+  <suppress>
+    <!-- Hadoop shades Jetty 9.4.58 for its own internal HTTP components. Druid uses
+         Jetty for its server and does not expose Hadoop's embedded Jetty server or
+         Digest authentication. Keep the selectors limited to the Hadoop shaded JAR. -->
+    <notes><![CDATA[
+      file name: hadoop-client-runtime-3.5.0.jar (shaded jetty-http/jetty-io 9.4.58.v20250814)
+    ]]></notes>
+    <filePath regex="true">.*hadoop-client-runtime-3\.5\.0\.jar.*</filePath>
+    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty-(http|io)@9\.4\.58.*$</packageUrl>
+    <cve>CVE-2026-2332</cve>
+    <cve>CVE-2026-10050</cve>
+  </suppress>
+
+  <suppress>
+    <!-- Hadoop shades JLine for its interactive CLI. Druid does not expose a JLine
+         Telnet server endpoint. Keep this scoped to Hadoop's shaded copy. -->
+    <notes><![CDATA[
+      file name: hadoop-client-runtime-3.5.0.jar (shaded jline 3.9.0)
+    ]]></notes>
+    <filePath regex="true">.*hadoop-client-runtime-3\.5\.0\.jar.*</filePath>
+    <packageUrl regex="true">^pkg:maven/org\.jline/jline@3\.9\.0$</packageUrl>
+    <cve>CVE-2026-56741</cve>
+    <cve>CVE-2026-56740</cve>
+  </suppress>
+
+  <suppress>
+    <!-- Dependency-Check matches the Java GCP resource provider to OpenTelemetry Go
+         advisories. Druid uses the Java artifact only for GCP resource detection. -->
+    <notes><![CDATA[
+      file name: opentelemetry-gcp-resources-1.37.0-alpha.jar
+      The reported CVEs affect opentelemetry-go, not this Java artifact.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.contrib/opentelemetry-gcp-resources@1\.37\.0-alpha$</packageUrl>
+    <cve>CVE-2026-24051</cve>
+    <cve>CVE-2026-39883</cve>
+    <cve>CVE-2026-29181</cve>
+  </suppress>
+
+  <suppress>
+    <!-- docker-java-transport-zerodep embeds these HttpComponents versions. Druid uses
+         this dependency for container-based test infrastructure; normal Druid-managed
+         HttpClient versions cannot replace the relocated copies. Keep the suppression
+         limited to the exact embedded transport JAR and versions. -->
+    <notes><![CDATA[
+      file name: docker-java-transport-zerodep-3.7.1.jar (shaded httpclient5 5.5.1 and httpcore5 5.3.6)
+    ]]></notes>
+    <filePath regex="true">.*docker-java-transport-zerodep-3\.7\.1\.jar.*</filePath>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents\.(client5/httpclient5@5\.5\.1|core5/httpcore5@5\.3\.6)$</packageUrl>
+    <cve>CVE-2026-40542</cve>
+    <cve>CVE-2026-71290</cve>
+    <cve>CVE-2026-54399</cve>
+    <cve>CVE-2026-54428</cve>
+  </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -1965,7 +1965,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>12.2.0</version>
+                <version>12.2.2</version>
                 <configuration>
                     <nvdApiKey>${nvdApiKey}</nvdApiKey>
                     <failBuildOnCVSS>7</failBuildOnCVSS>

--- a/pom.xml
+++ b/pom.xml
@@ -1965,7 +1965,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>12.2.2</version>
+                <version>13.0.0</version>
                 <configuration>
                     <nvdApiKey>${nvdApiKey}</nvdApiKey>
                     <failBuildOnCVSS>7</failBuildOnCVSS>

--- a/pom.xml
+++ b/pom.xml
@@ -1967,7 +1967,7 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <version>13.0.0</version>
                 <configuration>
-                    <nvdApiKey>${nvdApiKey}</nvdApiKey>
+                    <nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>
                     <failBuildOnCVSS>7</failBuildOnCVSS>
                     <skipProvidedScope>true</skipProvidedScope>
                     <skipSystemScope>true</skipSystemScope>  <!-- avoid error when processing jdk.tools:jdk.tools:jar:1.8:system -->


### PR DESCRIPTION
## Description

- stop purging the OWASP Dependency-Check database before every scan
- restore and save the database through a dedicated GitHub Actions cache
- use a stable data directory and a 24-hour NVD freshness window
- add a manual workflow trigger for validation

## Testing

- `git diff --check`
- YAML parse validation
- Dependency-Check 12.2.0 parameter validation
- Cron Job ITs workflow run to be triggered after PR creation

The first run is expected to initialize the cache; a subsequent run will verify that the cached database is restored and only incremental NVD updates are downloaded.