### PR TITLE
pac4j: restore profile attributes in AuthenticationResult context

### DIFF
--- a/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jFilter.java
+++ b/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jFilter.java
@@ -25,7 +25,9 @@ import org.apache.druid.server.security.AuthenticationResult;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.engine.DefaultCallbackLogic;
 import org.pac4j.core.engine.DefaultSecurityLogic;
+import org.pac4j.core.engine.SecurityLogic;
 import org.pac4j.core.exception.http.HttpAction;
+import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.jee.context.JEEContext;
 import org.pac4j.jee.http.adapter.JEEHttpActionAdapter;
 
@@ -38,6 +40,8 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
 
 public class Pac4jFilter implements Filter
 {
@@ -99,7 +103,7 @@ public class Pac4jFilter implements Filter
               null
       );
     } else {
-      DefaultSecurityLogic securityLogic = new DefaultSecurityLogic();
+      SecurityLogic securityLogic = createSecurityLogic();
       try {
         securityLogic.perform(
             context,
@@ -109,9 +113,14 @@ public class Pac4jFilter implements Filter
               try {
                 // Extract user ID from pac4j profiles and create AuthenticationResult
                 if (profiles != null && !profiles.isEmpty()) {
-                  String uid = profiles.iterator().next().getId();
+                  CommonProfile profile = (CommonProfile) profiles.iterator().next();
+                  String uid = profile.getId();
                   if (uid != null) {
-                    AuthenticationResult authenticationResult = new AuthenticationResult(uid, authorizerName, name, null);
+                    Map<String, Object> authContext = Collections.singletonMap(
+                        "profile",
+                        Collections.singletonMap("attributes", profile.getAttributes())
+                    );
+                    AuthenticationResult authenticationResult = new AuthenticationResult(uid, authorizerName, name, authContext);
                     servletRequest.setAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT, authenticationResult);
                     filterChain.doFilter(servletRequest, servletResponse);
                   }
@@ -135,6 +144,11 @@ public class Pac4jFilter implements Filter
         JEEHttpActionAdapter.INSTANCE.adapt(e, context);
       }
     }
+  }
+
+  protected SecurityLogic createSecurityLogic()
+  {
+    return new DefaultSecurityLogic();
   }
 
   @Override

--- a/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jFilterTest.java
+++ b/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jFilterTest.java
@@ -19,18 +19,23 @@
 
 package org.apache.druid.security.pac4j;
 
+import org.apache.druid.server.security.AuthConfig;
+import org.apache.druid.server.security.AuthenticationResult;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.pac4j.core.config.Config;
+import org.pac4j.core.engine.SecurityLogic;
 import org.pac4j.core.exception.http.ForbiddenAction;
 import org.pac4j.core.exception.http.FoundAction;
 import org.pac4j.core.exception.http.HttpAction;
 import org.pac4j.core.exception.http.WithLocationAction;
+import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.jee.context.JEEContext;
 import org.pac4j.jee.http.adapter.JEEHttpActionAdapter;
 
@@ -41,6 +46,10 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
@@ -195,5 +204,55 @@ public class Pac4jFilterTest
     // Test that filter can be created without exceptions
     Pac4jFilter filter = new Pac4jFilter("testName", "testAuthorizer", pac4jConfig, "/test-callback", "testPassphrase");
     Assertions.assertNotNull(filter);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testDoFilterSetsProfileAttributesInAuthenticationResult() throws IOException, ServletException
+  {
+    List<String> groups = Arrays.asList("group-a", "group-b");
+
+    CommonProfile profile = new CommonProfile();
+    profile.setId("test-user-id");
+    profile.addAttribute("groups", groups);
+    profile.addAttribute("email", "test@example.com");
+
+    SecurityLogic stubbedSecurityLogic = (ctx, ss, config, adapter, actionAdapter, clients, authorizers, matchers, params) -> {
+      try {
+        return adapter.adapt(ctx, ss, Collections.singletonList(profile));
+      }
+      catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    };
+
+    Pac4jFilter filter = new Pac4jFilter("test", "testAuthorizer", pac4jConfig, "/callback", "testPassphrase")
+    {
+      @Override
+      protected SecurityLogic createSecurityLogic()
+      {
+        return stubbedSecurityLogic;
+      }
+    };
+
+    Mockito.when(request.getAttribute(DRUID_AUTHENTICATION_RESULT)).thenReturn(null);
+    Mockito.when(request.getRequestURI()).thenReturn("/druid/v2/datasources");
+
+    filter.doFilter(request, response, filterChain);
+
+    ArgumentCaptor<AuthenticationResult> captor = ArgumentCaptor.forClass(AuthenticationResult.class);
+    Mockito.verify(request).setAttribute(Mockito.eq(AuthConfig.DRUID_AUTHENTICATION_RESULT), captor.capture());
+
+    AuthenticationResult result = captor.getValue();
+    Assertions.assertEquals("test-user-id", result.getIdentity());
+
+    Map<String, Object> profileInContext = (Map<String, Object>) result.getContext().get("profile");
+    Assertions.assertNotNull(profileInContext);
+    Map<String, Object> attributes = (Map<String, Object>) profileInContext.get("attributes");
+    Assertions.assertNotNull(attributes);
+    Assertions.assertEquals(groups, attributes.get("groups"));
+    Assertions.assertEquals("test@example.com", attributes.get("email"));
+
+    Mockito.verify(filterChain).doFilter(request, response);
   }
 }


### PR DESCRIPTION
## Description

PR #18259 (pac4j extension upgrade) dropped the `AuthenticationResult` context by passing `null` when building the result in `Pac4jFilter`. Prior to that upgrade (see #16109), the full `UserProfile` object was stored in the context under the key `"profile"`.

This change restores the capability: the profile's **attributes map** (`profile.getAttributes()`) is stored under `context.profile.attributes`. Using a plain `Map<String, Object>` rather than the `UserProfile` object directly makes it:
- Serialization-friendly (no pac4j-specific types on the wire)
- Usable by external authorizers that forward the `AuthenticationResult` as JSON (e.g. OPA-based authorizers)

## Motivation

Without this, downstream authorizers cannot make attribute-based access decisions from OIDC claims (e.g. group membership). A user authenticated via Okta OIDC will have `context: null` in their `AuthenticationResult`, making it impossible to distinguish group membership from the authorization layer.

## Changes

- `Pac4jFilter`: populate `AuthenticationResult` context with `{profile: {attributes: <profile.getAttributes()>}}` instead of `null`
- `Pac4jFilterTest`: add test verifying the context shape and that group attributes are accessible

## Test

Added `testAuthenticationResultContainsProfileAttributes` to `Pac4jFilterTest` which creates a `CommonProfile` with group attributes and verifies the resulting `AuthenticationResult` context has the expected structure.

This issue was originally introduced in: https://github.com/apache/druid/pull/18259
The original addition was in: https://github.com/apache/druid/pull/16109