### PR TITLE
fix: Make HttpLoadQueuePeon degrade gracefully instead of throwing on fetch failure

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeon.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeon.java
@@ -178,7 +178,13 @@ public class HttpLoadQueuePeon implements LoadQueuePeon
         return defaultCapabilities;
       } else if (HttpServletResponse.SC_OK != responseHandler.getStatus()) {
         log.makeAlert("Received status[%s] when fetching loading capabilities from server[%s]", responseHandler.getStatus(), serverId);
-        throw new RE("Received status[%s] when fetching loading capabilities from server[%s]", responseHandler.getStatus(), serverId);
+        int batchSize = config.getBatchSize() == null ? 1 : config.getBatchSize();
+        SegmentLoadingCapabilities defaultCapabilities = new SegmentLoadingCapabilities(batchSize, batchSize);
+        log.warn(
+            "Failed to fetch loading capabilities from server[%s]. Received status[%s]. Using default capabilities[%s].",
+            serverId, responseHandler.getStatus(), defaultCapabilities
+        );
+        return defaultCapabilities;
       }
 
       return jsonMapper.readValue(
@@ -187,7 +193,9 @@ public class HttpLoadQueuePeon implements LoadQueuePeon
       );
     }
     catch (Throwable th) {
-      throw new RE(th, "Received error while fetching historical capabilities from Server[%s].", serverId);
+      log.warn(th, "Failed to fetch loading capabilities from server[%s]. Using default capabilities.", serverId);
+      int batchSize = config.getBatchSize() == null ? 1 : config.getBatchSize();
+      return new SegmentLoadingCapabilities(batchSize, batchSize);
     }
   }
 


### PR DESCRIPTION
### Description

Fixes #19950

When a historical server returns a non-200/404 response or is unreachable
during `fetchSegmentLoadingCapabilities()`, the `HttpLoadQueuePeon` constructor
throws an `RE`. This exception propagates through
`LoadQueueTaskMaster.resetPeonsForNewServers()` into
`PrepareBalancerAndLoadQueues`, which is the first duty in the
`HistoricalManagementDuties` group. The top-level
`DruidCoordinator.DutiesRunnable.run()` catches and logs the exception, but
segment management (loading, balancing, handoffs) stops entirely for **all**
servers — not just the unhealthy one. Ingestion tasks back up waiting for
handoff.

### Changes

- `fetchSegmentLoadingCapabilities()`: Instead of throwing `RE` on non-200/404
  responses or any `Throwable`, return default `SegmentLoadingCapabilities`
  derived from the configured batch size, with a warning log. The peon is still
  created, the server is still managed with conservative defaults, and the rest
  of the duty group proceeds normally.
- Mirror the existing 404 branch's fallback behavior (already returned default
  capabilities).

### Key design decisions

- The 404 branch already existed and returned default capabilities. The fix
  extends this same graceful degradation to non-200 responses and exceptions.
- `log.makeAlert()` is preserved for non-200 responses so operators still get
  alerted about the unhealthy server.
- The catch block now logs a warning instead of throwing, keeping the
  Coordinator ticking.

### Release notes

Fixed a bug where a single unhealthy or unreachable historical server could
stall all segment loading and balancing across the cluster.