### PR TITLE
fix: restore master CI

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/executor/ExecutorLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/executor/ExecutorLifecycleTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.indexing.overlord.TaskRunner;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.ISE;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -43,7 +43,7 @@ public class ExecutorLifecycleTest
     final FileLock lock = Mockito.mock(FileLock.class);
     Mockito.when(channel.tryLock()).thenReturn(null, lock);
 
-    Assert.assertSame(lock, lifecycle.acquireTaskFileLock(channel, new File("task.lock")));
+    Assertions.assertSame(lock, lifecycle.acquireTaskFileLock(channel, new File("task.lock")));
     Mockito.verify(channel, Mockito.times(2)).tryLock();
 
     lifecycle.stop();
@@ -57,12 +57,12 @@ public class ExecutorLifecycleTest
     final FileChannel channel = Mockito.mock(FileChannel.class);
     final File lockFile = new File("task.lock");
 
-    final ISE exception = Assert.assertThrows(
+    final ISE exception = Assertions.assertThrows(
         ISE.class,
         () -> lifecycle.acquireTaskFileLock(channel, lockFile)
     );
 
-    Assert.assertEquals("Could not acquire lock file[task.lock] within 0ms.", exception.getMessage());
+    Assertions.assertEquals("Could not acquire lock file[task.lock] within 0ms.", exception.getMessage());
     Mockito.verifyNoInteractions(channel);
     lifecycle.stop();
   }


### PR DESCRIPTION
### Description

The current `master` build fails during test compilation because `ExecutorLifecycleTest` imports JUnit 4 classes even though the JUnit 4 dependencies were removed as part of the JUnit 5 migration.

This change migrates the test to JUnit 5 by using `org.junit.jupiter.api.Test` and `org.junit.jupiter.api.Assertions`, preserving the existing test behavior.

#### Release note

No release note is needed; this is a test-only CI fix.

<hr>

##### Key changed/added classes in this PR

 * `ExecutorLifecycleTest`

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in `licenses.yaml`
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added or updated unit tests to cover the affected code path.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

### Verification

`mvn -ntp test -pl indexing-service -am -Dtest=org.apache.druid.indexing.worker.executor.ExecutorLifecycleTest -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks -Dweb.console.skip=true -T1C`

Result: 2 tests run, 0 failures, 0 errors.
