### PR TITLE
fix: validate blockSize and numBlocks in CompressedBlockReader

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedBlockReader.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedBlockReader.java
@@ -77,7 +77,8 @@ public final class CompressedBlockReader implements Closeable
       Preconditions.checkArgument(numBlocks > 0, "Number of blocks[%s] must be positive", numBlocks);
       Preconditions.checkArgument(
           (long) numBlocks * Integer.BYTES <= buffer.remaining(),
-          "Number of blocks[%s] exceeds the available buffer"
+          "Number of blocks[%s] exceeds the available buffer",
+          numBlocks
       );
       final int offsetsSize = numBlocks * Integer.BYTES;
       // buffer is at start of ending offsets

--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedBlockReader.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedBlockReader.java
@@ -72,7 +72,13 @@ public final class CompressedBlockReader implements Closeable
           blockSize <= CompressedPools.BUFFER_SIZE,
           "Maximum block size must be less than " + CompressedPools.BUFFER_SIZE
       );
+      Preconditions.checkArgument(blockSize > 0, "Block size[%s] must be positive", blockSize);
       final int numBlocks = buffer.getInt();
+      Preconditions.checkArgument(numBlocks > 0, "Number of blocks[%s] must be positive", numBlocks);
+      Preconditions.checkArgument(
+          (long) numBlocks * Integer.BYTES <= buffer.remaining(),
+          "Number of blocks[%s] exceeds the available buffer"
+      );
       final int offsetsSize = numBlocks * Integer.BYTES;
       // buffer is at start of ending offsets
       final ByteBuffer offsets = buffer.asReadOnlyBuffer().order(compressionOrder);

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedBlockReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedBlockReaderTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class CompressedBlockReaderTest
+{
+  private static ByteBuffer header(int blockSize, int numBlocks)
+  {
+    final ByteBuffer buffer = ByteBuffer.allocate(64).order(ByteOrder.nativeOrder());
+    buffer.put(CompressedBlockReader.VERSION);
+    buffer.put(CompressionStrategy.UNCOMPRESSED.getId());
+    buffer.putInt(blockSize);
+    buffer.putInt(numBlocks);
+    buffer.flip();
+    return buffer;
+  }
+
+  @Test
+  public void testNumBlocksZeroRejected()
+  {
+    final IllegalArgumentException e = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> CompressedBlockReader.fromByteBuffer(
+            header(64, 0), ByteOrder.nativeOrder(), ByteOrder.nativeOrder(), false
+        )
+    );
+    Assertions.assertTrue(e.getMessage().contains("Number of blocks[0] must be positive"), e.getMessage());
+  }
+
+  @Test
+  public void testNumBlocksNegativeRejected()
+  {
+    final IllegalArgumentException e = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> CompressedBlockReader.fromByteBuffer(
+            header(64, -5), ByteOrder.nativeOrder(), ByteOrder.nativeOrder(), false
+        )
+    );
+    Assertions.assertTrue(e.getMessage().contains("Number of blocks[-5] must be positive"), e.getMessage());
+  }
+
+  @Test
+  public void testBlockSizeZeroRejected()
+  {
+    final IllegalArgumentException e = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> CompressedBlockReader.fromByteBuffer(
+            header(0, 1), ByteOrder.nativeOrder(), ByteOrder.nativeOrder(), false
+        )
+    );
+    Assertions.assertTrue(e.getMessage().contains("Block size[0] must be positive"), e.getMessage());
+  }
+
+  @Test
+  public void testNumBlocksBeyondBufferRejected()
+  {
+    final IllegalArgumentException e = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> CompressedBlockReader.fromByteBuffer(
+            header(64, 32), ByteOrder.nativeOrder(), ByteOrder.nativeOrder(), false
+        )
+    );
+    Assertions.assertTrue(e.getMessage().contains("exceeds the available buffer"), e.getMessage());
+  }
+
+  @Test
+  public void testValidHeaderAccepted()
+  {
+    final ByteBuffer buffer = ByteBuffer.allocate(64).order(ByteOrder.nativeOrder());
+    buffer.put(CompressedBlockReader.VERSION);
+    buffer.put(CompressionStrategy.UNCOMPRESSED.getId());
+    buffer.putInt(64); // blockSize
+    buffer.putInt(2);  // numBlocks
+    buffer.putInt(4);  // offsets
+    buffer.putInt(8);
+    buffer.putInt(0);  // compressed bytes
+    buffer.putInt(0);
+    buffer.flip();
+
+    CompressedBlockReader.fromByteBuffer(
+        buffer, ByteOrder.nativeOrder(), ByteOrder.nativeOrder(), false
+    );
+    Assertions.assertTrue(true);
+  }
+}

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedBlockReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedBlockReaderTest.java
@@ -100,9 +100,7 @@ public class CompressedBlockReaderTest
     buffer.putInt(0);
     buffer.flip();
 
-    CompressedBlockReader.fromByteBuffer(
-        buffer, ByteOrder.nativeOrder(), ByteOrder.nativeOrder(), false
-    );
+    CompressedBlockReader.fromByteBuffer(buffer, ByteOrder.nativeOrder(), ByteOrder.nativeOrder(), false);
     Assertions.assertTrue(true);
   }
 }


### PR DESCRIPTION
### Description

`CompressedBlockReader.fromByteBuffer()` only checks the upper bound of the `blockSize` header field. The lower bound of `blockSize` and the `numBlocks` field are trusted verbatim, and the offset-table arithmetic (`numBlocks * Integer.BYTES`) is done without checking it against the remaining buffer. A corrupted or tampered header therefore surfaces as raw JVM exceptions on first use instead of a descriptive error:

- `numBlocks = 0` -> `IndexOutOfBoundsException` (`offsetView.get(-1)`)
- `numBlocks = -5` -> `IllegalArgumentException: newLimit < 0 (-10 < 0)`
- `blockSize = 0` -> `IllegalArgumentException: newPosition > limit (30 > 14)`
- oversized `numBlocks` makes the reader slice the offsets table beyond the buffer

#### Fixed the bug ...

Validate the header before any offset math: `blockSize > 0`, `numBlocks > 0`, and `numBlocks * Integer.BYTES <= buffer.remaining()`, raising a descriptive `IllegalArgumentException` (`"Block size[%s] must be positive"` / `"Number of blocks[%s] must be positive"` / `"Number of blocks[%s] exceeds the available buffer"`).

Added `CompressedBlockReaderTest` covering rejection of the zero/negative/beyond-buffer cases plus a valid-header acceptance case. I verified the tests fail without the fix (they reproduce the raw `IndexOutOfBoundsException` / `IllegalArgumentException` above) and pass with it; `git diff --check` is clean.

#### Release note

- Reject malformed `CompressedBlockReader` headers (`blockSize`/`numBlocks` of zero, negative, or exceeding the buffer) with a descriptive error instead of failing later with an unrelated JVM exception.

<hr>

##### Key changed/added classes in this PR
 * `CompressedBlockReader`
 * `CompressedBlockReaderTest`

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.