### PR TITLE
release: Suppress CVEs that do not affect Druid

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -274,6 +274,69 @@
     <cve>CVE-2025-58057</cve> <!-- Netty 3.x not affected; compression issue only in 4.x -->
     <cve>CVE-2026-33870</cve> <!-- We don't use HttpPostRequestDecoder -->
     <cve>CVE-2026-33871</cve> <!-- Netty 3.x not affected; HTTP/2 issues only in 4.x -->
+    <cve>CVE-2026-44893</cve> <!-- We don't use the HAProxy codec -->
+    <cve>CVE-2026-44250</cve> <!-- We don't use the Redis codec -->
+    <cve>CVE-2026-48059</cve> <!-- We don't use the HAProxy codec -->
+    <cve>CVE-2026-44890</cve> <!-- We don't use the Redis codec -->
+    <cve>CVE-2026-44891</cve> <!-- We don't use the STOMP codec -->
+    <cve>CVE-2026-50011</cve> <!-- We don't use the Redis codec -->
+    <cve>CVE-2026-59901</cve> <!-- We don't use Netty's Bzip2Decoder; Druid uses Apache Commons Compress for bzip2 -->
+    <cve>CVE-2026-62380</cve> <!-- We don't use the SOCKS codec; Druid uses HTTP CONNECT proxy tunneling -->
+    <cve>CVE-2026-59898</cve> <!-- Server-side WebSocket vulnerability; Druid's HTTP server is Jetty, not Netty -->
+    <cve>CVE-2026-59899</cve> <!-- Server-side HttpContentEncoder vulnerability; Druid uses Netty 3.x as HTTP client only -->
+    <cve>CVE-2026-42587</cve> <!-- Affects brotli/zstd/snappy decompression added in Netty 4.x; Netty 3.x only supports gzip/deflate -->
+    <cve>CVE-2026-42586</cve> <!-- We don't use the Redis codec -->
+    <cve>CVE-2026-44248</cve> <!-- We don't use the MQTT codec -->
+    <cve>CVE-2026-44249</cve> <!-- We don't use Netty's IpSubnetFilterRule; Druid uses Jetty for HTTP access control -->
+    <cve>CVE-2026-45416</cve> <!-- Server-side TLS SNI vulnerability; Druid uses Netty 3.x as TLS client only, never as a server -->
+    <cve>CVE-2026-42581</cve> <!-- Server-side HTTP request smuggling; Druid's HTTP server is Jetty, not Netty -->
+    <cve>CVE-2026-45674</cve> <!-- Affects netty-resolver-dns which Druid doesn't use; Druid uses JDK DNS resolution -->
+    <cve>CVE-2026-48006</cve> <!-- We don't use the Redis codec -->
+    <cve>CVE-2026-42585</cve> <!-- Server-side HTTP request smuggling; Druid's HTTP server is Jetty, not Netty -->
+    <cve>CVE-2026-42584</cve> <!-- HttpClientCodec response desynchronization in Netty 4.x codec; Druid uses Netty 3.x's HttpClientCodec which has a different implementation -->
+    <cve>CVE-2026-46340</cve> <!-- We don't use SCTP transport; Druid uses TCP/NIO -->
+    <cve>CVE-2026-42583</cve> <!-- We don't use Netty's Lz4FrameDecoder; Druid uses lz4-java directly -->
+    <cve>CVE-2026-48043</cve> <!-- We don't use netty-codec-http2 directly; Druid's HTTP/2 is served by Jetty -->
+    <cve>CVE-2026-56822</cve> <!-- We don't use netty-handler-ssl-ocsp -->
+    <cve>CVE-2026-56821</cve> <!-- We don't use netty-handler-ssl-ocsp -->
+    <cve>CVE-2026-47691</cve> <!-- Affects netty-resolver-dns which Druid doesn't use; Druid uses JDK DNS resolution -->
+    <cve>CVE-2026-56820</cve> <!-- We don't use netty-handler-ssl-ocsp -->
+    <cve>CVE-2026-50010</cve> <!-- Druid's Netty 3.x HTTP client does not use SslContextBuilder; gRPC/AWS SDK paths use managed SSL contexts -->
+    <cve>CVE-2026-42578</cve> <!-- We don't use HttpProxyHandler; Druid uses a custom HTTP CONNECT tunnel via HttpClientCodec -->
+    <cve>CVE-2026-42579</cve> <!-- We don't use netty-codec-dns; Druid uses JDK DNS resolution -->
+  </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+      file name: async-http-client-3.0.2.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.asynchttpclient/async-http-client@3.0.2$</packageUrl>
+    <cve>CVE-2026-45300</cve> <!-- Cookie leak on cross-origin redirect: Druid does not configure automatic redirect following or a cookie store in AHC; redirects are handled manually at application level in ServiceClientImpl without forwarding cookies -->
+  </suppress>
+
+  <suppress>
+    <!-- Netty 4.x CVEs for codecs/features that Druid never activates.
+         Druid's HTTP server is Jetty; Netty 4.x is present as a transitive dependency
+         (gRPC, AWS SDK) for buffer management and internal comms only. -->
+    <notes><![CDATA[
+      file name: netty-codec-protobuf-4.2.15.Final.jar netty-transport-4.2.15.Final.jar (and other netty-*.jar at 4.2.x)
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.netty/netty-.*@4\.2\..*$</packageUrl>
+    <cve>CVE-2026-56819</cve> <!-- HTTP/2 decompressor ByteBuf leak: Druid does not run a Netty 4.x HTTP/2 server -->
+    <cve>CVE-2026-56817</cve> <!-- XML injection/XXE in netty-codec-xml: Druid does not use the XML codec -->
+    <cve>CVE-2026-44891</cve> <!-- STOMP header OOM: Druid does not use the STOMP codec -->
+    <cve>CVE-2026-55833</cve> <!-- SPDY zlib expansion: Druid does not use SPDY -->
+    <cve>CVE-2026-56745</cve> <!-- SPDY RST_STREAM ByteBuf leak: Druid does not use SPDY -->
+    <cve>CVE-2026-56822</cve> <!-- OCSP TOCTOU race: Druid does not use netty-handler-ssl-ocsp -->
+    <cve>CVE-2026-55831</cve> <!-- SPDY SETTINGS frame unbounded map: Druid does not use SPDY -->
+    <cve>CVE-2026-56821</cve> <!-- OCSP stale response: Druid does not use netty-handler-ssl-ocsp -->
+    <cve>CVE-2026-56820</cve> <!-- OCSP CertificateID not validated: Druid does not use netty-handler-ssl-ocsp -->
+    <cve>CVE-2026-56816</cve> <!-- HTTP/3 reserved frame memory exhaustion: Druid does not use HTTP/3 -->
+    <cve>CVE-2026-59901</cve> <!-- Bzip2Decoder infinite loop: Druid uses Apache Commons Compress for bzip2, not Netty's codec -->
+    <cve>CVE-2026-62380</cve> <!-- SOCKS encoder CRLF injection: Druid does not use the SOCKS codec -->
+    <cve>CVE-2026-59898</cve> <!-- WebSocket handshake smuggling (server-side): Druid's HTTP server is Jetty -->
+    <cve>CVE-2026-59899</cve> <!-- HttpContentEncoder pipelining OOM (server-side): Druid's HTTP server is Jetty -->
+    <cve>CVE-2026-55851</cve> <!-- HAProxy decoder OOM: Druid does not use the HAProxy codec -->
   </suppress>
 
   <suppress>


### PR DESCRIPTION
This patch suppresses some CVEs encountered while preparing the release of Apache Druid 38.0.0
https://github.com/apache/druid/actions/runs/31012362900/job/92327549691

The patch is mostly Claude-generated.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.