### PR TITLE
fix: Treat empty string in hadoop.auth cookie as no cookie

### DIFF
--- a/extensions-core/druid-kerberos/pom.xml
+++ b/extensions-core/druid-kerberos/pom.xml
@@ -47,6 +47,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>compile</scope>

--- a/extensions-core/druid-kerberos/pom.xml
+++ b/extensions-core/druid-kerberos/pom.xml
@@ -375,6 +375,11 @@
 
     <!-- Tests -->
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>

--- a/extensions-core/druid-kerberos/src/main/java/org/apache/druid/security/kerberos/KerberosAuthenticator.java
+++ b/extensions-core/druid-kerberos/src/main/java/org/apache/druid/security/kerberos/KerberosAuthenticator.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.security.authentication.util.SignerSecretProvider;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.http.HttpCookie;
 
+import javax.annotation.Nullable;
 import javax.security.auth.Subject;
 import javax.security.auth.kerberos.KerberosPrincipal;
 import javax.security.auth.login.AppConfigurationEntry;
@@ -188,11 +189,15 @@ public class KerberosAuthenticator implements Authenticator
           for (Cookie cookie : cookies) {
             if (cookie.getName().equals(AuthenticatedURL.AUTH_COOKIE)) {
               tokenStr = cookie.getValue();
-              try {
-                tokenStr = mySigner.verifyAndExtract(tokenStr);
-              }
-              catch (SignerException ex) {
-                throw new AuthenticationException(ex);
+              if (tokenStr == null || tokenStr.isEmpty()) {
+                tokenStr = null;
+              } else {
+                try {
+                  tokenStr = mySigner.verifyAndExtract(tokenStr);
+                }
+                catch (SignerException ex) {
+                  throw new AuthenticationException(ex);
+                }
               }
               break;
             }
@@ -266,7 +271,7 @@ public class KerberosAuthenticator implements Authenticator
               }
               token = getAuthenticationHandler().authenticate(httpRequest, httpResponse);
               if (token != null && token.getExpires() != 0 &&
-                  token != AuthenticationToken.ANONYMOUS) {
+                  !AuthenticationToken.ANONYMOUS.equals(token)) {
                 token.setExpires(System.currentTimeMillis() + getValidity() * 1000);
               }
               newToken = true;
@@ -293,12 +298,13 @@ public class KerberosAuthenticator implements Authenticator
                 }
 
                 @Override
+                @Nullable
                 public Principal getUserPrincipal()
                 {
-                  return (authToken != AuthenticationToken.ANONYMOUS) ? authToken : null;
+                  return (!AuthenticationToken.ANONYMOUS.equals(authToken)) ? authToken : null;
                 }
               };
-              if (newToken && !token.isExpired() && token != AuthenticationToken.ANONYMOUS) {
+              if (newToken && !token.isExpired() && !AuthenticationToken.ANONYMOUS.equals(token)) {
                 String signedToken = mySigner.sign(token.toString());
                 tokenToAuthCookie(
                     httpResponse,
@@ -374,6 +380,7 @@ public class KerberosAuthenticator implements Authenticator
   }
 
   @Override
+  @Nullable
   public Class<? extends Filter> getFilterClass()
   {
     return null;
@@ -398,6 +405,7 @@ public class KerberosAuthenticator implements Authenticator
   }
 
   @Override
+  @Nullable
   public EnumSet<DispatcherType> getDispatcherType()
   {
     return null;
@@ -423,9 +431,8 @@ public class KerberosAuthenticator implements Authenticator
   )
   {
     Object cookieToken = clientRequest.getAttribute(SIGNED_TOKEN_ATTRIBUTE);
-    if (cookieToken != null && cookieToken instanceof String) {
+    if (cookieToken instanceof String authResult) {
       log.debug("Found cookie token will attache it to proxyRequest as cookie");
-      String authResult = (String) cookieToken;
       proxyRequest.cookie(HttpCookie.from(SIGNED_TOKEN_ATTRIBUTE, authResult));
     }
   }
@@ -435,8 +442,8 @@ public class KerberosAuthenticator implements Authenticator
    */
   public static class DruidKerberosConfiguration extends Configuration
   {
-    private String keytab;
-    private String principal;
+    private final String keytab;
+    private final String principal;
 
     public DruidKerberosConfiguration(String keytab, String principal)
     {
@@ -497,11 +504,11 @@ public class KerberosAuthenticator implements Authenticator
     String keytab;
 
     try {
-      if (serverPrincipal == null || serverPrincipal.trim().length() == 0) {
+      if (serverPrincipal == null || serverPrincipal.trim().isEmpty()) {
         throw new ServletException("Principal not defined in configuration");
       }
       keytab = serverKeytab;
-      if (keytab == null || keytab.trim().length() == 0) {
+      if (keytab == null || keytab.trim().isEmpty()) {
         throw new ServletException("Keytab not defined in configuration");
       }
       if (!new File(keytab).exists()) {
@@ -568,7 +575,7 @@ public class KerberosAuthenticator implements Authenticator
   {
     StringBuilder sb = new StringBuilder(AuthenticatedURL.AUTH_COOKIE)
         .append("=");
-    if (token != null && token.length() > 0) {
+    if (token != null && !token.isEmpty()) {
       sb.append("\"").append(token).append("\"");
     }
 
@@ -580,7 +587,9 @@ public class KerberosAuthenticator implements Authenticator
       sb.append("; Domain=").append(domain);
     }
 
-    if (expires >= 0 && isCookiePersistent) {
+    if (expires == 0) {
+      sb.append("; Max-Age=0");
+    } else if (expires > 0 && isCookiePersistent) {
       Date date = new Date(expires);
       SimpleDateFormat df = new SimpleDateFormat("EEE, dd-MMM-yyyy HH:mm:ss zzz", Locale.ENGLISH);
       df.setTimeZone(TimeZone.getTimeZone("GMT"));

--- a/extensions-core/druid-kerberos/src/test/java/org/apache/druid/security/kerberos/KerberosAuthenticatorTest.java
+++ b/extensions-core/druid-kerberos/src/test/java/org/apache/druid/security/kerberos/KerberosAuthenticatorTest.java
@@ -21,19 +21,26 @@ package org.apache.druid.security.kerberos;
 
 import org.apache.druid.error.DruidException;
 import org.apache.druid.server.DruidNode;
+import org.apache.druid.server.security.AuthConfig;
 import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
 import org.apache.hadoop.security.authentication.server.AuthenticationToken;
 import org.apache.hadoop.security.authentication.util.Signer;
 import org.apache.hadoop.security.authentication.util.SignerSecretProvider;
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.http.HttpCookie;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import javax.servlet.Filter;
+import javax.servlet.FilterChain;
 import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
@@ -146,18 +153,15 @@ public class KerberosAuthenticatorTest
 
     DruidException exception = Assert.assertThrows(
         DruidException.class,
-        () -> {
-          @SuppressWarnings("unused")
-          KerberosAuthenticator authenticator = new KerberosAuthenticator(
-              TEST_SERVER_PRINCIPAL,
-              TEST_SERVER_KEYTAB,
-              TEST_AUTH_TO_LOCAL,
-              null, // null cookie signature secret
-              TEST_AUTHORIZER_NAME,
-              TEST_NAME,
-              node
-          );
-        }
+        () -> new KerberosAuthenticator(
+            TEST_SERVER_PRINCIPAL,
+            TEST_SERVER_KEYTAB,
+            TEST_AUTH_TO_LOCAL,
+            null, // null cookie signature secret
+            TEST_AUTHORIZER_NAME,
+            TEST_NAME,
+            node
+        )
     );
 
     Assert.assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
@@ -179,18 +183,15 @@ public class KerberosAuthenticatorTest
 
     DruidException exception = Assert.assertThrows(
         DruidException.class,
-        () -> {
-          @SuppressWarnings("unused")
-          KerberosAuthenticator authenticator = new KerberosAuthenticator(
-              TEST_SERVER_PRINCIPAL,
-              TEST_SERVER_KEYTAB,
-              TEST_AUTH_TO_LOCAL,
-              "", // empty cookie signature secret
-              TEST_AUTHORIZER_NAME,
-              TEST_NAME,
-              node
-          );
-        }
+        () -> new KerberosAuthenticator(
+            TEST_SERVER_PRINCIPAL,
+            TEST_SERVER_KEYTAB,
+            TEST_AUTH_TO_LOCAL,
+            "", // empty cookie signature secret
+            TEST_AUTHORIZER_NAME,
+            TEST_NAME,
+            node
+        )
     );
 
     Assert.assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
@@ -245,5 +246,173 @@ public class KerberosAuthenticatorTest
     );
     Assert.assertTrue("Persistent cookie should contain 'Expires='", persistentCookieString.contains("Expires="));
     Assert.assertFalse("Persistent cookie should not contain 'Max-Age=0'", persistentCookieString.contains("Max-Age=0"));
+  }
+
+  @Test
+  public void testTokenToCookieStringWithNullToken() throws Exception
+  {
+    final Method method = KerberosAuthenticator.class.getDeclaredMethod(
+        "tokenToCookieString",
+        String.class,
+        String.class,
+        String.class,
+        long.class,
+        boolean.class,
+        boolean.class
+    );
+    method.setAccessible(true);
+
+    final String cookieString = (String) method.invoke(null, null, "localhost", "/", 0, false, false);
+
+    Assert.assertFalse("Null token should not add quoted value", cookieString.contains("\""));
+    Assert.assertTrue("Cookie string should contain Max-Age=0", cookieString.contains("Max-Age=0"));
+  }
+
+  @Test
+  public void testTokenToCookieStringWithNonPersistentPositiveExpires() throws Exception
+  {
+    final Method method = KerberosAuthenticator.class.getDeclaredMethod(
+        "tokenToCookieString",
+        String.class,
+        String.class,
+        String.class,
+        long.class,
+        boolean.class,
+        boolean.class
+    );
+    method.setAccessible(true);
+
+    final String cookieString = (String) method.invoke(
+        null,
+        "some-token",
+        "localhost",
+        "/",
+        System.currentTimeMillis() + 3600,
+        false,  // isCookiePersistent = false
+        false
+    );
+
+    Assert.assertFalse("Non-persistent cookie should not contain 'Expires='", cookieString.contains("Expires="));
+    Assert.assertFalse("Non-persistent cookie should not contain 'Max-Age=0'", cookieString.contains("Max-Age=0"));
+  }
+
+  @Test
+  public void testDecorateProxyRequestWithStringToken()
+  {
+    final KerberosAuthenticator authenticator = new KerberosAuthenticator(
+        TEST_SERVER_PRINCIPAL,
+        TEST_SERVER_KEYTAB,
+        TEST_AUTH_TO_LOCAL,
+        TEST_COOKIE_SECRET,
+        TEST_AUTHORIZER_NAME,
+        TEST_NAME,
+        createTestNode()
+    );
+    final HttpServletRequest clientRequest = Mockito.mock(HttpServletRequest.class);
+    final HttpServletResponse proxyResponse = Mockito.mock(HttpServletResponse.class);
+    final Request proxyRequest = Mockito.mock(Request.class);
+    Mockito.when(clientRequest.getAttribute(KerberosAuthenticator.SIGNED_TOKEN_ATTRIBUTE)).thenReturn("signed-token-value");
+
+    authenticator.decorateProxyRequest(clientRequest, proxyResponse, proxyRequest);
+
+    Mockito.verify(proxyRequest).cookie(ArgumentMatchers.any(HttpCookie.class));
+  }
+
+  @Test
+  public void testDecorateProxyRequestWithoutToken()
+  {
+    final KerberosAuthenticator authenticator = new KerberosAuthenticator(
+        TEST_SERVER_PRINCIPAL,
+        TEST_SERVER_KEYTAB,
+        TEST_AUTH_TO_LOCAL,
+        TEST_COOKIE_SECRET,
+        TEST_AUTHORIZER_NAME,
+        TEST_NAME,
+        createTestNode()
+    );
+    final HttpServletRequest clientRequest = Mockito.mock(HttpServletRequest.class);
+    final HttpServletResponse proxyResponse = Mockito.mock(HttpServletResponse.class);
+    final Request proxyRequest = Mockito.mock(Request.class);
+    Mockito.when(clientRequest.getAttribute(KerberosAuthenticator.SIGNED_TOKEN_ATTRIBUTE)).thenReturn(null);
+
+    authenticator.decorateProxyRequest(clientRequest, proxyResponse, proxyRequest);
+
+    Mockito.verify(proxyRequest, Mockito.never()).cookie(ArgumentMatchers.any());
+  }
+
+  @Test
+  public void testDoFilterWithNullPrincipalThrowsServletException()
+  {
+    // null serverPrincipal causes initializeKerberosLogin to throw "Principal not defined"
+    final KerberosAuthenticator authenticator = new KerberosAuthenticator(
+        null,
+        TEST_SERVER_KEYTAB,
+        TEST_AUTH_TO_LOCAL,
+        TEST_COOKIE_SECRET,
+        TEST_AUTHORIZER_NAME,
+        TEST_NAME,
+        createTestNode()
+    );
+    final Filter filter = authenticator.getFilter();
+    final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+    final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+    final FilterChain chain = Mockito.mock(FilterChain.class);
+    Mockito.when(request.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).thenReturn(null);
+
+    final ServletException ex = Assert.assertThrows(
+        ServletException.class,
+        () -> filter.doFilter(request, response, chain)
+    );
+    Assert.assertTrue(ex.getMessage().contains("Principal not defined"));
+  }
+
+  @Test
+  public void testDoFilterWithNullKeytabThrowsServletException()
+  {
+    final KerberosAuthenticator authenticator = new KerberosAuthenticator(
+        TEST_SERVER_PRINCIPAL,
+        null,  // null keytab
+        TEST_AUTH_TO_LOCAL,
+        TEST_COOKIE_SECRET,
+        TEST_AUTHORIZER_NAME,
+        TEST_NAME,
+        createTestNode()
+    );
+    final Filter filter = authenticator.getFilter();
+    final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+    final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+    final FilterChain chain = Mockito.mock(FilterChain.class);
+    Mockito.when(request.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).thenReturn(null);
+
+    final ServletException ex = Assert.assertThrows(
+        ServletException.class,
+        () -> filter.doFilter(request, response, chain)
+    );
+    Assert.assertTrue(ex.getMessage().contains("Keytab not defined"));
+  }
+
+  @Test
+  public void testDoFilterWithEmptyKeytabThrowsServletException()
+  {
+    final KerberosAuthenticator authenticator = new KerberosAuthenticator(
+        TEST_SERVER_PRINCIPAL,
+        "",  // empty keytab
+        TEST_AUTH_TO_LOCAL,
+        TEST_COOKIE_SECRET,
+        TEST_AUTHORIZER_NAME,
+        TEST_NAME,
+        createTestNode()
+    );
+    final Filter filter = authenticator.getFilter();
+    final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+    final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+    final FilterChain chain = Mockito.mock(FilterChain.class);
+    Mockito.when(request.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).thenReturn(null);
+
+    final ServletException ex = Assert.assertThrows(
+        ServletException.class,
+        () -> filter.doFilter(request, response, chain)
+    );
+    Assert.assertTrue(ex.getMessage().contains("Keytab not defined"));
   }
 }

--- a/extensions-core/druid-kerberos/src/test/java/org/apache/druid/security/kerberos/KerberosAuthenticatorTest.java
+++ b/extensions-core/druid-kerberos/src/test/java/org/apache/druid/security/kerberos/KerberosAuthenticatorTest.java
@@ -21,8 +21,23 @@ package org.apache.druid.security.kerberos;
 
 import org.apache.druid.error.DruidException;
 import org.apache.druid.server.DruidNode;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
+import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
+import org.apache.hadoop.security.authentication.server.AuthenticationToken;
+import org.apache.hadoop.security.authentication.util.Signer;
+import org.apache.hadoop.security.authentication.util.SignerSecretProvider;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.servlet.Filter;
+import javax.servlet.ServletContext;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
 
 public class KerberosAuthenticatorTest
 {
@@ -39,33 +54,121 @@ public class KerberosAuthenticatorTest
   }
 
 
+  /**
+   * Verifies that an empty hadoop.auth cookie value is treated as "no cookie" rather than
+   * causing a SignerException. An empty cookie results from a prior session expiry where
+   * Druid cleared the cookie. Without this fix, the empty value would be passed to
+   * Signer.verifyAndExtract("") which throws SignerException, setting authenticationEx
+   * and causing the entire auth chain to short-circuit with a 403.
+   */
+  @Test
+  public void testGetTokenWithEmptyCookieReturnsNull() throws Exception
+  {
+    final Filter filter = createFilterWithSigner();
+    final Method getToken = findGetTokenMethod();
+
+    // Empty cookie value - the real-world scenario after session expiry clears the cookie.
+    // Without the fix, Signer.verifyAndExtract("") throws SignerException.
+    final HttpServletRequest requestWithEmptyCookie = mockRequestWithEmptyCookie();
+    final AuthenticationToken token = (AuthenticationToken) getToken.invoke(filter, requestWithEmptyCookie);
+    Assert.assertNull("Empty hadoop.auth cookie should be treated as no cookie", token);
+
+    // No cookie at all - baseline, should return null
+    final HttpServletRequest requestWithNoCookie = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(requestWithNoCookie.getCookies()).thenReturn(null);
+    final AuthenticationToken tokenForNoCookie = (AuthenticationToken) getToken.invoke(filter, requestWithNoCookie);
+    Assert.assertNull("Missing hadoop.auth cookie should return null", tokenForNoCookie);
+  }
+
+  private Filter createFilterWithSigner() throws Exception
+  {
+    final Filter filter = new KerberosAuthenticator(
+        TEST_SERVER_PRINCIPAL,
+        TEST_SERVER_KEYTAB,
+        TEST_AUTH_TO_LOCAL,
+        TEST_COOKIE_SECRET,
+        TEST_AUTHORIZER_NAME,
+        TEST_NAME,
+        createTestNode()
+    ).getFilter();
+
+    final SignerSecretProvider secretProvider = new SignerSecretProvider()
+    {
+      @Override
+      public void init(Properties config, ServletContext servletContext, long tokenValidity)
+      {
+      }
+
+      @Override
+      public byte[] getCurrentSecret()
+      {
+        return TEST_COOKIE_SECRET.getBytes(StandardCharsets.UTF_8);
+      }
+
+      @Override
+      public byte[][] getAllSecrets()
+      {
+        return new byte[][]{TEST_COOKIE_SECRET.getBytes(StandardCharsets.UTF_8)};
+      }
+    };
+    final Signer signer = new Signer(secretProvider);
+
+    // Inject mySigner into the anonymous AuthenticationFilter subclass via reflection
+    for (Field field : filter.getClass().getDeclaredFields()) {
+      if (field.getType().equals(Signer.class)) {
+        field.setAccessible(true);
+        field.set(filter, signer);
+        break;
+      }
+    }
+    return filter;
+  }
+
+  private Method findGetTokenMethod() throws Exception
+  {
+    final Method method = AuthenticationFilter.class.getDeclaredMethod("getToken", HttpServletRequest.class);
+    method.setAccessible(true);
+    return method;
+  }
+
+  private HttpServletRequest mockRequestWithEmptyCookie()
+  {
+    final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+    final Cookie cookie = new Cookie(AuthenticatedURL.AUTH_COOKIE, "");
+    Mockito.when(request.getCookies()).thenReturn(new Cookie[]{cookie});
+    return request;
+  }
+
   @Test
   public void testConstructorWithNullCookieSignatureSecret()
   {
     DruidNode node = createTestNode();
 
-    DruidException exception = Assertions.assertThrows(
+    DruidException exception = Assert.assertThrows(
         DruidException.class,
-        () -> new KerberosAuthenticator(
-            TEST_SERVER_PRINCIPAL,
-            TEST_SERVER_KEYTAB,
-            TEST_AUTH_TO_LOCAL,
-            null, // null cookie signature secret
-            TEST_AUTHORIZER_NAME,
-            TEST_NAME,
-            node
-        )
+        () -> {
+          @SuppressWarnings("unused")
+          KerberosAuthenticator authenticator = new KerberosAuthenticator(
+              TEST_SERVER_PRINCIPAL,
+              TEST_SERVER_KEYTAB,
+              TEST_AUTH_TO_LOCAL,
+              null, // null cookie signature secret
+              TEST_AUTHORIZER_NAME,
+              TEST_NAME,
+              node
+          );
+        }
     );
 
-    Assertions.assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
-    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
-    Assertions.assertTrue(
-        exception.getMessage().contains("cookieSignatureSecret"),
-        "Exception message should mention cookieSignatureSecret"
+    Assert.assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
+    Assert.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    Assert.assertTrue(
+        "Exception message should mention cookieSignatureSecret",
+        exception.getMessage().contains("cookieSignatureSecret")
     );
-    Assertions.assertTrue(
-        exception.getMessage().contains("is not set"),
-        "Exception message should mention 'is not set'"
+    Assert.assertTrue(
+        "Exception message should mention 'is not set'",
+        exception.getMessage().contains("is not set")
     );
   }
 
@@ -74,28 +177,73 @@ public class KerberosAuthenticatorTest
   {
     DruidNode node = createTestNode();
 
-    DruidException exception = Assertions.assertThrows(
+    DruidException exception = Assert.assertThrows(
         DruidException.class,
-        () -> new KerberosAuthenticator(
-            TEST_SERVER_PRINCIPAL,
-            TEST_SERVER_KEYTAB,
-            TEST_AUTH_TO_LOCAL,
-            "", // empty cookie signature secret
-            TEST_AUTHORIZER_NAME,
-            TEST_NAME,
-            node
-        )
+        () -> {
+          @SuppressWarnings("unused")
+          KerberosAuthenticator authenticator = new KerberosAuthenticator(
+              TEST_SERVER_PRINCIPAL,
+              TEST_SERVER_KEYTAB,
+              TEST_AUTH_TO_LOCAL,
+              "", // empty cookie signature secret
+              TEST_AUTHORIZER_NAME,
+              TEST_NAME,
+              node
+          );
+        }
     );
 
-    Assertions.assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
-    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
-    Assertions.assertTrue(
-        exception.getMessage().contains("cookieSignatureSecret"),
-        "Exception message should mention cookieSignatureSecret"
+    Assert.assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
+    Assert.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    Assert.assertTrue(
+        "Exception message should mention cookieSignatureSecret",
+        exception.getMessage().contains("cookieSignatureSecret")
     );
-    Assertions.assertTrue(
-        exception.getMessage().contains("is not set"),
-        "Exception message should mention 'is not set'"
+    Assert.assertTrue(
+        "Exception message should mention 'is not set'",
+        exception.getMessage().contains("is not set")
     );
+  }
+
+  @Test
+  public void testTokenToCookieStringWithZeroExpiresIncludesMaxAge() throws Exception
+  {
+    final Method method = KerberosAuthenticator.class.getDeclaredMethod(
+        "tokenToCookieString",
+        String.class,
+        String.class,
+        String.class,
+        long.class,
+        boolean.class,
+        boolean.class
+    );
+    method.setAccessible(true);
+
+    // Test case: expires = 0 (intended for cookie deletion)
+    final String cookieString = (String) method.invoke(
+        null,
+        "",         // token
+        "localhost", // domain
+        "/",        // path
+        0,          // expires
+        false,      // isCookiePersistent
+        false       // isSecure
+    );
+
+    Assert.assertTrue("Cookie string should contain 'Max-Age=0'", cookieString.contains("Max-Age=0"));
+    Assert.assertFalse("Cookie string should not contain 'Expires=' when expires is 0", cookieString.contains("Expires="));
+
+    // Test case: expires > 0 and persistent
+    final String persistentCookieString = (String) method.invoke(
+        null,
+        "some-token",
+        "localhost",
+        "/",
+        System.currentTimeMillis() + 3600,
+        true,
+        false
+    );
+    Assert.assertTrue("Persistent cookie should contain 'Expires='", persistentCookieString.contains("Expires="));
+    Assert.assertFalse("Persistent cookie should not contain 'Max-Age=0'", persistentCookieString.contains("Max-Age=0"));
   }
 }

--- a/extensions-core/druid-kerberos/src/test/java/org/apache/druid/security/kerberos/KerberosAuthenticatorTest.java
+++ b/extensions-core/druid-kerberos/src/test/java/org/apache/druid/security/kerberos/KerberosAuthenticatorTest.java
@@ -29,8 +29,7 @@ import org.apache.hadoop.security.authentication.util.Signer;
 import org.apache.hadoop.security.authentication.util.SignerSecretProvider;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.http.HttpCookie;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -45,6 +44,12 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KerberosAuthenticatorTest
 {
@@ -78,13 +83,13 @@ public class KerberosAuthenticatorTest
     // Without the fix, Signer.verifyAndExtract("") throws SignerException.
     final HttpServletRequest requestWithEmptyCookie = mockRequestWithEmptyCookie();
     final AuthenticationToken token = (AuthenticationToken) getToken.invoke(filter, requestWithEmptyCookie);
-    Assert.assertNull("Empty hadoop.auth cookie should be treated as no cookie", token);
+    assertNull(token, "Empty hadoop.auth cookie should be treated as no cookie");
 
     // No cookie at all - baseline, should return null
     final HttpServletRequest requestWithNoCookie = Mockito.mock(HttpServletRequest.class);
     Mockito.when(requestWithNoCookie.getCookies()).thenReturn(null);
     final AuthenticationToken tokenForNoCookie = (AuthenticationToken) getToken.invoke(filter, requestWithNoCookie);
-    Assert.assertNull("Missing hadoop.auth cookie should return null", tokenForNoCookie);
+    assertNull(tokenForNoCookie, "Missing hadoop.auth cookie should return null");
   }
 
   private Filter createFilterWithSigner() throws Exception
@@ -151,7 +156,7 @@ public class KerberosAuthenticatorTest
   {
     DruidNode node = createTestNode();
 
-    DruidException exception = Assert.assertThrows(
+    DruidException exception = assertThrows(
         DruidException.class,
         () -> new KerberosAuthenticator(
             TEST_SERVER_PRINCIPAL,
@@ -164,15 +169,15 @@ public class KerberosAuthenticatorTest
         )
     );
 
-    Assert.assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
-    Assert.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
-    Assert.assertTrue(
-        "Exception message should mention cookieSignatureSecret",
-        exception.getMessage().contains("cookieSignatureSecret")
+    assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
+    assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    assertTrue(
+        exception.getMessage().contains("cookieSignatureSecret"),
+        "Exception message should mention cookieSignatureSecret"
     );
-    Assert.assertTrue(
-        "Exception message should mention 'is not set'",
-        exception.getMessage().contains("is not set")
+    assertTrue(
+        exception.getMessage().contains("is not set"),
+        "Exception message should mention 'is not set'"
     );
   }
 
@@ -181,7 +186,7 @@ public class KerberosAuthenticatorTest
   {
     DruidNode node = createTestNode();
 
-    DruidException exception = Assert.assertThrows(
+    DruidException exception = assertThrows(
         DruidException.class,
         () -> new KerberosAuthenticator(
             TEST_SERVER_PRINCIPAL,
@@ -194,15 +199,15 @@ public class KerberosAuthenticatorTest
         )
     );
 
-    Assert.assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
-    Assert.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
-    Assert.assertTrue(
-        "Exception message should mention cookieSignatureSecret",
-        exception.getMessage().contains("cookieSignatureSecret")
+    assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
+    assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    assertTrue(
+        exception.getMessage().contains("cookieSignatureSecret"),
+        "Exception message should mention cookieSignatureSecret"
     );
-    Assert.assertTrue(
-        "Exception message should mention 'is not set'",
-        exception.getMessage().contains("is not set")
+    assertTrue(
+        exception.getMessage().contains("is not set"),
+        "Exception message should mention 'is not set'"
     );
   }
 
@@ -231,8 +236,8 @@ public class KerberosAuthenticatorTest
         false       // isSecure
     );
 
-    Assert.assertTrue("Cookie string should contain 'Max-Age=0'", cookieString.contains("Max-Age=0"));
-    Assert.assertFalse("Cookie string should not contain 'Expires=' when expires is 0", cookieString.contains("Expires="));
+    assertTrue(cookieString.contains("Max-Age=0"), "Cookie string should contain 'Max-Age=0'");
+    assertFalse(cookieString.contains("Expires="), "Cookie string should not contain 'Expires=' when expires is 0");
 
     // Test case: expires > 0 and persistent
     final String persistentCookieString = (String) method.invoke(
@@ -244,8 +249,8 @@ public class KerberosAuthenticatorTest
         true,
         false
     );
-    Assert.assertTrue("Persistent cookie should contain 'Expires='", persistentCookieString.contains("Expires="));
-    Assert.assertFalse("Persistent cookie should not contain 'Max-Age=0'", persistentCookieString.contains("Max-Age=0"));
+    assertTrue(persistentCookieString.contains("Expires="), "Persistent cookie should contain 'Expires='");
+    assertFalse(persistentCookieString.contains("Max-Age=0"), "Persistent cookie should not contain 'Max-Age=0'");
   }
 
   @Test
@@ -264,8 +269,8 @@ public class KerberosAuthenticatorTest
 
     final String cookieString = (String) method.invoke(null, null, "localhost", "/", 0, false, false);
 
-    Assert.assertFalse("Null token should not add quoted value", cookieString.contains("\""));
-    Assert.assertTrue("Cookie string should contain Max-Age=0", cookieString.contains("Max-Age=0"));
+    assertFalse(cookieString.contains("\""), "Null token should not add quoted value");
+    assertTrue(cookieString.contains("Max-Age=0"), "Cookie string should contain Max-Age=0");
   }
 
   @Test
@@ -292,8 +297,8 @@ public class KerberosAuthenticatorTest
         false
     );
 
-    Assert.assertFalse("Non-persistent cookie should not contain 'Expires='", cookieString.contains("Expires="));
-    Assert.assertFalse("Non-persistent cookie should not contain 'Max-Age=0'", cookieString.contains("Max-Age=0"));
+    assertFalse(cookieString.contains("Expires="), "Non-persistent cookie should not contain 'Expires='");
+    assertFalse(cookieString.contains("Max-Age=0"), "Non-persistent cookie should not contain 'Max-Age=0'");
   }
 
   @Test
@@ -359,11 +364,11 @@ public class KerberosAuthenticatorTest
     final FilterChain chain = Mockito.mock(FilterChain.class);
     Mockito.when(request.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).thenReturn(null);
 
-    final ServletException ex = Assert.assertThrows(
+    final ServletException ex = assertThrows(
         ServletException.class,
         () -> filter.doFilter(request, response, chain)
     );
-    Assert.assertTrue(ex.getMessage().contains("Principal not defined"));
+    assertTrue(ex.getMessage().contains("Principal not defined"));
   }
 
   @Test
@@ -384,11 +389,11 @@ public class KerberosAuthenticatorTest
     final FilterChain chain = Mockito.mock(FilterChain.class);
     Mockito.when(request.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).thenReturn(null);
 
-    final ServletException ex = Assert.assertThrows(
+    final ServletException ex = assertThrows(
         ServletException.class,
         () -> filter.doFilter(request, response, chain)
     );
-    Assert.assertTrue(ex.getMessage().contains("Keytab not defined"));
+    assertTrue(ex.getMessage().contains("Keytab not defined"));
   }
 
   @Test
@@ -409,10 +414,10 @@ public class KerberosAuthenticatorTest
     final FilterChain chain = Mockito.mock(FilterChain.class);
     Mockito.when(request.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).thenReturn(null);
 
-    final ServletException ex = Assert.assertThrows(
+    final ServletException ex = assertThrows(
         ServletException.class,
         () -> filter.doFilter(request, response, chain)
     );
-    Assert.assertTrue(ex.getMessage().contains("Keytab not defined"));
+    assertTrue(ex.getMessage().contains("Keytab not defined"));
   }
 }


### PR DESCRIPTION
Taking over https://github.com/apache/druid/pull/19520 - Requested by @rzepinskip 

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

### Description

This PR fixes a bug (#19519) in the `druid-kerberos` extension where an expired or empty Kerberos authentication cookie would short-circuit the entire authenticator chain, resulting in a persistent HTTP 403 error and preventing other authenticators (like LDAP) from handling the request.

#### Fixed Kerberos authentication chain short-circuit
When a Kerberos session expires, the browser may be left with an empty `hadoop.auth` cookie. Previously, `KerberosAuthenticator` would attempt to verify this empty cookie, causing a `SignerException` that blocked the rest of the authenticator chain.

Key fixes:
*   **Cookie Deletion:** Added `Max-Age=0` to the `Set-Cookie` header when clearing the `hadoop.auth` cookie. Previously, the browser would treat the empty-value cookie as a session cookie rather than deleting it.
*   **Empty Cookie Handling:** Updated `getToken()` to explicitly check for empty cookie values. Empty cookies are now treated as "no cookie present," allowing the request to proceed to the next authenticator in the chain instead of throwing a 403 error.

#### Tests
*   Added `KerberosAuthenticatorTest` (JUnit 5 + Mockito) covering empty/missing `hadoop.auth` cookie handling, `tokenToCookieString()` `Max-Age=0`/`Expires=` behavior, proxy request decoration, and constructor/filter validation errors.
*   Added the `mockito-core` (test scope) and `jsr305` (provided scope) dependencies to the `druid-kerberos` `pom.xml`, which are required by the new test and the `@Nullable` annotations.

#### Code quality
*   **Modernized Java:** Adopted Java 17 pattern variables and updated string checks to use `isEmpty()`.
*   **Resolved lint warnings:**
    *   Replaced identity comparison (`!=`) for `AuthenticationToken.ANONYMOUS` with `.equals()`.
    *   Added missing `@Nullable` annotations to standard override methods.
    *   Marked internal configuration fields as `final`.

#### Release note
Fixed a bug in `druid-kerberos` where an expired authentication cookie could prevent other authenticators in the chain from working, causing a persistent 403 error.

<hr>

##### Key changed/added classes in this PR
* `KerberosAuthenticator`
* `KerberosAuthenticatorTest`
* `pom.xml` (druid-kerberos)

<hr>

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
