### PR TITLE
minor: don't compile the reactor twice in the strict-compilation CI job

### DIFF
--- a/.github/scripts/strict-compilation.sh
+++ b/.github/scripts/strict-compilation.sh
@@ -18,4 +18,4 @@
 set -e
 set -x
 
-mvn -B clean -DstrictCompile compile test-compile --fail-at-end -P skip-tests -Dweb.console.skip=true -T1C
+mvn -B clean -DstrictCompile test-compile --fail-at-end -P skip-tests -Dweb.console.skip=true -T1C


### PR DESCRIPTION
### Description
The strict-compilation CI job runs:

 ` mvn -B clean -DstrictCompile compile test-compile --fail-at-end -P skip-tests -Dweb.console.skip=true -T1C`

` test-compile` already implies compile, and Maven builds a separate execution plan per task on the command line  so every phase up to and including compile runs twice for all 75 modules. That means two full Error Prone compile passes over src/main, plus two rounds of every plugin bound at or before compile.
 
 Removing the compile keyword should speed up the CI. 
 
 #### Release notes
 
 None, CI only fix. 