### PR TITLE
fix: validate numBytes in CompressedVSizeColumnarIntsSupplier

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSupplier.java
@@ -69,6 +69,12 @@ public class CompressedVSizeColumnarIntsSupplier implements WritableSupplier<Col
         sizePer == (1 << Integer.numberOfTrailingZeros(sizePer)),
         "Number of entries per chunk must be a power of 2"
     );
+    Preconditions.checkArgument(
+        numBytes >= 1 && numBytes <= Integer.BYTES,
+        "Invalid numBytes[%s] in CompressedVSizeColumnarIntsSupplier. Must be in range[1, %s]",
+        numBytes,
+        Integer.BYTES
+    );
 
     this.totalSize = totalSize;
     this.sizePer = sizePer;

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSupplierTest.java
@@ -243,6 +243,30 @@ public class CompressedVSizeColumnarIntsSupplierTest
     assertIndexMatchesVals();
   }
 
+  @Test
+  public void testInvalidNumBytesRejected() throws Exception
+  {
+    vals = new int[]{0, 1, 2, 3};
+    CloseableUtils.closeAndWrapExceptions(columnarInts);
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    final CompressedVSizeColumnarIntsSupplier serialized = CompressedVSizeColumnarIntsSupplier.fromList(
+        IntArrayList.wrap(vals), Ints.max(vals), 4, byteOrder, compressionStrategy, closer
+    );
+    serialized.writeTo(Channels.newChannel(baos), null);
+    final byte[] bytes = baos.toByteArray();
+
+    for (byte invalidNumBytes : new byte[]{0, 5, 100, -1}) {
+      final byte[] corrupted = bytes.clone();
+      corrupted[1] = invalidNumBytes;
+      final IllegalArgumentException e = Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> CompressedVSizeColumnarIntsSupplier.fromByteBuffer(ByteBuffer.wrap(corrupted), byteOrder, null)
+      );
+      Assertions.assertTrue(e.getMessage().contains("numBytes"), e.getMessage());
+    }
+  }
+
 
   // This test attempts to cause a race condition with the DirectByteBuffers, it's non-deterministic in causing it,
   // which sucks but I can't think of a way to deterministically cause it...


### PR DESCRIPTION
### Description

`CompressedVSizeColumnarIntsSupplier.fromByteBuffer()` trusts the `numBytes` byte in the serialized column header. Writers only ever emit values 1..4 (`VSizeColumnarInts.getNumBytesForMax()`), but the read path never verifies it: the byte directly drives the shift/mask constants (`bigEndianShift`, `littleEndianMask`) and the per-value absolute reads (`buffer.getInt(bufferIndex * numBytes)`).

A segment carrying any other value reads back silently corrupted data. Using a serialized supplier with the `numBytes` byte tampered to 100, `get(0)` returns 50462976 instead of 0 and `get(4)` returns 117835012 instead of 4, with no error raised. With `numBytes=0` every value reads as 0. This reader backs every dictionary-encoded column, multi-value columns, and nested variant columns, so malformed storage can silently poison query results. JVM bounds checks contain reads to the decompressed buffer, so this is an integrity/robustness issue rather than a memory-safety one.

#### Fixed the bug ...

Validate `numBytes` in the `CompressedVSizeColumnarIntsSupplier` constructor with `Preconditions.checkArgument` (range `[1, Integer.BYTES]`), so malformed headers fail fast with a descriptive message on both the read (`fromByteBuffer`) and construction (`fromList`) paths, before any shift/mask constants or offsets are computed.

Added `testInvalidNumBytesRejected` to `CompressedVSizeColumnarIntsSupplierTest`: it serializes a real supplier, tampers the `numBytes` header byte with 0, 5, 100 and -1, and asserts rejection. I verified the test fails without the fix and passes with it; the control round-trip still reads all values correctly.

#### Release note

- Fix a potential silent data corruption when reading a column whose serialized header carries an invalid `numBytes` value. Druid now rejects such columns with a descriptive `IllegalArgumentException` instead of returning wrong values.

<hr>

##### Key changed/added classes in this PR
 * `CompressedVSizeColumnarIntsSupplier`
 * `CompressedVSizeColumnarIntsSupplierTest`

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.