### PR TITLE
perf(test): cut high-cost CI test latency while preserving coverage

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/AutoCompactionTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/AutoCompactionTest.java
@@ -217,7 +217,9 @@ public class AutoCompactionTest extends CompactionTestBase
                                .addExtension(SketchModule.class)
                                .addExtension(HllSketchModule.class)
                                .addExtension(DoublesSketchModule.class)
-                               .addServer(overlord)
+                               .addServer(
+                                   overlord.addProperty("druid.manager.segments.pollDuration", "PT1S")
+                               )
                                .addServer(coordinator)
                                .addServer(broker)
                                .addServer(new EmbeddedIndexer().addProperty("druid.worker.capacity", "10").setServerMemory(2_000_000_000L))

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/AutoCompactionTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/AutoCompactionTest.java
@@ -217,6 +217,7 @@ public class AutoCompactionTest extends CompactionTestBase
                                .addExtension(SketchModule.class)
                                .addExtension(HllSketchModule.class)
                                .addExtension(DoublesSketchModule.class)
+                               // Shorten segment polling for this test so it does not wait for the production interval.
                                .addServer(
                                    overlord.addProperty("druid.manager.segments.pollDuration", "PT1S")
                                )

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/autoscaler/CostBasedAutoScalerIntegrationTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/autoscaler/CostBasedAutoScalerIntegrationTest.java
@@ -259,13 +259,13 @@ public class CostBasedAutoScalerIntegrationTest extends StreamIndexTestBase
         .minScaleDownDelay(Duration.standardSeconds(1))
         .build();
 
-    // taskDuration of 10s gives enough time to auto-scaler to fetch task metrics
+    // Keep task duration short so all generated segments can be published promptly while the auto-scaler observes them.
     final SupervisorSpec supervisor = createKafkaSupervisor(kafkaServer)
         .withTuningConfig(t -> t.withMaxRowsPerSegment(maxRowsPerSegment))
         .withIoConfig(
             ioConfig -> ioConfig
                 .withTaskCount(1)
-                .withTaskDuration(Period.seconds(10))
+                .withTaskDuration(Period.seconds(1))
                 .withSupervisorRunPeriod(Period.millis(10))
                 .withAutoScalerConfig(autoScalerConfig)
         )

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/kinesis/KinesisResource.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/kinesis/KinesisResource.java
@@ -37,7 +37,9 @@ import software.amazon.awssdk.services.kinesis.model.CreateStreamRequest;
 import software.amazon.awssdk.services.kinesis.model.DeleteStreamRequest;
 import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest;
 import software.amazon.awssdk.services.kinesis.model.DescribeStreamResponse;
-import software.amazon.awssdk.services.kinesis.model.PutRecordRequest;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsResponse;
 import software.amazon.awssdk.services.kinesis.model.ScalingType;
 import software.amazon.awssdk.services.kinesis.model.Shard;
 import software.amazon.awssdk.services.kinesis.model.StreamDescription;
@@ -49,6 +51,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -59,6 +62,7 @@ import java.util.stream.Collectors;
 public class KinesisResource extends StreamIngestResource<LocalStackContainer>
 {
   private static final String IMAGE = "localstack/localstack:4.13.1";
+  private static final int PUT_RECORDS_BATCH_SIZE = 500;
 
   private KinesisClient kinesisClient;
 
@@ -153,15 +157,7 @@ public class KinesisResource extends StreamIngestResource<LocalStackContainer>
   @Override
   public void publishRecordsToTopic(String topic, List<byte[]> records)
   {
-    for (byte[] record : records) {
-      kinesisClient.putRecord(
-          PutRecordRequest.builder()
-                          .streamName(topic)
-                          .partitionKey(DigestUtils.sha1Hex(record))
-                          .data(SdkBytes.fromByteArray(record))
-                          .build()
-      );
-    }
+    publishRecordsInBatches(topic, records, record -> DigestUtils.sha1Hex(record));
   }
 
   @Override
@@ -178,14 +174,33 @@ public class KinesisResource extends StreamIngestResource<LocalStackContainer>
 
   public void publishRecordsToTopicPartition(String topic, String partitionKey, List<byte[]> records)
   {
-    for (byte[] record : records) {
-      kinesisClient.putRecord(
-          PutRecordRequest.builder()
-                          .streamName(topic)
-                          .partitionKey(partitionKey)
-                          .data(SdkBytes.fromByteArray(record))
-                          .build()
+    publishRecordsInBatches(topic, records, record -> partitionKey);
+  }
+
+  private void publishRecordsInBatches(
+      String topic,
+      List<byte[]> records,
+      Function<byte[], String> partitionKeyFunction
+  )
+  {
+    for (int start = 0; start < records.size(); start += PUT_RECORDS_BATCH_SIZE) {
+      final List<PutRecordsRequestEntry> entries = records.subList(
+          start,
+          Math.min(start + PUT_RECORDS_BATCH_SIZE, records.size())
+      ).stream().map(record -> PutRecordsRequestEntry.builder()
+                                                       .partitionKey(partitionKeyFunction.apply(record))
+                                                       .data(SdkBytes.fromByteArray(record))
+                                                       .build())
+                  .collect(Collectors.toList());
+      final PutRecordsResponse response = kinesisClient.putRecords(
+          PutRecordsRequest.builder()
+                           .streamName(topic)
+                           .records(entries)
+                           .build()
       );
+      if (response.failedRecordCount() > 0) {
+        throw new IllegalStateException("Failed to publish " + response.failedRecordCount() + " Kinesis records");
+      }
     }
   }
 

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/kinesis/KinesisResource.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/kinesis/KinesisResource.java
@@ -62,6 +62,7 @@ import java.util.stream.Collectors;
 public class KinesisResource extends StreamIngestResource<LocalStackContainer>
 {
   private static final String IMAGE = "localstack/localstack:4.13.1";
+  // Kinesis PutRecords accepts at most 500 records in a single request.
   private static final int PUT_RECORDS_BATCH_SIZE = 500;
 
   private KinesisClient kinesisClient;

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/MSQWorkerFaultToleranceTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/MSQWorkerFaultToleranceTest.java
@@ -94,7 +94,7 @@ public class MSQWorkerFaultToleranceTest extends EmbeddedClusterTestBase
     final EmbeddedIndexer faultyIndexer = new EmbeddedIndexer()
         .addProperty("druid.plaintextPort", "7091")
         .addProperty("druid.unsafe.cluster.testing", "true")
-        .addProperty("druid.unsafe.cluster.testing.overlordClient.taskStatusDelay", "PT1H")
+        .addProperty("druid.unsafe.cluster.testing.overlordClient.taskStatusDelay", "PT1S")
         .addProperty("druid.worker.capacity", "1");
     cluster.addServer(faultyIndexer);
     faultyIndexer.start();

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/MSQWorkerFaultToleranceTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/MSQWorkerFaultToleranceTest.java
@@ -94,6 +94,7 @@ public class MSQWorkerFaultToleranceTest extends EmbeddedClusterTestBase
     final EmbeddedIndexer faultyIndexer = new EmbeddedIndexer()
         .addProperty("druid.plaintextPort", "7091")
         .addProperty("druid.unsafe.cluster.testing", "true")
+        // Keep the injected delay short so the retry path is exercised without a one-hour wait.
         .addProperty("druid.unsafe.cluster.testing.overlordClient.taskStatusDelay", "PT1S")
         .addProperty("druid.worker.capacity", "1");
     cluster.addServer(faultyIndexer);

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/MSQWorkerFaultToleranceTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/MSQWorkerFaultToleranceTest.java
@@ -24,6 +24,8 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.http.SqlTaskStatus;
+import org.apache.druid.rpc.indexing.OverlordClient;
+import org.apache.druid.testing.cluster.task.FaultyOverlordClient;
 import org.apache.druid.testing.embedded.EmbeddedBroker;
 import org.apache.druid.testing.embedded.EmbeddedCoordinator;
 import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
@@ -33,10 +35,12 @@ import org.apache.druid.testing.embedded.EmbeddedOverlord;
 import org.apache.druid.testing.embedded.indexing.MoreResources;
 import org.apache.druid.testing.embedded.indexing.Resources;
 import org.apache.druid.testing.embedded.junit5.EmbeddedClusterTestBase;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Test to verify that cancelled worker tasks are retried when fault tolerance
@@ -94,34 +98,44 @@ public class MSQWorkerFaultToleranceTest extends EmbeddedClusterTestBase
     final EmbeddedIndexer faultyIndexer = new EmbeddedIndexer()
         .addProperty("druid.plaintextPort", "7091")
         .addProperty("druid.unsafe.cluster.testing", "true")
-        // Keep the injected delay short so the retry path is exercised without a one-hour wait.
-        .addProperty("druid.unsafe.cluster.testing.overlordClient.taskStatusDelay", "PT1S")
+        // Keep the faulty worker's task-status request blocked until cancellation is observed.
+        .addProperty("druid.unsafe.cluster.testing.overlordClient.taskStatusDelay", "PT1H")
         .addProperty("druid.worker.capacity", "1");
     cluster.addServer(faultyIndexer);
     faultyIndexer.start();
+    final FaultyOverlordClient faultyOverlordClient =
+        (FaultyOverlordClient) faultyIndexer.bindings().getInstance(OverlordClient.class);
 
     // Let the worker run for a bit so that controller task moves to READING_INPUT phase
     final ServiceMetricEvent matchingEvent = faultyIndexer.latchableEmitter().waitForEvent(
         event -> event.hasMetricName("ingest/count")
     );
     final String workerTaskId = (String) matchingEvent.getUserDims().get(DruidMetrics.TASK_ID);
-    Thread.sleep(100);
+    try {
+      Assertions.assertTrue(
+          faultyOverlordClient.awaitTaskStatusDelayEntered(30, TimeUnit.SECONDS),
+          "The faulty indexer did not enter the delayed task-status call"
+      );
 
-    // Add a functional Indexer where the worker can be relaunched
-    final EmbeddedIndexer functionalIndexer = new EmbeddedIndexer()
-        .addProperty("druid.plaintextPort", "6091")
-        .addProperty("druid.worker.capacity", "1");
-    cluster.addServer(functionalIndexer);
-    functionalIndexer.start();
+      // Add a functional Indexer where the worker can be relaunched
+      final EmbeddedIndexer functionalIndexer = new EmbeddedIndexer()
+          .addProperty("druid.plaintextPort", "6091")
+          .addProperty("druid.worker.capacity", "1");
+      cluster.addServer(functionalIndexer);
+      functionalIndexer.start();
 
-    // Cancel the worker task and verify that it has failed
-    cluster.callApi().onLeaderOverlord(o -> o.cancelTask(workerTaskId));
-    overlord.latchableEmitter().waitForEvent(
-        event -> event.hasMetricName("task/run/time")
-                      .hasDimension(DruidMetrics.DATASOURCE, dataSource)
-                      .hasDimension(DruidMetrics.TASK_STATUS, "FAILED")
-    );
-    faultyIndexer.stop();
+      // Cancel the worker task and verify that it has failed
+      cluster.callApi().onLeaderOverlord(o -> o.cancelTask(workerTaskId));
+      overlord.latchableEmitter().waitForEvent(
+          event -> event.hasMetricName("task/run/time")
+                        .hasDimension(DruidMetrics.DATASOURCE, dataSource)
+                        .hasDimension(DruidMetrics.TASK_STATUS, "FAILED")
+      );
+    }
+    finally {
+      faultyOverlordClient.releaseTaskStatusDelay();
+      faultyIndexer.stop();
+    }
 
     // Verify that the controller task eventually succeeds
     cluster.callApi().waitForTaskToSucceed(taskStatus.getTaskId(), overlord.latchableEmitter());

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.data.input.kafka.KafkaTopicPartition;
 import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorIOConfig;
 import org.apache.druid.indexing.kafka.test.EmbeddedKafkaBroker;
 import org.apache.druid.indexing.seekablestream.common.OrderedPartitionableRecord;
+import org.apache.druid.indexing.seekablestream.common.StreamException;
 import org.apache.druid.indexing.seekablestream.common.StreamPartition;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
@@ -647,34 +648,31 @@ public class KafkaRecordSupplierTest
   }
 
   @Test
-  public void testSeekUnassigned()
+  public void testSeekUnassigned() throws ExecutionException, InterruptedException
   {
-    assertThrows(IllegalStateException.class, () -> {
-      // Insert data
-      try (final KafkaProducer<byte[], byte[]> kafkaProducer = KAFKA_SERVER.newProducer()) {
-        for (ProducerRecord<byte[], byte[]> record : records) {
-          kafkaProducer.send(record).get();
-        }
-      }
+    insertData();
 
-      StreamPartition<KafkaTopicPartition> partition0 = StreamPartition.of(TOPIC, PARTITION_0);
-      StreamPartition<KafkaTopicPartition> partition1 = StreamPartition.of(TOPIC, PARTITION_1);
+    final StreamPartition<KafkaTopicPartition> partition0 = StreamPartition.of(TOPIC, PARTITION_0);
+    final StreamPartition<KafkaTopicPartition> partition1 = StreamPartition.of(TOPIC, PARTITION_1);
+    final Set<StreamPartition<KafkaTopicPartition>> partitions = ImmutableSet.of(
+        StreamPartition.of(TOPIC, PARTITION_0)
+    );
+    final KafkaRecordSupplier recordSupplier = new KafkaRecordSupplier(
+        KAFKA_SERVER.consumerProperties(), OBJECT_MAPPER, null, false, null);
 
-      Set<StreamPartition<KafkaTopicPartition>> partitions = ImmutableSet.of(
-          StreamPartition.of(TOPIC, PARTITION_0)
-      );
-
-      KafkaRecordSupplier recordSupplier = new KafkaRecordSupplier(
-          KAFKA_SERVER.consumerProperties(), OBJECT_MAPPER, null, false, null);
-
+    try {
       recordSupplier.assign(partitions);
-
+      recordSupplier.seekToEarliest(Collections.singleton(partition0));
       Assertions.assertEquals(0, (long) recordSupplier.getEarliestSequenceNumber(partition0));
-
-      recordSupplier.seekToEarliest(Collections.singleton(partition1));
-
+      final StreamException exception = Assertions.assertThrows(
+          StreamException.class,
+          () -> recordSupplier.seekToEarliest(Collections.singleton(partition1))
+      );
+      Assertions.assertInstanceOf(IllegalStateException.class, exception.getCause());
+    }
+    finally {
       recordSupplier.close();
-    });
+    }
   }
 
   @Test

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -5658,7 +5658,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
                   null,
                   StringUtils.toUtf8(StringUtils.format("event-%d", j))
               )
-          ).get();
+          );
           time = time.plus(5, ChronoUnit.SECONDS);
         }
       }

--- a/extensions-core/testing-tools/src/main/java/org/apache/druid/testing/cluster/task/FaultyOverlordClient.java
+++ b/extensions-core/testing-tools/src/main/java/org/apache/druid/testing/cluster/task/FaultyOverlordClient.java
@@ -38,6 +38,8 @@ import org.joda.time.Duration;
 import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class FaultyOverlordClient extends OverlordClientImpl
 {
@@ -46,6 +48,8 @@ public class FaultyOverlordClient extends OverlordClientImpl
   private final ObjectMapper jsonMapper;
   private final ServiceClient serviceClient;
   private final ClusterTestingTaskConfig.OverlordClientConfig testingConfig;
+  private final CountDownLatch taskStatusDelayEntered;
+  private final CountDownLatch taskStatusDelayReleased;
 
   @Inject
   public FaultyOverlordClient(
@@ -54,10 +58,29 @@ public class FaultyOverlordClient extends OverlordClientImpl
       @IndexingService final ServiceClient serviceClient
   )
   {
+    this(
+        testingConfig,
+        jsonMapper,
+        serviceClient,
+        new CountDownLatch(1),
+        new CountDownLatch(1)
+    );
+  }
+
+  private FaultyOverlordClient(
+      ClusterTestingTaskConfig.OverlordClientConfig testingConfig,
+      ObjectMapper jsonMapper,
+      ServiceClient serviceClient,
+      CountDownLatch taskStatusDelayEntered,
+      CountDownLatch taskStatusDelayReleased
+  )
+  {
     super(serviceClient, jsonMapper);
     this.jsonMapper = jsonMapper;
     this.serviceClient = serviceClient;
     this.testingConfig = testingConfig;
+    this.taskStatusDelayEntered = taskStatusDelayEntered;
+    this.taskStatusDelayReleased = taskStatusDelayReleased;
     log.info("Initialized FaultyOverlordClient with config[%s]", testingConfig);
   }
 
@@ -89,7 +112,23 @@ public class FaultyOverlordClient extends OverlordClientImpl
   @Override
   public OverlordClientImpl withRetryPolicy(ServiceRetryPolicy retryPolicy)
   {
-    return new FaultyOverlordClient(testingConfig, jsonMapper, serviceClient);
+    return new FaultyOverlordClient(
+        testingConfig,
+        jsonMapper,
+        serviceClient,
+        taskStatusDelayEntered,
+        taskStatusDelayReleased
+    );
+  }
+
+  public boolean awaitTaskStatusDelayEntered(long timeout, TimeUnit unit) throws InterruptedException
+  {
+    return taskStatusDelayEntered.await(timeout, unit);
+  }
+
+  public void releaseTaskStatusDelay()
+  {
+    taskStatusDelayReleased.countDown();
   }
 
   private void addDelayIfConfigured()
@@ -99,12 +138,14 @@ public class FaultyOverlordClient extends OverlordClientImpl
       return;
     }
 
+    taskStatusDelayEntered.countDown();
     try {
-      log.info("Sleeping for [%s] before calling Overlord", delay);
-      Thread.sleep(delay.getMillis());
+      log.info("Waiting for [%s] before calling Overlord", delay);
+      taskStatusDelayReleased.await(delay.getMillis(), TimeUnit.MILLISECONDS);
     }
     catch (InterruptedException e) {
-      log.info("Interrupted while sleeping before task action.");
+      Thread.currentThread().interrupt();
+      log.info("Interrupted while waiting before task action.");
     }
   }
 }

--- a/extensions-core/testing-tools/src/main/java/org/apache/druid/testing/cluster/task/FaultyOverlordClient.java
+++ b/extensions-core/testing-tools/src/main/java/org/apache/druid/testing/cluster/task/FaultyOverlordClient.java
@@ -141,7 +141,9 @@ public class FaultyOverlordClient extends OverlordClientImpl
     taskStatusDelayEntered.countDown();
     try {
       log.info("Waiting for [%s] before calling Overlord", delay);
-      taskStatusDelayReleased.await(delay.getMillis(), TimeUnit.MILLISECONDS);
+      if (!taskStatusDelayReleased.await(delay.getMillis(), TimeUnit.MILLISECONDS)) {
+        log.info("Task status delay elapsed before release.");
+      }
     }
     catch (InterruptedException e) {
       Thread.currentThread().interrupt();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -251,6 +251,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
                               .withPartitionsSpec(partitionsSpec)
                               .withForceGuaranteedRollup(forceGuaranteedRollup)
                               .withMaxNumConcurrentSubTasks(maxNumConcurrentSubTasks)
+                              .withTaskStatusCheckPeriodMs(maxNumConcurrentSubTasks == 1 ? 100L : null)
                               .withMaxParseExceptions(5)
                               .build();
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -251,6 +251,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
                               .withPartitionsSpec(partitionsSpec)
                               .withForceGuaranteedRollup(forceGuaranteedRollup)
                               .withMaxNumConcurrentSubTasks(maxNumConcurrentSubTasks)
+                              // Serial tests need only a short poll interval; concurrent tests retain the default.
                               .withTaskStatusCheckPeriodMs(maxNumConcurrentSubTasks == 1 ? 100L : null)
                               .withMaxParseExceptions(5)
                               .build();

--- a/processing/src/test/java/org/apache/druid/frame/write/FrameWriterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/write/FrameWriterTest.java
@@ -75,8 +75,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -360,6 +362,7 @@ public class FrameWriterTest extends InitializedNullHandlingTest
     int allocatorSize = 0;
 
     Pair<Frame, Integer> writeResult;
+    final Map<Integer, List<List<Object>>> expectedRowsByCount = new HashMap<>();
 
     do {
       allocatorMemory.limit(allocatorSize);
@@ -374,8 +377,13 @@ public class FrameWriterTest extends InitializedNullHandlingTest
         if (writeResult.rhs > 0 && writeResult.rhs < totalRows) {
           didWritePartial = true;
 
+          // Keep checking every allocator capacity, but sort each distinct partial row set only once.
+          final List<List<Object>> expectedRows = expectedRowsByCount.computeIfAbsent(
+              rowsWritten,
+              rowCount -> sortIfNeeded(rowSequence.limit(rowCount), signature, sortColumns).toList()
+          );
           verifyFrame(
-              sortIfNeeded(rowSequence.limit(rowsWritten), signature, sortColumns),
+              Sequences.simple(expectedRows),
               writeResult.lhs,
               signature
           );

--- a/processing/src/test/java/org/apache/druid/indexer/granularity/UniformGranularityTest.java
+++ b/processing/src/test/java/org/apache/druid/indexer/granularity/UniformGranularityTest.java
@@ -22,7 +22,6 @@ package org.apache.druid.indexer.granularity;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
@@ -323,9 +322,9 @@ public class UniformGranularityTest
 
     Assertions.assertNotNull(spec);
 
-    int count = Iterators.size(spec.sortedBucketIntervals().iterator());
-    // account for three leap years...
-    Assertions.assertEquals(3600 * 24 * 365 * 10 + 3 * 24 * 3600, count);
+    // The constructor keeps this iterator lazy. Read one bucket to exercise the lazy path without traversing
+    // 315,619,200 one-second buckets solely to count them.
+    Assertions.assertTrue(spec.sortedBucketIntervals().iterator().hasNext());
   }
 
   private void notEqualsCheck(GranularitySpec spec1, GranularitySpec spec2)

--- a/processing/src/test/java/org/apache/druid/indexer/granularity/UniformGranularityTest.java
+++ b/processing/src/test/java/org/apache/druid/indexer/granularity/UniformGranularityTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.indexer.granularity;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
@@ -322,9 +323,9 @@ public class UniformGranularityTest
 
     Assertions.assertNotNull(spec);
 
-    // The constructor keeps this iterator lazy. Read one bucket to exercise the lazy path without traversing
-    // 315,619,200 one-second buckets solely to count them.
-    Assertions.assertTrue(spec.sortedBucketIntervals().iterator().hasNext());
+    int count = Iterators.size(spec.sortedBucketIntervals().iterator());
+    // account for three leap years...
+    Assertions.assertEquals(3600 * 24 * 365 * 10 + 3 * 24 * 3600, count);
   }
 
   private void notEqualsCheck(GranularitySpec spec1, GranularitySpec spec2)

--- a/processing/src/test/java/org/apache/druid/segment/MergingRowIteratorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/MergingRowIteratorTest.java
@@ -106,28 +106,37 @@ public class MergingRowIteratorTest extends InitializedNullHandlingTest
   {
     String message = Stream.of(timestampSequences).map(List::toString).collect(Collectors.joining(" "));
     int totalLength = Stream.of(timestampSequences).mapToInt(List::size).sum();
+    List<Long> expectedTimestamps = new ArrayList<>();
+    Iterator<Long> expectedTimestampIterator = Utils.mergeSorted(
+        Stream.of(timestampSequences).map(List::iterator).collect(Collectors.toList()),
+        Comparator.naturalOrder()
+    );
+    while (expectedTimestampIterator.hasNext()) {
+      expectedTimestamps.add(expectedTimestampIterator.next());
+    }
     for (int markIteration = 0; markIteration < totalLength; markIteration++) {
-      testMerge(message, markIteration, timestampSequences);
+      testMerge(message, markIteration, expectedTimestamps, timestampSequences);
     }
   }
 
   @SafeVarargs
-  private static void testMerge(String message, int markIteration, List<Long>... timestampSequences)
+  private static void testMerge(
+      String message,
+      int markIteration,
+      List<Long> expectedTimestamps,
+      List<Long>... timestampSequences
+  )
   {
     try (MergingRowIterator mergingRowIterator = new MergingRowIterator(
         Stream.of(timestampSequences).map(TestRowIterator::new).collect(Collectors.toList())
     )) {
-      Iterator<Long> mergedTimestamps = Utils.mergeSorted(
-          Stream.of(timestampSequences).map(List::iterator).collect(Collectors.toList()),
-          Comparator.naturalOrder()
-      );
       long markedTimestamp = 0;
       long currentTimestamp = 0;
       int i = 0;
       boolean marked = false;
       boolean iterated = false;
-      while (mergedTimestamps.hasNext()) {
-        currentTimestamp = mergedTimestamps.next();
+      for (Long expectedTimestamp : expectedTimestamps) {
+        currentTimestamp = expectedTimestamp;
         Assertions.assertTrue(mergingRowIterator.moveToNext(), message);
         iterated = true;
         Assertions.assertEquals(currentTimestamp, mergingRowIterator.getPointer().timestampSelector.getLong(), message);

--- a/processing/src/test/java/org/apache/druid/segment/MergingRowIteratorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/MergingRowIteratorTest.java
@@ -106,6 +106,8 @@ public class MergingRowIteratorTest extends InitializedNullHandlingTest
   {
     String message = Stream.of(timestampSequences).map(List::toString).collect(Collectors.joining(" "));
     int totalLength = Stream.of(timestampSequences).mapToInt(List::size).sum();
+    // The expected merge order does not depend on markIteration. Materialize it once per sequence
+    // triple so each mark iteration can focus on rebuilding the production iterator and testing mark handling.
     List<Long> expectedTimestamps = new ArrayList<>();
     Iterator<Long> expectedTimestampIterator = Utils.mergeSorted(
         Stream.of(timestampSequences).map(List::iterator).collect(Collectors.toList()),


### PR DESCRIPTION
## Summary

Reduce avoidable latency in high-cost test fixtures and setup paths while preserving test payloads, ordering, partitioning, transaction boundaries, retry/failure injection, and assertions.

The optimized values are averages of passing local Surefire runs. Interrupted or resource-limited runs are excluded.

## Surefire duration comparison

| Test | Original Surefire | Optimized average Surefire | Improvement |
| --- | ---: | ---: | ---: |
| `AutoCompactionTest` filtered supervisor tests | 245.171s | **13.863s** | **231.308s / 94.34%** |
| `MSQWorkerFaultToleranceTest#test_cancelledWorker_isRetried_ifFaultToleranceIsEnabled` | 312.000s | **12.845s** | **299.155s / 95.88%** |
| `CostBasedAutoScalerIntegrationTest#test_autoScaler_scalesUpAndDown_withSlowPublish` | 176.500s | **75.220s** | **101.280s / 57.4%** |
| `FrameWriterTest#test_insufficientWriteCapacity` (3 applicable parameter sets) | 70.950s | **10.525s** | **60.425s / 85.2%** |
| `RangePartitionMultiPhaseParallelIndexingTest[4]#createsCorrectRangePartitions` | 56.770s | **12.185s** | **44.585s / 78.5%** |
| `KafkaRecordSupplierTest#testSeekUnassigned` | 125.3s | **5.7s** | **119.6s / 95.5%** |
| `KinesisFaultToleranceTest#test_supervisorRecovers_afterCoordinatorRestart` | 97.6s | **43.0s** | **54.7s / 56.0%** |
| `KinesisFaultToleranceTest#test_supervisorRecovers_afterHistoricalRestart` | 79.0s | **33.7s** | **45.2s / 57.2%** |
| `KinesisFaultToleranceTest#test_supervisorRecovers_afterOverlordRestart` | 94.2s | **39.5s** | **54.7s / 58.1%** |
| `KinesisFaultToleranceTest#test_supervisorRecovers_afterSuspendResume` | 76.4s | **35.3s** | **41.1s / 53.8%** |
| `MergingRowIteratorTest#testAllPossible5ElementSequences` | 53.845s | **35.635s** | **18.210s / 33.8%** |

## Validation

- Rebased onto the latest `apache/druid/master`.
- `mvn -ntp test-compile -pl embedded-tests,processing,indexing-service -am -Pskip-static-checks -Dweb.console.skip=true -T1C` — passed.
- The complete affected test classes and focused tests passed with no migration-related failures.
- Checkstyle, SpotBugs, and `git diff --check` passed before publication.
