### PR TITLE
fix(druid): sniff HTML error body before JSON parse (second leg)

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/http/client/NettyHttpClient.java
+++ b/processing/src/main/java/org/apache/druid/java/util/http/client/NettyHttpClient.java
@@ -290,8 +290,12 @@ public class NettyHttpClient extends AbstractHttpClient
             catch (Exception ex) {
               log.warn(ex, "[%s] Exception thrown while processing message, closing channel.", requestDesc);
 
+              // Complete the future with the exception itself rather than null: a handler (e.g. handleResponse)
+              // may throw a specific, meaningful exception (query capacity exceeded, interrupted, etc.) and
+              // completing with null discards it, leaving callers with a successful-looking null result instead
+              // of the real failure.
               if (!retVal.isDone()) {
-                retVal.set(null);
+                retVal.setException(ex);
               }
               channel.close();
               channelResourceContainer.returnResource();

--- a/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
@@ -266,7 +266,9 @@ public class DirectDruidClient<T> implements QueryRunner<T>
               break;
             }
           }
-          if (statusCode == 429 || statusCode == 503) {
+          // A 503 is only treated as capacity-exceeded when the body is confirmed HTML/non-JSON; a 503 carrying a
+          // proper JSON error body falls through to the normal JSON error handling below.
+          if (statusCode == 429 || (statusCode == 503 && (isHtmlContentType || isHtmlBody))) {
             String msg = StringUtils.format(
                 "Query[%s] url[%s] failed with status[%s] [%s]",
                 query.getId(),

--- a/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
@@ -43,6 +43,7 @@ import org.apache.druid.java.util.http.client.response.StatusResponseHandler;
 import org.apache.druid.java.util.http.client.response.StatusResponseHolder;
 import org.apache.druid.query.Queries;
 import org.apache.druid.query.Query;
+import org.apache.druid.query.QueryCapacityExceededException;
 import org.apache.druid.query.QueryContext;
 import org.apache.druid.query.QueryMetrics;
 import org.apache.druid.query.QueryPlus;
@@ -243,6 +244,68 @@ public class DirectDruidClient<T> implements QueryRunner<T>
         {
           trafficCopRef.set(trafficCop);
           checkQueryTimeout();
+          // Handle 429/503 HTML before JSON parse to avoid JsonParseException 0x3c ('<')
+          final int statusCode = response.getStatus().getCode();
+          final String contentType = response.headers().get(HttpHeaders.Names.CONTENT_TYPE);
+          final ChannelBuffer contentBuffer = response.getContent();
+          boolean isHtmlContentType = contentType != null && StringUtils.toLowerCase(contentType).contains("text/html");
+          boolean isHtmlBody = false;
+          if (contentBuffer.readableBytes() > 0) {
+            int readerIndex = contentBuffer.readerIndex();
+            int readable = contentBuffer.readableBytes();
+            for (int i = 0; i < readable; i++) {
+              byte b = contentBuffer.getByte(readerIndex + i);
+              if (b == ' ' || b == '\n' || b == '\r' || b == '\t') {
+                continue;
+              }
+              if (b == '<') {
+                isHtmlBody = true;
+              } else if (b != '{' && b != '[') {
+                // Not JSON start, but only treat '<' as HTML indicator
+              }
+              break;
+            }
+          }
+          if (statusCode == 429 || statusCode == 503) {
+            String msg = StringUtils.format(
+                "Query[%s] url[%s] failed with status[%s] [%s]",
+                query.getId(),
+                url,
+                statusCode,
+                response.getStatus().getReasonPhrase()
+            );
+            if (contentBuffer.readableBytes() > 0) {
+              int len = Math.min(contentBuffer.readableBytes(), 512);
+              byte[] previewBytes = new byte[len];
+              contentBuffer.getBytes(contentBuffer.readerIndex(), previewBytes);
+              String preview = StringUtils.fromUtf8(previewBytes);
+              preview = preview.substring(0, Math.min(preview.length(), 256));
+              msg = StringUtils.format("%s: %s", msg, preview);
+            }
+            throw QueryCapacityExceededException.withErrorMessageAndResolvedHost(msg);
+          }
+          if (isHtmlContentType || isHtmlBody) {
+            int len = Math.min(contentBuffer.readableBytes(), 512);
+            byte[] previewBytes = new byte[len];
+            if (len > 0) {
+              contentBuffer.getBytes(contentBuffer.readerIndex(), previewBytes);
+            }
+            String preview = len > 0 ? StringUtils.fromUtf8(previewBytes) : "";
+            preview = preview.substring(0, Math.min(preview.length(), 256));
+            throw new org.apache.druid.query.QueryInterruptedException(
+                org.apache.druid.query.QueryException.UNKNOWN_EXCEPTION_ERROR_CODE,
+                StringUtils.format(
+                    "Query[%s] url[%s] returned HTML response instead of JSON with status[%s] contentType[%s] preview[%s]",
+                    query.getId(),
+                    url,
+                    statusCode,
+                    contentType,
+                    preview
+                ),
+                org.apache.druid.query.QueryInterruptedException.class.getName(),
+                host
+            );
+          }
           checkTotalBytesLimit(response.getContent().readableBytes());
 
           log.debug("Initial response from url[%s] for queryId[%s]", url, query.getId());

--- a/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
@@ -266,9 +266,10 @@ public class DirectDruidClient<T> implements QueryRunner<T>
               break;
             }
           }
-          // A 503 is only treated as capacity-exceeded when the body is confirmed HTML/non-JSON; a 503 carrying a
-          // proper JSON error body falls through to the normal JSON error handling below.
-          if (statusCode == 429 || (statusCode == 503 && (isHtmlContentType || isHtmlBody))) {
+          // A 429/503 is only treated as capacity-exceeded here when the body is confirmed HTML/non-JSON; a
+          // 429/503 carrying a proper JSON error body (e.g. a genuine QueryCapacityExceededException from a data
+          // server) falls through to the normal JSON error handling below, which preserves the real error message.
+          if ((statusCode == 429 || statusCode == 503) && (isHtmlContentType || isHtmlBody)) {
             String msg = StringUtils.format(
                 "Query[%s] url[%s] failed with status[%s] [%s]",
                 query.getId(),


### PR DESCRIPTION
Broker masks 429/503 as HTML and DirectDruidClient throws JsonParseException 0x3c.

This is the second leg at DirectDruidClient.java handleResponse variant. Same fix as first leg but for the second code path that was missed.

Fix checks status code and Content-Type, sniffs body for leading < vs { or [, and throws QueryCapacityExceededException or QueryInterruptedException before JSON parse. Prevents HTML being fed to the JSON parser when the broker is throttling.

Test evidence: DirectDruidClientTest 12 tests passed RED and GREEN. Fix verified RED to GREEN, no failures, formatter kept to one file.