### PR TITLE
feat: warn when hash/range ingest publishes oversized segments

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -227,6 +227,7 @@ If SQL is enabled, the Broker will emit the following metrics for SQL.
 |------|-----------|----------|------------|
 |`ingest/count`|Count of `1` every time an ingestion job runs (includes compaction jobs). Aggregate using dimensions. | `dataSource`, `taskId`, `taskType`, `groupId`, `taskIngestionMode`, `tags` |Always `1`.|
 |`ingest/segments/count`|Count of final segments created by job (includes tombstones). | `dataSource`, `taskId`, `taskType`, `groupId`, `taskIngestionMode`, `tags` |At least `1`.|
+|`ingest/segments/oversized`|Count of final segments created by job that were detected as being oversized, meaning the number of rows in the segment exceeded more than 2x the maxRowsPerSegment in the spec. This is relevant only for hash and range partitioned ingestions. | `dataSource`, `taskId`, `taskType`, `groupId`, `taskIngestionMode`, `tags` |At least `1`.|
 |`ingest/rows/published`|Number of rows successfully published by the job. | `dataSource`, `taskId`, `taskType`, `groupId`, `taskIngestionMode`, `tags` |At least `1`.|
 |`ingest/tombstones/count`|Count of tombstones created by job. | `dataSource`, `taskId`, `taskType`, `groupId`, `taskIngestionMode`, `tags` |Zero or more for replace. Always zero for non-replace tasks (always zero for legacy replace, see below).|
 

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -227,7 +227,7 @@ If SQL is enabled, the Broker will emit the following metrics for SQL.
 |------|-----------|----------|------------|
 |`ingest/count`|Count of `1` every time an ingestion job runs (includes compaction jobs). Aggregate using dimensions. | `dataSource`, `taskId`, `taskType`, `groupId`, `taskIngestionMode`, `tags` |Always `1`.|
 |`ingest/segments/count`|Count of final segments created by job (includes tombstones). | `dataSource`, `taskId`, `taskType`, `groupId`, `taskIngestionMode`, `tags` |At least `1`.|
-|`ingest/segments/oversized`|Count of final segments created by job that were detected as being oversized, meaning the number of rows in the segment exceeded more than 2x the maxRowsPerSegment in the spec. This is relevant only for hash and range partitioned ingestions. | `dataSource`, `taskId`, `taskType`, `groupId`, `taskIngestionMode`, `tags` |At least `1`.|
+|`ingest/segments/oversized`|Count of final segments created by job that were detected as being oversized, meaning the number of rows in the segment exceeded more than twice the maxRowsPerSegment in the spec. This is relevant only for hash and range partitioned ingestions. | `dataSource`, `taskId`, `taskType`, `groupId`, `taskIngestionMode`, `tags` |At least `1`.|
 |`ingest/rows/published`|Number of rows successfully published by the job. | `dataSource`, `taskId`, `taskType`, `groupId`, `taskIngestionMode`, `tags` |At least `1`.|
 |`ingest/tombstones/count`|Count of tombstones created by job. | `dataSource`, `taskId`, `taskType`, `groupId`, `taskIngestionMode`, `tags` |Zero or more for replace. Always zero for non-replace tasks (always zero for legacy replace, see below).|
 

--- a/extensions-contrib/prometheus-emitter/src/main/resources/defaultMetrics.json
+++ b/extensions-contrib/prometheus-emitter/src/main/resources/defaultMetrics.json
@@ -102,6 +102,7 @@
 
   "ingest/count" : { "dimensions" : ["dataSource", "taskType"], "type" : "count", "help": "Count of 1 every time an ingestion job runs (includes compaction jobs). Aggregate using dimensions." },
   "ingest/segments/count" : { "dimensions" : ["dataSource", "taskType"], "type" : "count", "help": "Count of final segments created by job (includes tombstones)." },
+  "ingest/segments/oversized" : { "dimensions" : ["dataSource", "taskType"], "type" : "count", "help": "Count of final segments created by job that were detected as being oversized, meaning the number of rows in the segment exceeded more than 2x the maxRowsPerSegment in the spec. This is relevant only for hash and range partitioned ingestions." },
   "ingest/tombstones/count" : { "dimensions" : ["dataSource", "taskType"], "type" : "count", "help": "Count of tombstones created by job." },
   "ingest/rows/published": { "dimensions" : ["dataSource", "taskType"], "type" : "count", "help": "Number of rows successfully published by the job." },
 

--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -55,6 +55,7 @@
   "ingest/merge/time" : { "dimensions" : ["dataSource"], "type" : "timer" },
   "ingest/merge/cpu" : { "dimensions" : ["dataSource"], "type" : "timer" },
   "ingest/segments/count" : { "dimensions" : ["dataSource"], "type" : "count" },
+  "ingest/segments/oversized" : { "dimensions" : ["dataSource"], "type" : "count" },
   "ingest/rows/published": { "dimensions" : ["dataSource"], "type" : "count" },
 
   "ingest/realtime/segmentUpgrade/persisted" : { "dimensions" : ["dataSource", "interval", "version"], "type" : "count" },

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
@@ -929,6 +929,16 @@ public abstract class AbstractBatchIndexTask extends AbstractTask
     return null;
   }
 
+  /**
+   * Number of published segments whose row count exceeds {@code maxRowsPerSegment} times the oversize ratio.
+   * Null when the check does not apply (for example dynamic partitioning, or when no target is configured).
+   */
+  @Nullable
+  protected Long getTaskCompletionOversizedSegments()
+  {
+    return null;
+  }
+
   protected TaskReport.ReportMap buildLiveIngestionStatsReport(
       IngestionState ingestionState,
       Map<String, Object> unparseableEvents,
@@ -945,6 +955,7 @@ public abstract class AbstractBatchIndexTask extends AbstractTask
                 null,
                 false,
                 0L,
+                null,
                 null,
                 null,
                 null
@@ -1008,7 +1019,8 @@ public abstract class AbstractBatchIndexTask extends AbstractTask
             segmentAvailabilityWaitTimeMs,
             Collections.emptyMap(),
             segmentsRead,
-            segmentsPublished
+            segmentsPublished,
+            getTaskCompletionOversizedSegments()
         )
     );
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTaskUtils.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTaskUtils.java
@@ -142,6 +142,19 @@ public class IndexTaskUtils
   }
 
   /**
+   * Counts published segments whose row count exceeds {@code maxRowsPerSegment * oversizedRatio}.
+   * Segments without {@link DataSegment#getTotalRows()} populated are ignored.
+   */
+  public static long getOversizedSegments(Collection<DataSegment> segments, int maxRowsPerSegment, double oversizedRatio)
+  {
+    return segments.stream()
+        .map(DataSegment::getTotalRows)
+        .filter(Objects::nonNull)
+        .filter(rowCount -> rowCount > maxRowsPerSegment * oversizedRatio)
+        .count();
+  }
+
+  /**
    * Adds the upgraded pending segment's {@code interval} and {@code version} to a metric builder so that every
    * segment-upgrade metric can be sliced by the specific segment being re-announced. Mirrors
    * {@code IndexTaskUtils.setSegmentDimensions}, which serves the same purpose for {@code DataSegment}s.

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -42,6 +42,7 @@ import org.apache.druid.indexer.granularity.GranularitySpec;
 import org.apache.druid.indexer.partitions.DimensionRangePartitionsSpec;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
+import org.apache.druid.indexer.partitions.SecondaryPartitionType;
 import org.apache.druid.indexer.report.IngestionStatsAndErrors;
 import org.apache.druid.indexer.report.IngestionStatsAndErrorsTaskReport;
 import org.apache.druid.indexer.report.TaskReport;
@@ -154,6 +155,10 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
   // and fix
   private static final long DEFAULT_NUM_SHARDS_WHEN_ESTIMATE_GOES_NEGATIVE = 7L;
 
+  // Ratio of the total rows of a segment to the max rows per segment, above which the segment is considered oversized
+  // For range partitioning, max rows per segment is set to 1.5x target rows, so the ratio comparison is effectively 3x target rows.
+  private static final double DEFAULT_OVERSIZE_RATIO = 2.0;
+
   private final ParallelIndexIngestionSpec ingestionSchema;
   /**
    * Base name for the {@link SubTaskSpec} ID.
@@ -210,6 +215,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
   private TaskReport.ReportMap completionReports;
   private Long segmentsRead;
   private Long segmentsPublished;
+  private Long oversizedSegments; // Number of segments whose row count exceeds maxRowsPerSegment * DEFAULT_OVERSIZE_RATIO
   private final boolean isCompactionTask;
 
   @JsonCreator
@@ -1161,6 +1167,8 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
     final Set<DataSegment> oldSegments = new HashSet<>();
     final Set<DataSegment> newSegments = new HashSet<>();
     final SegmentSchemaMapping segmentSchemaMapping = new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION);
+    final SecondaryPartitionType type = ingestionSchema.getTuningConfig().getGivenOrDefaultPartitionsSpec().getType();
+    final Integer maxRowsPerSegment = ingestionSchema.getTuningConfig().getGivenOrDefaultPartitionsSpec().getMaxRowsPerSegment();
 
     reportsMap
         .values()
@@ -1224,6 +1232,19 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
       emitMetric(toolbox.getEmitter(), "ingest/tombstones/count", tombStones.size());
       emitMetric(toolbox.getEmitter(), "ingest/segments/count", newSegments.size());
       emitMetric(toolbox.getEmitter(), "ingest/rows/published", IndexTaskUtils.getTotalRowCount(newSegments));
+      // If partitionsSpec is range or hash, we emit info about the size in rows of generated partitions, to detect a hot partition.
+      if ((type == SecondaryPartitionType.RANGE || type == SecondaryPartitionType.HASH) && maxRowsPerSegment != null) {
+        oversizedSegments = IndexTaskUtils.getOversizedSegments(newSegments, maxRowsPerSegment, DEFAULT_OVERSIZE_RATIO);
+        if (oversizedSegments > 0) {
+          LOG.warn(
+              "Published [%d] oversized segments with more than (maxRowsPerSegment [%d] x ratio [%s]) rows.",
+              oversizedSegments,
+              maxRowsPerSegment,
+              DEFAULT_OVERSIZE_RATIO
+          );
+          emitMetric(toolbox.getEmitter(), "ingest/segments/oversized", oversizedSegments);
+        }
+      }
     } else {
       throw new ISE("Failed to publish segments");
     }
@@ -1274,6 +1295,12 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
         segmentsRead,
         segmentsPublished
     );
+  }
+
+  @Override
+  protected Long getTaskCompletionOversizedSegments()
+  {
+    return oversizedSegments;
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeTask.java
@@ -286,7 +286,8 @@ abstract class PartialSegmentMergeTask<S extends ShardSpec> extends PerfectRollu
         final List<String> metricNames = Arrays.stream(dataSchema.getAggregators())
                                                .map(AggregatorFactory::getName)
                                                .collect(Collectors.toList());
-        SegmentId segmentId = SegmentId.of(
+        final int numRows;
+        final SegmentId segmentId = SegmentId.of(
             getDataSource(),
             interval,
             Preconditions.checkNotNull(AbstractBatchIndexTask.findVersion(
@@ -295,6 +296,9 @@ abstract class PartialSegmentMergeTask<S extends ShardSpec> extends PerfectRollu
             ), "version for interval[%s]", interval),
             0
         );
+        try (QueryableIndex index = toolbox.getIndexIO().loadIndex(mergedFileAndDimensionNames.lhs)) {
+          numRows = index.getNumRows();
+        }
 
         final DataSegment segment = segmentPusher.push(
             mergedFileAndDimensionNames.lhs,
@@ -302,6 +306,7 @@ abstract class PartialSegmentMergeTask<S extends ShardSpec> extends PerfectRollu
                        .shardSpec(createShardSpec(toolbox, interval, bucketId))
                        .dimensions(mergedFileAndDimensionNames.rhs)
                        .metrics(metricNames)
+                       .totalRows(numRows)
                        .projections(dataSchema.getProjectionNames())
                        .build(),
             false
@@ -324,12 +329,13 @@ abstract class PartialSegmentMergeTask<S extends ShardSpec> extends PerfectRollu
         }
 
         LOG.info("Built segment [%s] for interval [%s] (from [%d] input segment(s) in [%,d]ms) of "
-            + "size [%d] bytes and pushed ([%,d]ms) to deep storage [%s].",
+            + "size [%d] bytes, [%d] rows and pushed ([%,d]ms) to deep storage [%s].",
             segment.getId(),
             interval,
             segmentFilesToMerge.size(),
             (mergeFinishTime - startTime) / 1000000,
             segment.getSize(),
+            segment.getTotalRows(),
             (pushFinishTime - mergeFinishTime) / 1000000,
             segment.getLoadSpec()
         );

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -1230,6 +1230,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
                 handoffWaitMs,
                 getPartitionStats(),
                 null,
+                null,
                 null
             )
         ),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskUtilsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskUtilsTest.java
@@ -19,20 +19,28 @@
 
 package org.apache.druid.indexing.common.task;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.query.DruidMetrics;
+import org.apache.druid.timeline.DataSegment;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -109,5 +117,41 @@ public class IndexTaskUtilsTest
     Mockito.when(abstractTask.getGroupId()).thenReturn(null);
     IndexTaskUtils.setTaskDimensions(metricBuilder, abstractTask);
     Assertions.assertNull(metricBuilder.getDimension(DruidMetrics.GROUP_ID));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("oversizedSegmentCases")
+  public void testGetOversizedSegments(
+      String name,
+      List<Integer> rowCounts,
+      int maxRowsPerSegment,
+      double oversizedRatio,
+      long expected
+  )
+  {
+    final List<DataSegment> segments = rowCounts.stream()
+        .map(rowCount -> {
+          DataSegment segment = Mockito.mock(DataSegment.class);
+          Mockito.when(segment.getTotalRows()).thenReturn(rowCount);
+          return segment;
+        })
+        .collect(ImmutableList.toImmutableList());
+    Assertions.assertEquals(
+        expected,
+        IndexTaskUtils.getOversizedSegments(segments, maxRowsPerSegment, oversizedRatio)
+    );
+    segments.forEach(segment -> {
+      Mockito.verify(segment, Mockito.times(1)).getTotalRows();
+    });
+  }
+  public static Stream<Arguments> oversizedSegmentCases()
+  {
+    return Stream.of(
+        Arguments.of("empty", List.<Integer>of(), 5, 2.0, 0L),
+        Arguments.of("equal to threshold is not oversized", List.of(10), 5, 2.0, 0L),
+        Arguments.of("over threshold", List.of(11), 5, 2.0, 1L),
+        Arguments.of("null totalRows ignored", Arrays.asList(11, null, 3), 5, 2.0, 1L),
+        Arguments.of("mixed", List.of(3, 11, 10, 21), 5, 2.0, 2L)
+    );
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractMultiPhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractMultiPhaseParallelIndexingTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.indexing.common.task.batch.parallel;
 
-import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.LocalInputSource;
@@ -168,7 +167,10 @@ abstract class AbstractMultiPhaseParallelIndexingTest extends AbstractParallelIn
   TaskReport.ReportMap runTaskAndGetReports(Task task, TaskState expectedTaskStatus)
   {
     runTaskAndVerifyStatus(task, expectedTaskStatus);
-    return FutureUtils.getUnchecked(getIndexingServiceClient().taskReportAsMap(task.getId()), true);
+    // Live reports always omit oversizedSegments; use the completion report written after publish.
+    final ParallelIndexSupervisorTask executedTask =
+        (ParallelIndexSupervisorTask) getIndexingServiceClient().getTaskContainer(task.getId()).getTask();
+    return executedTask.getCompletionReports();
   }
 
   protected ParallelIndexSupervisorTask createTask(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -786,6 +786,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
                 0L,
                 null,
                 null,
+                null,
                 null
             )
         )
@@ -795,7 +796,8 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
   protected TaskReport.ReportMap buildExpectedTaskReportParallel(
       String taskId,
       List<ParseExceptionReport> expectedUnparseableEvents,
-      RowIngestionMetersTotals expectedTotals
+      RowIngestionMetersTotals expectedTotals,
+      Long oversizedSegments
   )
   {
     Map<String, Object> unparseableEvents = ImmutableMap.of("buildSegments", expectedUnparseableEvents);
@@ -812,7 +814,8 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
                 0L,
                 null,
                 null,
-                null
+                null,
+                oversizedSegments
             )
         )
     );
@@ -861,6 +864,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
         .stream().map(ParseExceptionReport::getInput).collect(Collectors.toList());
     List<String> actualInputs = actualParseExceptionReports
         .stream().map(ParseExceptionReport::getInput).collect(Collectors.toList());
+    Assertions.assertEquals(expectedPayload.getOversizedSegments(), actualPayload.getOversizedSegments());
     Assertions.assertEquals(expectedInputs, actualInputs);
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/MultiPhaseParallelIndexingRowStatsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/MultiPhaseParallelIndexingRowStatsTest.java
@@ -66,6 +66,13 @@ public class MultiPhaseParallelIndexingRowStatsTest extends AbstractMultiPhasePa
 
   private static final Interval INTERVAL_TO_INDEX = Intervals.of("2017-12/P1M");
 
+  // Same day and dim1 so range cannot split the hot key. Unique dim2 avoids rollup.
+  // Hashing only on dim1 still maps all rows into one bucket.
+  private static final String SKEWED_DAY = "2017-12-1";
+  private static final int SKEWED_DIM1 = 0;
+  private static final int SKEWED_FILE_COUNT = 5;
+  private static final int SKEWED_ROWS_PER_FILE = 20;
+
   private File inputDir;
 
   public MultiPhaseParallelIndexingRowStatsTest()
@@ -89,6 +96,15 @@ public class MultiPhaseParallelIndexingRowStatsTest extends AbstractMultiPhasePa
         for (int j = 0; j < 10; j++) {
           writer.write(StringUtils.format("2017-12-%d,%d,%d th test file\n", j + 1, i + 10, i));
           writer.write(StringUtils.format("2017-12-%d,%d,%d th test file\n", j + 2, i + 11, i));
+        }
+      }
+    }
+
+    for (int i = 0; i < SKEWED_FILE_COUNT; i++) {
+      try (final Writer writer =
+               Files.newBufferedWriter(new File(inputDir, "skewed_" + i).toPath(), StandardCharsets.UTF_8)) {
+        for (int j = 0; j < SKEWED_ROWS_PER_FILE; j++) {
+          writer.write(StringUtils.format("%s,%d,%d th test file\n", SKEWED_DAY, SKEWED_DIM1, i * SKEWED_ROWS_PER_FILE + j));
         }
       }
     }
@@ -143,7 +159,8 @@ public class MultiPhaseParallelIndexingRowStatsTest extends AbstractMultiPhasePa
         : buildExpectedTaskReportParallel(
             task.getId(),
             ImmutableList.of(),
-            expectedTotals
+            expectedTotals,
+            null
         );
 
     TaskReport.ReportMap actualReports = runTaskAndGetReports(task, TaskState.SUCCESS);
@@ -169,8 +186,71 @@ public class MultiPhaseParallelIndexingRowStatsTest extends AbstractMultiPhasePa
     TaskReport.ReportMap expectedReports = buildExpectedTaskReportParallel(
         task.getId(),
         ImmutableList.of(),
-        new RowIngestionMetersTotals(200, 5630, 0, 0, 0)
+        new RowIngestionMetersTotals(200, 5630, 0, 0, 0),
+        0L
     );
+    TaskReport.ReportMap actualReports = runTaskAndGetReports(task, TaskState.SUCCESS);
+    compareTaskReports(expectedReports, actualReports);
+  }
+
+  @Test
+  public void testHashPartitionRowStatsWithOversizedSegments()
+  {
+    final int maxNumConcurrentSubTasks = 10;
+    final int maxRowsPerSegment = 20;
+
+    ParallelIndexSupervisorTask task = createTask(
+        TIMESTAMP_SPEC,
+        DIMENSIONS_SPEC,
+        INPUT_FORMAT,
+        INTERVAL_TO_INDEX,
+        inputDir,
+        "skewed_*",
+        new HashedPartitionsSpec(maxRowsPerSegment, null, ImmutableList.of(DIM1), null),
+        maxNumConcurrentSubTasks,
+        false,
+        false
+    );
+
+    final RowIngestionMetersTotals expectedTotals = RowMeters.with().bytes(2790).totalProcessed(100);
+    final TaskReport.ReportMap expectedReports = buildExpectedTaskReportParallel(
+        task.getId(),
+        ImmutableList.of(),
+        expectedTotals,
+        1L
+    );
+
+    TaskReport.ReportMap actualReports = runTaskAndGetReports(task, TaskState.SUCCESS);
+    compareTaskReports(expectedReports, actualReports);
+  }
+
+  @Test
+  public void testRangePartitionRowStatsWithOversizedSegments()
+  {
+    final int maxNumConcurrentSubTasks = 10;
+    final int targetRowsPerSegment = 20;
+
+    ParallelIndexSupervisorTask task = createTask(
+        TIMESTAMP_SPEC,
+        DIMENSIONS_SPEC,
+        INPUT_FORMAT,
+        INTERVAL_TO_INDEX,
+        inputDir,
+        "skewed_*",
+        new SingleDimensionPartitionsSpec(targetRowsPerSegment, null, DIM1, false),
+        maxNumConcurrentSubTasks,
+        false,
+        false
+    );
+
+    final RowIngestionMetersTotals expectedTotals = RowMeters.with().bytes(2790).totalProcessed(100);
+    final TaskReport.ReportMap expectedReports = buildExpectedTaskReportParallel(
+        task.getId(),
+        ImmutableList.of(),
+        expectedTotals,
+        1L
+    );
+
     TaskReport.ReportMap actualReports = runTaskAndGetReports(task, TaskState.SUCCESS);
     compareTaskReports(expectedReports, actualReports);
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
@@ -498,7 +498,8 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
                 1L
             )
         ),
-        new RowIngestionMetersTotals(10, 335, 1, expectedThrownAwayByReason, 1)
+        new RowIngestionMetersTotals(10, 335, 1, expectedThrownAwayByReason, 1),
+        null
     );
     compareTaskReports(expectedReports, actualReports);
   }
@@ -564,7 +565,8 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
       expectedReports = buildExpectedTaskReportParallel(
           task.getId(),
           expectedUnparseableEvents,
-          expectedTotals
+          expectedTotals,
+          null
       );
     }
 

--- a/processing/src/main/java/org/apache/druid/indexer/report/IngestionStatsAndErrors.java
+++ b/processing/src/main/java/org/apache/druid/indexer/report/IngestionStatsAndErrors.java
@@ -38,6 +38,7 @@ public class IngestionStatsAndErrors
   private final Map<String, Long> recordsProcessed;
   private final Long segmentsRead;
   private final Long segmentsPublished;
+  private final Long oversizedSegments;
 
   public IngestionStatsAndErrors(
       @JsonProperty("ingestionState") IngestionState ingestionState,
@@ -48,7 +49,8 @@ public class IngestionStatsAndErrors
       @JsonProperty("segmentAvailabilityWaitTimeMs") long segmentAvailabilityWaitTimeMs,
       @JsonProperty("recordsProcessed") Map<String, Long> recordsProcessed,
       @Nullable @JsonProperty("segmentsRead") Long segmentsRead,
-      @Nullable @JsonProperty("segmentsPublished") Long segmentsPublished
+      @Nullable @JsonProperty("segmentsPublished") Long segmentsPublished,
+      @Nullable @JsonProperty("oversizedSegments") Long oversizedSegments
   )
   {
     this.ingestionState = ingestionState;
@@ -60,6 +62,7 @@ public class IngestionStatsAndErrors
     this.recordsProcessed = recordsProcessed;
     this.segmentsRead = segmentsRead;
     this.segmentsPublished = segmentsPublished;
+    this.oversizedSegments = oversizedSegments;
   }
 
   @JsonProperty
@@ -122,6 +125,14 @@ public class IngestionStatsAndErrors
     return segmentsPublished;
   }
 
+  @JsonProperty
+  @Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public Long getOversizedSegments()
+  {
+    return oversizedSegments;
+  }
+
   public static IngestionStatsAndErrors getPayloadFromTaskReports(
       Map<String, TaskReport> taskReports
   )
@@ -148,7 +159,8 @@ public class IngestionStatsAndErrors
            Objects.equals(getSegmentAvailabilityWaitTimeMs(), that.getSegmentAvailabilityWaitTimeMs()) &&
            Objects.equals(getRecordsProcessed(), that.getRecordsProcessed()) &&
            Objects.equals(getSegmentsRead(), that.getSegmentsRead()) &&
-           Objects.equals(getSegmentsPublished(), that.getSegmentsPublished());
+           Objects.equals(getSegmentsPublished(), that.getSegmentsPublished()) &&
+           Objects.equals(getOversizedSegments(), that.getOversizedSegments());
   }
 
   @Override
@@ -163,7 +175,8 @@ public class IngestionStatsAndErrors
         getSegmentAvailabilityWaitTimeMs(),
         getRecordsProcessed(),
         getSegmentsRead(),
-        getSegmentsPublished()
+        getSegmentsPublished(),
+        getOversizedSegments()
     );
   }
 
@@ -180,6 +193,7 @@ public class IngestionStatsAndErrors
            ", recordsProcessed=" + recordsProcessed +
            ", segmentsRead=" + segmentsRead +
            ", segmentsPublished=" + segmentsPublished +
+           ", oversizedSegments=" + oversizedSegments +
            '}';
   }
 }

--- a/processing/src/main/resources/loggingEmitterAllowedMetrics.json
+++ b/processing/src/main/resources/loggingEmitterAllowedMetrics.json
@@ -37,6 +37,7 @@
     "ingest/persists/time": [],
     "ingest/rows/output": [],
     "ingest/segments/count": [],
+    "ingest/segments/oversized": [],
     "ingest/rows/published": [],
     "ingest/sink/count": [],
     "ingest/tombstones/count": [],

--- a/processing/src/test/java/org/apache/druid/indexer/report/TaskReportSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/indexer/report/TaskReportSerdeTest.java
@@ -273,6 +273,7 @@ public class TaskReportSerdeTest
             1000L,
             null,
             null,
+            null,
             null
         )
     );
@@ -311,7 +312,8 @@ public class TaskReportSerdeTest
             1000L,
             Collections.singletonMap("PartitionA", 5000L),
             5L,
-            10L
+            10L,
+            2L
         )
     );
   }

--- a/processing/src/test/resources/loggingEmitterAllowedMetrics.json
+++ b/processing/src/test/resources/loggingEmitterAllowedMetrics.json
@@ -37,6 +37,7 @@
   "ingest/persists/time": [],
   "ingest/rows/output": [],
   "ingest/segments/count": [],
+  "ingest/segments/oversized": [],
   "ingest/rows/published": [],
   "ingest/sink/count": [],
   "ingest/tombstones/count": [],


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #19573.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
Hash and range native batch ingest can publish segments much larger than `maxRowsPerSegment` / `targetRowsPerSegment` when a partition key is hot. Operators had no signal for that besides noticing huge segments later.
This PR counts published segments whose row count exceeds `maxRowsPerSegment × 2`, then warns, emits a metric, and records the count on the completion report.

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->


#### Detect oversized segments at supervisor publish
After a successful publish, `ParallelIndexSupervisorTask` runs the check only for **HASH** or **RANGE** when `getMaxRowsPerSegment()` is non-null (so hashed + `numShards` with no max is skipped). Ratio is `2.0`. For range, resolved max is already `target + target/2`, so the warn is effectively **3×** the user’s `targetRowsPerSegment`.
If the count is > 0:
- WARN on the supervisor task
- metric `ingest/segments/oversized`
Live reports omit the field. Completion reports include `oversizedSegments` (`Long`, omitted when null). Sequential `IndexTask` (`maxNumConcurrentSubTasks: 1`) does not run this check.
#### Tests 
- `IndexTaskUtils.getOversizedSegments` unit cases (threshold, null `totalRows`, mixed)
- Multi-phase hashed and range skewed ingest expecting `oversizedSegments = 1`; even range expects `0`; hashed + `numShards` omits the field
- Task report serde round-trips a non-null `oversizedSegments`
- Metric listed in `metrics.md`, logging emitter allow-list, Prometheus, and StatsD catalogs


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->
### Implementation decision
In the cited issue it was recomended to set this logic in the PartialHashSegmentGenerateTask hooks and to use Appenderator.getRowCount(SegmentIdWithShardSpec) to get the row count. I ended up not doing this because I realized in the partial tasks we don't yet have the final segments. The final segments are only available after the final merge, right after publishing to S3. So, I instead went with wiring this through in the PartialSegmentMergetask instead. 

#### Side effect
Those jobs merge and push DataSegments without going through an appenderator, so totalRows was never set. The supervisor still emits ingest/rows/published via IndexTaskUtils.getTotalRowCount(), which skips nulls, so the metric was always 0. After this change the metric should emit correctly for range and hash index_parallel jobs.

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->


<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->
#### Release note
You can now have visibility into when your range and hash partitioning settings are resulting in creating overly large segment files (hot partitions) in a time chunk. Native batch hash and range ingest now warns and emits a count of segments `ingest/segments/oversized` for all published segments with more than 2× `maxRowsPerSegment` rows (for range, that is 3× `targetRowsPerSegment`). The count is also on the task completion report as `oversizedSegments`.
<hr>

##### Key changed/added classes in this PR
 * `IndexTaskUtils`
 * `ParallelIndexSupervisorTask`
 * `PartialSegmentMergeTask`
 * `IngestionStatsAndErrors`
 * `AbstractBatchIndexTask`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster. 

### Verification
Ran the cluster locally, and submitted an ingestion spec with hashed partitioning for wikipedia, using channel as a partition key: 
```
...
"tuningConfig": {
      "type": "index_parallel",
      "maxRowsInMemory": 25000,
      "forceGuaranteedRollup": true,
      "maxNumConcurrentSubTasks": 2,
      "partitionsSpec": {
        "type": "hashed",
        "maxRowsPerSegment": 2000,
        "partitionDimensions": ["channel"]
      }
    }
  }
...
```
since channel is often wikipedia#en for many rows, this will cause a hot partition for the same time chunk. Confirmed in report that oversizedSegments is set: 
<img width="520" height="502" alt="image" src="https://github.com/user-attachments/assets/6e0c63c2-bea9-4c28-b1c7-68b44ef2a08e" />
and the warn log: 
<img width="1251" height="58" alt="image" src="https://github.com/user-attachments/assets/f32f41a9-94d8-4148-9bfa-3e66a61994ea" />
