### PR TITLE
refactor: use AsyncResource instead of Future to acquire segment references

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/ServerManagerForQueryErrorTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/ServerManagerForQueryErrorTest.java
@@ -231,8 +231,7 @@ public class ServerManagerForQueryErrorTest extends ServerManager
             segmentReferences.add(
                 new SegmentReference(
                     segment.getDescriptor(),
-                    segmentMapFunction.apply(ref),
-                    null
+                    segmentMapFunction.apply(ref)
                 )
             );
           } else if (segmentManager.canLoadSegmentOnDemand(dataSegment)) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -36,7 +36,6 @@ import com.google.common.collect.Lists;
 import org.apache.druid.client.indexing.ClientCompactionTaskGranularitySpec;
 import org.apache.druid.client.indexing.ClientCompactionTaskQuery;
 import org.apache.druid.collections.ResourceHolder;
-import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.data.input.SplitHintSpec;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
 import org.apache.druid.data.input.impl.BaseTableProjectionSpec;
@@ -89,7 +88,6 @@ import org.apache.druid.segment.AggregateProjectionMetadata;
 import org.apache.druid.segment.IndexSpec;
 import org.apache.druid.segment.Metadata;
 import org.apache.druid.segment.QueryableIndex;
-import org.apache.druid.segment.ReferenceCountedObjectProvider;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnHolder;
@@ -99,6 +97,7 @@ import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.TuningConfig;
 import org.apache.druid.segment.loading.AcquireMode;
 import org.apache.druid.segment.loading.AcquireSegmentAction;
+import org.apache.druid.segment.loading.AcquireSegmentResult;
 import org.apache.druid.segment.loading.SegmentCacheManager;
 import org.apache.druid.segment.projections.AggregateProjectionSchema;
 import org.apache.druid.segment.realtime.appenderator.AppenderatorsManager;
@@ -933,9 +932,21 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
     try {
       final AcquireSegmentAction acquireAction =
           closer.register(segmentCacheManager.acquireSegment(dataSegment, AcquireMode.FULL));
-      final ReferenceCountedObjectProvider<Segment> segmentProvider =
-          FutureUtils.getUnchecked(acquireAction.getSegmentFuture(), true).getReferenceProvider();
-      final Segment segment = segmentProvider.acquireReference().map(closer::register).get();
+      acquireAction.await();
+      // take ownership of the result (the registered action close becomes a no-op) and register it so closing the
+      // holder releases the segment reference and any cache holds folded into it
+      final AcquireSegmentResult result = closer.register(acquireAction.release());
+      // an empty delivery is a first-class outcome (segment no longer in the cache or deep storage), so surface it
+      // with the segment id rather than a bare NoSuchElementException
+      final Segment segment = result.getSegment().orElseThrow(
+          () -> DruidException.forPersona(DruidException.Persona.OPERATOR)
+                              .ofCategory(DruidException.Category.RUNTIME_FAILURE)
+                              .build(
+                                  "Could not load segment[%s] to compact; it is no longer available in the cache or "
+                                  + "deep storage",
+                                  dataSegment.getId()
+                              )
+      );
       return new ResourceHolder<>()
       {
         @Override
@@ -952,6 +963,12 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
       };
     }
     catch (Exception e) {
+      // await() clears the interrupt flag when it throws InterruptedException; restore it so the task's unwind and
+      // any downstream blocking work still observe the interrupt (matches ServerManager and the prior
+      // FutureUtils.getUnchecked behavior this replaced).
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       throw CloseableUtils.closeAndWrapInCatch(e, closer);
     }
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -2005,10 +2005,7 @@ public class CompactionTaskTest
         final Segment segment =
             new QueryableIndexSegment(indexIO.loadIndex(segments.get(dataSegment)), dataSegment.getId());
         final ReferenceCountedSegmentProvider provider = ReferenceCountedSegmentProvider.of(segment);
-        return new AcquireSegmentAction(
-            () -> Futures.immediateFuture(AcquireSegmentResult.cached(provider)),
-            null
-        );
+        return AcquireSegmentAction.completed(AcquireSegmentResult.of(provider.acquireReference()));
       }
 
       @Override

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/input/AcquireSegmentHandles.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/input/AcquireSegmentHandles.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.input;
+
+import org.apache.druid.common.asyncresource.AsyncResource;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.segment.ReferenceCountedSegmentProvider;
+import org.apache.druid.segment.Segment;
+import org.apache.druid.segment.loading.AcquireSegmentAction;
+import org.apache.druid.segment.loading.AcquireSegmentResult;
+import org.apache.druid.utils.CloseableUtils;
+
+import java.io.Closeable;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+/**
+ * Shared machinery for bridging {@link AsyncResource}-producing segment sources into the releasable
+ * {@link AcquireSegmentAction} consumer handle. Used by {@link AdaptedLoadableSegment} (combinator-produced
+ * resources) and {@link RegularLoadableSegment} (the deferred two-stage Coordinator-fetch chain).
+ */
+final class AcquireSegmentHandles
+{
+  private static final Logger log = new Logger(AcquireSegmentHandles.class);
+
+  private AcquireSegmentHandles()
+  {
+    // No instantiation.
+  }
+
+  /**
+   * Wraps {@code target} with a CAS guard so it is closed at most once. {@link AcquireSegmentAction#close()} is not
+   * idempotent, and a bridge's error path can race its canceler — every dual-owner close goes through one of these.
+   */
+  static Runnable closeOnce(Closeable target)
+  {
+    final AtomicBoolean closed = new AtomicBoolean(false);
+    return () -> {
+      if (closed.compareAndSet(false, true)) {
+        CloseableUtils.closeAndSuppressExceptions(
+            target,
+            e -> log.warn(e, "Failed to close acquire resource of class[%s]", target.getClass().getName())
+        );
+      }
+    };
+  }
+
+  /**
+   * Bridges a NON-releasable {@code inner} resource (e.g. one produced by {@code AsyncResources.collect/transform/
+   * recover} combinators) into a releasable {@link AcquireSegmentAction}. The lifecycle of {@code inner} is folded
+   * into the delivered result: when the delivered result carries a segment, that segment's close also closes
+   * {@code inner} (releasing whatever the combinator chain owns, e.g. cached source files — which therefore strictly
+   * outlive the segment); when it is empty, {@code inner} is closed at delivery. Closing the returned action before
+   * readiness closes {@code inner} (cancelling in-flight work).
+   * <p>
+   * Uses {@code inner.get()}, not {@code release()}: combinator-produced resources are not releasable; inner keeps
+   * nominal ownership and the fold transfers the close responsibility onto the delivered segment.
+   */
+  static AcquireSegmentAction fromResource(AsyncResource<AcquireSegmentResult> inner)
+  {
+    final Runnable closeInnerOnce = closeOnce(inner);
+    final AcquireSegmentAction outer = new AcquireSegmentAction(closeInnerOnce);
+    deliverOnReady(inner, outer, closeInnerOnce, () -> foldInnerClose(inner.get(), closeInnerOnce));
+    return outer;
+  }
+
+  /**
+   * Wires a releasable {@code inner} handle into {@code outer}: on readiness, ownership of the result transfers
+   * inner → outer. Used for the second stage of {@link RegularLoadableSegment}'s deferred chain, where the inner
+   * handle comes from the cache manager and its result is already self-contained (holds folded into the segment).
+   *
+   * @param inner          the source handle
+   * @param outer          the handle handed to the consumer
+   * @param closeInnerOnce close-once guard for {@code inner}, shared with the canceler that may race this transfer
+   */
+  static void transferOnReady(AcquireSegmentAction inner, AcquireSegmentAction outer, Runnable closeInnerOnce)
+  {
+    deliverOnReady(inner, outer, closeInnerOnce, inner::release);
+  }
+
+  /**
+   * Shared delivery skeleton for the two bridges: on {@code inner}'s readiness, obtain the result and deliver it to
+   * {@code outer}; on failure report to {@code outer} (silently absorbed if outer was closed first) and release
+   * {@code inner} exactly once; if delivery loses the race with {@code outer}'s close, close the orphaned result.
+   * <p>
+   * The callback body handles every throwable internally (the orphan close is suppressed-and-logged), so the
+   * registration catch below only ever sees {@code addReadyCallback} itself rejecting a concurrently-closed
+   * {@code inner} — never errors escaping an immediately-fired callback.
+   */
+  private static void deliverOnReady(
+      AsyncResource<AcquireSegmentResult> inner,
+      AcquireSegmentAction outer,
+      Runnable closeInnerOnce,
+      Supplier<AcquireSegmentResult> obtainResult
+  )
+  {
+    try {
+      inner.addReadyCallback(() -> {
+        final AcquireSegmentResult delivered;
+        try {
+          delivered = obtainResult.get();
+        }
+        catch (Throwable t) {
+          // a real load failure, or "Closed" when the canceler won the race (in which case outer absorbs silently)
+          outer.setException(t);
+          closeInnerOnce.run();
+          return;
+        }
+        if (!outer.set(delivered)) {
+          // the action was closed while delivering; we own the orphaned result (closing it releases inner too)
+          CloseableUtils.closeAndSuppressExceptions(
+              delivered,
+              e -> log.warn(e, "Failed to close orphaned acquire result after losing the delivery race")
+          );
+        }
+      });
+    }
+    catch (DruidException e) {
+      // inner was concurrently closed by the canceler before the callback could be registered; nothing to do
+    }
+  }
+
+  /**
+   * Rebuilds {@code result} so the contained segment's close also runs {@code closeInnerOnce}; an empty result
+   * closes {@code inner} immediately (nothing can carry the close). The segment must be a
+   * {@link ReferenceCountedSegmentProvider.LeafReference} — an MSQ-internal contract of all
+   * {@link AdaptedLoadableSegment} suppliers.
+   */
+  private static AcquireSegmentResult foldInnerClose(AcquireSegmentResult result, Runnable closeInnerOnce)
+  {
+    final Optional<Segment> segment = result.getSegment();
+    if (segment.isEmpty()) {
+      closeInnerOnce.run();
+      return result;
+    }
+    if (!(segment.get() instanceof ReferenceCountedSegmentProvider.LeafReference leaf)) {
+      throw DruidException.defensive(
+          "Segment[%s] of type[%s] is not a LeafReference; cannot fold resource close into it",
+          segment.get().getDebugString(),
+          segment.get().getClass().getSimpleName()
+      );
+    }
+    return new AcquireSegmentResult(
+        ReferenceCountedSegmentProvider.wrapCloseable(leaf, closeInnerOnce::run),
+        result.getLoadSizeBytes(),
+        result.getWaitTimeNanos(),
+        result.getLoadTimeNanos()
+    );
+  }
+}

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/input/AdaptedLoadableSegment.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/input/AdaptedLoadableSegment.java
@@ -21,12 +21,9 @@ package org.apache.druid.msq.input;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import org.apache.druid.common.asyncresource.AsyncResource;
 import org.apache.druid.common.asyncresource.AsyncResources;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.java.util.common.ISE;
-import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.msq.counters.ChannelCounters;
 import org.apache.druid.query.SegmentDescriptor;
 import org.apache.druid.segment.ReferenceCountedSegmentProvider;
@@ -59,12 +56,15 @@ public class AdaptedLoadableSegment implements LoadableSegment
 
   /**
    * Creates a wrapper around a supplier of an {@link AcquireSegmentResult}. The lifecycle of the supplied
-   * {@link AsyncResource} is tied to the {@link AcquireSegmentAction} returned from {@link #acquire()}.
+   * {@link AsyncResource} is folded into the {@link AcquireSegmentAction} returned from {@link #acquire}: closing
+   * the delivered segment (or the un-released action) closes the resource, releasing whatever it owns.
    *
-   * @param asyncSegmentSupplier the supplier to wrap
+   * @param asyncSegmentSupplier the supplier to wrap. The supplied resource's result must carry its segment as a
+   *                             {@link ReferenceCountedSegmentProvider.LeafReference} so the resource's close can be
+   *                             folded into the segment's close.
    * @param descriptor           descriptor containing the interval to use for filtering
    * @param description          user-oriented description for error messages
-   * @param inputCounters        counters for tracking input via {@link LoadableSegmentUtils#countedLoad}.
+   * @param inputCounters        counters for tracking input, updated at delivery via {@link #countDelivered}.
    */
   public AdaptedLoadableSegment(
       final Supplier<AsyncResource<AcquireSegmentResult>> asyncSegmentSupplier,
@@ -95,9 +95,10 @@ public class AdaptedLoadableSegment implements LoadableSegment
       @Nullable final ChannelCounters inputCounters
   )
   {
-    // Pre-create the acquire result since the segment is already available
+    // Pre-create the acquire result since the segment is already available. The segment's lifecycle is unmanaged:
+    // the delivered UnmanagedReference's close is a no-op on the wrapped segment.
     final AcquireSegmentResult acquireSegmentResult =
-        AcquireSegmentResult.cached(ReferenceCountedSegmentProvider.of(segment));
+        AcquireSegmentResult.of(ReferenceCountedSegmentProvider.unmanaged(segment));
 
     final AsyncResource<AcquireSegmentResult> resource = AsyncResources.unmanaged(acquireSegmentResult);
     return new AdaptedLoadableSegment(
@@ -150,44 +151,22 @@ public class AdaptedLoadableSegment implements LoadableSegment
       throw DruidException.defensive("Segment with descriptor[%s] is already acquired", descriptor);
     }
 
-    // Synchronized by itself; Closer is not thread-safe.
-    final Closer closer = Closer.create();
-    final AtomicBoolean closed = new AtomicBoolean(false);
+    // The supplier starts the underlying work (e.g. VSF file fetches); fromResource folds the resource's lifecycle
+    // into the delivered segment's close (and cancels it if the action is closed before readiness).
+    return AcquireSegmentHandles.fromResource(asyncSegmentSupplier.get());
+  }
 
-    return new AcquireSegmentAction(
-        () -> {
-          final AsyncResource<AcquireSegmentResult> asyncSegment = asyncSegmentSupplier.get();
-          synchronized (closer) {
-            if (closed.get()) {
-              asyncSegment.close();
-              return Futures.immediateFailedFuture(new ISE("Already closed"));
-            } else {
-              closer.register(asyncSegment);
-            }
-          }
-
-          final SettableFuture<AcquireSegmentResult> retVal = SettableFuture.create();
-
-          asyncSegment.addReadyCallback(() -> {
-            try {
-              retVal.set(asyncSegment.get());
-            }
-            catch (Throwable e) {
-              retVal.setException(e);
-            }
-          });
-
-          // Use byteCount = 0 for adapted segments; we can't really tell what it is from the AcquireSegmentResult
-          // (the "load size" may not be the entire size if the segment was fully or partially cached). Implementations
-          // call ChannelCounters#incrementBytes if they have something useful to put there.
-          return LoadableSegmentUtils.countedLoad(retVal, 0, inputCounters);
-        },
-        () -> {
-          synchronized (closer) {
-            closed.set(true);
-            closer.close();
-          }
-        }
-    );
+  @Override
+  public void countDelivered(AcquireSegmentResult result)
+  {
+    if (inputCounters == null) {
+      return;
+    }
+    inputCounters.addLoad(result);
+    final int rowCount = result.getSegment().map(LoadableSegmentUtils::getSegmentRowCount).orElse(0);
+    // Use byteCount = 0 for adapted segments; we can't really tell what it is from the AcquireSegmentResult
+    // (the "load size" may not be the entire size if the segment was fully or partially cached). Implementations
+    // call ChannelCounters#incrementBytes if they have something useful to put there.
+    inputCounters.addFile(rowCount, 0);
   }
 }

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/input/LoadableSegment.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/input/LoadableSegment.java
@@ -26,6 +26,7 @@ import org.apache.druid.query.SegmentDescriptor;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.loading.AcquireMode;
 import org.apache.druid.segment.loading.AcquireSegmentAction;
+import org.apache.druid.segment.loading.AcquireSegmentResult;
 import org.apache.druid.server.SegmentManager;
 import org.apache.druid.timeline.DataSegment;
 
@@ -76,8 +77,17 @@ public interface LoadableSegment
   Optional<Segment> acquireIfCached(AcquireMode acquireMode);
 
   /**
-   * Acquire the actual segment. Non-blocking operation. Once this is called, callers are responsible for closing the
-   * {@link AcquireSegmentAction}.
+   * Acquire the actual segment. Non-blocking operation; the load (if one is needed) starts immediately. The returned
+   * {@link AcquireSegmentAction} is an async handle: register it with cleanup machinery right away (safe at any
+   * lifecycle point), wait for readiness via {@link AcquireSegmentAction#addReadyCallback} or
+   * {@link AcquireSegmentAction#await}, then {@link AcquireSegmentAction#release()} to take ownership of the
+   * {@link org.apache.druid.segment.loading.AcquireSegmentResult} — closing the delivered {@link Segment} releases
+   * everything associated with the acquisition. Closing the action without releasing cancels an in-flight load or
+   * discards a delivered result; close-after-release is a no-op, and ready callbacks are dropped if the action is
+   * closed before it becomes ready.
+   *
+   * The consumer that successfully releases the result must call {@link #countDelivered} exactly once, at the moment
+   * ownership transfers.
    *
    * The {@code acquireMode} selects how the segment is loaded; see {@link AcquireMode}. With {@link AcquireMode#PARTIAL}
    * the returned {@link Segment} is mounted but, for a partial-download (virtual storage) segment, may not be fully
@@ -88,6 +98,19 @@ public interface LoadableSegment
    * @throws DruidException if the segment has already been acquired
    */
   AcquireSegmentAction acquire(AcquireMode acquireMode);
+
+  /**
+   * Called by the consumer that successfully {@link AcquireSegmentAction#release()}s the result of {@link #acquire},
+   * exactly once, at the moment ownership transfers. Implementations update their {@code ChannelCounters} here. Not
+   * called when the load fails or is cancelled. {@link #acquireIfCached} counts inline and does not use this hook.
+   * <p>
+   * Counting happens post-release (rather than in a producer-registered ready callback) because the blessed
+   * {@code isReady()}-polling consumer idiom can release before producer callbacks fire, at which point a peeking
+   * {@code get()} would throw; post-release counting is exactly-once by construction.
+   */
+  default void countDelivered(AcquireSegmentResult result)
+  {
+  }
 
   /**
    * Returns a future for the {@link DataSegment} object. For {@link RegularLoadableSegment}, the future is created

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/input/LoadableSegmentUtils.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/input/LoadableSegmentUtils.java
@@ -19,59 +19,11 @@
 
 package org.apache.druid.msq.input;
 
-import com.google.common.util.concurrent.ListenableFuture;
-import org.apache.druid.common.guava.FutureUtils;
-import org.apache.druid.msq.counters.ChannelCounters;
 import org.apache.druid.segment.RowCountInspector;
 import org.apache.druid.segment.Segment;
-import org.apache.druid.segment.loading.AcquireSegmentAction;
-import org.apache.druid.segment.loading.AcquireSegmentResult;
-
-import javax.annotation.Nullable;
-import java.util.Optional;
 
 public class LoadableSegmentUtils
 {
-  /**
-   * Given a future from {@link AcquireSegmentAction#getSegmentFuture()}, wraps it with logic to increment
-   * counters as follows:
-   *
-   * <ul>
-   *   <li>{@link ChannelCounters#addLoad(AcquireSegmentResult)} when the load completes</li>
-   *   <li>{@link ChannelCounters#addFile(long, long)} each time a reference is acquired from
-   *   {@link AcquireSegmentResult#getReferenceProvider()}. The row count is taken from
-   *   {@link #getSegmentRowCount(Segment)}, and byte count is taken from {@code byteCount}.</li>
-   * </ul>
-   */
-  public static ListenableFuture<AcquireSegmentResult> countedLoad(
-      final ListenableFuture<AcquireSegmentResult> segmentFuture,
-      final long byteCount,
-      @Nullable final ChannelCounters channelCounters
-  )
-  {
-    if (channelCounters == null) {
-      return segmentFuture;
-    } else {
-      return FutureUtils.transform(
-          segmentFuture,
-          result -> {
-            channelCounters.addLoad(result);
-            return new AcquireSegmentResult(
-                () -> {
-                  final Optional<Segment> segment = result.getReferenceProvider().acquireReference();
-                  final int rowCount = segment.map(LoadableSegmentUtils::getSegmentRowCount).orElse(0);
-                  channelCounters.addFile(rowCount, byteCount);
-                  return segment;
-                },
-                result.getLoadSizeBytes(),
-                result.getWaitTimeNanos(),
-                result.getLoadTimeNanos()
-            );
-          }
-      );
-    }
-  }
-
   /**
    * Gets the number of rows for a segment, using a {@link RowCountInspector}. Returns 0 when unknown.
    */

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/input/RegularLoadableSegment.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/input/RegularLoadableSegment.java
@@ -21,19 +21,20 @@ package org.apache.druid.msq.input;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.apache.druid.client.coordinator.CoordinatorClient;
-import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.msq.counters.ChannelCounters;
 import org.apache.druid.query.SegmentDescriptor;
 import org.apache.druid.query.TableDataSource;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.loading.AcquireMode;
 import org.apache.druid.segment.loading.AcquireSegmentAction;
+import org.apache.druid.segment.loading.AcquireSegmentResult;
 import org.apache.druid.server.SegmentManager;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
@@ -68,6 +69,13 @@ public class RegularLoadableSegment implements LoadableSegment
   private final DataSegment cachedDataSegment;
 
   /**
+   * DataSegment fetched from the Coordinator by the deferred acquire chain. Written before the inner (stage 2)
+   * acquire starts, so it is always visible to {@link #countDelivered} for a delivered deferred acquire.
+   */
+  @Nullable
+  private volatile DataSegment fetchedDataSegment;
+
+  /**
    * Memoized supplier for the DataSegment future.
    */
   private final Supplier<ListenableFuture<DataSegment>> dataSegmentFutureSupplier;
@@ -78,7 +86,7 @@ public class RegularLoadableSegment implements LoadableSegment
    * @param segmentManager    segment manager for loading and caching segments
    * @param segmentId         the segment ID to load
    * @param descriptor        segment descriptor for querying
-   * @param inputCounters     optional counters for tracking input via {@link LoadableSegmentUtils#countedLoad}
+   * @param inputCounters     optional counters for tracking input, updated at delivery via {@link #countDelivered}
    * @param coordinatorClient optional client for fetching DataSegment from Coordinator when not available locally
    * @param isReindex         true if this is a DML command writing to the same table it's reading from
    */
@@ -138,7 +146,7 @@ public class RegularLoadableSegment implements LoadableSegment
     if (cachedSegment.isPresent()) {
       acquired = true;
 
-      // Update counters in the manner of LoadableSegmentUtils#countedLoad (which we aren't using here).
+      // Update counters inline; the countDelivered hook is only for the acquire() path.
       if (inputCounters != null) {
         final int rowCount = LoadableSegmentUtils.getSegmentRowCount(cachedSegment.get());
         final long byteCount = cachedDataSegment != null ? cachedDataSegment.getSize() : 0;
@@ -158,34 +166,113 @@ public class RegularLoadableSegment implements LoadableSegment
     acquired = true;
 
     if (cachedDataSegment != null) {
-      final AcquireSegmentAction action = segmentManager.acquireSegment(cachedDataSegment, acquireMode);
-      return new AcquireSegmentAction(
-          () -> LoadableSegmentUtils.countedLoad(
-              action.getSegmentFuture(),
-              cachedDataSegment.getSize(),
-              inputCounters
-          ),
-          action
-      );
+      // The SegmentManager handle is already the right shape; counter updates happen at delivery via countDelivered.
+      return segmentManager.acquireSegment(cachedDataSegment, acquireMode);
     } else {
-      // Create a shim AcquireSegmentAction that doesn't acquire a hold (yet). We can't make a real
-      // AcquireSegmentAction yet because we don't have the DataSegment object. It needs to be fetched
-      // from the Coordinator. That call is deferred until we're actually ready to load the segment, because
-      // we don't make the calls all at once when loading a lot of segments.
+      // We can't acquire from the SegmentManager yet because we don't have the DataSegment object; it needs to be
+      // fetched from the Coordinator first. Hand-rolled two-stage chain: an outer handle whose canceler tears down
+      // whichever stage is active, a DataSegment-future callback that starts the inner (cache manager) acquire under
+      // a state guard, and a ready-callback that transfers the inner result to the outer handle.
+      final DeferredAcquireState state = new DeferredAcquireState();
+      final ListenableFuture<DataSegment> dsFuture = dataSegmentFutureSupplier.get();
+      final AcquireSegmentAction outer = new AcquireSegmentAction(() -> {
+        final Runnable closeInner;
+        synchronized (state) {
+          state.closed = true;
+          closeInner = state.closeInnerOnce;
+        }
+        // Cancelling the memoized DataSegment future poisons later dataSegmentFuture() calls, which is safe today:
+        // acquire() is once-only and there are no other production consumers of dataSegmentFuture() after acquire.
+        dsFuture.cancel(true);
+        if (closeInner != null) {
+          closeInner.run();
+        }
+      });
+      Futures.addCallback(
+          dsFuture,
+          new FutureCallback<>()
+          {
+            @Override
+            public void onSuccess(DataSegment dataSegment)
+            {
+              fetchedDataSegment = dataSegment;
+              final AcquireSegmentAction inner;
+              final Runnable closeInnerOnce;
+              try {
+                synchronized (state) {
+                  if (state.closed) {
+                    // outer was closed before stage 2 could start; nothing acquired, nothing to clean up
+                    return;
+                  }
+                }
+                // Acquire OUTSIDE the state lock: acquireSegment can do real work (storage-location reservation,
+                // eviction, info-file writes), and the outer canceler takes the state lock — which a closer (e.g.
+                // ReadableInputQueue.close) may drive — so holding it here would stall cancellation behind
+                // deep-storage-side work. acquireSegment can also throw synchronously (e.g. CAPACITY_EXCEEDED, or a
+                // rejected load-pool submit); a throw escaping this callback would be swallowed by the direct
+                // executor, leaving outer never delivered and its consumer hung — route it to outer.setException.
+                inner = segmentManager.acquireSegment(dataSegment, acquireMode);
+              }
+              catch (Throwable t) {
+                outer.setException(t);
+                return;
+              }
+              closeInnerOnce = AcquireSegmentHandles.closeOnce(inner::close);
+              final boolean closedWhileAcquiring;
+              synchronized (state) {
+                closedWhileAcquiring = state.closed;
+                if (!closedWhileAcquiring) {
+                  state.closeInnerOnce = closeInnerOnce;
+                }
+              }
+              if (closedWhileAcquiring) {
+                // the outer handle was closed while we were acquiring; the canceler ran before closeInnerOnce was
+                // published, so we own the freshly-acquired inner handle and must close it ourselves
+                closeInnerOnce.run();
+                return;
+              }
+              // outside the state lock: ready callbacks can fire immediately on the registering thread
+              AcquireSegmentHandles.transferOnReady(inner, outer, closeInnerOnce);
+            }
 
-      final Closer closer = Closer.create();
-      return new AcquireSegmentAction(
-          Suppliers.memoize(() -> FutureUtils.transformAsync(
-              dataSegmentFutureSupplier.get(),
-              dataSegment -> LoadableSegmentUtils.countedLoad(
-                  closer.register(segmentManager.acquireSegment(dataSegment, acquireMode)).getSegmentFuture(),
-                  dataSegment.getSize(),
-                  inputCounters
-              )
-          )),
-          closer
+            @Override
+            public void onFailure(Throwable t)
+            {
+              // silently absorbed if the outer handle was closed first
+              outer.setException(t);
+            }
+          },
+          MoreExecutors.directExecutor()
       );
+      return outer;
     }
+  }
+
+  @Override
+  public void countDelivered(AcquireSegmentResult result)
+  {
+    if (inputCounters == null) {
+      return;
+    }
+    inputCounters.addLoad(result);
+    final int rowCount = result.getSegment().map(LoadableSegmentUtils::getSegmentRowCount).orElse(0);
+    final DataSegment sizeSource = cachedDataSegment != null ? cachedDataSegment : fetchedDataSegment;
+    // Parity with the old countedLoad: addFile fires even for an empty delivery, with rowCount 0.
+    inputCounters.addFile(rowCount, sizeSource == null ? 0 : sizeSource.getSize());
+  }
+
+  /**
+   * Stage guard for the deferred acquire chain: serializes "outer closed" against "stage 2 started" so the inner
+   * handle is either never created, or is closed exactly once (by the canceler or by the transfer's failure path,
+   * whichever comes first — both go through {@link #closeInnerOnce}).
+   */
+  private static final class DeferredAcquireState
+  {
+    @GuardedBy("this")
+    boolean closed;
+    @GuardedBy("this")
+    @Nullable
+    Runnable closeInnerOnce;
   }
 
   /**

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSliceReader.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSliceReader.java
@@ -200,8 +200,11 @@ public class ExternalInputSliceReader implements InputSliceReader
                         signature
                     );
 
+                    // The ExternalSegment itself owns no resources (the fetched files are owned by the collected
+                    // resources, whose close is folded into the delivered segment by AdaptedLoadableSegment), so it
+                    // is delivered unmanaged.
                     return new AcquireSegmentResult(
-                        ReferenceCountedSegmentProvider.of(segment),
+                        ReferenceCountedSegmentProvider.unmanaged(segment),
                         totalSize,
                         0L,
                         System.nanoTime() - startTime
@@ -217,8 +220,8 @@ public class ExternalInputSliceReader implements InputSliceReader
                     if (VirtualStorageManager.isInsufficientStorage(e)) {
                       log.noStackTrace()
                          .info(e, "Insufficient storage space to prefetch[%s]; streaming instead.", description);
-                      return AcquireSegmentResult.cached(
-                          ReferenceCountedSegmentProvider.of(
+                      return AcquireSegmentResult.of(
+                          ReferenceCountedSegmentProvider.unmanaged(
                               new ExternalSegment(
                                   inputSource,
                                   makeReader(schema, inputSource, inputFormat, channelCounters),

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/ReadableInputQueue.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/ReadableInputQueue.java
@@ -22,8 +22,8 @@ package org.apache.druid.msq.querykit;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
-import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.frame.channel.ReadableFrameChannel;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -36,6 +36,7 @@ import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.SegmentReference;
 import org.apache.druid.segment.loading.AcquireMode;
 import org.apache.druid.segment.loading.AcquireSegmentAction;
+import org.apache.druid.segment.loading.AcquireSegmentResult;
 import org.apache.druid.utils.CloseableUtils;
 
 import javax.annotation.Nullable;
@@ -43,6 +44,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -80,10 +82,14 @@ public class ReadableInputQueue implements Closeable
   private final Queue<DataServerQueryHandler> queryableServers = new ArrayDeque<>();
 
   /**
-   * Segments currently being loaded.
+   * Segments currently being loaded: the acquire handle mapped to the future its delivery (or failure) completes.
+   * Map membership under the queue monitor is the single terminal-ownership protocol: exactly one of
+   * {@link #onSegmentReady} and {@link #close()} removes an entry and is thereafter the only party that touches
+   * that handle terminally.
    */
   @GuardedBy("this")
-  private final Set<AcquireSegmentAction> loadingSegments = new LinkedHashSet<>();
+  private final LinkedHashMap<AcquireSegmentAction, SettableFuture<ReadableInput>> loadingSegments =
+      new LinkedHashMap<>();
 
   /**
    * Segments that have been loaded. These are tracked here so we can close them if needed.
@@ -96,6 +102,20 @@ public class ReadableInputQueue implements Closeable
    */
   @GuardedBy("this")
   private final Set<ListenableFuture<ReadableInput>> pendingNextInputs = Sets.newIdentityHashSet();
+
+  /**
+   * Futures whose delivery is mid-flight: removed from {@link #loadingSegments} by {@link #onSegmentReady} but not
+   * yet completed. {@link #close()} fails these too; {@link SettableFuture}'s first-write-wins semantics arbitrate
+   * the race (the losing write is a harmless no-op).
+   */
+  @GuardedBy("this")
+  private final Set<SettableFuture<ReadableInput>> inFlightDeliveries = Sets.newIdentityHashSet();
+
+  /**
+   * Set by {@link #close()}; checked by {@link #onSegmentReady} just before completing a delivery successfully.
+   */
+  @GuardedBy("this")
+  private boolean closed = false;
 
   private final StandardPartitionReader partitionReader;
   private final int loadahead;
@@ -144,7 +164,7 @@ public class ReadableInputQueue implements Closeable
           final Optional<Segment> cachedSegment = loadableSegment.acquireIfCached(acquireMode);
           if (cachedSegment.isPresent()) {
             final SegmentReferenceHolder holder = new SegmentReferenceHolder(
-                new SegmentReference(loadableSegment.descriptor(), cachedSegment, null),
+                new SegmentReference(loadableSegment.descriptor(), cachedSegment),
                 loadableSegment.description()
             );
             loadedSegments.add(holder);
@@ -298,41 +318,92 @@ public class ReadableInputQueue implements Closeable
         return null;
       }
 
+      final SettableFuture<ReadableInput> future = SettableFuture.create();
       final AcquireSegmentAction acquireSegmentAction = nextLoadableSegment.acquire(acquireMode);
-      loadingSegments.add(acquireSegmentAction);
-      return FutureUtils.transform(
-          acquireSegmentAction.getSegmentFuture(),
-          segment -> {
-            synchronized (ReadableInputQueue.this) {
-              // Transfer segment from "loadingSegments" to "loadedSegments" and return a reference to it.
-              if (loadingSegments.remove(acquireSegmentAction)) {
-                try {
-                  final SegmentReferenceHolder referenceHolder = new SegmentReferenceHolder(
-                      new SegmentReference(
-                          nextLoadableSegment.descriptor(),
-                          segment.getReferenceProvider().acquireReference(),
-                          acquireSegmentAction // Release the hold when the SegmentReference is closed.
-                      ),
-                      nextLoadableSegment.description()
-                  );
-                  loadedSegments.add(referenceHolder);
-                  return ReadableInput.segment(referenceHolder);
-                }
-                catch (Throwable e) {
-                  // Javadoc for segment.acquireReference() suggests it can throw exceptions; handle that here
-                  // by closing the original AcquireSegmentAction.
-                  throw CloseableUtils.closeAndWrapInCatch(e, acquireSegmentAction);
-                }
-              } else {
-                throw DruidException.defensive(
-                    "Segment[%s] removed from loadingSegments before loading complete. It is possible that close() "
-                    + "was called with futures in flight.",
-                    nextLoadableSegment.description()
-                );
-              }
-            }
-          }
-      );
+      loadingSegments.put(acquireSegmentAction, future);
+      // may fire immediately on this thread for an already-ready acquire; the queue monitor is reentrant
+      acquireSegmentAction.addReadyCallback(() -> onSegmentReady(nextLoadableSegment, acquireSegmentAction));
+      return future;
+    }
+  }
+
+  /**
+   * Delivery path for {@link #loadNextSegment}: transfers ownership of the acquired segment out of the handle and
+   * into a {@link SegmentReferenceHolder}, then completes the future handed to the frame processor. The future is
+   * completed OUTSIDE the queue monitor so downstream listeners never run while holding the queue lock; deliveries
+   * racing {@link #close()} are arbitrated by a closed re-check plus {@link SettableFuture}'s first-write-wins
+   * semantics (close() also fails in-flight futures; the losing write is a harmless no-op).
+   */
+  private void onSegmentReady(LoadableSegment loadableSegment, AcquireSegmentAction acquireSegmentAction)
+  {
+    ReadableInput readableInput = null;
+    Throwable failure = null;
+    final SettableFuture<ReadableInput> future;
+
+    synchronized (this) {
+      future = loadingSegments.remove(acquireSegmentAction);
+      if (future == null) {
+        // close() already processed this handle: it closed the handle (and any delivered result) and failed the
+        // future; nothing left to do.
+        return;
+      }
+      // visible to close() as a mid-delivery future it must also fail
+      inFlightDeliveries.add(future);
+      // Tracks the released result until ownership transfers to a SegmentReferenceHolder in loadedSegments. If a step
+      // after release() throws while this is still non-null, we own the orphaned result and must close it (close on
+      // the RELEASED action is a no-op, so closing the action alone would leak the segment and its folded holds).
+      AcquireSegmentResult releasedResult = null;
+      try {
+        // Ownership transfer; the delivered segment's close releases everything the acquire placed.
+        releasedResult = acquireSegmentAction.release();
+        loadableSegment.countDelivered(releasedResult);
+        final SegmentReferenceHolder referenceHolder = new SegmentReferenceHolder(
+            new SegmentReference(loadableSegment.descriptor(), releasedResult.getSegment()),
+            loadableSegment.description()
+        );
+        loadedSegments.add(referenceHolder);
+        // ownership is now with loadedSegments; close() will close the holder if it is never handed out
+        releasedResult = null;
+        readableInput = ReadableInput.segment(referenceHolder);
+      }
+      catch (Throwable t) {
+        failure = t;
+        if (releasedResult != null) {
+          // release() succeeded but a later step threw before ownership transferred; close the orphaned result so its
+          // segment reference and folded cache holds are released rather than leaked.
+          CloseableUtils.closeAndSuppressExceptions(
+              releasedResult,
+              e -> log.warn(e, "Failed to close acquired segment for segment[%s]", loadableSegment.description())
+          );
+        } else {
+          // release() itself surfaced the producer's load failure; close the handle so it reaches a terminal state
+          // (a no-op close of the null result for a failed load).
+          CloseableUtils.closeAndSuppressExceptions(
+              acquireSegmentAction,
+              e -> log.warn(e, "Failed to close acquire action for segment[%s]", loadableSegment.description())
+          );
+        }
+      }
+    }
+
+    // Re-check for close under the monitor immediately before completing: if the queue closed after the ownership
+    // work above, close() has drained (or is draining) the holder we just handed to loadedSegments, so fail the
+    // future rather than delivering a dead holder. A success that lands in the last instructions before close()
+    // drains can still hand the consumer a drained holder — SegmentReferenceHolder.getSegmentReferenceOnce() is the
+    // designed exactly-once arbiter backstopping that pre-existing window.
+    final boolean queueClosed;
+    synchronized (this) {
+      queueClosed = closed;
+    }
+    if (failure != null) {
+      future.setException(failure);
+    } else if (queueClosed) {
+      future.setException(DruidException.defensive("Input queue closed while segment load was in flight"));
+    } else {
+      future.set(readableInput);
+    }
+    synchronized (this) {
+      inFlightDeliveries.remove(future);
     }
   }
 
@@ -356,36 +427,69 @@ public class ReadableInputQueue implements Closeable
   @Override
   public void close()
   {
+    final List<AcquireSegmentAction> handlesToClose;
+    final List<SegmentReferenceHolder> holdersToDrain;
+    final List<SettableFuture<ReadableInput>> futuresToFail = new ArrayList<>();
+
+    // Snapshot and clear everything under the monitor, but do the actual closing OUTSIDE it: closing a handle can
+    // synchronously run its canceler (a deferred acquire's canceler takes its own stage lock and may complete the
+    // handle), and holding the queue monitor across that work would stall every concurrent delivery and nextInput()
+    // call behind it. Clearing the loading map first means a late-arriving onSegmentReady finds no entry
+    // (future == null) and returns without touching queue state.
     synchronized (this) {
+      closed = true;
       readablePartitions.clear();
       queryableServers.clear();
       loadableSegments.clear();
 
-      // Cancel all pending segment loads.
-      for (AcquireSegmentAction acquireSegmentAction : loadingSegments) {
-        CloseableUtils.closeAndSuppressExceptions(
-            acquireSegmentAction,
-
-            // AcquireSegmentAction currently doesn't have a meaningful toString method, so if this message
-            // ever actually gets logged, it won't mention the specific segment that had a problem. Perhaps
-            // one day this will change.
-            e -> log.warn(e, "Failed to close loadingSegment[%s]", acquireSegmentAction)
-        );
-      }
+      handlesToClose = new ArrayList<>(loadingSegments.keySet());
+      futuresToFail.addAll(loadingSegments.values());
       loadingSegments.clear();
 
-      // Close all segments that have been loaded and not yet transferred to callers. (Segments transferred to
-      // callers must be closed by the callers.)
-      for (SegmentReferenceHolder referenceHolder : loadedSegments) {
-        final SegmentReference ref = referenceHolder.getSegmentReferenceOnce();
-        if (ref != null) {
-          CloseableUtils.closeAndSuppressExceptions(
-              ref,
-              e -> log.warn(e, "Failed to close loadedSegment[%s]", ref.getSegmentDescriptor())
-          );
-        }
-      }
+      // Also fail deliveries that are mid-completion (removed from loadingSegments but not yet completed);
+      // SettableFuture's first-write-wins semantics make whichever write loses a harmless no-op.
+      futuresToFail.addAll(inFlightDeliveries);
+
+      holdersToDrain = new ArrayList<>(loadedSegments);
       loadedSegments.clear();
+
+      // Drop loadahead futures that were never handed out: their loads are covered by the closing/failing here, and
+      // handing them out after close would deliver holders this close() is draining. Also keeps remaining()
+      // reporting 0 after close.
+      pendingNextInputs.clear();
+    }
+
+    // Cancel all pending segment loads: closing a NEW handle runs its canceler (aborting the load); closing a
+    // READY-but-unclaimed handle (its ready callback hasn't reached the queue monitor yet) closes the delivered
+    // result.
+    for (final AcquireSegmentAction acquireSegmentAction : handlesToClose) {
+      CloseableUtils.closeAndSuppressExceptions(
+          acquireSegmentAction,
+
+          // AcquireSegmentAction currently doesn't have a meaningful toString method, so if this message
+          // ever actually gets logged, it won't mention the specific segment that had a problem. Perhaps
+          // one day this will change.
+          e -> log.warn(e, "Failed to close loadingSegment[%s]", acquireSegmentAction)
+      );
+    }
+
+    // Close all segments that have been loaded and not yet transferred to callers. (Segments transferred to
+    // callers must be closed by the callers.)
+    for (SegmentReferenceHolder referenceHolder : holdersToDrain) {
+      final SegmentReference ref = referenceHolder.getSegmentReferenceOnce();
+      if (ref != null) {
+        CloseableUtils.closeAndSuppressExceptions(
+            ref,
+            e -> log.warn(e, "Failed to close loadedSegment[%s]", ref.getSegmentDescriptor())
+        );
+      }
+    }
+
+    // Explicitly fail the futures of the loads we just cancelled. This is load-bearing — ready callbacks are dropped
+    // when a handle is closed before becoming ready, so without this the frame processors awaiting these futures
+    // would hang forever.
+    for (final SettableFuture<ReadableInput> future : futuresToFail) {
+      future.setException(DruidException.defensive("Input queue closed while segment load was in flight"));
     }
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/counters/CountersSnapshotTreeTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/counters/CountersSnapshotTreeTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Objects;
+import java.util.Optional;
 
 public class CountersSnapshotTreeTest
 {
@@ -44,7 +45,7 @@ public class CountersSnapshotTreeTest
     channelCounters.addFile(10, 13);
     channelCounters.addTotalFiles(14);
     // fake load to set some counters
-    channelCounters.addLoad(new AcquireSegmentResult(null, 1234L, 1L, 1L));
+    channelCounters.addLoad(new AcquireSegmentResult(Optional.empty(), 1234L, 1L, 1L));
 
     final CounterSnapshotsTree snapshotsTree = new CounterSnapshotsTree();
     snapshotsTree.put(1, 2, new CounterSnapshots(ImmutableMap.of("ctr", channelCounters.snapshot())));

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQCompactionTaskRunTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQCompactionTaskRunTest.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.Futures;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
@@ -220,9 +219,9 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
           new TestUtils().getTestIndexIO().loadIndex(new File((String) segment.getLoadSpec().get("path"))),
           segment.getId()
       );
-      return new AcquireSegmentAction(
-          () -> Futures.immediateFuture(new AcquireSegmentResult(new ReferenceCountedSegmentProvider(index), 0, 0, 0)),
-          null
+      // a fresh reference per acquire; the consumer's close of the delivered segment closes the index
+      return AcquireSegmentAction.completed(
+          AcquireSegmentResult.of(new ReferenceCountedSegmentProvider(index).acquireReference())
       );
     });
     when(segmentCacheManager.acquireCachedSegment(any(), any())).thenReturn(Optional.empty());

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/AdaptedLoadableSegmentTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/AdaptedLoadableSegmentTest.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.input;
+
+import org.apache.druid.common.asyncresource.AsyncResource;
+import org.apache.druid.common.asyncresource.AsyncResources;
+import org.apache.druid.common.asyncresource.SettableAsyncResource;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.query.SegmentDescriptor;
+import org.apache.druid.segment.ReferenceCountedSegmentProvider;
+import org.apache.druid.segment.Segment;
+import org.apache.druid.segment.loading.AcquireMode;
+import org.apache.druid.segment.loading.AcquireSegmentAction;
+import org.apache.druid.segment.loading.AcquireSegmentResult;
+import org.apache.druid.timeline.SegmentId;
+import org.joda.time.Interval;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tests for {@link AdaptedLoadableSegment}'s forward bridge: a combinator-produced (non-releasable)
+ * {@code AsyncResource<AcquireSegmentResult>} folded into the releasable {@link AcquireSegmentAction} handle, with
+ * the resource chain's close riding the delivered segment's close.
+ */
+class AdaptedLoadableSegmentTest
+{
+  private static final SegmentDescriptor DESCRIPTOR = SegmentId.dummy("adapted").toDescriptor();
+
+  private static class TestSegment implements Segment
+  {
+    final AtomicInteger closes = new AtomicInteger();
+
+    @Override
+    public SegmentId getId()
+    {
+      return SegmentId.dummy("adapted");
+    }
+
+    @Override
+    public Interval getDataInterval()
+    {
+      return Intervals.ETERNITY;
+    }
+
+    @Nullable
+    @Override
+    public <T> T as(@Nonnull Class<T> clazz)
+    {
+      return null;
+    }
+
+    @Override
+    public void close()
+    {
+      closes.incrementAndGet();
+    }
+  }
+
+  /**
+   * Mirrors the {@code ExternalInputSliceReader} chain shape: collect over source resources, transform to a result
+   * whose segment is delivered unmanaged (the chain owns the sources).
+   */
+  private static AsyncResource<AcquireSegmentResult> makeChain(
+      final TestSegment segment,
+      final List<SettableAsyncResource<String>> sources
+  )
+  {
+    return AsyncResources.transform(
+        AsyncResources.collect(List.copyOf(sources)),
+        files -> new AcquireSegmentResult(ReferenceCountedSegmentProvider.unmanaged(segment), 0L, 0L, 0L)
+    );
+  }
+
+  @Test
+  void testSegmentCloseClosesChainSourcesExactlyOnce() throws Exception
+  {
+    final TestSegment segment = new TestSegment();
+    final AtomicInteger sourceCloses = new AtomicInteger();
+    final SettableAsyncResource<String> source = new SettableAsyncResource<>();
+    source.set("file", sourceCloses::incrementAndGet);
+
+    final AdaptedLoadableSegment adapted =
+        new AdaptedLoadableSegment(() -> makeChain(segment, List.of(source)), DESCRIPTOR, "test", null);
+    final AcquireSegmentAction action = adapted.acquire(AcquireMode.FULL);
+    action.await();
+    final AcquireSegmentResult result = action.release();
+    action.close();
+
+    final Segment delivered = result.getSegment().orElseThrow();
+    Assertions.assertEquals(0, sourceCloses.get(), "sources must outlive the delivered segment");
+
+    delivered.close();
+    Assertions.assertEquals(1, sourceCloses.get(), "segment close must close the chain sources exactly once");
+    Assertions.assertEquals(0, segment.closes.get(), "unmanaged segment itself is not closed by the wrapper");
+  }
+
+  @Test
+  void testCancelBeforeReadyClosesChain()
+  {
+    final TestSegment segment = new TestSegment();
+    final SettableAsyncResource<String> source = new SettableAsyncResource<>();
+
+    final AdaptedLoadableSegment adapted =
+        new AdaptedLoadableSegment(() -> makeChain(segment, List.of(source)), DESCRIPTOR, "test", null);
+    final AcquireSegmentAction action = adapted.acquire(AcquireMode.FULL);
+    Assertions.assertFalse(action.isReady());
+
+    // closing the un-released handle cancels: the chain (and its sources) are closed
+    action.close();
+
+    // a source completing after the cancel loses the set() race: the producer retains ownership
+    final AtomicInteger lateCloses = new AtomicInteger();
+    Assertions.assertFalse(source.set("late", lateCloses::incrementAndGet));
+  }
+
+  @Test
+  void testChainFailureSurfacesAndClosesSources()
+  {
+    final TestSegment segment = new TestSegment();
+    final AtomicInteger okSourceCloses = new AtomicInteger();
+    final SettableAsyncResource<String> okSource = new SettableAsyncResource<>();
+    okSource.set("ok", okSourceCloses::incrementAndGet);
+    final SettableAsyncResource<String> failedSource = new SettableAsyncResource<>();
+
+    final AdaptedLoadableSegment adapted = new AdaptedLoadableSegment(
+        () -> makeChain(segment, List.of(okSource, failedSource)),
+        DESCRIPTOR,
+        "test",
+        null
+    );
+    final AcquireSegmentAction action = adapted.acquire(AcquireMode.FULL);
+    failedSource.setException(new IllegalStateException("fetch failed"));
+
+    Assertions.assertTrue(action.isReady());
+    Assertions.assertThrows(IllegalStateException.class, action::release);
+    Assertions.assertEquals(1, okSourceCloses.get(), "chain failure must release the successful sources");
+    action.close();
+    Assertions.assertEquals(1, okSourceCloses.get(), "close after failure must not double-close sources");
+  }
+
+  @Test
+  void testCloseAfterDeliveryWithoutReleaseClosesEverything()
+  {
+    final TestSegment segment = new TestSegment();
+    final AtomicInteger sourceCloses = new AtomicInteger();
+    final SettableAsyncResource<String> source = new SettableAsyncResource<>();
+    source.set("file", sourceCloses::incrementAndGet);
+
+    final AdaptedLoadableSegment adapted =
+        new AdaptedLoadableSegment(() -> makeChain(segment, List.of(source)), DESCRIPTOR, "test", null);
+    final AcquireSegmentAction action = adapted.acquire(AcquireMode.FULL);
+    Assertions.assertTrue(action.isReady());
+
+    // never released: closing the handle closes the delivered result, whose segment close tears down the chain
+    action.close();
+    Assertions.assertEquals(1, sourceCloses.get());
+  }
+
+  @Test
+  void testFromUnmanagedSegmentDeliversNoopCloseWrapper() throws Exception
+  {
+    final TestSegment segment = new TestSegment();
+    final AdaptedLoadableSegment adapted =
+        AdaptedLoadableSegment.fromUnmanagedSegment(segment, DESCRIPTOR, "test", null);
+
+    final AcquireSegmentAction action = adapted.acquire(AcquireMode.FULL);
+    action.await();
+    final AcquireSegmentResult result = action.release();
+    final Segment delivered = result.getSegment().orElseThrow();
+    delivered.close();
+    Assertions.assertEquals(0, segment.closes.get(), "unmanaged segment must not be closed by the wrapper");
+    action.close();
+  }
+
+  @Test
+  void testAcquireTwiceThrows()
+  {
+    final AdaptedLoadableSegment adapted =
+        AdaptedLoadableSegment.fromUnmanagedSegment(new TestSegment(), DESCRIPTOR, "test", null);
+    adapted.acquire(AcquireMode.FULL).close();
+    Assertions.assertThrows(Exception.class, () -> adapted.acquire(AcquireMode.FULL));
+  }
+}

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/RegularLoadableSegmentTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/RegularLoadableSegmentTest.java
@@ -24,22 +24,26 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
 import org.apache.druid.client.coordinator.NoopCoordinatorClient;
 import org.apache.druid.common.guava.FutureUtils;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.jackson.SegmentizerModule;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
-import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.jackson.JacksonUtils;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.msq.counters.ChannelCounters;
+import org.apache.druid.query.TableDataSource;
 import org.apache.druid.query.expression.TestExprMacroTable;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.IndexSpec;
@@ -63,6 +67,7 @@ import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.utils.CompressionUtils;
 import org.joda.time.DateTime;
@@ -246,16 +251,18 @@ class RegularLoadableSegmentTest extends InitializedNullHandlingTest
                   f,
                   ls -> {
                     final AcquireSegmentAction acquireAction = ls.acquire(AcquireMode.PARTIAL);
-                    return FutureUtils.transform(acquireAction.getSegmentFuture(), f2 -> Pair.of(acquireAction, f2));
+                    final SettableFuture<AcquireSegmentAction> ready = SettableFuture.create();
+                    acquireAction.addReadyCallback(() -> ready.set(acquireAction));
+                    return ready;
                   }
               ),
-              pair -> {
-                final AcquireSegmentResult acquireResult = pair.rhs;
-                final Optional<Segment> acquiredSegmentOptional =
-                    acquireResult.getReferenceProvider().acquireReference();
+              (AcquireSegmentAction action) -> {
+                final AcquireSegmentResult acquireResult = action.release();
+                final Optional<Segment> acquiredSegmentOptional = acquireResult.getSegment();
                 Assertions.assertTrue(acquiredSegmentOptional.isPresent());
 
-                try (final AcquireSegmentAction ignored = pair.lhs;
+                // closing the action after release is a no-op; the segment carries all cleanup
+                try (final AcquireSegmentAction ignored = action;
                      final Segment acquiredSegment = acquiredSegmentOptional.get()) {
                   Assertions.assertEquals(segment.getId(), acquiredSegment.getId());
                   RowCountInspector gadget = acquiredSegment.as(RowCountInspector.class);
@@ -317,16 +324,18 @@ class RegularLoadableSegmentTest extends InitializedNullHandlingTest
                   f,
                   ls -> {
                     final AcquireSegmentAction acquireAction = ls.acquire(AcquireMode.PARTIAL);
-                    return FutureUtils.transform(acquireAction.getSegmentFuture(), f2 -> Pair.of(acquireAction, f2));
+                    final SettableFuture<AcquireSegmentAction> ready = SettableFuture.create();
+                    acquireAction.addReadyCallback(() -> ready.set(acquireAction));
+                    return ready;
                   }
               ),
-              pair -> {
-                final AcquireSegmentResult acquireResult = pair.rhs;
-                final Optional<Segment> acquiredSegmentOptional =
-                    acquireResult.getReferenceProvider().acquireReference();
+              (AcquireSegmentAction action) -> {
+                final AcquireSegmentResult acquireResult = action.release();
+                final Optional<Segment> acquiredSegmentOptional = acquireResult.getSegment();
                 Assertions.assertTrue(acquiredSegmentOptional.isPresent());
 
-                try (final AcquireSegmentAction ignored = pair.lhs;
+                // closing the action after release is a no-op; the segment carries all cleanup
+                try (final AcquireSegmentAction ignored = action;
                      final Segment acquiredSegment = acquiredSegmentOptional.get()) {
                   Assertions.assertEquals(segment.getId(), acquiredSegment.getId());
                   RowCountInspector gadget = acquiredSegment.as(RowCountInspector.class);
@@ -422,7 +431,7 @@ class RegularLoadableSegmentTest extends InitializedNullHandlingTest
    * Tests fetching a single segment with CoordinatorClient.
    */
   @Test
-  public void test_fetchSegment_dynamic() throws IOException
+  public void test_fetchSegment_dynamic() throws IOException, InterruptedException
   {
     final DataSegment segment = segments.get(0);
     final TestCoordinatorClientImpl coordinatorClient = new TestCoordinatorClientImpl();
@@ -442,8 +451,9 @@ class RegularLoadableSegmentTest extends InitializedNullHandlingTest
 
     // Verify segment acquisition works.
     final AcquireSegmentAction acquireAction = loadableSegment.acquire(AcquireMode.PARTIAL);
-    final AcquireSegmentResult acquireResult = FutureUtils.getUnchecked(acquireAction.getSegmentFuture(), false);
-    final Optional<Segment> acquiredSegmentOptional = acquireResult.getReferenceProvider().acquireReference();
+    acquireAction.await();
+    final AcquireSegmentResult acquireResult = acquireAction.release();
+    final Optional<Segment> acquiredSegmentOptional = acquireResult.getSegment();
     Assertions.assertTrue(acquiredSegmentOptional.isPresent());
 
     try (final AcquireSegmentAction ignored = acquireAction;
@@ -459,7 +469,7 @@ class RegularLoadableSegmentTest extends InitializedNullHandlingTest
    * Tests fetching a single segment with locally-cached DataSegment.
    */
   @Test
-  public void test_fetchSegment_preLoaded() throws IOException, SegmentLoadingException
+  public void test_fetchSegment_preLoaded() throws IOException, SegmentLoadingException, InterruptedException
   {
     final DataSegment segment = segments.get(0);
 
@@ -481,8 +491,9 @@ class RegularLoadableSegmentTest extends InitializedNullHandlingTest
 
     // Verify segment acquisition works.
     final AcquireSegmentAction acquireAction = loadableSegment.acquire(AcquireMode.PARTIAL);
-    final AcquireSegmentResult acquireResult = FutureUtils.getUnchecked(acquireAction.getSegmentFuture(), false);
-    final Optional<Segment> acquiredSegmentOptional = acquireResult.getReferenceProvider().acquireReference();
+    acquireAction.await();
+    final AcquireSegmentResult acquireResult = acquireAction.release();
+    final Optional<Segment> acquiredSegmentOptional = acquireResult.getSegment();
     Assertions.assertTrue(acquiredSegmentOptional.isPresent());
 
     try (final AcquireSegmentAction ignored = acquireAction;
@@ -523,6 +534,204 @@ class RegularLoadableSegmentTest extends InitializedNullHandlingTest
       catch (IOException e) {
         throw new SegmentLoadingException(e, "Failed to load segment in location [%s]", destDir);
       }
+    }
+  }
+
+  /**
+   * Deferred chain, stage-1 cancel: closing the outer handle before the Coordinator fetch resolves must cancel the
+   * fetch and acquire nothing.
+   */
+  @Test
+  public void test_deferredAcquire_closeBeforeCoordinatorFetch()
+  {
+    final DataSegment segment = segments.get(0);
+    final SettableFuture<DataSegment> gate = SettableFuture.create();
+    final RegularLoadableSegment loadableSegment = new RegularLoadableSegment(
+        segmentManagerDynamic,
+        segment.getId(),
+        segment.toDescriptor(),
+        null,
+        new GatedCoordinatorClient(gate),
+        false
+    );
+
+    final AcquireSegmentAction action = loadableSegment.acquire(AcquireMode.PARTIAL);
+    Assertions.assertFalse(action.isReady());
+    action.close();
+
+    Assertions.assertTrue(gate.isCancelled(), "closing the outer handle must cancel the Coordinator fetch");
+    assertCacheDirClean();
+  }
+
+  /**
+   * Deferred chain, closed-before-stage-2 guard: when the Coordinator fetch completes after the outer handle was
+   * closed (simulated with a cancel-resistant future), the inner acquire must never start.
+   */
+  @Test
+  public void test_deferredAcquire_fetchCompletesAfterClose()
+  {
+    final DataSegment segment = segments.get(0);
+    final UncancellableFuture<DataSegment> gate = new UncancellableFuture<>();
+    final RegularLoadableSegment loadableSegment = new RegularLoadableSegment(
+        segmentManagerDynamic,
+        segment.getId(),
+        segment.toDescriptor(),
+        null,
+        new GatedCoordinatorClient(gate),
+        false
+    );
+
+    final AcquireSegmentAction action = loadableSegment.acquire(AcquireMode.PARTIAL);
+    action.close();
+
+    // the fetch survives the cancel attempt and completes; the stage guard must prevent the inner acquire
+    Assertions.assertTrue(gate.setValue(segment));
+    assertCacheDirClean();
+  }
+
+  /**
+   * Deferred chain, stage-2 synchronous throw: if segmentManager.acquireSegment() throws synchronously after the
+   * Coordinator fetch resolves, the failure must surface from the outer handle rather than being swallowed by the
+   * direct-executor callback (which would hang the consumer forever).
+   */
+  @Test
+  public void test_deferredAcquire_innerAcquireThrowIsSurfacedNotSwallowed()
+  {
+    final DataSegment segment = segments.get(0);
+    final DruidException boom = DruidException.forPersona(DruidException.Persona.USER)
+                                             .ofCategory(DruidException.Category.CAPACITY_EXCEEDED)
+                                             .build("no room for segment[%s]", segment.getId());
+    final SegmentManager throwingManager = new SegmentManager(null)
+    {
+      @Override
+      public Optional<VersionedIntervalTimeline<String, DataSegment>> getTimeline(TableDataSource dataSource)
+      {
+        // force the deferred (cachedDataSegment == null) path
+        return Optional.empty();
+      }
+
+      @Override
+      public AcquireSegmentAction acquireSegment(DataSegment dataSegment, AcquireMode acquireMode)
+      {
+        throw boom;
+      }
+    };
+    final RegularLoadableSegment loadableSegment = new RegularLoadableSegment(
+        throwingManager,
+        segment.getId(),
+        segment.toDescriptor(),
+        null,
+        new TestCoordinatorClientImpl(),
+        false
+    );
+
+    final AcquireSegmentAction action = loadableSegment.acquire(AcquireMode.PARTIAL);
+    // bounded await: a hang (swallowed throw) would surface as TimeoutException and fail the test
+    final DruidException thrown = Assertions.assertThrows(DruidException.class, () -> action.await(10_000L));
+    Assertions.assertTrue(thrown.getMessage().contains("no room for segment["), thrown.getMessage());
+    action.close();
+  }
+
+  /**
+   * Deferred chain, close-after-ready without release: closing the outer handle discards the delivered result and
+   * releases everything the acquire placed.
+   */
+  @Test
+  public void test_deferredAcquire_closeAfterReadyUnreleased() throws Exception
+  {
+    final DataSegment segment = segments.get(0);
+    final RegularLoadableSegment loadableSegment = new RegularLoadableSegment(
+        segmentManagerDynamic,
+        segment.getId(),
+        segment.toDescriptor(),
+        null,
+        new TestCoordinatorClientImpl(),
+        false
+    );
+
+    final AcquireSegmentAction action = loadableSegment.acquire(AcquireMode.PARTIAL);
+    action.await();
+    action.close();
+    assertCacheDirClean();
+  }
+
+  /**
+   * Counter accounting happens at delivery via {@link LoadableSegment#countDelivered}: addLoad (when bytes were
+   * loaded) + one addFile with the segment's row count.
+   */
+  @Test
+  public void test_countDelivered_accounting() throws Exception
+  {
+    final DataSegment segment = segments.get(0);
+    final ChannelCounters counters = new ChannelCounters();
+    final RegularLoadableSegment loadableSegment = new RegularLoadableSegment(
+        segmentManagerDynamic,
+        segment.getId(),
+        segment.toDescriptor(),
+        counters,
+        new TestCoordinatorClientImpl(),
+        false
+    );
+
+    final AcquireSegmentAction action = loadableSegment.acquire(AcquireMode.PARTIAL);
+    action.await();
+    final AcquireSegmentResult result = action.release();
+    loadableSegment.countDelivered(result);
+
+    final ChannelCounters.Snapshot snapshot = counters.snapshot();
+    Assertions.assertNotNull(snapshot.getFiles());
+    Assertions.assertEquals(1, snapshot.getFiles()[snapshot.getFiles().length - 1], "exactly one file per delivery");
+    Assertions.assertNotNull(snapshot.getRows());
+    Assertions.assertEquals(1209, snapshot.getRows()[snapshot.getRows().length - 1]);
+
+    try (Segment acquiredSegment = result.getSegment().orElseThrow()) {
+      Assertions.assertEquals(segment.getId(), acquiredSegment.getId());
+    }
+    action.close();
+  }
+
+  /**
+   * Ephemeral virtual storage deletes segment files once all holds are released, so a clean cache dir proves the
+   * acquire leaked nothing.
+   */
+  private void assertCacheDirClean()
+  {
+    if (!cacheDir.exists()) {
+      // nothing was ever downloaded, which is as clean as it gets
+      return;
+    }
+    Assertions.assertEquals(Set.of("info_dir", "__drop"), Set.of(cacheDir.list()));
+    Assertions.assertEquals(Collections.emptyList(), Arrays.asList(new File(cacheDir, "__drop").list()));
+    Assertions.assertEquals(Collections.emptyList(), Arrays.asList(new File(cacheDir, "info_dir").list()));
+  }
+
+  private static class GatedCoordinatorClient extends NoopCoordinatorClient
+  {
+    private final ListenableFuture<DataSegment> future;
+
+    GatedCoordinatorClient(ListenableFuture<DataSegment> future)
+    {
+      this.future = future;
+    }
+
+    @Override
+    public ListenableFuture<DataSegment> fetchSegment(String dataSource, String segmentId, boolean includeUnused)
+    {
+      return future;
+    }
+  }
+
+  private static class UncancellableFuture<T> extends AbstractFuture<T>
+  {
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning)
+    {
+      return false;
+    }
+
+    boolean setValue(T value)
+    {
+      return set(value);
     }
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/ReadableInputQueueTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/ReadableInputQueueTest.java
@@ -1,0 +1,422 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.querykit;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.msq.input.LoadableSegment;
+import org.apache.druid.msq.input.PhysicalInputSlice;
+import org.apache.druid.msq.input.stage.ReadablePartitions;
+import org.apache.druid.query.SegmentDescriptor;
+import org.apache.druid.segment.Segment;
+import org.apache.druid.segment.SegmentReference;
+import org.apache.druid.segment.loading.AcquireMode;
+import org.apache.druid.segment.loading.AcquireSegmentAction;
+import org.apache.druid.segment.loading.AcquireSegmentResult;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
+import org.joda.time.Interval;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tests for {@link ReadableInputQueue}'s segment-load lifecycle: close-while-loading must promptly fail the futures
+ * handed to frame processors (ready callbacks are dropped on close-before-ready, so this is load-bearing), delivered
+ * segments transfer exactly once, and everything un-transferred is closed by the queue.
+ */
+class ReadableInputQueueTest
+{
+  private static final SegmentDescriptor DESCRIPTOR = SegmentId.dummy("test").toDescriptor();
+
+  private static class CountingSegment implements Segment
+  {
+    final AtomicInteger closes = new AtomicInteger();
+
+    @Override
+    public SegmentId getId()
+    {
+      return SegmentId.dummy("test");
+    }
+
+    @Override
+    public Interval getDataInterval()
+    {
+      return Intervals.ETERNITY;
+    }
+
+    @Nullable
+    @Override
+    public <T> T as(@Nonnull Class<T> clazz)
+    {
+      return null;
+    }
+
+    @Override
+    public void close()
+    {
+      closes.incrementAndGet();
+    }
+  }
+
+  private static class TestLoadableSegment implements LoadableSegment
+  {
+    private final AcquireSegmentAction action;
+    private final Optional<Segment> cached;
+    private final boolean throwOnCountDelivered;
+    final AtomicInteger countDeliveredCalls = new AtomicInteger();
+
+    TestLoadableSegment(AcquireSegmentAction action)
+    {
+      this(action, Optional.empty(), false);
+    }
+
+    TestLoadableSegment(AcquireSegmentAction action, Optional<Segment> cached)
+    {
+      this(action, cached, false);
+    }
+
+    TestLoadableSegment(AcquireSegmentAction action, Optional<Segment> cached, boolean throwOnCountDelivered)
+    {
+      this.action = action;
+      this.cached = cached;
+      this.throwOnCountDelivered = throwOnCountDelivered;
+    }
+
+    @Override
+    public SegmentDescriptor descriptor()
+    {
+      return DESCRIPTOR;
+    }
+
+    @Nullable
+    @Override
+    public String description()
+    {
+      return "test-loadable";
+    }
+
+    @Override
+    public Optional<Segment> acquireIfCached(AcquireMode acquireMode)
+    {
+      return cached;
+    }
+
+    @Override
+    public AcquireSegmentAction acquire(AcquireMode acquireMode)
+    {
+      return action;
+    }
+
+    @Override
+    public void countDelivered(AcquireSegmentResult result)
+    {
+      countDeliveredCalls.incrementAndGet();
+      if (throwOnCountDelivered) {
+        throw new IllegalStateException("countDelivered blew up");
+      }
+    }
+
+    @Override
+    public ListenableFuture<DataSegment> dataSegmentFuture()
+    {
+      return Futures.immediateFailedFuture(DruidException.defensive("not available"));
+    }
+  }
+
+  private static ReadableInputQueue makeQueue(int loadahead, LoadableSegment... segments)
+  {
+    return new ReadableInputQueue(
+        null,
+        List.of(new PhysicalInputSlice(ReadablePartitions.empty(), List.of(segments), List.of())),
+        loadahead,
+        AcquireMode.FULL
+    );
+  }
+
+  @Test
+  void testCloseWhileLoadingFailsPendingFutureWithoutHanging() throws Exception
+  {
+    final AtomicInteger cancels = new AtomicInteger();
+    final AcquireSegmentAction pending = new AcquireSegmentAction(cancels::incrementAndGet);
+    final TestLoadableSegment loadable = new TestLoadableSegment(pending);
+
+    final ReadableInputQueue queue = makeQueue(0, loadable);
+    queue.start();
+    final ListenableFuture<ReadableInput> future = queue.nextInput();
+    Assertions.assertNotNull(future);
+    Assertions.assertFalse(future.isDone());
+
+    queue.close();
+
+    // the future must fail promptly; a dropped ready-callback with no explicit failure would hang forever
+    final ExecutionException e = Assertions.assertThrows(
+        ExecutionException.class,
+        () -> future.get(10, TimeUnit.SECONDS)
+    );
+    Assertions.assertTrue(e.getCause().getMessage().contains("Input queue closed"), e.getCause().getMessage());
+    Assertions.assertEquals(1, cancels.get(), "canceler must run exactly once");
+    Assertions.assertEquals(0, loadable.countDeliveredCalls.get(), "cancelled loads must not be counted");
+  }
+
+  @Test
+  void testCloseWithReentrantDeliveringCancelerFailsAllFutures() throws Exception
+  {
+    // Reproduces the deferred-acquire close race: closing a NEW handle runs a canceler that synchronously completes
+    // the SAME handle (mimicking dsFuture.cancel(true) -> onFailure -> outer.setException). With multiple such handles
+    // in flight, close() must not throw ConcurrentModificationException from a reentrant onSegmentReady, and must fail
+    // every pending future rather than leaving frame processors hung.
+    final int count = 4;
+    final List<ListenableFuture<ReadableInput>> futures = new ArrayList<>();
+    final TestLoadableSegment[] loadables = new TestLoadableSegment[count];
+    for (int i = 0; i < count; i++) {
+      final AcquireSegmentAction[] holder = new AcquireSegmentAction[1];
+      // canceler completes the handle in place, as the real deferred canceler does via the coordinator future
+      final AcquireSegmentAction action = new AcquireSegmentAction(
+          () -> holder[0].setException(DruidException.defensive("canceled"))
+      );
+      holder[0] = action;
+      loadables[i] = new TestLoadableSegment(action);
+    }
+
+    final ReadableInputQueue queue = makeQueue(0, loadables);
+    queue.start();
+    for (int i = 0; i < count; i++) {
+      final ListenableFuture<ReadableInput> future = queue.nextInput();
+      Assertions.assertNotNull(future);
+      Assertions.assertFalse(future.isDone());
+      futures.add(future);
+    }
+
+    // Must not throw ConcurrentModificationException.
+    queue.close();
+
+    for (final ListenableFuture<ReadableInput> future : futures) {
+      final ExecutionException e = Assertions.assertThrows(
+          ExecutionException.class,
+          () -> future.get(10, TimeUnit.SECONDS)
+      );
+      Assertions.assertTrue(e.getCause().getMessage().contains("Input queue closed"), e.getCause().getMessage());
+    }
+    for (final TestLoadableSegment loadable : loadables) {
+      Assertions.assertEquals(0, loadable.countDeliveredCalls.get(), "canceled loads must not be counted");
+    }
+  }
+
+  @Test
+  void testPostReleaseFailureClosesResultInsteadOfLeaking() throws Exception
+  {
+    // release() succeeds, then a later step (countDelivered) throws: the released result must be closed, not leaked
+    // (closing the RELEASED action is a no-op, so the segment + its folded holds would otherwise leak forever).
+    final CountingSegment segment = new CountingSegment();
+    final AcquireSegmentAction completed =
+        AcquireSegmentAction.completed(AcquireSegmentResult.of(Optional.of(segment)));
+    final TestLoadableSegment loadable = new TestLoadableSegment(completed, Optional.empty(), true);
+
+    final ReadableInputQueue queue = makeQueue(0, loadable);
+    queue.start();
+    final ListenableFuture<ReadableInput> future = queue.nextInput();
+    Assertions.assertNotNull(future);
+
+    final ExecutionException e = Assertions.assertThrows(
+        ExecutionException.class,
+        () -> future.get(10, TimeUnit.SECONDS)
+    );
+    Assertions.assertTrue(e.getCause().getMessage().contains("countDelivered blew up"), e.getCause().getMessage());
+    Assertions.assertEquals(1, segment.closes.get(), "post-release failure must close the delivered segment");
+
+    // nothing left to close on queue teardown
+    queue.close();
+    Assertions.assertEquals(1, segment.closes.get(), "segment must not be double-closed");
+  }
+
+  @Test
+  void testProducerOwnsResultDeliveredAfterQueueClose()
+  {
+    final AcquireSegmentAction pending = new AcquireSegmentAction();
+    final TestLoadableSegment loadable = new TestLoadableSegment(pending);
+
+    final ReadableInputQueue queue = makeQueue(0, loadable);
+    queue.start();
+    final ListenableFuture<ReadableInput> future = queue.nextInput();
+    Assertions.assertNotNull(future);
+    queue.close();
+
+    // the producer's delivery loses the race with close: set() returns false and the producer closes the orphan
+    final CountingSegment segment = new CountingSegment();
+    final AcquireSegmentResult result = AcquireSegmentResult.of(Optional.of(segment));
+    Assertions.assertFalse(pending.set(result));
+    result.close();
+    Assertions.assertEquals(1, segment.closes.get());
+    Assertions.assertEquals(0, loadable.countDeliveredCalls.get());
+  }
+
+  @Test
+  void testReadyButUncollectedSegmentClosedOnQueueClose()
+  {
+    final CountingSegment segment = new CountingSegment();
+    final AcquireSegmentAction completed =
+        AcquireSegmentAction.completed(AcquireSegmentResult.of(Optional.of(segment)));
+    final TestLoadableSegment loadable = new TestLoadableSegment(completed);
+
+    // loadahead=1: start() drives the load and the immediate-fire ready callback delivers into loadedSegments
+    final ReadableInputQueue queue = makeQueue(1, loadable);
+    queue.start();
+    Assertions.assertEquals(1, loadable.countDeliveredCalls.get(), "delivery must be counted exactly once");
+
+    // never call nextInput(): the loaded-but-untransferred segment must be closed by the queue
+    queue.close();
+    Assertions.assertEquals(1, segment.closes.get());
+  }
+
+  @Test
+  void testTransferredReferenceIsCallersResponsibility() throws Exception
+  {
+    final CountingSegment segment = new CountingSegment();
+    final AcquireSegmentAction completed =
+        AcquireSegmentAction.completed(AcquireSegmentResult.of(Optional.of(segment)));
+    final TestLoadableSegment loadable = new TestLoadableSegment(completed);
+
+    final ReadableInputQueue queue = makeQueue(0, loadable);
+    queue.start();
+    final ListenableFuture<ReadableInput> future = queue.nextInput();
+    Assertions.assertNotNull(future);
+    final ReadableInput input = future.get(10, TimeUnit.SECONDS);
+    Assertions.assertTrue(input.hasSegment());
+
+    final SegmentReference ref = input.getSegment().getSegmentReferenceOnce();
+    Assertions.assertNotNull(ref);
+    Assertions.assertEquals(1, loadable.countDeliveredCalls.get());
+
+    // queue close must not close a transferred reference
+    queue.close();
+    Assertions.assertEquals(0, segment.closes.get());
+
+    ref.close();
+    Assertions.assertEquals(1, segment.closes.get());
+  }
+
+  @Test
+  void testLoadFailurePropagatesToFuture()
+  {
+    final AcquireSegmentAction failed = new AcquireSegmentAction();
+    failed.setException(new IllegalStateException("load went sideways"));
+    final TestLoadableSegment loadable = new TestLoadableSegment(failed);
+
+    final ReadableInputQueue queue = makeQueue(0, loadable);
+    queue.start();
+    final ListenableFuture<ReadableInput> future = queue.nextInput();
+    Assertions.assertNotNull(future);
+    Assertions.assertTrue(future.isDone());
+    final ExecutionException e = Assertions.assertThrows(
+        ExecutionException.class,
+        () -> future.get(10, TimeUnit.SECONDS)
+    );
+    Assertions.assertTrue(e.getCause().getMessage().contains("load went sideways"));
+    Assertions.assertEquals(0, loadable.countDeliveredCalls.get(), "failed loads must not be counted");
+    queue.close();
+  }
+
+  @Test
+  void testMissingSegmentDelivery() throws Exception
+  {
+    final TestLoadableSegment loadable = new TestLoadableSegment(AcquireSegmentAction.missingSegment());
+
+    final ReadableInputQueue queue = makeQueue(0, loadable);
+    queue.start();
+    final ListenableFuture<ReadableInput> future = queue.nextInput();
+    Assertions.assertNotNull(future);
+    final ReadableInput input = future.get(10, TimeUnit.SECONDS);
+    Assertions.assertTrue(input.hasSegment());
+    final SegmentReference ref = input.getSegment().getSegmentReferenceOnce();
+    Assertions.assertNotNull(ref);
+    Assertions.assertTrue(ref.getSegmentReference().isEmpty());
+    Assertions.assertEquals(1, loadable.countDeliveredCalls.get());
+    ref.close();
+    queue.close();
+  }
+
+  @Test
+  void testCachedAtStartPathBypassesAcquire()
+      throws Exception
+  {
+    final CountingSegment cachedSegment = new CountingSegment();
+    // the action would throw if released; the cached path must never touch it
+    final TestLoadableSegment loadable = new TestLoadableSegment(
+        new AcquireSegmentAction(),
+        Optional.of(cachedSegment)
+    );
+
+    final ReadableInputQueue queue = makeQueue(0, loadable);
+    queue.start();
+    final ListenableFuture<ReadableInput> future = queue.nextInput();
+    Assertions.assertNotNull(future);
+    Assertions.assertTrue(future.isDone());
+    final ReadableInput input = future.get(10, TimeUnit.SECONDS);
+    final SegmentReference ref = input.getSegment().getSegmentReferenceOnce();
+    Assertions.assertNotNull(ref);
+    Assertions.assertSame(cachedSegment, ref.getSegmentReference().orElseThrow());
+    Assertions.assertEquals(0, loadable.countDeliveredCalls.get(), "acquireIfCached counts inline, not via the hook");
+    ref.close();
+    queue.close();
+  }
+
+  @Test
+  void testCloseClearsPendingLoadaheadInputs() throws Exception
+  {
+    final CountingSegment segment = new CountingSegment();
+    final AcquireSegmentAction completed =
+        AcquireSegmentAction.completed(AcquireSegmentResult.of(Optional.of(segment)));
+    final TestLoadableSegment loadable = new TestLoadableSegment(completed);
+
+    // loadahead=1: start() loads and parks a done future in pendingNextInputs that is never handed out
+    final ReadableInputQueue queue = makeQueue(1, loadable);
+    queue.start();
+    Assertions.assertEquals(1, queue.remaining());
+
+    queue.close();
+    Assertions.assertEquals(1, segment.closes.get(), "unclaimed loadahead holder must be drained on close");
+    Assertions.assertEquals(0, queue.remaining(), "close must clear pending loadahead inputs");
+    Assertions.assertNull(queue.nextInput(), "no inputs may be handed out after close");
+  }
+
+  @Test
+  void testRemainingCountsPendingInputs()
+  {
+    final TestLoadableSegment loadable = new TestLoadableSegment(AcquireSegmentAction.missingSegment());
+    final ReadableInputQueue queue = makeQueue(0, loadable);
+    queue.start();
+    Assertions.assertEquals(1, queue.remaining());
+    Assertions.assertNotNull(queue.nextInput());
+    Assertions.assertEquals(0, queue.remaining());
+    Assertions.assertNull(queue.nextInput());
+    queue.close();
+  }
+}

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessorTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessorTest.java
@@ -344,8 +344,7 @@ public class ScanQueryFrameProcessorTest extends FrameProcessorTestBase
             new SegmentReferenceHolder(
                 new SegmentReference(
                     SegmentId.dummy("test").toDescriptor(),
-                    segmentReferenceProvider.acquireReference(),
-                    null
+                    segmentReferenceProvider.acquireReference()
                 ),
                 null
             )
@@ -408,8 +407,7 @@ public class ScanQueryFrameProcessorTest extends FrameProcessorTestBase
             new SegmentReferenceHolder(
                 new SegmentReference(
                     SegmentId.dummy("test").toDescriptor(),
-                    segmentReferenceProvider.acquireReference(),
-                    null
+                    segmentReferenceProvider.acquireReference()
                 ),
                 null
             )

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -40,7 +40,6 @@ import org.apache.calcite.avatica.remote.TypedValue;
 import org.apache.druid.client.ImmutableSegmentLoadInfo;
 import org.apache.druid.client.coordinator.CoordinatorClient;
 import org.apache.druid.client.coordinator.NoopCoordinatorClient;
-import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
@@ -159,6 +158,7 @@ import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.loading.AcquireMode;
+import org.apache.druid.segment.loading.AcquireSegmentAction;
 import org.apache.druid.segment.loading.DataSegmentPusher;
 import org.apache.druid.segment.loading.LeastBytesUsedStorageLocationSelectorStrategy;
 import org.apache.druid.segment.loading.LocalDataSegmentPusher;
@@ -1463,46 +1463,47 @@ public class MSQTestBase extends BaseCalciteQueryTest
                 dataSegment.getDataSource()
             );
           }
-          FutureUtils.getUnchecked(
-              segmentCacheManager.acquireSegment(dataSegment, AcquireMode.FULL).getSegmentFuture(),
-              false
-          );
-          final QueryableIndex queryableIndex = indexIO.loadIndex(segmentCacheManager.getSegmentFiles(dataSegment));
-          final CursorFactory cursorFactory = new QueryableIndexCursorFactory(queryableIndex);
+          // Keep the acquire open across the direct file reads below so the (possibly ephemeral) cache keeps the
+          // segment files on disk; closing the un-released action afterwards releases everything.
+          try (AcquireSegmentAction acquireAction = segmentCacheManager.acquireSegment(dataSegment, AcquireMode.FULL)) {
+            acquireAction.await();
+            final QueryableIndex queryableIndex = indexIO.loadIndex(segmentCacheManager.getSegmentFiles(dataSegment));
+            final CursorFactory cursorFactory = new QueryableIndexCursorFactory(queryableIndex);
 
-          // assert rowSignature
-          Assertions.assertEquals(expectedRowSignature, resultSignatureFromRowSignature(cursorFactory.getRowSignature()));
+            // assert rowSignature
+            Assertions.assertEquals(expectedRowSignature, resultSignatureFromRowSignature(cursorFactory.getRowSignature()));
 
-          // assert rollup
-          Assertions.assertEquals(expectedRollUp, queryableIndex.getMetadata().isRollup());
+            // assert rollup
+            Assertions.assertEquals(expectedRollUp, queryableIndex.getMetadata().isRollup());
 
-          // assert query granularity
-          Assertions.assertEquals(expectedQueryGranularity, queryableIndex.getMetadata().getQueryGranularity());
+            // assert query granularity
+            Assertions.assertEquals(expectedQueryGranularity, queryableIndex.getMetadata().getQueryGranularity());
 
-          // assert aggregator factories; clustered base table segments have no aggregator metadata (never rollup),
-          // so treat null as empty
-          Assertions.assertArrayEquals(
-              expectedAggregatorFactories.toArray(new AggregatorFactory[0]),
-              queryableIndex.getMetadata().getAggregators() == null
-              ? new AggregatorFactory[0]
-              : queryableIndex.getMetadata().getAggregators()
-          );
+            // assert aggregator factories; clustered base table segments have no aggregator metadata (never rollup),
+            // so treat null as empty
+            Assertions.assertArrayEquals(
+                expectedAggregatorFactories.toArray(new AggregatorFactory[0]),
+                queryableIndex.getMetadata().getAggregators() == null
+                ? new AggregatorFactory[0]
+                : queryableIndex.getMetadata().getAggregators()
+            );
 
-          if (expectedProjections != null) {
-            Assertions.assertEquals(expectedProjections, queryableIndex.getMetadata().getProjections());
-          }
+            if (expectedProjections != null) {
+              Assertions.assertEquals(expectedProjections, queryableIndex.getMetadata().getProjections());
+            }
 
-          if (expectedClusterGroups != null) {
-            Assertions.assertEquals(expectedClusterGroups, dataSegment.getClusterGroups());
-            Assertions.assertNotNull(queryableIndex.getMetadata().getClusteredBaseTable());
-          }
+            if (expectedClusterGroups != null) {
+              Assertions.assertEquals(expectedClusterGroups, dataSegment.getClusterGroups());
+              Assertions.assertNotNull(queryableIndex.getMetadata().getClusteredBaseTable());
+            }
 
-          for (List<Object> row : FrameTestUtil.readRowsFromCursorFactory(cursorFactory).toList()) {
-            // transforming rows for sketch assertions
-            List<Object> transformedRow = row.stream()
-                                             .map(MSQTestBase.this::segmentToAssertionValueMapper)
-                                             .collect(Collectors.toList());
-            segmentIdVsOutputRowsMap.computeIfAbsent(dataSegment.getId(), r -> new ArrayList<>()).add(transformedRow);
+            for (List<Object> row : FrameTestUtil.readRowsFromCursorFactory(cursorFactory).toList()) {
+              // transforming rows for sketch assertions
+              List<Object> transformedRow = row.stream()
+                                               .map(MSQTestBase.this::segmentToAssertionValueMapper)
+                                               .collect(Collectors.toList());
+              segmentIdVsOutputRowsMap.computeIfAbsent(dataSegment.getId(), r -> new ArrayList<>()).add(transformedRow);
+            }
           }
         }
 

--- a/processing/src/main/java/org/apache/druid/common/asyncresource/SettableAsyncResource.java
+++ b/processing/src/main/java/org/apache/druid/common/asyncresource/SettableAsyncResource.java
@@ -263,9 +263,12 @@ public class SettableAsyncResource<T> implements AsyncResource<T>
         default -> throw DruidException.defensive("Already closed");
       };
 
-      // Clear result and canceler to allow GC.
+      // Clear result and canceler to allow GC. Drop any pending ready callbacks: per the AsyncResource contract
+      // they are not fired once close() has happened before the resource became ready, and a later set()/setException()
+      // (e.g. a producer losing a cancel/close race) must not replay them.
       result = null;
       canceler = null;
+      readyCallbacks.clear();
       state = State.CLOSED;
     }
 
@@ -306,7 +309,9 @@ public class SettableAsyncResource<T> implements AsyncResource<T>
 
       // Clear canceler to allow GC.
       canceler = null;
-      callbacksToFire = drainCallbacks();
+      // Only fire callbacks when this call actually completed the resource; a set/setException that lost the race with
+      // close() (didSet == false) must not fire callbacks, which close() has already dropped.
+      callbacksToFire = didSet ? drainCallbacks() : List.of();
     }
     fireCallbacks(callbacksToFire);
     return didSet;

--- a/processing/src/main/java/org/apache/druid/segment/SegmentReference.java
+++ b/processing/src/main/java/org/apache/druid/segment/SegmentReference.java
@@ -20,12 +20,9 @@
 package org.apache.druid.segment;
 
 import org.apache.druid.error.DruidException;
-import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.query.SegmentDescriptor;
-import org.apache.druid.segment.loading.AcquireSegmentAction;
 import org.apache.druid.utils.CloseableUtils;
 
-import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Optional;
@@ -38,32 +35,28 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * If the {@link SegmentMapFunction} you want to apply is not available at the time the {@link SegmentReference}
  * is created, use {@link #map(SegmentMapFunction)} to apply it.
  *
- * Closing this object closes both the {@link #getSegmentReference()} and any closeables attached from the process of
- * creating this object, such as from {@link AcquireSegmentAction}. The object from {@link #getSegmentReference()}
- * should not be closed directly by callers.
+ * Closing this object closes the {@link #getSegmentReference()}, whose own close releases everything associated with
+ * its acquisition (references and any cache holds folded in by the loader). The object from
+ * {@link #getSegmentReference()} should not be closed directly by callers.
  */
 public class SegmentReference implements Closeable
 {
   public static SegmentReference missing(SegmentDescriptor segmentDescriptor)
   {
-    return new SegmentReference(segmentDescriptor, Optional.empty(), null);
+    return new SegmentReference(segmentDescriptor, Optional.empty());
   }
 
   private final SegmentDescriptor segmentDescriptor;
   private final Optional<Segment> segmentReference;
-  @Nullable
-  private final Closeable cleanupHold;
   private final AtomicBoolean closed = new AtomicBoolean(false);
 
   public SegmentReference(
       SegmentDescriptor segmentDescriptor,
-      Optional<Segment> segmentReference,
-      @Nullable Closeable cleanupHold
+      Optional<Segment> segmentReference
   )
   {
     this.segmentDescriptor = segmentDescriptor;
     this.segmentReference = segmentReference;
-    this.cleanupHold = cleanupHold;
   }
 
   public SegmentDescriptor getSegmentDescriptor()
@@ -90,11 +83,7 @@ public class SegmentReference implements Closeable
       final Optional<Segment> mappedSegment = segmentMapFn.apply(segmentReference);
 
       // Resources are handed off to the new reference.
-      return new SegmentReference(
-          segmentDescriptor,
-          mappedSegment,
-          cleanupHold
-      );
+      return new SegmentReference(segmentDescriptor, mappedSegment);
     }
     catch (Throwable e) {
       // segmentMapFn threw an error
@@ -113,9 +102,8 @@ public class SegmentReference implements Closeable
       throw DruidException.defensive("Reference is closed, cannot close again");
     }
 
-    final Closer closer = Closer.create();
-    closer.register(cleanupHold);
-    segmentReference.ifPresent(closer::register);
-    closer.close();
+    if (segmentReference.isPresent()) {
+      segmentReference.get().close();
+    }
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/loading/AcquireSegmentAction.java
+++ b/processing/src/main/java/org/apache/druid/segment/loading/AcquireSegmentAction.java
@@ -19,76 +19,87 @@
 
 package org.apache.druid.segment.loading;
 
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import org.apache.druid.error.DruidException;
-import org.apache.druid.segment.ReferenceCountedObjectProvider;
-import org.apache.druid.segment.ReferenceCountedSegmentProvider;
+import org.apache.druid.common.asyncresource.AsyncResource;
+import org.apache.druid.common.asyncresource.SettableAsyncResource;
 import org.apache.druid.segment.Segment;
 
 import javax.annotation.Nullable;
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
 
 /**
- * This class represents an intent to acquire a reference to a {@link Segment} and then use it to do stuff, and finally
- * closing when done.
+ * Handle for acquiring a reference to a {@link Segment} which might need to be loaded on demand: an
+ * {@link AsyncResource} delivering an {@link AcquireSegmentResult} whose pre-acquired segment reference carries
+ * every hold and reference associated with the acquisition inside its own {@link Segment#close()}.
  * <p>
- * When an {@link AcquireSegmentAction} is created, segment cache implementations will create a
- * 'hold' to ensure it cannot be removed from the cache until this action has been closed.
+ * The load (if one is needed) starts when the handle is created; there is no separate initiation step.
+ *
+ * <h3>Consumer protocol</h3>
+ * Register the handle with cleanup machinery (e.g. a {@code Closer}) immediately — this is safe at any lifecycle
+ * point. Wait for {@link #isReady()} via {@link #addReadyCallback} or {@link #await}, then call {@link #release()}
+ * to take ownership of the {@link AcquireSegmentResult} (or surface the producer's exception). After release, the
+ * caller owns closing the result (or the segment inside it); {@link #close()} on this handle becomes a no-op.
  * <p>
- * Calling {@link #getSegmentFuture()} is what actually initiates the 'action', and will return a segment reference
- * provider if already cached, or attempt to download from deep storage to load into the cache if not. The
- * {@link Segment} returned by acquiring a reference from the {@link ReferenceCountedObjectProvider} returned by the
- * future places a separate hold on the cache until the segment itself is closed, and MUST be closed when the caller is
- * finished doing segment things with it.
- * <p>
- * The caller must also call {@link #close()} on this object to clean up the hold that exists while possibly loading
- * the segment, and may do so as soon as the {@link Segment} is acquired (or can do so earlier to abort the load and
- * release the hold).
+ * Closing the handle without releasing cancels an in-flight load (releasing any cache holds placed for it), or
+ * closes an already-delivered result. Note that ready callbacks are never fired if the handle is closed before the
+ * result arrives, and that {@link #close()} is <b>not</b> idempotent (it throws if called twice), close exactly
+ * once.
  */
-public class AcquireSegmentAction implements Closeable
+public class AcquireSegmentAction extends SettableAsyncResource<AcquireSegmentResult>
 {
+  /**
+   * Handle representing a segment that is known to be missing: immediately ready with
+   * {@link AcquireSegmentResult#empty()}.
+   */
   public static AcquireSegmentAction missingSegment()
   {
-    return new AcquireSegmentAction(() -> Futures.immediateFuture(AcquireSegmentResult.empty()), null);
-  }
-
-  private final Supplier<ListenableFuture<AcquireSegmentResult>> segmentFutureSupplier;
-  @Nullable
-  private final Closeable loadCleanup;
-  private final AtomicBoolean closed = new AtomicBoolean(false);
-
-  public AcquireSegmentAction(
-      Supplier<ListenableFuture<AcquireSegmentResult>> segmentFutureSupplier,
-      @Nullable Closeable loadCleanup
-  )
-  {
-    this.segmentFutureSupplier = segmentFutureSupplier;
-    this.loadCleanup = loadCleanup;
+    return completed(AcquireSegmentResult.empty());
   }
 
   /**
-   * Get a {@link ReferenceCountedObjectProvider<Segment>} to acquire a reference to an item that exists in the cache,
-   * or if necessary/possible, fetching it from deep storage. This is typically {@link ReferenceCountedSegmentProvider},
-   * either as an immediate future if the segment already exists in cache. The 'action' to fetch the segment and return
-   * the reference provider is not initiated until this method is called.
+   * Handle that is immediately ready with the given result, for segments that did not require an asynchronous load.
    */
-  public ListenableFuture<AcquireSegmentResult> getSegmentFuture()
+  public static AcquireSegmentAction completed(AcquireSegmentResult result)
   {
-    if (closed.get()) {
-      throw DruidException.defensive("Cannot getSegmentFuture() after close()");
-    }
-    return segmentFutureSupplier.get();
+    final AcquireSegmentAction action = new AcquireSegmentAction();
+    action.set(result);
+    return action;
   }
 
-  @Override
-  public void close() throws IOException
+  /**
+   * Constructor for producers that install a canceler after creating whatever the canceler must cancel (calling
+   * {@link #setCanceler} on a handle that has already become ready is a safe no-op).
+   */
+  public AcquireSegmentAction()
   {
-    if (loadCleanup != null && closed.compareAndSet(false, true)) {
-      loadCleanup.close();
+    super(true);
+  }
+
+  /**
+   * @param canceler optional callback invoked from {@link #close()} when the handle is closed before the result has
+   *                 been delivered ({@link #set} or {@link #setException}). Producers that support cancellation
+   *                 should provide one; producers that don't can pass {@code null}, in which case {@link #close()}
+   *                 just stops observing the result.
+   */
+  public AcquireSegmentAction(@Nullable Runnable canceler)
+  {
+    this();
+    if (canceler != null) {
+      setCanceler(canceler);
     }
+  }
+
+  /**
+   * Convenience setter: the result acts as its own closer, so closing an un-released ready handle closes the
+   * delivered result. Returns false if this handle was closed before delivery, in which case the producer retains
+   * ownership of the result and must close it.
+   */
+  public boolean set(AcquireSegmentResult result)
+  {
+    return super.set(result, result);
+  }
+
+  @Override // Overridden to change access from protected to public
+  public synchronized AcquireSegmentResult release()
+  {
+    return super.release();
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/loading/AcquireSegmentResult.java
+++ b/processing/src/main/java/org/apache/druid/segment/loading/AcquireSegmentResult.java
@@ -19,53 +19,73 @@
 
 package org.apache.druid.segment.loading;
 
-import org.apache.druid.segment.ReferenceCountedObjectProvider;
 import org.apache.druid.segment.Segment;
+import org.apache.druid.utils.CloseableUtils;
 
+import java.io.Closeable;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Wraps a {@link ReferenceCountedObjectProvider<Segment>} with additional measurements about segment loading, if it
- * was required
+ * The deliverable of {@link AcquireSegmentAction}: a pre-acquired {@link Segment} reference, along with measurements
+ * about segment loading if it was required.
+ * <p>
+ * The segment, when present, is a single already-acquired reference whose {@link Segment#close()} releases everything
+ * associated with the acquisition: the reference itself plus any eviction-protective cache holds the loader folded
+ * into it. An empty segment means the segment could not be acquired (no longer in the cache, and could not be or was
+ * not fetched from deep storage) — a first-class outcome, not an error.
+ * <p>
+ * Whoever owns this result must {@link #close()} it (closing the contained segment, if any). Close is idempotent:
+ * a result may be closed by {@link AcquireSegmentAction#close()} (when the action was never released), by the
+ * producer (when delivery lost a race with close/cancel), or by the consumer that
+ * {@link AcquireSegmentAction#release()}d it — exactly one of these wins.
  */
-public class AcquireSegmentResult
+public class AcquireSegmentResult implements Closeable
 {
-  private static final AcquireSegmentResult EMPTY = new AcquireSegmentResult(Optional::empty, 0L, 0L, 0L);
-
+  /**
+   * Result with no segment (missing from cache and deep storage) and zero metrics. Returns a fresh instance since
+   * results are stateful {@link Closeable}s.
+   */
   public static AcquireSegmentResult empty()
   {
-    return EMPTY;
+    return new AcquireSegmentResult(Optional.empty(), 0L, 0L, 0L);
   }
 
-  public static AcquireSegmentResult cached(ReferenceCountedObjectProvider<Segment> provider)
+  /**
+   * Result for a segment that was already available, with zero load metrics.
+   */
+  public static AcquireSegmentResult of(Optional<Segment> segment)
   {
-    return new AcquireSegmentResult(provider, 0L, 0L, 0L);
+    return new AcquireSegmentResult(segment, 0L, 0L, 0L);
   }
 
-  private final ReferenceCountedObjectProvider<Segment> referenceProvider;
+  private final Optional<Segment> segment;
   private final long loadSizeBytes;
   private final long waitTimeNanos;
   private final long loadTimeNanos;
+  private final AtomicBoolean closed = new AtomicBoolean(false);
 
   public AcquireSegmentResult(
-      ReferenceCountedObjectProvider<Segment> referenceProvider,
+      Optional<Segment> segment,
       long loadSizeBytes,
       long waitTimeNanos,
       long loadTimeNanos
   )
   {
-    this.referenceProvider = referenceProvider;
+    this.segment = segment;
     this.loadSizeBytes = loadSizeBytes;
     this.waitTimeNanos = waitTimeNanos;
     this.loadTimeNanos = loadTimeNanos;
   }
 
   /**
-   * Segment reference provider for loaded segment
+   * The acquired segment reference, or empty if the segment is not available. Unlike the reference providers this
+   * type once wrapped, this is a single pre-acquired reference: callers must not attempt to mint additional
+   * references from it, and must arrange for it to be closed exactly once (directly, or via {@link #close()}).
    */
-  public ReferenceCountedObjectProvider<Segment> getReferenceProvider()
+  public Optional<Segment> getSegment()
   {
-    return referenceProvider;
+    return segment;
   }
 
   /**
@@ -90,5 +110,13 @@ public class AcquireSegmentResult
   public long getLoadTimeNanos()
   {
     return loadTimeNanos;
+  }
+
+  @Override
+  public void close()
+  {
+    if (closed.compareAndSet(false, true) && segment.isPresent()) {
+      CloseableUtils.closeAndWrapExceptions(segment.get());
+    }
   }
 }

--- a/processing/src/test/java/org/apache/druid/common/asyncresource/SettableAsyncResourceTest.java
+++ b/processing/src/test/java/org/apache/druid/common/asyncresource/SettableAsyncResourceTest.java
@@ -218,6 +218,32 @@ public class SettableAsyncResourceTest
   }
 
   @Test
+  public void testReadyCallbackNotFiredWhenSetLosesRaceWithClose()
+  {
+    // A callback registered before close(), followed by a producer's late set() that loses the race, must NOT fire:
+    // close() is contractually "callbacks are not fired if close() happened first". (Regression: setInternal used to
+    // drain+fire callbacks even on the CLOSED no-op path, replaying consumer callbacks against torn-down state.)
+    final AtomicInteger fired = new AtomicInteger();
+    final SettableAsyncResource<String> resource = new SettableAsyncResource<>();
+    resource.addReadyCallback(fired::incrementAndGet);
+    resource.close();
+    Assertions.assertFalse(resource.set("value", null));
+    Assertions.assertEquals(0, fired.get());
+  }
+
+  @Test
+  public void testReadyCallbackNotFiredWhenSetExceptionLosesRaceWithClose()
+  {
+    final AtomicInteger fired = new AtomicInteger();
+    final SettableAsyncResource<String> resource = new SettableAsyncResource<>();
+    resource.addReadyCallback(fired::incrementAndGet);
+    resource.close();
+    // setException on a CLOSED resource is a silent no-op and must not fire the dropped callback.
+    resource.setException(new IllegalStateException("late failure"));
+    Assertions.assertEquals(0, fired.get());
+  }
+
+  @Test
   public void testAwaitReturnsValueWhenReady() throws InterruptedException
   {
     final SettableAsyncResource<String> resource = new SettableAsyncResource<>();

--- a/processing/src/test/java/org/apache/druid/segment/loading/AcquireSegmentActionTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/loading/AcquireSegmentActionTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.loading;
+
+import org.apache.druid.error.DruidException;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.segment.Segment;
+import org.apache.druid.segment.TestSegmentUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class AcquireSegmentActionTest
+{
+  private static Segment makeSegment()
+  {
+    return new TestSegmentUtils.SegmentForTesting("test", Intervals.of("2020-01-01/2020-01-02"), "v1");
+  }
+
+  private static class CloseCountingSegment extends TestSegmentUtils.SegmentForTesting
+  {
+    private final AtomicInteger closeCount = new AtomicInteger();
+
+    CloseCountingSegment()
+    {
+      super("test", Intervals.of("2020-01-01/2020-01-02"), "v1");
+    }
+
+    @Override
+    public void close()
+    {
+      closeCount.incrementAndGet();
+      super.close();
+    }
+  }
+
+  @Test
+  public void testCompletedReleaseThenCloseIsNoop()
+  {
+    final CloseCountingSegment segment = new CloseCountingSegment();
+    final AcquireSegmentAction action = AcquireSegmentAction.completed(
+        AcquireSegmentResult.of(Optional.of(segment))
+    );
+    Assertions.assertTrue(action.isReady());
+    final AcquireSegmentResult released = action.release();
+    Assertions.assertSame(segment, released.getSegment().orElseThrow());
+    // close after release is a no-op; the caller owns the released result
+    action.close();
+    Assertions.assertEquals(0, segment.closeCount.get());
+    released.close();
+    Assertions.assertEquals(1, segment.closeCount.get());
+  }
+
+  @Test
+  public void testCloseWithoutReleaseClosesDeliveredResult()
+  {
+    final CloseCountingSegment segment = new CloseCountingSegment();
+    final AcquireSegmentAction action = AcquireSegmentAction.completed(
+        AcquireSegmentResult.of(Optional.of(segment))
+    );
+    action.close();
+    Assertions.assertEquals(1, segment.closeCount.get());
+  }
+
+  @Test
+  public void testReleaseAfterCloseThrows()
+  {
+    final AcquireSegmentAction action = AcquireSegmentAction.completed(
+        AcquireSegmentResult.of(Optional.of(makeSegment()))
+    );
+    action.close();
+    Assertions.assertThrows(DruidException.class, action::release);
+  }
+
+  @Test
+  public void testDoubleCloseThrows()
+  {
+    final AcquireSegmentAction action = AcquireSegmentAction.missingSegment();
+    action.close();
+    Assertions.assertThrows(DruidException.class, action::close);
+  }
+
+  @Test
+  public void testReleaseBeforeReadyThrows()
+  {
+    final AcquireSegmentAction action = new AcquireSegmentAction();
+    Assertions.assertThrows(DruidException.class, action::release);
+    action.close();
+  }
+
+  @Test
+  public void testCloseBeforeReadyRunsCancelerAndOrphanedSetReturnsFalse()
+  {
+    final AtomicInteger cancels = new AtomicInteger();
+    final AcquireSegmentAction action = new AcquireSegmentAction(cancels::incrementAndGet);
+    action.close();
+    Assertions.assertEquals(1, cancels.get());
+
+    // producer loses the delivery race and retains ownership of the orphaned result
+    final CloseCountingSegment segment = new CloseCountingSegment();
+    final AcquireSegmentResult result = AcquireSegmentResult.of(Optional.of(segment));
+    Assertions.assertFalse(action.set(result));
+    Assertions.assertEquals(0, segment.closeCount.get());
+    result.close();
+    Assertions.assertEquals(1, segment.closeCount.get());
+  }
+
+  @Test
+  public void testSetExceptionSurfacesFromReleaseAndGet()
+  {
+    final AcquireSegmentAction action = new AcquireSegmentAction();
+    action.setException(new IllegalStateException("boom"));
+    Assertions.assertTrue(action.isReady());
+    Assertions.assertThrows(IllegalStateException.class, action::get);
+    Assertions.assertThrows(IllegalStateException.class, action::release);
+    action.close();
+  }
+
+  @Test
+  public void testMissingSegmentDeliversEmptyResult()
+  {
+    final AcquireSegmentAction action = AcquireSegmentAction.missingSegment();
+    Assertions.assertTrue(action.isReady());
+    final AcquireSegmentResult result = action.release();
+    Assertions.assertTrue(result.getSegment().isEmpty());
+    Assertions.assertEquals(0, result.getLoadSizeBytes());
+    // closing an empty result is a no-op
+    result.close();
+    result.close();
+    action.close();
+  }
+
+  @Test
+  public void testResultCloseIsIdempotent()
+  {
+    final CloseCountingSegment segment = new CloseCountingSegment();
+    final AcquireSegmentResult result = new AcquireSegmentResult(Optional.of(segment), 1L, 2L, 3L);
+    Assertions.assertEquals(1L, result.getLoadSizeBytes());
+    Assertions.assertEquals(2L, result.getWaitTimeNanos());
+    Assertions.assertEquals(3L, result.getLoadTimeNanos());
+    result.close();
+    result.close();
+    Assertions.assertEquals(1, segment.closeCount.get());
+  }
+
+  @Test
+  public void testSetCancelerAfterReadyIsNoop()
+  {
+    final AtomicInteger cancels = new AtomicInteger();
+    final AcquireSegmentAction action = AcquireSegmentAction.completed(
+        AcquireSegmentResult.of(Optional.of(makeSegment()))
+    );
+    action.setCanceler(cancels::incrementAndGet);
+    action.close();
+    Assertions.assertEquals(0, cancels.get());
+  }
+}

--- a/server/src/main/java/org/apache/druid/segment/loading/PartialSegmentMetadataCacheEntry.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/PartialSegmentMetadataCacheEntry.java
@@ -1193,6 +1193,12 @@ public class PartialSegmentMetadataCacheEntry implements SegmentCacheEntry, Resi
       }
       index = queryableIndex;
     }
+    catch (Throwable t) {
+      // We took ownership of extraOnClose; a failure building the queryable index must release it rather than leak
+      // the caller's eviction-protective hold.
+      CloseableUtils.closeAndSuppressExceptions(extraOnClose, t::addSuppressed);
+      throw t;
+    }
     finally {
       entryLock.unlock();
     }
@@ -1221,14 +1227,21 @@ public class PartialSegmentMetadataCacheEntry implements SegmentCacheEntry, Resi
       onClose.register(extraOnClose);
     }
     onClose.register(metadataRef);
-    return Optional.of(
-        new PartialQueryableIndexSegment(
-            index,
-            segmentId,
-            onClose,
-            bundleAcquirer
-        )
-    );
+    try {
+      return Optional.of(
+          new PartialQueryableIndexSegment(
+              index,
+              segmentId,
+              onClose,
+              bundleAcquirer
+          )
+      );
+    }
+    catch (Throwable t) {
+      // The segment did not take ownership of onClose; close it here so extraOnClose and the metadata reference are
+      // both released rather than leaked.
+      throw CloseableUtils.closeAndWrapInCatch(t, onClose);
+    }
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentCacheManager.java
@@ -20,7 +20,6 @@
 package org.apache.druid.segment.loading;
 
 import org.apache.druid.segment.CursorFactory;
-import org.apache.druid.segment.ReferenceCountedObjectProvider;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.SegmentLazyLoadFailCallback;
 import org.apache.druid.timeline.DataSegment;
@@ -122,14 +121,16 @@ public interface SegmentCacheManager
   Optional<Segment> acquireCachedSegment(SegmentId segmentId, AcquireMode acquireMode);
 
   /**
-   * Returns a {@link AcquireSegmentAction} for a given {@link DataSegment}, which returns a reference provider for the
-   * {@link Segment} if already present in the cache, or tries to fetch from deep storage and map if not. The
-   * {@link Segment} returned by the provider returned by this method are considered an open reference, cache
-   * implementations must not allow the segment to be dropped until it has been closed. As such, the returned
-   * {@link Segment} from {@link ReferenceCountedObjectProvider#acquireReference()} must be closed when the caller is
-   * finished doing segment things.
+   * Returns an {@link AcquireSegmentAction} for a given {@link DataSegment}: an async handle delivering an
+   * {@link AcquireSegmentResult} whose pre-acquired {@link Segment} reference is served from the cache if already
+   * present, or fetched from deep storage and mapped if not (the load, if any, starts immediately). The delivered
+   * {@link Segment} is an open reference: cache implementations must not allow the segment to be dropped until it
+   * has been closed, and its close releases everything associated with the acquisition (the reference plus any
+   * eviction-protective cache holds). Callers own the action: release the result and close the segment when done, or
+   * close the action without releasing to cancel an in-flight load / discard a delivered result. See
+   * {@link AcquireSegmentAction} for the consumer protocol.
    * <p>
-   * The {@code acquireMode} controls how much of the segment is downloaded before the action's future resolves. With
+   * The {@code acquireMode} controls how much of the segment is downloaded before the action becomes ready. With
    * {@link AcquireMode#FULL} the segment is fully materialized up front. With {@link AcquireMode#PARTIAL}, when the
    * segment's {@link LoadSpec} supports range reads, only a minimal amount of metadata is downloaded and additional
    * loading is deferred to the async methods callers use to interact with the returned segment; partial-ineligible

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -21,8 +21,6 @@ package org.apache.druid.segment.loading;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Suppliers;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
@@ -72,11 +70,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Supplier;
 
 /**
  *
@@ -513,9 +511,9 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
                 hold.getEntry().setOnUnmount(() -> deleteSegmentInfoFile(dataSegment));
               }
 
-              return new AcquireSegmentAction(
-                  makeOnDemandLoadSupplier(hold.getEntry(), location),
-                  hold
+              return submitAcquireTask(
+                  hold,
+                  (taskHolds, waitNanos) -> loadCompleteEntry(hold.getEntry(), location, taskHolds, waitNanos)
               );
             }
           }
@@ -587,13 +585,12 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
    * {@link PartialSegmentFileMapperV10#ensureAllDownloaded} so the returned segment is fully-materialized).
    * <p>
    * Fast path: {@link #findExistingPartialWithHold} locates an existing entry across locations under a hold. If the
-   * entry is already usable (mounted, and fully-downloaded when required), return an immediate-future action whose
-   * {@code loadCleanup} is the hold (the supplier mints fresh segments per call, each with its own metadata
-   * reference, so no separate cleanup is needed).
+   * entry is already usable (mounted, and fully-downloaded when required), return a completed action whose segment
+   * has the hold folded into its close.
    * <p>
    * Slow path: under the per-segment lock, {@link #findOrReservePartial} reuses an existing not-yet-usable entry or
-   * reserves a fresh weak one, and the action submits mount (+ optional ensureAllDownloaded) to
-   * {@link #virtualStorageLoadingThreadPool} so callers that yield on the future never block a processing thread on
+   * reserves a fresh weak one, and {@link #submitAcquireTask} runs mount (+ optional ensureAllDownloaded) on
+   * {@link #virtualStorageLoadingThreadPool} so callers that wait on the action never block a processing thread on
    * deep-storage I/O.
    */
   private AcquireSegmentAction acquirePartialInternal(
@@ -607,15 +604,13 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
       final PartialSegmentMetadataCacheEntry partial = existing.metadata;
       if (!fullDownload && partial.isMounted()) {
         // Lazy/PARTIAL contract: hand back a metadata-anchored segment; bundles mount on demand at query time via the
-        // async cursor factory, so a metadata-only hold is correct here. The full-download fast path is intentionally
-        // omitted: a FULL segment must hold every bundle for its lifetime (the sync cursor factory requires
-        // isFullyDownloaded(), which a metadata-only hold can't guarantee under SIEVE eviction), so it goes through
-        // the slow path's bundle-holding + ensureAllDownloaded dance. The resident full case is already served without
-        // an executor hop upstream by acquireCachedSegment -> acquireCachedInternal -> acquireFullReference.
-        return new AcquireSegmentAction(
-            () -> Futures.immediateFuture(AcquireSegmentResult.cached(partial::acquireReference)),
-            existing.hold
-        );
+        // async cursor factory, so a metadata-only hold (folded into the segment's close by acquireReference) is
+        // correct here. The full-download fast path is intentionally omitted: a FULL segment must hold every bundle
+        // for its lifetime (the sync cursor factory requires isFullyDownloaded(), which a metadata-only hold can't
+        // guarantee under SIEVE eviction), so it goes through the slow path's bundle-holding + ensureAllDownloaded
+        // dance. The resident full case is already served without an executor hop upstream by acquireCachedSegment ->
+        // acquireCachedInternal -> acquireFullReference.
+        return AcquireSegmentAction.completed(AcquireSegmentResult.of(partial.acquireReference(existing.hold)));
       }
       // Entry exists but isn't usable on the fast path (not mounted, or a full download is required). Release the
       // fast-path hold and let the slow path re-find with a fresh hold and drive mount on the executor.
@@ -629,102 +624,73 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
         // or reserve a fresh weak entry with a hold if none exists. The metadata entry's mount-future dedup makes a
         // no-op cheap when the entry is already mounted (the typical re-find case after the fast path closed its hold).
         final ReservedPartial reserved = findOrReservePartial(dataSegment, rangeReader);
-        // holdHolder holds the metadata reservation hold immediately; the full-download path adds a hold for every
-        // bundle it mounts, all released together when the AcquireSegmentAction closes.
-        final HoldHolder holdHolder = new HoldHolder(reserved.hold);
-        return new AcquireSegmentAction(
-            // Memoized so repeat getSegmentFuture() calls return the same future rather than scheduling duplicate
-            // executor tasks. The entry's own mount-future dedup would prevent the actual work from being duplicated,
-            // but the executor scheduling and timing capture would still be wasted.
-            Suppliers.memoize(() -> {
-              // Capture submit time on first invocation of getSegmentFuture(). loadTime then covers mount
-              // (+ ensureAllDownloaded for the full-download path).
-              final long submitNanos = System.nanoTime();
-              return virtualStorageLoadingThreadPool.getExecutorService().submit(() -> {
-                // waitNanos is only the executor scheduling delay until this task body starts; it no longer reflects
-                // load-slot contention when using virtual threads. Load permits are acquired inside the deep-storage
-                // reads now, so that wait is folded into loadTime instead, and the query-time bundle/column fetches
-                // (separate permit-bounded tasks) are not reflected here at all. A meaningful load-wait metric would
-                // have to time the permit acquire at the read sites and aggregate it across those fetches.
-                final long taskStartNanos = System.nanoTime();
-                final long waitNanos = taskStartNanos - submitNanos;
-                final boolean wasMounted = reserved.metadata.isMounted();
-                // mount() is idempotent via PartialSegmentMetadataCacheEntry's mount-future dedup; already-mounted
-                // returns immediately, a concurrent mount is awaited, a fresh entry is mounted. The weak entry's
-                // hold-release runnable removes a never-mounted entry from the cache when our loadCleanup hold
-                // closes, so no explicit rollback is needed on failure.
-                try {
-                  reserved.metadata.mount(reserved.location);
-                }
-                catch (IOException | RuntimeException e) {
-                  // only fail if caller was expecting this to finish
-                  if (holdHolder.isClosed()) {
-                    log.debug(e, "Mount of segment[%s] failed after its acquire was abandoned", dataSegment.getId());
-                    return AcquireSegmentResult.empty();
-                  }
-                  throw DruidException.defensive(
-                      e,
-                      "Failed to mount partial metadata for segment[%s]",
-                      dataSegment.getId()
-                  );
-                }
-                // Pin the metadata across the rest of the task
-                final Closeable taskMetadataRef;
-                try {
-                  taskMetadataRef = reserved.metadata.acquireMetadataReference();
-                }
-                catch (DruidException raceLost) {
-                  // The entry was evicted between mounting it and pinning it. What keeps it resident across that
-                  // window is the hold in holdHolder, so an acquire that still holds one is entitled to its segment
-                  // and getting here means that guarantee has been broken so rethrow
-                  if (!holdHolder.isClosed()) {
-                    throw raceLost;
-                  }
-                  // hold is release so we have an abandoned acquire; nothing is waiting on this result, report
-                  // the segment as unavailable rather than failing a query that is already on its way down
-                  return AcquireSegmentResult.empty();
-                }
-                try {
-                  final PartialSegmentFileMapperV10 mapper = reserved.metadata.getFileMapper();
-                  final long loadSizeBytes;
-                  if (fullDownload) {
-                    // Delta of internal-file bytes downloaded by this task
-                    final long downloadedBefore = mapper.getDownloadedBytes();
-                    // Mount every bundle so the containers it owns are reserved on the location, and keep those
-                    // references here for the duration of the download instead of handing them straight to
-                    // holdHolder so that the caller abandoning a load doesn't release the holds until load is
-                    // finished.
-                    final List<Closeable> bundleRefs = new ArrayList<>();
-                    try {
-                      for (String bundleName : PartialSegmentBundleCacheEntry.bundleNames(mapper)) {
-                        bundleRefs.add(reserved.metadata.getBundleAcquirer().acquire(bundleName));
-                      }
-                      mapper.ensureAllDownloaded();
-                    }
-                    finally {
-                      bundleRefs.forEach(holdHolder::add);
-                    }
-                    loadSizeBytes = mapper.getDownloadedBytes() - downloadedBefore;
-                  } else {
-                    // Lazy mount: the header bytes when this task caused the mount; 0 when the entry was already
-                    // mounted (a concurrent acquirer or earlier query did the load).
-                    loadSizeBytes = wasMounted ? 0L : mapper.getOnDiskHeaderSize();
-                  }
-                  final long loadNanos = System.nanoTime() - taskStartNanos;
-                  return new AcquireSegmentResult(
-                      reserved.metadata::acquireReference,
-                      loadSizeBytes,
-                      waitNanos,
-                      loadNanos
-                  );
-                }
-                finally {
-                  CloseableUtils.closeAndSuppressExceptions(taskMetadataRef, ignored -> {});
-                }
-              });
-            }),
-            holdHolder
-        );
+        // The metadata reservation hold seeds the task holds; the full-download path registers a hold for every
+        // bundle it mounts. All of them fold into the delivered segment's close. The task owns every hold until the
+        // fold (or the failure unwind), so a caller closing the action while the task runs cannot release them
+        // mid-mount or mid-download: the entry stays pinned for the task's whole duration.
+        return submitAcquireTask(reserved.hold, (taskHolds, waitNanos) -> {
+          final long taskStartNanos = System.nanoTime();
+          final boolean wasMounted = reserved.metadata.isMounted();
+          // mount() is idempotent via PartialSegmentMetadataCacheEntry's mount-future dedup; already-mounted
+          // returns immediately, a concurrent mount is awaited, a fresh entry is mounted. The weak entry's
+          // hold-release runnable removes a never-mounted entry from the cache when the reservation hold closes,
+          // so no explicit rollback is needed on failure.
+          try {
+            reserved.metadata.mount(reserved.location);
+          }
+          catch (IOException | RuntimeException e) {
+            throw DruidException.defensive(
+                e,
+                "Failed to mount partial metadata for segment[%s]",
+                dataSegment.getId()
+            );
+          }
+          // Pin the metadata across the rest of the task
+          final Closeable taskMetadataRef;
+          try {
+            taskMetadataRef = reserved.metadata.acquireMetadataReference();
+          }
+          catch (DruidException raceLost) {
+            // The reservation hold in taskHolds keeps the entry resident for the task's duration, so an eviction
+            // between mounting and pinning means that guarantee has been broken.
+            throw DruidException.defensive(
+                raceLost,
+                "Partial metadata for segment[%s] was dropped before the [%s] task could complete",
+                dataSegment.getId(),
+                fullDownload ? "full-download" : "lazy mount"
+            );
+          }
+          try {
+            final PartialSegmentFileMapperV10 mapper = reserved.metadata.getFileMapper();
+            final long loadSizeBytes;
+            if (fullDownload) {
+              // Delta of internal-file bytes downloaded by this task
+              final long downloadedBefore = mapper.getDownloadedBytes();
+              // Mount every bundle so the containers it owns are reserved on the location
+              for (String bundleName : PartialSegmentBundleCacheEntry.bundleNames(mapper)) {
+                taskHolds.register(reserved.metadata.getBundleAcquirer().acquire(bundleName));
+              }
+              mapper.ensureAllDownloaded();
+              loadSizeBytes = mapper.getDownloadedBytes() - downloadedBefore;
+            } else {
+              // Lazy mount: the header bytes when this task caused the mount; 0 when the entry was already
+              // mounted (a concurrent acquirer or earlier query did the load).
+              loadSizeBytes = wasMounted ? 0L : mapper.getOnDiskHeaderSize();
+            }
+            final long loadNanos = System.nanoTime() - taskStartNanos;
+            // Fold as the final act: metadata reservation hold + every bundle hold ride the segment's close (or are
+            // closed by the fold on a miss).
+            return new AcquireSegmentResult(
+                reserved.metadata.acquireReference(taskHolds),
+                loadSizeBytes,
+                waitNanos,
+                loadNanos
+            );
+          }
+          finally {
+            CloseableUtils.closeAndSuppressExceptions(taskMetadataRef, ignored -> {});
+          }
+        });
       }
       finally {
         unlock(dataSegment, lock);
@@ -735,8 +701,10 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
   /**
    * Locate an existing partial metadata entry across storage locations and attach a eviction-protective hold to it.
    * Returns {@code null} when no entry exists at any location. Race-safe (the hold prevents eviction from picking
-   * the entry between this lookup and the caller's subsequent use). Caller must close the returned hold (typically
-   * via {@link AcquireSegmentAction#loadCleanup} or by closing it directly when falling through to a reserve path).
+   * the entry between this lookup and the caller's subsequent use). Caller must arrange for the returned hold to be
+   * closed (typically by folding it into an acquired segment's close via
+   * {@link SegmentCacheEntry#acquireReference(Closeable)}, or by closing it directly when falling through to a
+   * reserve path).
    */
   @Nullable
   private ReservedPartial findExistingPartialWithHold(SegmentId segmentId)
@@ -960,10 +928,9 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
    * Return a handle to a partial metadata entry for the given segment, paired with a eviction-protective hold: either
    * an existing entry (in any mount state, located by {@link #findExistingPartialWithHold}), or a fresh weak
    * reservation from {@link #reservePartial}. The caller is expected to drive
-   * {@link PartialSegmentMetadataCacheEntry#mount} on the returned handle inside the
-   * {@link AcquireSegmentAction}'s future; mount is idempotent via its mount-future dedup, so an already-mounted
-   * entry's mount call is cheap. The hold rides in the action's {@code loadCleanup} and is released when the
-   * action closes.
+   * {@link PartialSegmentMetadataCacheEntry#mount} on the returned handle inside a {@link #submitAcquireTask} task;
+   * mount is idempotent via its mount-future dedup, so an already-mounted entry's mount call is cheap. The hold seeds
+   * the task holds and is folded into the delivered segment's close (or released on failure/cancel).
    */
   private ReservedPartial findOrReservePartial(DataSegment dataSegment, SegmentRangeReader rangeReader)
   {
@@ -987,9 +954,9 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
 
   /**
    * Pairing of a partial metadata entry (either pre-existing, discovered via {@link #findExistingPartialWithHold}, or
-   * freshly reserved by {@link #reservePartial}) with the storage location it lives on plus a eviction-protective hold.
-   * The hold rides in the {@link AcquireSegmentAction#loadCleanup} so the entry is protected from eviction across
-   * the action's lifetime; closing the action releases the hold.
+   * freshly reserved by {@link #reservePartial}) with the storage location it lives on plus a eviction-protective
+   * hold. The hold protects the entry from eviction across the acquire, and ends up folded into the delivered
+   * segment's close (or released on miss/failure/cancel).
    */
   private record ReservedPartial(
       PartialSegmentMetadataCacheEntry metadata,
@@ -1319,57 +1286,48 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
   @Nullable
   private AcquireSegmentAction acquireExistingSegment(SegmentCacheEntryIdentifier identifier)
   {
-    final Closer safetyNet = Closer.create();
     for (StorageLocation location : locations) {
+      final StorageLocation.ReservationHold<SegmentCacheEntry> hold =
+          location.addWeakReservationHoldIfExists(identifier);
+      if (hold == null) {
+        continue;
+      }
+      final CompleteSegmentCacheEntry complete;
       try {
-        final StorageLocation.ReservationHold<SegmentCacheEntry> hold = safetyNet.register(
-            location.addWeakReservationHoldIfExists(identifier)
-        );
-        if (hold != null) {
-          if (!(hold.getEntry() instanceof CompleteSegmentCacheEntry complete)) {
-            // The eager (complete) acquire path found a non-complete entry under this id. Defensive backstop: when
-            // partial downloads are disabled, getCachedSegments now deletes any on-disk partial layout at bootstrap
-            // rather than reserving it, so a partial entry should not exist on this path. If one somehow does (e.g. a
-            // bootstrap delete failed), surface a clear operator error rather than a ClassCastException.
-            throw DruidException.forPersona(DruidException.Persona.OPERATOR)
-                                .ofCategory(DruidException.Category.RUNTIME_FAILURE)
-                                .build(
-                                    "Segment[%s] has partial-load cache state on disk but partial downloads are "
-                                    + "disabled; clear the segment cache directory or re-enable "
-                                    + "druid.segmentCache.virtualStoragePartialDownloadsEnabled",
-                                    identifier
-                                );
-          }
-          if (complete.isMounted()) {
-            // the entry is already mounted, so hand back its cached reference provider. Read the volatile
-            // referenceProvider exactly once, inside the supplier, rather than trusting the isMounted() check above and
-            // reading the field again when the supplier runs later: for a static (non-virtual-storage) entry a
-            // concurrent drop (release() -> unmount()) can null it in between. The reservation hold does not prevent
-            // this (it only guards weak entries against reclaim), so a weak entry would stay mounted here, but a
-            // static entry can be unmounted out from under us. A dropped entry is reported as absent (empty) rather
-            // than reloaded.
-            return new AcquireSegmentAction(
-                () -> {
-                  final ReferenceCountedSegmentProvider provider = complete.referenceProvider;
-                  return Futures.immediateFuture(
-                      provider != null ? AcquireSegmentResult.cached(provider) : AcquireSegmentResult.empty()
-                  );
-                },
-                hold
-            );
-          } else {
-            // go ahead and mount it, someone else is probably trying this as well, but mount is done under a segment
-            // lock and is a no-op if already mounted, and if we win we need it to be mounted
-            return new AcquireSegmentAction(
-                makeOnDemandLoadSupplier(complete, location),
-                hold
-            );
-          }
+        if (!(hold.getEntry() instanceof CompleteSegmentCacheEntry completeEntry)) {
+          // The eager (complete) acquire path found a non-complete entry under this id. Defensive backstop: when
+          // partial downloads are disabled, getCachedSegments now deletes any on-disk partial layout at bootstrap
+          // rather than reserving it, so a partial entry should not exist on this path. If one somehow does (e.g. a
+          // bootstrap delete failed), surface a clear operator error rather than a ClassCastException.
+          throw DruidException.forPersona(DruidException.Persona.OPERATOR)
+                              .ofCategory(DruidException.Category.RUNTIME_FAILURE)
+                              .build(
+                                  "Segment[%s] has partial-load cache state on disk but partial downloads are "
+                                  + "disabled; clear the segment cache directory or re-enable "
+                                  + "druid.segmentCache.virtualStoragePartialDownloadsEnabled",
+                                  identifier
+                              );
         }
+        complete = completeEntry;
       }
       catch (Throwable t) {
-        throw CloseableUtils.closeAndWrapInCatch(t, safetyNet);
+        throw CloseableUtils.closeAndWrapInCatch(t, hold);
       }
+      if (complete.isMounted()) {
+        // acquireReference takes ownership of the hold: it is folded into the segment's close on success, and closed
+        // by the callee on a miss or throw. It re-reads referenceProvider under the entry lock rather than trusting
+        // the isMounted() check above: for a static (non-virtual-storage) entry a concurrent drop
+        // (release() -> unmount()) can null it in between (the reservation hold only guards weak entries against
+        // reclaim). A dropped entry is reported as absent (empty) rather than reloaded.
+        return AcquireSegmentAction.completed(AcquireSegmentResult.of(complete.acquireReference(hold)));
+      }
+      // go ahead and mount it, someone else is probably trying this as well, but mount is done under a segment
+      // lock and is a no-op if already mounted, and if we win we need it to be mounted. submitAcquireTask takes
+      // ownership of the hold in all cases.
+      return submitAcquireTask(
+          hold,
+          (taskHolds, waitNanos) -> loadCompleteEntry(complete, location, taskHolds, waitNanos)
+      );
     }
     return null;
   }
@@ -1907,32 +1865,117 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
     return infoDir;
   }
 
-  private Supplier<ListenableFuture<AcquireSegmentResult>> makeOnDemandLoadSupplier(
-      final CompleteSegmentCacheEntry entry,
-      final StorageLocation location
-  )
+  /**
+   * Body of an on-demand acquire task submitted via {@link #submitAcquireTask}. Runs on the loading pool.
+   */
+  @FunctionalInterface
+  private interface AcquireTaskBody
   {
-    return Suppliers.memoize(
-        () -> {
-          final long startTime = System.nanoTime();
-          return virtualStorageLoadingThreadPool.getExecutorService().submit(
-              () -> {
-                // waitTime is only the executor scheduling delay; when using virtual threads for the pool, load-slot
-                // contention is folded into loadTime now, since mount acquires the load permit around the deep-storage
-                // read.
-                final long execStartTime = System.nanoTime();
-                final long waitTime = execStartTime - startTime;
-                entry.mount(location);
-                return new AcquireSegmentResult(
-                    entry.referenceProvider,
-                    entry.dataSegment.getSize(),
-                    waitTime,
-                    System.nanoTime() - execStartTime
-                );
-              }
-          );
+    /**
+     * Perform the load and deliver the result. {@code taskHolds} is pre-seeded with the reservation hold placed at
+     * {@link #acquireSegment} time; the body may register additional holds (e.g. per-bundle holds) as it acquires
+     * them. The body MUST make the hold-fold ({@code entry.acquireReference(taskHolds)} or a variant) its final
+     * act: after the fold, ownership of every registered hold lives inside the returned result's segment (or was
+     * closed by the fold on a miss), and nothing that can throw may run between the fold and returning. On any
+     * throw before the fold, {@link #submitAcquireTask} closes {@code taskHolds}.
+     */
+    AcquireSegmentResult load(Closer taskHolds, long waitNanos) throws Exception;
+  }
+
+  /**
+   * Shared scaffolding for on-demand acquires: runs {@code taskBody} on {@link #virtualStorageLoadingThreadPool},
+   * delivering its result to the returned {@link AcquireSegmentAction}. Closing the action before delivery cancels a
+   * still-queued task (it never runs); a task already running is deliberately NOT interrupted (see the
+   * {@code cancel(false)} rationale in the canceler below) — it runs to completion, loses the delivery race, and
+   * closes its own orphaned result.
+   * <p>
+   * Takes ownership of {@code preplacedHold} in all cases, with exactly one owner ever touching it (decided by a
+   * claim token; {@link StorageLocation.ReservationHold#close()} is additionally idempotent as a backstop):
+   * <ul>
+   *   <li>task delivers: the hold is folded into the delivered segment's close (or closed by the fold on a miss)</li>
+   *   <li>task delivers but the action was closed first: the orphaned result is closed here, releasing the folded
+   *   holds along with the segment reference</li>
+   *   <li>task throws: the task closes all accumulated holds and the failure is delivered (or silently absorbed if
+   *   the action was closed first)</li>
+   *   <li>action closed before the task ever runs (canceled while queued): the canceler claims and closes the
+   *   hold</li>
+   *   <li>submitting the task fails synchronously: the hold is closed here and the failure propagates to the
+   *   {@link #acquireSegment} caller</li>
+   * </ul>
+   */
+  private AcquireSegmentAction submitAcquireTask(final Closeable preplacedHold, final AcquireTaskBody taskBody)
+  {
+    final AcquireSegmentAction action = new AcquireSegmentAction();
+    final AtomicBoolean holdClaimed = new AtomicBoolean(false);
+    final long submitNanos = System.nanoTime();
+    final ListenableFuture<?> taskFuture;
+    try {
+      taskFuture = virtualStorageLoadingThreadPool.getExecutorService().submit(() -> {
+        if (!holdClaimed.compareAndSet(false, true)) {
+          // the canceler won the claim and closed the pre-placed hold, nothing to do
+          return null;
         }
-    );
+        final Closer taskHolds = Closer.create();
+        taskHolds.register(preplacedHold);
+        try {
+          // waitNanos is only the executor scheduling delay until the task body starts; it no longer reflects
+          // load-slot contention when using virtual threads. Load permits are acquired inside the deep-storage
+          // reads now, so that wait is folded into loadTime instead, and the query-time bundle/column fetches
+          // (separate permit-bounded tasks) are not reflected here at all. A meaningful load-wait metric would
+          // have to time the permit acquire at the read sites and aggregate it across those fetches.
+          final AcquireSegmentResult result = taskBody.load(taskHolds, System.nanoTime() - submitNanos);
+          if (!action.set(result)) {
+            // the action was closed while the task was completing; close the orphaned result
+            result.close();
+          }
+        }
+        catch (Throwable t) {
+          CloseableUtils.closeAndSuppressExceptions(taskHolds, t::addSuppressed);
+          // silently absorbed if the action was closed first
+          action.setException(t);
+        }
+        return null;
+      });
+    }
+    catch (Throwable t) {
+      throw CloseableUtils.closeAndWrapInCatch(t, preplacedHold);
+    }
+    action.setCanceler(() -> {
+      // cancel(false), NOT cancel(true): a still-queued task is prevented from running (the canceler then wins the
+      // claim CAS below and releases the pre-placed hold); a task already running is left to finish rather than
+      // interrupted. Interrupting a running task is unsafe here for the same reason documented on
+      // awaitEagerDownloadsOrClearRule's cancel(false) — an interrupt landing mid-NIO can raise
+      // ClosedByInterruptException on a shared mapper FD, and interrupting a task that is driving a deduped mount
+      // fails every other query awaiting that same mount. A running task that finishes after close loses the
+      // set() race and closes its own orphaned result, releasing the holds then.
+      taskFuture.cancel(false);
+      if (holdClaimed.compareAndSet(false, true)) {
+        CloseableUtils.closeAndSuppressExceptions(
+            preplacedHold,
+            e -> log.warn(e, "Failed to release reservation hold while canceling a segment acquire")
+        );
+      }
+    });
+    return action;
+  }
+
+  /**
+   * {@link AcquireTaskBody} for a {@link CompleteSegmentCacheEntry}: mount (idempotent, done under the entry lock)
+   * then acquire a reference with the task holds folded into the segment's close.
+   */
+  private AcquireSegmentResult loadCompleteEntry(
+      final CompleteSegmentCacheEntry entry,
+      final StorageLocation location,
+      final Closer taskHolds,
+      final long waitNanos
+  ) throws SegmentLoadingException
+  {
+    final long loadStartNanos = System.nanoTime();
+    entry.mount(location);
+    final long loadSizeBytes = entry.dataSegment.getSize();
+    // Fold as the final act: the reservation hold rides the segment's close (or is closed by the fold on a miss)
+    final Optional<Segment> segment = entry.acquireReference(taskHolds);
+    return new AcquireSegmentResult(segment, loadSizeBytes, waitNanos, System.nanoTime() - loadStartNanos);
   }
 
   private ReferenceCountingLock lock(final DataSegment dataSegment)
@@ -2482,60 +2525,4 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
     }
   }
 
-  /**
-   * The {@link AcquireSegmentAction#close()} cleanup for a partial acquire: a set of cache holds that keep the
-   * acquired segment's entries resident for the action's lifetime. Seeded with the metadata reservation hold at
-   * construction; the full-download path {@link #add adds} a hold per bundle it mounts while the load future runs.
-   * Closing releases everything (LIFO).
-   * <p>
-   * Thread-safe because the future that {@link #add}s bundle holds runs on the load executor while a different thread
-   * may close the action (query cancel / timeout racing a blocked {@code getSegmentFuture().get()}). A hold added
-   * after the action has already been closed is closed immediately rather than leaked.
-   */
-  private static final class HoldHolder implements Closeable
-  {
-    @GuardedBy("this")
-    private final Closer holds = Closer.create();
-    /**
-     * Volatile rather than guarded, so {@link #isClosed} can be answered without queueing behind a {@link #close}
-     * that is working through a hold-release cascade (location write lock, unmount, unmap, file deletion).
-     */
-    private volatile boolean closed = false;
-
-    private HoldHolder(Closeable initialHold)
-    {
-      holds.register(initialHold);
-    }
-
-    /**
-     * Whether the {@link AcquireSegmentAction} these holds belong to has been closed, i.e. whoever wanted the segment
-     * has stopped waiting for it and every hold taken so far is being (or has been) released.
-     */
-    private boolean isClosed()
-    {
-      return closed;
-    }
-
-    private void add(Closeable hold)
-    {
-      final boolean alreadyClosed;
-      synchronized (this) {
-        alreadyClosed = closed;
-        if (!alreadyClosed) {
-          holds.register(hold);
-        }
-      }
-      if (alreadyClosed) {
-        // the action was closed while the load future was still running; release the late hold rather than leak it
-        CloseableUtils.closeAndSuppressExceptions(hold, ignored -> {});
-      }
-    }
-
-    @Override
-    public synchronized void close() throws IOException
-    {
-      closed = true;
-      holds.close();
-    }
-  }
 }

--- a/server/src/main/java/org/apache/druid/segment/loading/StorageLoadingThreadPool.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/StorageLoadingThreadPool.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment.loading;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.druid.common.asyncresource.AsyncResource;
@@ -124,7 +125,13 @@ public class StorageLoadingThreadPool
   @Nullable
   private final Semaphore permits;
 
-  private StorageLoadingThreadPool(@Nullable final ListeningExecutorService exec, @Nullable final Semaphore permits)
+  /**
+   * Package-private for tests that need to control task dispatch (e.g. to deterministically construct the
+   * submitted-but-not-yet-started state, which cannot be forced through {@link #createFromConfig} since the
+   * virtual-thread mode starts tasks immediately). Production code should use {@link #createFromConfig}.
+   */
+  @VisibleForTesting
+  StorageLoadingThreadPool(@Nullable final ListeningExecutorService exec, @Nullable final Semaphore permits)
   {
     this.exec = exec;
     this.permits = permits;

--- a/server/src/main/java/org/apache/druid/server/SegmentManager.java
+++ b/server/src/main/java/org/apache/druid/server/SegmentManager.java
@@ -177,13 +177,7 @@ public class SegmentManager
         if (ref.isPresent()) {
           try {
             final Optional<Segment> mapped = segmentMapFunction.apply(ref).map(safetyNet::register);
-            segmentReferences.add(
-                new SegmentReference(
-                    segment.getDescriptor(),
-                    mapped,
-                    null
-                )
-            );
+            segmentReferences.add(new SegmentReference(segment.getDescriptor(), mapped));
           }
           catch (Throwable t) {
             // If applying the mapFn failed, attach the base segment to the closer and rethrow
@@ -226,13 +220,12 @@ public class SegmentManager
   }
 
   /**
-   * Returns a {@link AcquireSegmentAction}, where calling {@link AcquireSegmentAction#getSegmentFuture()} will either
-   * return immediately if the {@link Segment} is in the cache, or possibly try to fetch the segment from deep storage
-   * if not. The returned {@link Segment}, if present, must be closed when the caller is finished doing segment things.
-   * <p>
-   * Calling this method is treated as an intent to acquire and use the segment via resolving the future, and cache
-   * manager implementations will place a hold on this segment until the 'loadCleanup' closer is closed - typically
-   * after resolving the future to acquire the reference to the actual {@link Segment} object.
+   * Returns an {@link AcquireSegmentAction}: an async handle that becomes ready immediately if the {@link Segment}
+   * is in the cache, or after fetching the segment from deep storage if not (the load starts immediately). Callers
+   * wait for readiness and then {@link AcquireSegmentAction#release()} the result, closing the delivered
+   * {@link Segment} when finished doing segment things (its close releases the reference plus any cache holds placed
+   * for the acquisition); closing the action without releasing cancels an in-flight load or discards a delivered
+   * result. See {@link AcquireSegmentAction} for the full consumer protocol.
    * <p>
    * With {@link AcquireMode#PARTIAL} the action resolves to a partial-load capable segment (when the segment supports
    * range reads), and callers must use async methods like

--- a/server/src/main/java/org/apache/druid/server/ServerManager.java
+++ b/server/src/main/java/org/apache/druid/server/ServerManager.java
@@ -22,8 +22,6 @@ package org.apache.druid.server;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
 import org.apache.druid.client.CachingQueryRunner;
 import org.apache.druid.client.cache.Cache;
@@ -87,8 +85,6 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -255,8 +251,7 @@ public class ServerManager implements QuerySegmentWalker
         segmentReferences.add(
             new SegmentReference(
                 segment.getDescriptor(),
-                Optional.of(new VirtualPlaceholderSegment(segment.getDataSegment())),
-                null
+                Optional.of(new VirtualPlaceholderSegment(segment.getDataSegment()))
             )
         );
       }
@@ -300,9 +295,10 @@ public class ServerManager implements QuerySegmentWalker
     // closing the segment reference handles everything and it is the callers responsibility
     final Closer safetyNet = Closer.create();
 
-    // build list of acquire reference actions, this does not initiate the actions until we collect the futures. this
-    // does place a hold on any weakly held references if the cache includes segments that reside on virtual storage
-    // fabric
+    // Acquire an action per segment; this kicks off any on-demand loads immediately, and places a hold on any weakly
+    // held references if the cache includes segments that reside on virtual storage fabric. Closing an action before
+    // its result has been released cancels an in-flight load, so registering them all with the safetyNet covers the
+    // failure paths below.
     final List<AcquireSegmentAction> actions = new ArrayList<>();
     try {
       for (DataSegmentAndDescriptor segment : segmentsToMap) {
@@ -328,33 +324,6 @@ public class ServerManager implements QuerySegmentWalker
 
     Throwable failure = null;
 
-    // getting the future kicks off any background action, so materialize them all to a list to get things started
-    final List<ListenableFuture<AcquireSegmentResult>> futures = new ArrayList<>(actions.size());
-    for (AcquireSegmentAction acquireSegmentAction : actions) {
-      // if we haven't failed yet, keep collecting futures
-      if (failure == null) {
-        try {
-          futures.add(acquireSegmentAction.getSegmentFuture());
-        }
-        catch (Throwable t) {
-          failure = t;
-        }
-      } else {
-        futures.add(Futures.immediateFuture(AcquireSegmentResult.empty()));
-      }
-    }
-
-    if (failure != null) {
-      throw CloseableUtils.closeInCatch(
-          failure instanceof DruidException
-          ? (DruidException) failure
-          : DruidException.forPersona(DruidException.Persona.OPERATOR)
-                          .ofCategory(DruidException.Category.RUNTIME_FAILURE)
-                          .build(failure, "Failed to acquire segment references to process query"),
-          safetyNet
-      );
-    }
-
     final ArrayList<SegmentReference> segmentReferences = new ArrayList<>(actions.size());
     long totalSegmentsLoadTime = 0;
     long totalSegmentsLoadWaitTime = 0;
@@ -363,49 +332,49 @@ public class ServerManager implements QuerySegmentWalker
     long bytesLoaded = 0;
     boolean timedOut = false;
     boolean interrupted = false;
+    boolean firstFailureFromAcquire = false;
     for (int i = 0; i < actions.size(); i++) {
+      // distinguishes acquire-phase failures (await/release, where AsyncResource.get() launders checked producer
+      // exceptions into UNCATEGORIZED DruidExceptions) from map-phase failures for the classification below
+      boolean acquirePhase = true;
       try {
         final DataSegmentAndDescriptor segmentAndDescriptor = segmentsToMap.get(i);
         final AcquireSegmentAction action = actions.get(i);
-        final ListenableFuture<AcquireSegmentResult> future = futures.get(i);
-        final AcquireSegmentResult result = future.get(timeoutAt - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
-        if (result == null) {
-          segmentReferences.add(
-              new SegmentReference(segmentAndDescriptor.getDescriptor(), Optional.empty(), action)
-          );
-        } else {
-          totalSegmentsLoadTime += result.getLoadTimeNanos();
-          totalSegmentsLoadWaitTime += result.getWaitTimeNanos();
-          maxSegmentLoadTime = Math.max(maxSegmentLoadTime, result.getLoadTimeNanos());
-          maxSegmentWaitTime = Math.max(maxSegmentWaitTime, result.getWaitTimeNanos());
-          bytesLoaded += result.getLoadSizeBytes();
-          final Optional<Segment> segment = result.getReferenceProvider().acquireReference();
-          try {
-            final Optional<Segment> mappedSegment = segmentMapFunction.apply(segment).map(safetyNet::register);
-            segmentReferences.add(
-                new SegmentReference(
-                    segmentAndDescriptor.getDescriptor(),
-                    mappedSegment,
-                    action
-                )
-            );
-          }
-          catch (Throwable t) {
-            // if applying the mapFn failed, attach the base segment to the closer and rethrow
-            segment.ifPresent(safetyNet::register);
-            throw t;
-          }
+        action.await(timeoutAt - System.currentTimeMillis());
+        // Take ownership of the result. After release, the safetyNet-registered action close is a no-op; the
+        // delivered segment (registered below, or folded into the returned SegmentReference) carries all cleanup.
+        final AcquireSegmentResult result = action.release();
+        totalSegmentsLoadTime += result.getLoadTimeNanos();
+        totalSegmentsLoadWaitTime += result.getWaitTimeNanos();
+        maxSegmentLoadTime = Math.max(maxSegmentLoadTime, result.getLoadTimeNanos());
+        maxSegmentWaitTime = Math.max(maxSegmentWaitTime, result.getWaitTimeNanos());
+        bytesLoaded += result.getLoadSizeBytes();
+        final Optional<Segment> segment = result.getSegment();
+        acquirePhase = false;
+        try {
+          final Optional<Segment> mappedSegment = segmentMapFunction.apply(segment).map(safetyNet::register);
+          segmentReferences.add(new SegmentReference(segmentAndDescriptor.getDescriptor(), mappedSegment));
+        }
+        catch (Throwable t) {
+          // if applying the mapFn failed, attach the base segment to the closer and rethrow
+          segment.ifPresent(safetyNet::register);
+          throw t;
         }
       }
       catch (Throwable t) {
         if (t instanceof InterruptedException) {
           interrupted = true;
+          // Restore the interrupt status immediately (await() cleared it): subsequent await() calls in this loop then
+          // fail fast instead of blocking with the flag lost, and downstream cancellation checks keep working even if
+          // the classification below picks a different branch for the first-recorded failure.
+          Thread.currentThread().interrupt();
         }
         if (t instanceof TimeoutException) {
           timedOut = true;
         }
         if (failure == null) {
           failure = t;
+          firstFailureFromAcquire = acquirePhase;
         } else {
           // no need to get carried away, if a bunch fail this ceases to be useful
           if (failure.getSuppressed().length <= 10) {
@@ -416,16 +385,20 @@ public class ServerManager implements QuerySegmentWalker
     }
     if (failure != null) {
       final DruidException toThrow;
-      if (failure instanceof DruidException) {
-        toThrow = (DruidException) failure;
-      } else if (failure instanceof ExecutionException ee && ee.getCause() instanceof DruidException druidException) {
-        toThrow = druidException;
+      // Pass a genuine DruidException through as-is — including UNCATEGORIZED ones from the map phase (e.g. segment
+      // map functions or legacy compat layers), which old code surfaced verbatim. The one exception: an UNCATEGORIZED
+      // DruidException from the ACQUIRE phase is AsyncResource.get()'s laundering of a checked producer exception
+      // (e.g. SegmentLoadingException from an on-demand load); treat that like any other opaque failure and
+      // reclassify it to OPERATOR/RUNTIME_FAILURE with the query-facing context, matching the behavior before
+      // segment acquisition moved onto AsyncResource.
+      if (failure instanceof DruidException de
+          && (de.getCategory() != DruidException.Category.UNCATEGORIZED || !firstFailureFromAcquire)) {
+        toThrow = de;
       } else if (timedOut) {
         toThrow = DruidException.forPersona(DruidException.Persona.USER)
                                 .ofCategory(DruidException.Category.TIMEOUT)
                                 .build(failure, "Failed to acquire segment references to process query");
       } else if (interrupted) {
-        Thread.currentThread().interrupt();
         toThrow = DruidException.forPersona(DruidException.Persona.OPERATOR)
                                 .ofCategory(DruidException.Category.RUNTIME_FAILURE)
                                 .build(failure, "Interrupted waiting for segments");

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerAcquireLifecycleTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerAcquireLifecycleTest.java
@@ -1,0 +1,500 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.loading;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.segment.Segment;
+import org.apache.druid.segment.TestIndex;
+import org.apache.druid.segment.TestSegmentUtils;
+import org.apache.druid.server.metrics.NoopServiceEmitter;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
+import org.apache.druid.timeline.partition.NumberedShardSpec;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Lifecycle-focused tests for {@link SegmentLocalCacheManager#acquireSegment}'s hold-handoff choreography: the
+ * pre-placed reservation hold must be released exactly once on every path (cancel-while-queued, cancel-mid-load,
+ * delivery losing the race with close, empty delivery, normal release).
+ */
+class SegmentLocalCacheManagerAcquireLifecycleTest
+{
+  private static final long SEGMENT_SIZE = 1000L;
+
+  /**
+   * Per-segment-name gate controlling {@link GatedLoadSpec#loadSegment}. Static because Jackson materializes fresh
+   * {@link GatedLoadSpec} instances from the load spec map on every acquire.
+   */
+  static class Gate
+  {
+    final CountDownLatch entered = new CountDownLatch(1);
+    final CountDownLatch proceed = new CountDownLatch(1);
+    final CountDownLatch exited = new CountDownLatch(1);
+    final AtomicInteger loadCount = new AtomicInteger();
+    final AtomicBoolean sawInterrupt = new AtomicBoolean();
+    volatile boolean blockUninterruptibly = false;
+  }
+
+  private static final Map<String, Gate> GATES = new ConcurrentHashMap<>();
+
+  private static Gate gate(String name)
+  {
+    return GATES.computeIfAbsent(name, ignored -> new Gate());
+  }
+
+  @JsonTypeName("gated")
+  public static class GatedLoadSpec implements LoadSpec
+  {
+    private final int size;
+    private final String name;
+
+    @JsonCreator
+    public GatedLoadSpec(@JsonProperty("size") int size, @JsonProperty("name") String name)
+    {
+      this.size = size;
+      this.name = name;
+    }
+
+    @Override
+    public LoadSpecResult loadSegment(File destDir) throws SegmentLoadingException
+    {
+      final Gate gate = gate(name);
+      gate.loadCount.incrementAndGet();
+      gate.entered.countDown();
+      try {
+        if (gate.blockUninterruptibly) {
+          Uninterruptibles.awaitUninterruptibly(gate.proceed);
+        } else {
+          try {
+            gate.proceed.await();
+          }
+          catch (InterruptedException e) {
+            gate.sawInterrupt.set(true);
+            throw new SegmentLoadingException(e, "interrupted while loading[%s]", name);
+          }
+        }
+        return new TestSegmentUtils.TestLoadSpec(size, name).loadSegment(destDir);
+      }
+      finally {
+        gate.exited.countDown();
+      }
+    }
+  }
+
+  /**
+   * Executor that holds every submitted task instead of running it, until the test calls {@link #dispatchAll()}.
+   * Lets tests deterministically construct the submitted-but-not-yet-started state that a real pool (which starts
+   * tasks immediately, especially in the virtual-thread mode) cannot guarantee.
+   */
+  private static class DeferredDispatchExecutorService extends AbstractExecutorService
+  {
+    private final List<Runnable> held = new ArrayList<>();
+
+    @Override
+    public synchronized void execute(Runnable command)
+    {
+      held.add(command);
+    }
+
+    synchronized void dispatchAll()
+    {
+      // run inline: a cancelled FutureTask's run() is a no-op, so this is safe on the test thread
+      for (Runnable runnable : held) {
+        runnable.run();
+      }
+      held.clear();
+    }
+
+    @Override
+    public void shutdown()
+    {
+    }
+
+    @Override
+    public List<Runnable> shutdownNow()
+    {
+      synchronized (this) {
+        final List<Runnable> remaining = new ArrayList<>(held);
+        held.clear();
+        return remaining;
+      }
+    }
+
+    @Override
+    public boolean isShutdown()
+    {
+      return false;
+    }
+
+    @Override
+    public boolean isTerminated()
+    {
+      return false;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit)
+    {
+      return true;
+    }
+  }
+
+  @TempDir
+  File tempDir;
+
+  private ObjectMapper jsonMapper;
+  private SegmentLocalCacheManager manager;
+  private StorageLocation location;
+
+  @BeforeEach
+  void setUp() throws IOException
+  {
+    EmittingLogger.registerEmitter(new NoopServiceEmitter());
+    GATES.clear();
+    jsonMapper = new DefaultObjectMapper();
+    jsonMapper.registerSubtypes(GatedLoadSpec.class);
+    jsonMapper.registerSubtypes(TestSegmentUtils.TestLoadSpec.class);
+    jsonMapper.registerSubtypes(TestSegmentUtils.TestSegmentizerFactory.class);
+
+    final StorageLocationConfig locationConfig = new StorageLocationConfig(
+        new File(tempDir, "cache"),
+        100_000L,
+        null
+    );
+    final SegmentLoaderConfig loaderConfig = SegmentLoaderConfig.builder()
+                                                                .locations(locationConfig)
+                                                                .virtualStorage(true)
+                                                                .virtualStorageLoadThreads(1)
+                                                                .infoDir(new File(tempDir, "info"))
+                                                                .build();
+    final List<StorageLocation> storageLocations = loaderConfig.toStorageLocations();
+    location = storageLocations.get(0);
+    manager = new SegmentLocalCacheManager(
+        storageLocations,
+        loaderConfig,
+        StorageLoadingThreadPool.createFromConfig(loaderConfig),
+        new LeastBytesUsedStorageLocationSelectorStrategy(storageLocations),
+        TestIndex.INDEX_IO,
+        jsonMapper
+    );
+    manager.getCachedSegments();
+  }
+
+  @AfterEach
+  void tearDown()
+  {
+    // open all gates so any still-blocked load task can unwind before the executor is torn down
+    for (Gate gate : GATES.values()) {
+      gate.proceed.countDown();
+    }
+    manager.shutdown();
+  }
+
+  private DataSegment makeSegment(String name)
+  {
+    return DataSegment.builder()
+                      .dataSource("test_ds")
+                      .interval(Intervals.of("2024-01-01/2024-01-02"))
+                      .version("v1")
+                      .loadSpec(ImmutableMap.of("type", "gated", "size", (int) SEGMENT_SIZE, "name", name))
+                      .dimensions(ImmutableList.of())
+                      .metrics(ImmutableList.of())
+                      .shardSpec(new NumberedShardSpec(Integer.parseInt(name.substring(name.length() - 1)), 0))
+                      .binaryVersion(9)
+                      .size(SEGMENT_SIZE)
+                      .build();
+  }
+
+  private void awaitNoWeakHolds() throws InterruptedException
+  {
+    final long deadline = System.currentTimeMillis() + 30_000;
+    while (location.getWeakStats().getHoldCount() > 0) {
+      if (System.currentTimeMillis() > deadline) {
+        Assertions.assertEquals(0, location.getWeakStats().getHoldCount(), "holds did not drain");
+      }
+      Thread.sleep(5);
+    }
+  }
+
+  @Test
+  void testCloseBeforeTaskRunsReleasesPreplacedHold() throws Exception
+  {
+    // The submitted-but-not-yet-started state cannot be forced through a real pool (virtual-thread mode starts tasks
+    // immediately), so this test uses a dedicated manager whose pool defers task dispatch until the test releases it.
+    // Everything up to the dispatch is then synchronous and deterministic.
+    final DeferredDispatchExecutorService deferredExec = new DeferredDispatchExecutorService();
+    final StorageLocationConfig deferredLocationConfig = new StorageLocationConfig(
+        new File(tempDir, "cache-deferred"),
+        100_000L,
+        null
+    );
+    final SegmentLoaderConfig deferredLoaderConfig = SegmentLoaderConfig.builder()
+                                                                        .locations(deferredLocationConfig)
+                                                                        .virtualStorage(true)
+                                                                        .virtualStorageLoadThreads(1)
+                                                                        .infoDir(new File(tempDir, "info-deferred"))
+                                                                        .build();
+    final List<StorageLocation> deferredLocations = deferredLoaderConfig.toStorageLocations();
+    final StorageLocation deferredLocation = deferredLocations.get(0);
+    final SegmentLocalCacheManager deferredManager = new SegmentLocalCacheManager(
+        deferredLocations,
+        deferredLoaderConfig,
+        new StorageLoadingThreadPool(MoreExecutors.listeningDecorator(deferredExec), new Semaphore(1)),
+        new LeastBytesUsedStorageLocationSelectorStrategy(deferredLocations),
+        TestIndex.INDEX_IO,
+        jsonMapper
+    );
+    try {
+      final DataSegment blocked = makeSegment("queued1");
+
+      // acquire places the hold and submits the load task, but the deferred executor never dispatches it
+      final AcquireSegmentAction blockedAction = deferredManager.acquireSegment(blocked, AcquireMode.FULL);
+      Assertions.assertEquals(1, deferredLocation.getWeakStats().getHoldCount());
+
+      // close before the task can run: the canceler cancels the queued task, claims the pre-placed hold, and
+      // releases it synchronously; the hold release removes the never-mounted weak entry from the cache
+      blockedAction.close();
+      Assertions.assertEquals(0, deferredLocation.getWeakStats().getHoldCount());
+      Assertions.assertNull(
+          deferredLocation.getCacheEntry(new SegmentCacheEntryIdentifier(blocked.getId())),
+          "never-mounted weak entry must be removed when the pre-placed hold is released"
+      );
+
+      // dispatching the (cancelled) task afterwards must be a no-op: the load never runs
+      deferredExec.dispatchAll();
+      Assertions.assertEquals(0, gate("queued1").loadCount.get(), "cancelled queued load must never have started");
+      Assertions.assertEquals(0, deferredLocation.getWeakStats().getHoldCount());
+    }
+    finally {
+      deferredManager.shutdown();
+    }
+  }
+
+  @Test
+  void testCloseDuringLoadDoesNotInterruptRunningTaskAndReleasesHoldsWhenItFinishes() throws Exception
+  {
+    final DataSegment segment = makeSegment("running0");
+    final AcquireSegmentAction action = manager.acquireSegment(segment, AcquireMode.FULL);
+    Assertions.assertTrue(gate("running0").entered.await(10, TimeUnit.SECONDS));
+
+    // close mid-load: cancel(false) must NOT interrupt a running task (interrupting mid-NIO / a deduped mount is
+    // unsafe). The task keeps running.
+    action.close();
+
+    // let the load finish; it must not have observed an interrupt
+    gate("running0").proceed.countDown();
+    Assertions.assertTrue(gate("running0").exited.await(10, TimeUnit.SECONDS));
+    Assertions.assertFalse(gate("running0").sawInterrupt.get(), "a running load must not be interrupted by close");
+
+    // the finished task loses the set() race and closes its own orphaned result, releasing every hold
+    awaitNoWeakHolds();
+    final SegmentCacheEntryIdentifier id = new SegmentCacheEntryIdentifier(segment.getId());
+    final long deadline = System.currentTimeMillis() + 10_000;
+    while (location.getCacheEntry(id) != null && System.currentTimeMillis() < deadline) {
+      location.removeUnheldWeakEntry(id);
+      Thread.sleep(5);
+    }
+    Assertions.assertNull(location.getCacheEntry(id), "orphan-closed entry must be unheld and evictable");
+  }
+
+  @Test
+  void testSetLosesRaceWithCloseClosesOrphanedResult() throws Exception
+  {
+    final DataSegment segment = makeSegment("orphan0");
+    gate("orphan0").blockUninterruptibly = true;
+
+    final AcquireSegmentAction action = manager.acquireSegment(segment, AcquireMode.FULL);
+    Assertions.assertTrue(gate("orphan0").entered.await(10, TimeUnit.SECONDS));
+
+    // close does not stop the running load; the task completes and loses the delivery race with close
+    action.close();
+    gate("orphan0").proceed.countDown();
+    Assertions.assertTrue(gate("orphan0").exited.await(10, TimeUnit.SECONDS));
+
+    // set() returns false to the producer, which closes the orphaned result: segment reference + hold released
+    awaitNoWeakHolds();
+
+    // with no outstanding hold or reference, the mounted weak entry is now evictable
+    final SegmentCacheEntryIdentifier id = new SegmentCacheEntryIdentifier(segment.getId());
+    final long deadline = System.currentTimeMillis() + 10_000;
+    while (location.getCacheEntry(id) != null && System.currentTimeMillis() < deadline) {
+      location.removeUnheldWeakEntry(id);
+      Thread.sleep(5);
+    }
+    Assertions.assertNull(location.getCacheEntry(id), "orphan-closed entry must be unheld and evictable");
+  }
+
+  @Test
+  void testReleaseVersusCloseMatrix() throws Exception
+  {
+    final DataSegment segment = makeSegment("matrix0");
+    gate("matrix0").proceed.countDown();
+
+    // on-demand load, normal release: close after release is a no-op
+    final AcquireSegmentAction action = manager.acquireSegment(segment, AcquireMode.FULL);
+    action.await();
+    final AcquireSegmentResult result = action.release();
+    action.close();
+    Assertions.assertThrows(DruidException.class, action::close, "double close must throw");
+    try (Segment theSegment = result.getSegment().orElseThrow()) {
+      Assertions.assertEquals(segment.getId(), theSegment.getId());
+    }
+    awaitNoWeakHolds();
+
+    // second acquire hits the mounted fast path (completed action, no executor hop): close without release closes
+    // the delivered result, releasing reference + hold
+    final AcquireSegmentAction fastPath = manager.acquireSegment(segment, AcquireMode.FULL);
+    Assertions.assertTrue(fastPath.isReady());
+    Assertions.assertTrue(location.getWeakStats().getHoldCount() > 0);
+    fastPath.close();
+    Assertions.assertEquals(0, location.getWeakStats().getHoldCount());
+    Assertions.assertThrows(DruidException.class, fastPath::release, "release after close must throw");
+  }
+
+  @Test
+  void testMissingSegmentDeliversEmptyWithoutHolds()
+  {
+    final AcquireSegmentAction action = AcquireSegmentAction.missingSegment();
+    Assertions.assertTrue(action.isReady());
+    final AcquireSegmentResult result = action.release();
+    Assertions.assertTrue(result.getSegment().isEmpty());
+    result.close();
+    action.close();
+  }
+
+  @Test
+  void testEmptyDeliveryFromFoldClosesExtraOnClose()
+  {
+    // unit-level coverage of the fold contract: acquireReference(extraOnClose) owns the extra closeable on a miss
+    final AtomicInteger closes = new AtomicInteger();
+    final Closeable hold = closes::incrementAndGet;
+    final SegmentCacheEntry unmounted = new SegmentCacheEntry()
+    {
+      @Override
+      public SegmentId getSegmentId()
+      {
+        return makeSegment("empty0").getId();
+      }
+
+      @Override
+      public Optional<Segment> acquireReference()
+      {
+        return Optional.empty();
+      }
+
+      @Override
+      public void setOnUnmount(Runnable hook)
+      {
+      }
+
+      @Override
+      public boolean isFullyDownloaded()
+      {
+        return false;
+      }
+
+      @Override
+      public CacheEntryIdentifier getId()
+      {
+        return new SegmentCacheEntryIdentifier(getSegmentId());
+      }
+
+      @Override
+      public long getSize()
+      {
+        return 0;
+      }
+
+      @Override
+      public boolean isMounted()
+      {
+        return false;
+      }
+
+      @Override
+      public void mount(StorageLocation location)
+      {
+      }
+
+      @Override
+      public void unmount()
+      {
+      }
+    };
+    Assertions.assertTrue(unmounted.acquireReference(hold).isEmpty());
+    Assertions.assertEquals(1, closes.get(), "fold must close extraOnClose on a miss");
+  }
+
+  @Test
+  void testOnDemandLoadMetrics() throws Exception
+  {
+    final DataSegment segment = makeSegment("metrics0");
+    gate("metrics0").proceed.countDown();
+
+    final AcquireSegmentAction action = manager.acquireSegment(segment, AcquireMode.FULL);
+    action.await();
+    final AcquireSegmentResult result = action.release();
+    Assertions.assertEquals(SEGMENT_SIZE, result.getLoadSizeBytes());
+    Assertions.assertTrue(result.getLoadTimeNanos() > 0, "on-demand load must report load time");
+    Assertions.assertTrue(result.getWaitTimeNanos() >= 0);
+    result.close();
+    awaitNoWeakHolds();
+
+    // mounted fast path reports zero metrics
+    final AcquireSegmentAction fastPath = manager.acquireSegment(segment, AcquireMode.FULL);
+    Assertions.assertTrue(fastPath.isReady());
+    final AcquireSegmentResult fastResult = fastPath.release();
+    Assertions.assertEquals(0, fastResult.getLoadSizeBytes());
+    Assertions.assertEquals(0, fastResult.getLoadTimeNanos());
+    Assertions.assertEquals(0, fastResult.getWaitTimeNanos());
+    fastResult.close();
+    fastPath.close();
+  }
+}

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerConcurrencyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerConcurrencyTest.java
@@ -326,7 +326,7 @@ class SegmentLocalCacheManagerConcurrencyTest
   }
 
   @Test
-  public void testAcquireSegmentOnDemand() throws IOException
+  public void testAcquireSegmentOnDemand() throws IOException, InterruptedException
   {
     final int segmentCount = 100;
     final int iterations = 2000;
@@ -342,7 +342,7 @@ class SegmentLocalCacheManagerConcurrencyTest
   }
 
   @Test
-  public void testAcquireSegmentOnDemandRandomSegment() throws IOException
+  public void testAcquireSegmentOnDemandRandomSegment() throws IOException, InterruptedException
   {
     // moderate number of segments compared to threads, expect to have a decent hit rate
     final int segmentCount = 24;
@@ -360,7 +360,7 @@ class SegmentLocalCacheManagerConcurrencyTest
   }
 
   @Test
-  public void testAcquireSegmentOnDemandRandomSegmentHighHitRate() throws IOException
+  public void testAcquireSegmentOnDemandRandomSegmentHighHitRate() throws IOException, InterruptedException
   {
     // low number of total segments so expect many cache hits and few evictions
     final int segmentCount = 10;
@@ -378,7 +378,7 @@ class SegmentLocalCacheManagerConcurrencyTest
   }
 
   @Test
-  public void testAcquireSegmentOnDemandRandomSegmentNoEvictions() throws IOException
+  public void testAcquireSegmentOnDemandRandomSegmentNoEvictions() throws IOException, InterruptedException
   {
     // low number of total segments so expect many cache hits and few evictions
     final int segmentCount = 8;
@@ -679,7 +679,7 @@ class SegmentLocalCacheManagerConcurrencyTest
       boolean sleepy,
       boolean expectHits,
       boolean expectNoFailures
-  )
+  ) throws InterruptedException
   {
     int totalSuccess = 0;
     int totalFailures = 0;
@@ -1052,12 +1052,9 @@ class SegmentLocalCacheManagerConcurrencyTest
           segmentManager.acquireSegment(segment, AcquireMode.FULL)
       );
       try {
-        final AcquireSegmentResult result =
-            action.getSegmentFuture().get(timeout, TimeUnit.MILLISECONDS);
-        if (result == null) {
-          Assertions.fail("this shouldn't happen");
-        }
-        final Optional<Segment> segment = result.getReferenceProvider().acquireReference().map(closer::register);
+        action.await(timeout);
+        final AcquireSegmentResult result = closer.register(action.release());
+        final Optional<Segment> segment = result.getSegment();
         if (segment.isPresent()) {
           RowCountInspector gadget = segment.get().as(RowCountInspector.class);
           if (delayMin >= 0 && delayMax > 0) {
@@ -1145,15 +1142,15 @@ class SegmentLocalCacheManagerConcurrencyTest
           segmentManager.acquireSegment(segment, AcquireMode.FULL)
       );
       try {
-        final Future<AcquireSegmentResult> result = action.getSegmentFuture();
         Thread.sleep(ThreadLocalRandom.current().nextInt(50));
-        result.cancel(true);
         Thread.currentThread().interrupt();
       }
       catch (Throwable t) {
         throw new RuntimeException(t);
       }
       finally {
+        // closing the un-released action cancels a still-queued load; a running load is left to finish and its
+        // orphaned result is closed when it loses the delivery race (cancel(false) — no interrupt)
         CloseableUtils.closeAndWrapExceptions(closer);
       }
       return null;

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerPartialAcquireTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerPartialAcquireTest.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.ListBasedInputRow;
 import org.apache.druid.data.input.MapBasedInputRow;
@@ -85,7 +84,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -331,31 +329,44 @@ class SegmentLocalCacheManagerPartialAcquireTest
     // header through the same reader the download uses, so warming it means the gate below can only be reached from
     // inside ensureAllDownloaded. A partial acquire downloads nothing else, so no container is resident yet.
     try (AcquireSegmentAction warm = manager.acquireSegment(gatedSegment, AcquireMode.PARTIAL)) {
-      warm.getSegmentFuture().get();
+      warm.await();
+      final StorageLocation location = manager.getLocations().get(0);
 
       final DownloadGate gate = new DownloadGate();
       DOWNLOAD_GATE.set(gate);
       try {
         final AcquireSegmentAction full = manager.acquireSegment(gatedSegment, AcquireMode.FULL);
-        // Held across the close() below: getSegmentFuture() refuses to hand out the future once the action is closed,
-        // and the load task keeps running either way - closing an action cancels the caller's interest, not the task.
-        final ListenableFuture<AcquireSegmentResult> future = full.getSegmentFuture();
 
         Assertions.assertTrue(
             gate.entered.await(60, TimeUnit.SECONDS),
             "the full download should have reached a container fetch"
         );
+        // No container file has finished downloading yet: the first fetch is parked at the gate.
+        final long loadBytesAtGate = location.getWeakStats().getLoadBytes();
 
-        // Abandon the acquire while a fetch is parked mid-write. This closes the action's HoldHolder on THIS thread,
-        // which is what used to unmount the bundles - and evict the containers - out from under the running download.
+        // Abandon the acquire while a fetch is parked mid-write. The load task owns every bundle hold until it
+        // finishes (close cancels the caller's interest, not the running task), so this must not unmount the bundles
+        // - and evict the containers - out from under the running download the way releasing the holds here used to.
         full.close();
         gate.release.countDown();
 
-        // The download must still finish against containers that are all still there. Before the download owned its
-        // own bundle references, this failed: either an NPE from a fetch whose container file had been deleted, or
-        // ensureAllDownloaded's post-condition once the eviction cleared residency behind it.
-        final AcquireSegmentResult result = future.get(60, TimeUnit.SECONDS);
-        Assertions.assertNotNull(result);
+        // The download must still finish against containers that are all still there. Nothing observes the abandoned
+        // result directly (the producer closes it when delivery fails against the closed action), so completion shows
+        // up in the location's load-complete accounting: the gated fetch - exactly where an eviction-under-the-
+        // download used to fail - must complete its container file, and the task's holds must all unwind afterward.
+        final long deadline = System.currentTimeMillis() + 60_000;
+        while (location.getWeakStats().getLoadBytes() <= loadBytesAtGate && System.currentTimeMillis() < deadline) {
+          Thread.sleep(10);
+        }
+        Assertions.assertTrue(
+            location.getWeakStats().getLoadBytes() > loadBytesAtGate,
+            "the abandoned download should still complete container files"
+        );
+        // Only the warm action's metadata hold should remain once the abandoned task unwinds.
+        while (location.getWeakStats().getHoldCount() > 1 && System.currentTimeMillis() < deadline) {
+          Thread.sleep(10);
+        }
+        Assertions.assertEquals(1, location.getWeakStats().getHoldCount(), "task holds did not drain");
       }
       finally {
         DOWNLOAD_GATE.set(null);
@@ -367,8 +378,9 @@ class SegmentLocalCacheManagerPartialAcquireTest
   void testAcquirePartialSegmentReturnsPartialAwareSegment() throws ExecutionException, InterruptedException, IOException
   {
     try (AcquireSegmentAction action = manager.acquireSegment(partialSegment, AcquireMode.PARTIAL)) {
-      final AcquireSegmentResult result = action.getSegmentFuture().get();
-      try (Segment segment = result.getReferenceProvider().acquireReference().orElseThrow()) {
+      action.await();
+      final AcquireSegmentResult result = action.release();
+      try (Segment segment = result.getSegment().orElseThrow()) {
         Assertions.assertEquals(SEGMENT_ID, segment.getId());
         Assertions.assertInstanceOf(PartialQueryableIndexSegment.class, segment);
 
@@ -388,8 +400,9 @@ class SegmentLocalCacheManagerPartialAcquireTest
       throws ExecutionException, InterruptedException, IOException
   {
     try (AcquireSegmentAction action = manager.acquireSegment(partialSegment, AcquireMode.PARTIAL)) {
-      final AcquireSegmentResult result = action.getSegmentFuture().get();
-      try (Segment segment = result.getReferenceProvider().acquireReference().orElseThrow()) {
+      action.await();
+      final AcquireSegmentResult result = action.release();
+      try (Segment segment = result.getSegment().orElseThrow()) {
         final CursorFactory factory = segment.as(CursorFactory.class);
         Assertions.assertNotNull(factory);
         // Drive the async path; with the manager's executor the future will complete in the background.
@@ -419,7 +432,8 @@ class SegmentLocalCacheManagerPartialAcquireTest
     // A lazy (PARTIAL) acquire mounts only the metadata entry (downloads the header); bundles stay lazy until a cursor
     // is built, so exactly one weak reservation + one weak load is expected.
     try (AcquireSegmentAction action = manager.acquireSegment(partialSegment, AcquireMode.PARTIAL)) {
-      try (Segment ignored = action.getSegmentFuture().get().getReferenceProvider().acquireReference().orElseThrow()) {
+      action.await();
+      try (Segment ignored = action.release().getSegment().orElseThrow()) {
         final StorageLocation.WeakStats stats = loc.getWeakStats();
 
         // The header download is recorded as an actual load (previously partial mounts recorded no load at all).
@@ -446,7 +460,8 @@ class SegmentLocalCacheManagerPartialAcquireTest
   void testSecondAcquireReturnsCachedSegment() throws ExecutionException, InterruptedException, IOException
   {
     try (AcquireSegmentAction first = manager.acquireSegment(partialSegment, AcquireMode.PARTIAL)) {
-      try (Segment ignored = first.getSegmentFuture().get().getReferenceProvider().acquireReference().orElseThrow()) {
+      first.await();
+      try (Segment ignored = first.release().getSegment().orElseThrow()) {
         // entry is registered + mounted
       }
     }
@@ -473,13 +488,14 @@ class SegmentLocalCacheManagerPartialAcquireTest
     final long initialHoldBytes = loc.getWeakStats().getHoldBytes();
 
     try (AcquireSegmentAction action = manager.acquireSegment(partialSegment, AcquireMode.PARTIAL)) {
-      final AcquireSegmentResult result = action.getSegmentFuture().get();
-      // The action holds a SIEVE-protective hold on the metadata entry for its entire lifetime.
+      action.await();
+      final AcquireSegmentResult result = action.release();
+      // The acquire folds a SIEVE-protective hold on the metadata entry into the delivered segment's close.
       Assertions.assertTrue(
           loc.getWeakStats().getHoldBytes() > initialHoldBytes,
-          "metadata storage-location hold must be active for the acquire action's lifetime"
+          "metadata storage-location hold must be active while the delivered segment is open"
       );
-      try (Segment segment = result.getReferenceProvider().acquireReference().orElseThrow()) {
+      try (Segment segment = result.getSegment().orElseThrow()) {
         try (var asyncHolder = segment.as(CursorFactory.class).makeCursorHolderAsync(CursorBuildSpec.FULL_SCAN)) {
           final CountDownLatch ready = new CountDownLatch(1);
           asyncHolder.addReadyCallback(ready::countDown);
@@ -513,8 +529,9 @@ class SegmentLocalCacheManagerPartialAcquireTest
       throws ExecutionException, InterruptedException, IOException
   {
     try (AcquireSegmentAction action = manager.acquireSegment(partialSegment, AcquireMode.PARTIAL)) {
-      final AcquireSegmentResult result = action.getSegmentFuture().get();
-      try (Segment segment = result.getReferenceProvider().acquireReference().orElseThrow()) {
+      action.await();
+      final AcquireSegmentResult result = action.release();
+      try (Segment segment = result.getSegment().orElseThrow()) {
         // base-table cursor: drives the base bundle to mount via the cache layer
         final CursorBuildSpec scanSpec = CursorBuildSpec.FULL_SCAN;
         try (var asyncHolder = segment.as(CursorFactory.class).makeCursorHolderAsync(scanSpec)) {
@@ -551,8 +568,9 @@ class SegmentLocalCacheManagerPartialAcquireTest
                    .size(0)
                    .build();
     try (AcquireSegmentAction action = manager.acquireSegment(clusteredSegment, AcquireMode.PARTIAL)) {
-      final AcquireSegmentResult result = action.getSegmentFuture().get();
-      try (Segment segment = result.getReferenceProvider().acquireReference().orElseThrow()) {
+      action.await();
+      final AcquireSegmentResult result = action.release();
+      try (Segment segment = result.getSegment().orElseThrow()) {
         Assertions.assertEquals(CLUSTERED_SEGMENT_ID, segment.getId());
 
         // group-by tenant + sum(x) matches the aggregate projection. Building this cursor drives the 'proj' bundle to
@@ -605,8 +623,9 @@ class SegmentLocalCacheManagerPartialAcquireTest
     final PartialSegmentBundleCacheEntryIdentifier aggBundleId =
         new PartialSegmentBundleCacheEntryIdentifier(SEGMENT_ID, AGG_BUNDLE);
     try (AcquireSegmentAction action = manager.acquireSegment(partialSegment, AcquireMode.FULL)) {
-      final AcquireSegmentResult result = action.getSegmentFuture().get();
-      try (Segment segment = result.getReferenceProvider().acquireReference().orElseThrow()) {
+      action.await();
+      final AcquireSegmentResult result = action.release();
+      try (Segment segment = result.getSegment().orElseThrow()) {
         Assertions.assertInstanceOf(PartialQueryableIndexSegment.class, segment);
 
         // Sync makeCursorHolder must succeed, everything was force-downloaded during acquire.
@@ -641,13 +660,61 @@ class SegmentLocalCacheManagerPartialAcquireTest
   }
 
   @Test
+  void testFullAcquireBundleHoldsSurviveActionCloseUntilSegmentClose()
+      throws ExecutionException, InterruptedException, IOException
+  {
+    // The FULL acquire folds the metadata hold + every bundle hold into the delivered segment's close, so releasing
+    // the result and closing the action must NOT release the pins: they live exactly as long as the segment, which
+    // is what the sync cursor factory's isFullyDownloaded() expectation needs under SIEVE eviction pressure.
+    final StorageLocation loc = manager.getLocations().get(0);
+    final PartialSegmentBundleCacheEntryIdentifier baseBundleId =
+        new PartialSegmentBundleCacheEntryIdentifier(SEGMENT_ID, Projections.BASE_TABLE_PROJECTION_NAME);
+    final PartialSegmentBundleCacheEntryIdentifier aggBundleId =
+        new PartialSegmentBundleCacheEntryIdentifier(SEGMENT_ID, AGG_BUNDLE);
+
+    final AcquireSegmentAction action = manager.acquireSegment(partialSegment, AcquireMode.FULL);
+    action.await();
+    final AcquireSegmentResult result = action.release();
+    action.close();
+
+    try (Segment segment = result.getSegment().orElseThrow()) {
+      // Simulate SIEVE eviction under cache pressure: the pins held by the segment must keep the bundles in place
+      // even though the action is long gone.
+      loc.removeUnheldWeakEntry(baseBundleId);
+      loc.removeUnheldWeakEntry(aggBundleId);
+      Assertions.assertTrue(
+          loc.isWeakReserved(baseBundleId),
+          "base bundle pin must survive action close while the segment is open"
+      );
+      Assertions.assertTrue(
+          loc.isWeakReserved(aggBundleId),
+          "agg bundle pin must survive action close while the segment is open"
+      );
+      Assertions.assertTrue(loc.getWeakStats().getHoldBytes() > 0, "segment must hold the bundles it mounted");
+
+      // Still fully resident, so the sync cursor factory succeeds.
+      try (CursorHolder holder = segment.as(CursorFactory.class).makeCursorHolder(CursorBuildSpec.FULL_SCAN)) {
+        Assertions.assertNotNull(holder);
+      }
+    }
+
+    // After the segment closes, everything is unheld and free to reclaim (child-before-parent: the agg bundle holds
+    // the base bundle, so the base stays reserved until the agg is gone).
+    loc.removeUnheldWeakEntry(aggBundleId);
+    Assertions.assertFalse(loc.isWeakReserved(aggBundleId), "agg bundle evictable once the segment closes");
+    loc.removeUnheldWeakEntry(baseBundleId);
+    Assertions.assertFalse(loc.isWeakReserved(baseBundleId), "base bundle evictable once the agg bundle is gone");
+  }
+
+  @Test
   void testLazyColumnDownloadsAreRecordedInWeakLoadStats()
       throws ExecutionException, InterruptedException, IOException
   {
     final StorageLocation loc = manager.getLocations().get(0);
     try (AcquireSegmentAction action = manager.acquireSegment(partialSegment, AcquireMode.PARTIAL)) {
-      final AcquireSegmentResult result = action.getSegmentFuture().get();
-      try (Segment segment = result.getReferenceProvider().acquireReference().orElseThrow()) {
+      action.await();
+      final AcquireSegmentResult result = action.release();
+      try (Segment segment = result.getSegment().orElseThrow()) {
         // After a lazy mount only the metadata header has been pulled; no column files yet.
         final long headerLoadBytes = loc.getWeakStats().getLoadBytes();
         Assertions.assertTrue(headerLoadBytes > 0, "lazy mount records the header load");
@@ -718,7 +785,8 @@ class SegmentLocalCacheManagerPartialAcquireTest
       // Fully download + mount, then release the eager acquire so the bundles become unheld (resident but evictable) —
       // the state a previously-queried segment is in when the next query's acquireCachedSegment(FULL) finds it.
       try (AcquireSegmentAction action = plain.acquireSegment(partialSegment, AcquireMode.FULL)) {
-        action.getSegmentFuture().get();
+        // closing the un-released action closes the delivered segment, releasing every hold placed by the acquire
+        action.await();
       }
       Assertions.assertTrue(loc.isWeakReserved(baseBundleId), "base bundle resident after eager acquire");
       Assertions.assertTrue(loc.isWeakReserved(aggBundleId), "agg bundle resident after eager acquire");
@@ -780,8 +848,9 @@ class SegmentLocalCacheManagerPartialAcquireTest
 
     try {
       try (AcquireSegmentAction action = disabledManager.acquireSegment(partialSegment, AcquireMode.PARTIAL)) {
-        final AcquireSegmentResult result = action.getSegmentFuture().get();
-        try (Segment segment = result.getReferenceProvider().acquireReference().orElseThrow()) {
+        action.await();
+        final AcquireSegmentResult result = action.release();
+        try (Segment segment = result.getSegment().orElseThrow()) {
           Assertions.assertEquals(SEGMENT_ID, segment.getId());
           Assertions.assertFalse(
               segment instanceof PartialQueryableIndexSegment,
@@ -1030,22 +1099,34 @@ class SegmentLocalCacheManagerPartialAcquireTest
     final StorageLocation location = manager.getLocations().get(0);
     final SegmentCacheEntryIdentifier id = new SegmentCacheEntryIdentifier(SEGMENT_ID);
 
-    // Two acquires holding the same freshly reserved entry, neither of which resolves its future, so nothing mounts
-    // it. The acquire that created the entry gives up first - a canceled or timed out query, say.
+    // Two acquires holding the same freshly reserved entry. The acquire that created the entry gives up first - a
+    // canceled or timed out query, say - and its hold release (which happens when its load task unwinds, since the
+    // task owns the hold for its whole run) must not remove the entry out from under the second acquire.
     final PartialSegmentMetadataCacheEntry entry;
     final Closer acquires = Closer.create();
     try {
-      // The first acquire reserves the entry; the second joins it. Both are registered with the closer so a failed
-      // assertion cannot leak a hold into the shared manager fixture; AcquireSegmentAction.close() is idempotent, so
-      // closing the first one early below is safe.
-      final AcquireSegmentAction creator = acquires.register(
-          manager.acquireSegment(partialSegment, AcquireMode.PARTIAL)
+      // Only the second acquire is registered with the closer (so a failed assertion cannot leak a hold into the
+      // shared manager fixture); the first is closed early below, and close() is deliberately not idempotent, so it
+      // must not also be registered.
+      final AcquireSegmentAction creator = manager.acquireSegment(partialSegment, AcquireMode.PARTIAL);
+      try {
+        acquires.register(manager.acquireSegment(partialSegment, AcquireMode.PARTIAL));
+        entry = Assertions.assertInstanceOf(PartialSegmentMetadataCacheEntry.class, location.getCacheEntry(id));
+      }
+      finally {
+        creator.close();
+      }
+      // The abandoned acquire's hold releases asynchronously (its load task either never runs, or finishes and finds
+      // no one to deliver to), so wait for it to actually let go before asserting the entry survived.
+      final long deadline = System.currentTimeMillis() + 30_000;
+      while (location.getWeakStats().getHoldCount() > 1 && System.currentTimeMillis() < deadline) {
+        Thread.sleep(5);
+      }
+      Assertions.assertEquals(
+          1,
+          location.getWeakStats().getHoldCount(),
+          "the abandoned acquire's hold should release once its task unwinds"
       );
-      acquires.register(manager.acquireSegment(partialSegment, AcquireMode.PARTIAL));
-      entry = Assertions.assertInstanceOf(PartialSegmentMetadataCacheEntry.class, location.getCacheEntry(id));
-      Assertions.assertFalse(entry.isMounted());
-
-      creator.close();
       Assertions.assertSame(
           entry,
           location.getCacheEntry(id),
@@ -1056,14 +1137,15 @@ class SegmentLocalCacheManagerPartialAcquireTest
       acquires.close();
     }
     // The second acquire letting go does not remove it either - removal is the creating hold's job - so it is left
-    // registered and unmounted, reclaimable, and reusable by the next acquire.
+    // registered, reclaimable, and reusable by the next acquire. (The abandoned acquires' background tasks may or may
+    // not have mounted it already; either way the acquire below is served from this same entry.)
     Assertions.assertSame(entry, location.getCacheEntry(id));
-    Assertions.assertFalse(entry.isMounted());
 
     // A later acquire mounts that same entry and serves the segment from it.
     try (AcquireSegmentAction action = manager.acquireSegment(partialSegment, AcquireMode.PARTIAL)) {
-      final AcquireSegmentResult result = action.getSegmentFuture().get();
-      try (Segment segment = result.getReferenceProvider().acquireReference().orElseThrow()) {
+      action.await();
+      final AcquireSegmentResult result = action.release();
+      try (Segment segment = result.getSegment().orElseThrow()) {
         Assertions.assertEquals(SEGMENT_ID, segment.getId());
         final TimeBoundaryInspector inspector = segment.as(TimeBoundaryInspector.class);
         Assertions.assertNotNull(inspector);
@@ -1072,136 +1154,6 @@ class SegmentLocalCacheManagerPartialAcquireTest
       }
       Assertions.assertSame(entry, location.getCacheEntry(id));
       Assertions.assertTrue(entry.isMounted());
-    }
-  }
-
-  @Test
-  void testAbandonedAcquireWhoseMountFailsResolvesToAnUnavailableSegmentToo() throws Exception
-  {
-    // Deep storage that can produce a range reader now but not serve a read later: openRangeReader() checks the V10
-    // file at acquire time, and the test deletes it before the load task gets to run.
-    final File vanishingStorage = temporaryFolder.newFolder("vanishing_storage");
-    final File v10File = new File(vanishingStorage, IndexIO.V10_FILE_NAME);
-    Files.copy(new File(DEEP_STORAGE_DIR, IndexIO.V10_FILE_NAME).toPath(), v10File.toPath());
-    final DataSegment vanishingSegment = DataSegment.builder(SEGMENT_ID)
-                                                    .shardSpec(NoneShardSpec.instance())
-                                                    .loadSpec(Map.of("type", "local", "path", vanishingStorage.getAbsolutePath()))
-                                                    .size(0)
-                                                    .build();
-
-    final File gatedCacheRoot = temporaryFolder.newFolder("gated_cache_mount_failure");
-    final SegmentLoaderConfig gatedConfig = SegmentLoaderConfig.builder()
-        .locations(new StorageLocationConfig(gatedCacheRoot, 1024L * 1024L * 1024L, null))
-        .virtualStorage(true)
-        .virtualStoragePartialDownloadsEnabled(true)
-        .virtualStorageUseVirtualThreads(false)
-        .virtualStorageLoadThreads(1)
-        .build();
-    final List<StorageLocation> storageLocations = gatedConfig.toStorageLocations();
-    final StorageLoadingThreadPool gatedPool = StorageLoadingThreadPool.createFromConfig(gatedConfig);
-    final SegmentLocalCacheManager gatedManager = new SegmentLocalCacheManager(
-        storageLocations,
-        gatedConfig,
-        gatedPool,
-        new LeastBytesUsedStorageLocationSelectorStrategy(storageLocations),
-        TestHelper.getTestIndexIO(jsonMapper, ColumnConfig.DEFAULT),
-        jsonMapper
-    );
-
-    final CountDownLatch atGate = new CountDownLatch(1);
-    final CountDownLatch openGate = new CountDownLatch(1);
-    try {
-      // (intentionally unused) local so errorprone's CheckReturnValue is satisfied
-      @SuppressWarnings("unused")
-      ListenableFuture<?> unused = gatedPool.getExecutorService().submit(() -> {
-        atGate.countDown();
-        return openGate.await(30, TimeUnit.SECONDS);
-      });
-      Assertions.assertTrue(atGate.await(30, TimeUnit.SECONDS), "loading thread must reach the gate");
-
-      final ListenableFuture<AcquireSegmentResult> future;
-      try (AcquireSegmentAction action = gatedManager.acquireSegment(vanishingSegment, AcquireMode.PARTIAL)) {
-        future = action.getSegmentFuture();
-      }
-      // The mount will now fail on its header read rather than rolling back cleanly, so the loss surfaces from
-      // mount() instead of from the pin - which is no reason to fail a query that has already given up.
-      Assertions.assertTrue(v10File.delete(), "test needs the deep-storage file gone before the mount runs");
-      openGate.countDown();
-
-      final AcquireSegmentResult result = future.get(30, TimeUnit.SECONDS);
-      Assertions.assertTrue(
-          result.getReferenceProvider().acquireReference().isEmpty(),
-          "an abandoned acquire whose mount failed must resolve to an unavailable segment"
-      );
-    }
-    finally {
-      openGate.countDown();
-      gatedManager.drop(vanishingSegment);
-      gatedManager.shutdown();
-      gatedPool.stop();
-    }
-  }
-
-  @Test
-  void testAbandonedAcquireResolvesToAnUnavailableSegmentRatherThanFailing() throws Exception
-  {
-    // One fixed loading thread, so the test can hold the load task at a gate while it abandons the acquire.
-    final File gatedCacheRoot = temporaryFolder.newFolder("gated_cache");
-    final SegmentLoaderConfig gatedConfig = SegmentLoaderConfig.builder()
-        .locations(new StorageLocationConfig(gatedCacheRoot, 1024L * 1024L * 1024L, null))
-        .virtualStorage(true)
-        .virtualStoragePartialDownloadsEnabled(true)
-        .virtualStorageUseVirtualThreads(false)
-        .virtualStorageLoadThreads(1)
-        .build();
-    final List<StorageLocation> storageLocations = gatedConfig.toStorageLocations();
-    final StorageLoadingThreadPool gatedPool = StorageLoadingThreadPool.createFromConfig(gatedConfig);
-    final SegmentLocalCacheManager gatedManager = new SegmentLocalCacheManager(
-        storageLocations,
-        gatedConfig,
-        gatedPool,
-        new LeastBytesUsedStorageLocationSelectorStrategy(storageLocations),
-        TestHelper.getTestIndexIO(jsonMapper, ColumnConfig.DEFAULT),
-        jsonMapper
-    );
-
-    final CountDownLatch atGate = new CountDownLatch(1);
-    final CountDownLatch openGate = new CountDownLatch(1);
-    try {
-      // (intentionally unused) local so errorprone's CheckReturnValue is satisfied
-      @SuppressWarnings("unused")
-      ListenableFuture<?> unused = gatedPool.getExecutorService().submit(() -> {
-        atGate.countDown();
-        return openGate.await(30, TimeUnit.SECONDS);
-      });
-      Assertions.assertTrue(atGate.await(30, TimeUnit.SECONDS), "loading thread must reach the gate");
-
-      // Start the acquire (its load task queues behind the gate) and then abandon it (like a canceled or timed
-      // out query does); closing the action releases the hold that was keeping the reserved entry resident.
-      final ListenableFuture<AcquireSegmentResult> future;
-      try (AcquireSegmentAction action = gatedManager.acquireSegment(partialSegment, AcquireMode.PARTIAL)) {
-        future = action.getSegmentFuture();
-      }
-      openGate.countDown();
-
-      // The task now mounts an entry the location no longer knows about, so it can never pin it. Nothing is waiting
-      // on the result, and a segment that is not there is not a reason to fail a query.
-      final AcquireSegmentResult result = future.get(30, TimeUnit.SECONDS);
-      Assertions.assertTrue(
-          result.getReferenceProvider().acquireReference().isEmpty(),
-          "an abandoned acquire must resolve to an unavailable segment"
-      );
-      Assertions.assertNull(
-          gatedManager.getLocations().get(0).getCacheEntry(new SegmentCacheEntryIdentifier(SEGMENT_ID)),
-          "the abandoned entry must not be left behind in the cache"
-      );
-    }
-    finally {
-      openGate.countDown();
-      gatedManager.drop(partialSegment);
-      gatedManager.shutdown();
-      // shutdown() only stops the manager's own executor; the loading pool is stopped through its lifecycle hook
-      gatedPool.stop();
     }
   }
 

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLocalCacheManagerTest.java
@@ -917,8 +917,9 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
     Assertions.assertNull(manager.getSegmentFiles(segmentToLoad));
     Assertions.assertFalse(manager.acquireCachedSegment(segmentToLoad.getId(), AcquireMode.FULL).isPresent());
     AcquireSegmentAction segmentAction = manager.acquireSegment(segmentToLoad, AcquireMode.FULL);
-    AcquireSegmentResult result = segmentAction.getSegmentFuture().get();
-    Optional<Segment> theSegment = result.getReferenceProvider().acquireReference();
+    segmentAction.await();
+    AcquireSegmentResult result = segmentAction.release();
+    Optional<Segment> theSegment = result.getSegment();
     Assertions.assertTrue(theSegment.isPresent());
     Assertions.assertNotNull(manager.getSegmentFiles(segmentToLoad));
     Assertions.assertEquals(segmentToLoad.getId(), theSegment.get().getId());
@@ -932,8 +933,9 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
 
     // can actually load them again because load doesn't really do anything
     AcquireSegmentAction segmentActionAfterDrop = manager.acquireSegment(segmentToLoad, AcquireMode.FULL);
-    AcquireSegmentResult resultAfterDrop = segmentActionAfterDrop.getSegmentFuture().get();
-    Optional<Segment> theSegmentAfterDrop = resultAfterDrop.getReferenceProvider().acquireReference();
+    segmentActionAfterDrop.await();
+    AcquireSegmentResult resultAfterDrop = segmentActionAfterDrop.release();
+    Optional<Segment> theSegmentAfterDrop = resultAfterDrop.getSegment();
     Assertions.assertTrue(theSegmentAfterDrop.isPresent());
     Assertions.assertNotNull(manager.getSegmentFiles(segmentToLoad));
     Assertions.assertEquals(segmentToLoad.getId(), theSegmentAfterDrop.get().getId());
@@ -944,8 +946,13 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
   }
 
   @Test
-  public void testAcquireExistingSegmentDroppedBeforeSupplierRunsReportsAbsent() throws Exception
+  public void testAcquireExistingSegmentRacingDropDoesNotExplode() throws Exception
   {
+    // The acquire takes the segment reference eagerly at acquireSegment() time now (there is no separate supplier
+    // step), so a drop can only land before or after the acquire. Before: the dropped segment must be reported
+    // absent (empty result) rather than NPE or reload. After: the eagerly-taken reference must keep the segment
+    // usable despite the drop. (acquireReference re-reads referenceProvider under the entry lock, so the old
+    // dropped-between-check-and-read NPE cannot recur.)
     final DataSegment segmentToLoad = makeTestDataSegment(segmentDeepStorageDir);
     final File localSegmentFile = new File(segmentDeepStorageDir, TEST_DATA_RELATIVE_PATH);
     makeSegmentZip(
@@ -956,22 +963,29 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
     manager.load(segmentToLoad);
     Assertions.assertTrue(manager.isSegmentCached(segmentToLoad), "segment should be cached (static, mounted) after load");
 
-    // Take the already-loaded fast path, but do NOT invoke the supplier yet (getSegmentFuture() is what runs it).
-    final AcquireSegmentAction action = manager.acquireSegment(segmentToLoad, AcquireMode.FULL);
+    // acquire-then-drop: the reference taken at acquire time protects the segment across the drop
+    final AcquireSegmentAction actionBeforeDrop = manager.acquireSegment(segmentToLoad, AcquireMode.FULL);
+    actionBeforeDrop.await();
+    final AcquireSegmentResult resultBeforeDrop = actionBeforeDrop.release();
+    final Optional<Segment> segmentBeforeDrop = resultBeforeDrop.getSegment();
+    Assertions.assertTrue(segmentBeforeDrop.isPresent());
 
-    // Drop the segment: for a static entry release() unmounts it immediately, nulling referenceProvider out from
-    // under the still-outstanding (no-op) hold.
     manager.drop(segmentToLoad);
 
-    // Invoking the supplier now must not NPE; the segment is reported absent (empty) instead.
-    final AcquireSegmentResult result = action.getSegmentFuture().get();
-    Assertions.assertNotNull(result.getReferenceProvider(), "reference provider must never be null");
-    Assertions.assertFalse(
-        result.getReferenceProvider().acquireReference().isPresent(),
-        "a segment dropped before the supplier ran should be reported absent"
-    );
+    Assertions.assertEquals(segmentToLoad.getId(), segmentBeforeDrop.get().getId());
+    Assertions.assertEquals(segmentToLoad.getInterval(), segmentBeforeDrop.get().getDataInterval());
+    segmentBeforeDrop.get().close();
+    actionBeforeDrop.close();
 
-    action.close();
+    // drop-then-acquire: the dropped segment is reported absent (empty), not an NPE and not a reload
+    final AcquireSegmentAction actionAfterDrop = manager.acquireSegment(segmentToLoad, AcquireMode.FULL);
+    actionAfterDrop.await();
+    final AcquireSegmentResult resultAfterDrop = actionAfterDrop.release();
+    Assertions.assertFalse(
+        resultAfterDrop.getSegment().isPresent(),
+        "a segment dropped before the acquire should be reported absent"
+    );
+    actionAfterDrop.close();
   }
 
   @Test
@@ -1029,8 +1043,9 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
     Assertions.assertNull(manager.getSegmentFiles(segmentToBootstrap));
     Assertions.assertFalse(manager.acquireCachedSegment(segmentToBootstrap.getId(), AcquireMode.FULL).isPresent());
     AcquireSegmentAction segmentAction = manager.acquireSegment(segmentToBootstrap, AcquireMode.FULL);
-    AcquireSegmentResult result = segmentAction.getSegmentFuture().get();
-    Optional<Segment> theSegment = result.getReferenceProvider().acquireReference();
+    segmentAction.await();
+    AcquireSegmentResult result = segmentAction.release();
+    Optional<Segment> theSegment = result.getSegment();
     Assertions.assertTrue(theSegment.isPresent());
     Assertions.assertNotNull(manager.getSegmentFiles(segmentToBootstrap));
     Assertions.assertEquals(segmentToBootstrap.getId(), theSegment.get().getId());
@@ -1046,8 +1061,9 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
     // can actually load them again because bootstrap doesn't really do anything unless the segment is already
     // present in the cache
     AcquireSegmentAction segmentActionAfterDrop = manager.acquireSegment(segmentToBootstrap, AcquireMode.FULL);
-    AcquireSegmentResult resultAfterDrop = segmentActionAfterDrop.getSegmentFuture().get();
-    Optional<Segment> theSegmentAfterDrop = resultAfterDrop.getReferenceProvider().acquireReference();
+    segmentActionAfterDrop.await();
+    AcquireSegmentResult resultAfterDrop = segmentActionAfterDrop.release();
+    Optional<Segment> theSegmentAfterDrop = resultAfterDrop.getSegment();
     Assertions.assertTrue(theSegmentAfterDrop.isPresent());
     Assertions.assertNotNull(manager.getSegmentFiles(segmentToBootstrap));
     Assertions.assertEquals(segmentToBootstrap.getId(), theSegmentAfterDrop.get().getId());
@@ -1127,8 +1143,9 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
     // reference which was originally cached and then dropped before attempting to acquire a segment. if virtual storage
     // is not enabled, this should return a missing segment instead of downloading
     AcquireSegmentAction segmentAction = manager.acquireSegment(segmentToLoad, AcquireMode.FULL);
-    AcquireSegmentResult result = segmentAction.getSegmentFuture().get();
-    Optional<Segment> theSegment = result.getReferenceProvider().acquireReference();
+    segmentAction.await();
+    AcquireSegmentResult result = segmentAction.release();
+    Optional<Segment> theSegment = result.getSegment();
     Assertions.assertFalse(theSegment.isPresent());
     segmentAction.close();
 
@@ -1171,9 +1188,10 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
     Assertions.assertThrows(DruidException.class, () -> manager.acquireSegment(cannotLoad, AcquireMode.FULL));
 
     // and we can still mount and use the segment we are holding
-    AcquireSegmentResult result = segmentAction.getSegmentFuture().get();
+    segmentAction.await();
+    AcquireSegmentResult result = segmentAction.release();
     Assertions.assertNotNull(result);
-    Optional<Segment> theSegment = result.getReferenceProvider().acquireReference();
+    Optional<Segment> theSegment = result.getSegment();
     Assertions.assertTrue(theSegment.isPresent());
     Assertions.assertNotNull(manager.getSegmentFiles(segmentToLoad));
     Assertions.assertEquals(segmentToLoad.getId(), theSegment.get().getId());
@@ -1186,8 +1204,9 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
     createSegmentZipInLocation(segmentDeepStorageDir, TEST_DATA_RELATIVE_PATH_2);
     manager.load(cannotLoad);
     AcquireSegmentAction segmentActionAfterDrop = manager.acquireSegment(cannotLoad, AcquireMode.FULL);
-    AcquireSegmentResult resultDrop = segmentActionAfterDrop.getSegmentFuture().get();
-    Optional<Segment> theSegmentAfterDrop = resultDrop.getReferenceProvider().acquireReference();
+    segmentActionAfterDrop.await();
+    AcquireSegmentResult resultDrop = segmentActionAfterDrop.release();
+    Optional<Segment> theSegmentAfterDrop = resultDrop.getSegment();
     Assertions.assertTrue(theSegmentAfterDrop.isPresent());
     Assertions.assertNotNull(manager.getSegmentFiles(cannotLoad));
     Assertions.assertEquals(cannotLoad.getId(), theSegmentAfterDrop.get().getId());
@@ -1224,8 +1243,9 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
 
     // Acquire the segment (load() is not allowed with evictImmediately)
     AcquireSegmentAction segmentAction = manager.acquireSegment(segmentToLoad, AcquireMode.FULL);
-    AcquireSegmentResult result = segmentAction.getSegmentFuture().get();
-    Optional<Segment> theSegment = result.getReferenceProvider().acquireReference();
+    segmentAction.await();
+    AcquireSegmentResult result = segmentAction.release();
+    Optional<Segment> theSegment = result.getSegment();
     Assertions.assertTrue(theSegment.isPresent());
     Assertions.assertNotNull(manager.getSegmentFiles(segmentToLoad));
     Assertions.assertEquals(segmentToLoad.getId(), theSegment.get().getId());
@@ -1251,8 +1271,9 @@ public class SegmentLocalCacheManagerTest extends InitializedNullHandlingTest
 
     // Verify the segment can be loaded again if needed
     AcquireSegmentAction segmentActionAfterEvict = manager.acquireSegment(segmentToLoad, AcquireMode.FULL);
-    AcquireSegmentResult resultAfterEvict = segmentActionAfterEvict.getSegmentFuture().get();
-    Optional<Segment> theSegmentAfterEvict = resultAfterEvict.getReferenceProvider().acquireReference();
+    segmentActionAfterEvict.await();
+    AcquireSegmentResult resultAfterEvict = segmentActionAfterEvict.release();
+    Optional<Segment> theSegmentAfterEvict = resultAfterEvict.getSegment();
     Assertions.assertTrue(theSegmentAfterEvict.isPresent());
     Assertions.assertNotNull(manager.getSegmentFiles(segmentToLoad));
     Assertions.assertEquals(segmentToLoad.getId(), theSegmentAfterEvict.get().getId());

--- a/server/src/test/java/org/apache/druid/server/SegmentManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/SegmentManagerTest.java
@@ -461,7 +461,9 @@ public class SegmentManagerTest extends InitializedNullHandlingTest
     );
 
     final AcquireSegmentAction action = virtualSegmentManager.acquireSegment(toLoad, AcquireMode.FULL);
-    AcquireSegmentResult result = action.getSegmentFuture().get();
+    // await but do not release or close: the un-released action keeps the delivered segment reference open so the
+    // entry remains cached for the getSegmentsBundle call below
+    AcquireSegmentResult result = action.await();
     Assertions.assertNotNull(result);
     Assertions.assertEquals(1L, result.getLoadSizeBytes());
     Assertions.assertTrue(result.getLoadTimeNanos() > 0);

--- a/server/src/test/java/org/apache/druid/test/utils/TestSegmentCacheManager.java
+++ b/server/src/test/java/org/apache/druid/test/utils/TestSegmentCacheManager.java
@@ -21,7 +21,6 @@ package org.apache.druid.test.utils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.util.concurrent.Futures;
 import org.apache.druid.java.util.common.MapUtils;
 import org.apache.druid.segment.ReferenceCountedSegmentProvider;
 import org.apache.druid.segment.Segment;
@@ -162,9 +161,8 @@ public class TestSegmentCacheManager extends NoopSegmentCacheManager
     if (observedSegmentsRemovedFromCache.contains(dataSegment.getId())) {
       return AcquireSegmentAction.missingSegment();
     }
-    return new AcquireSegmentAction(
-        () -> Futures.immediateFuture(AcquireSegmentResult.cached(getSegmentInternal(dataSegment))),
-        null
+    return AcquireSegmentAction.completed(
+        AcquireSegmentResult.of(getSegmentInternal(dataSegment).acquireReference())
     );
   }
 


### PR DESCRIPTION
### Description
Exploration in replacing Future with AsyncResource for acquiring segment references and MSQ processing. 