### PR TITLE
minor: Prioritize load of unavailable segment

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java
@@ -167,7 +167,7 @@ public class ServerHolder implements Comparable<ServerHolder>
       }
 
       final SegmentAction action = holder.getAction();
-      addToQueuedSegments(holder.getSegment(), simplify(action));
+      addToQueuedSegments(holder.getSegment(), action);
       if (holder.getProfile() != null) {
         inFlightProfiles.put(holder.getSegment(), holder.getProfile());
       }
@@ -376,7 +376,8 @@ public class ServerHolder implements Comparable<ServerHolder>
 
   public boolean isLoadingSegment(DataSegment segment)
   {
-    return getActionOnSegment(segment) == SegmentAction.LOAD;
+    final SegmentAction action = getActionOnSegment(segment);
+    return action == SegmentAction.LOAD || action == SegmentAction.REPLICATE;
   }
 
   public boolean isDroppingSegment(DataSegment segment)
@@ -431,7 +432,7 @@ public class ServerHolder implements Comparable<ServerHolder>
       ++totalAssignmentsInRun;
     }
 
-    addToQueuedSegments(segment, simplify(action));
+    addToQueuedSegments(segment, action);
     if (profile != null) {
       inFlightProfiles.put(segment, profile);
     }
@@ -442,7 +443,7 @@ public class ServerHolder implements Comparable<ServerHolder>
   {
     // Cancel only if the action is currently in queue
     final SegmentAction queuedAction = queuedSegments.get(segment);
-    if (queuedAction != simplify(action)) {
+    if (queuedAction != action) {
       return false;
     }
 
@@ -455,6 +456,18 @@ public class ServerHolder implements Comparable<ServerHolder>
     } else {
       return false;
     }
+  }
+
+  /**
+   * Cancels a {@link SegmentAction#REPLICATE} or {@link SegmentAction#LOAD} if
+   * it is currently being performed on the given segment.
+   *
+   * @return true if the operation was cancelled successfully.
+   */
+  public boolean cancelLoad(DataSegment segment)
+  {
+    return cancelOperation(SegmentAction.REPLICATE, segment)
+           || cancelOperation(SegmentAction.LOAD, segment);
   }
 
   /**
@@ -495,11 +508,6 @@ public class ServerHolder implements Comparable<ServerHolder>
   {
     return server.getType() == ServerType.REALTIME
            || server.getType() == ServerType.INDEXER_EXECUTOR;
-  }
-
-  private SegmentAction simplify(SegmentAction action)
-  {
-    return action == SegmentAction.REPLICATE ? SegmentAction.LOAD : action;
   }
 
   private void addToQueuedSegments(DataSegment segment, SegmentAction action)

--- a/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java
@@ -350,7 +350,7 @@ public class ServerHolder implements Comparable<ServerHolder>
   {
     final List<DataSegment> loadingSegments = new ArrayList<>();
     queuedSegments.forEach((segment, action) -> {
-      if (action == SegmentAction.LOAD) {
+      if (action == SegmentAction.LOAD || action == SegmentAction.REPLICATE) {
         loadingSegments.add(segment);
       }
     });

--- a/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java
@@ -298,7 +298,6 @@ public class ServerHolder implements Comparable<ServerHolder>
    * <ul>
    * <li>Contains segments present in the queue when the current coordinator run started.</li>
    * <li>Contains segments added to the queue during the current run.</li>
-   * <li>Maps replicating segments to LOAD rather than REPLICATE for simplicity.</li>
    * <li>Does not contain segments whose actions were cancelled.</li>
    * </ul>
    */

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CloneHistoricals.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CloneHistoricals.java
@@ -185,7 +185,7 @@ public class CloneHistoricals implements CoordinatorDuty
   )
   {
     if (targetServer.isLoadingSegment(segment)) {
-      targetServer.cancelOperation(SegmentAction.LOAD, segment);
+      targetServer.cancelLoad(segment);
     } else if (loadQueueManager.dropSegment(segment, targetServer)) {
       params.getCoordinatorStats().add(
           Stats.Segments.DROPPED_FROM_CLONE,

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeon.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeon.java
@@ -704,11 +704,11 @@ public class HttpLoadQueuePeon implements LoadQueuePeon
   }
 
   @Override
-  public Set<SegmentHolder> getSegmentsInQueue()
+  public List<SegmentHolder> getSegmentsInQueue()
   {
-    final Set<SegmentHolder> segmentsInQueue;
+    final List<SegmentHolder> segmentsInQueue;
     synchronized (lock) {
-      segmentsInQueue = new HashSet<>(queuedSegments);
+      segmentsInQueue = new ArrayList<>(queuedSegments);
     }
     return segmentsInQueue;
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/LoadQueuePeon.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/LoadQueuePeon.java
@@ -23,6 +23,7 @@ import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.timeline.DataSegment;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -36,7 +37,7 @@ public interface LoadQueuePeon
 
   Set<DataSegment> getSegmentsToLoad();
 
-  Set<SegmentHolder> getSegmentsInQueue();
+  List<SegmentHolder> getSegmentsInQueue();
 
   Set<DataSegment> getSegmentsToDrop();
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentAction.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentAction.java
@@ -48,7 +48,6 @@ public enum SegmentAction
    *   <li>this action can be throttled by the {@code replicationThrottleLimit}</li>
    *   <li>it is given lower priority than LOAD on the load queue peon</li>
    * </ul>
-   * For all other purposes, REPLICATE is treated the same as LOAD.
    */
   REPLICATE(true),
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentReplicaCount.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentReplicaCount.java
@@ -38,6 +38,11 @@ public class SegmentReplicaCount
   private int movingFrom;
 
   /**
+   * Subset of {@link #loading}.
+   */
+  private int replicating;
+
+  /**
    * Increments number of replicas loaded on historical servers.
    */
   void incrementLoaded()
@@ -71,6 +76,7 @@ public class SegmentReplicaCount
   {
     switch (action) {
       case REPLICATE:
+        ++replicating;
       case LOAD:
         ++loading;
         break;
@@ -121,6 +127,15 @@ public class SegmentReplicaCount
   int loading()
   {
     return loading;
+  }
+
+  /**
+   * Number of replicas that are currently being loaded in the tier with action
+   * REPLICATE. Always less than or equal to {@link #loading()}.
+   */
+  int replicating()
+  {
+    return replicating;
   }
 
   int moving()
@@ -211,5 +226,6 @@ public class SegmentReplicaCount
     this.dropping += other.dropping;
     this.movingTo += other.movingTo;
     this.movingFrom += other.movingFrom;
+    this.replicating += other.replicating;
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -194,7 +195,7 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
 
     if (serverA.isLoadingSegment(segment)) {
       // Cancel the load on serverA and load on serverB instead
-      if (serverA.cancelOperation(SegmentAction.LOAD, segment)) {
+      if (serverA.cancelLoad(segment)) {
         int loadedCountOnTier = replicaCountMap.get(segment.getId(), tier)
                                                .loadedNotDropping();
         if (loadedCountOnTier >= 1) {
@@ -593,8 +594,7 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
         break;
       }
       // Try LOAD then REPLICATE; the queued action depends on whether this was a primary or a replica.
-      if (server.cancelOperation(SegmentAction.LOAD, segment)
-          || server.cancelOperation(SegmentAction.REPLICATE, segment)) {
+      if (server.cancelLoad(segment)) {
         canceledOut.add(server);
       }
     }
@@ -658,8 +658,15 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
     // clears the rule on the historical.
     final int replicasToRevert = requiredReplicas > 0 ? replicaCountOnTier.loadedWithPartialProfile() : 0;
 
+    final boolean shouldPrioritizeLoadOfUnavailableSegment =
+        replicaCountOnTier.loadedNotDropping() < 1
+        && replicaCountOnTier.replicating() >= 1;
+
     // Check if there is any action required on this tier
-    if (projectedReplicas == requiredReplicas && !shouldCancelMoves && replicasToRevert <= 0) {
+    if (projectedReplicas == requiredReplicas
+        && !shouldCancelMoves
+        && !shouldPrioritizeLoadOfUnavailableSegment
+        && replicasToRevert <= 0) {
       return 0;
     }
 
@@ -670,6 +677,13 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
     if (shouldCancelMoves) {
       cancelOperations(SegmentAction.MOVE_TO, movingReplicas, segment, segmentStatus);
       cancelOperations(SegmentAction.MOVE_FROM, movingReplicas, segment, segmentStatus);
+    }
+
+    // If segment is unavailable, prioritize load by changing REPLICATE actions to LOAD
+    if (shouldPrioritizeLoadOfUnavailableSegment) {
+      for (ServerHolder server : segmentStatus.getServersPerforming(SegmentAction.REPLICATE)) {
+        prioritizeLoadOfUnavailableSegment(segment, server, null);
+      }
     }
 
     // Cancel drops and queue loads if the projected count is below the requirement
@@ -692,7 +706,9 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
     if (projectedReplicas > requiredReplicas) {
       int replicaSurplus = projectedReplicas - requiredReplicas;
       int canceledLoads =
-          cancelOperations(SegmentAction.LOAD, replicaSurplus, segment, segmentStatus);
+          cancelOperations(SegmentAction.REPLICATE, replicaSurplus, segment, segmentStatus);
+      canceledLoads +=
+          cancelOperations(SegmentAction.LOAD, replicaSurplus - canceledLoads, segment, segmentStatus);
 
       int numReplicasToDrop = Math.min(replicaSurplus - canceledLoads, maxReplicasToDrop);
       if (numReplicasToDrop > 0) {
@@ -710,6 +726,8 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
         incrementStat(Stats.Segments.PARTIAL_RULE_REVERTED, segment, tier, reverted);
       }
     }
+
+
 
     return dropsQueuedOnTier;
   }
@@ -874,7 +892,7 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
   private boolean dropBroadcastSegment(DataSegment segment, ServerHolder server)
   {
     if (server.isLoadingSegment(segment)) {
-      return server.cancelOperation(SegmentAction.LOAD, segment);
+      return server.cancelLoad(segment);
     } else if (server.isServingSegment(segment)) {
       return loadQueueManager.dropSegment(segment, server);
     } else {
@@ -1001,6 +1019,25 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
     }
 
     return numLoadsQueued;
+  }
+
+  /**
+   * Tries to increase the load priority of the given unavailable segment (by
+   * changing the action from {@link SegmentAction#REPLICATE} to {@link SegmentAction#LOAD})
+   * if it is already present in the queue of the server.
+   *
+   * @return true only if the priority was increased successfully.
+   */
+  private boolean prioritizeLoadOfUnavailableSegment(
+      DataSegment segment,
+      ServerHolder server,
+      @Nullable PartialLoadProfile profile
+  )
+  {
+    return server.getActionOnSegment(segment) == SegmentAction.REPLICATE
+           && Objects.equals(profile, server.getProjectedProfile(segment))
+           && server.cancelOperation(SegmentAction.REPLICATE, segment)
+           && loadQueueManager.loadSegment(segment, server, SegmentAction.LOAD, profile);
   }
 
   private boolean loadSegment(DataSegment segment, ServerHolder server, @Nullable PartialLoadProfile profile)

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
@@ -679,13 +679,6 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
       cancelOperations(SegmentAction.MOVE_FROM, movingReplicas, segment, segmentStatus);
     }
 
-    // If segment is unavailable, prioritize load by changing REPLICATE actions to LOAD
-    if (shouldPrioritizeLoadOfUnavailableSegment) {
-      for (ServerHolder server : segmentStatus.getServersPerforming(SegmentAction.REPLICATE)) {
-        prioritizeLoadOfUnavailableSegment(segment, server, null);
-      }
-    }
-
     // Cancel drops and queue loads if the projected count is below the requirement
     if (projectedReplicas < requiredReplicas) {
       int replicaDeficit = requiredReplicas - projectedReplicas;
@@ -714,6 +707,13 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
       if (numReplicasToDrop > 0) {
         dropsQueuedOnTier = dropReplicas(numReplicasToDrop, segment, tier, segmentStatus);
         incrementStat(Stats.Segments.DROPPED, segment, tier, dropsQueuedOnTier);
+      }
+    }
+
+    // If segment is unavailable, prioritize load by changing REPLICATE actions to LOAD
+    if (shouldPrioritizeLoadOfUnavailableSegment) {
+      for (ServerHolder server : segmentStatus.getServersPerforming(SegmentAction.REPLICATE)) {
+        prioritizeLoadOfUnavailableSegment(segment, server, null);
       }
     }
 
@@ -1035,9 +1035,15 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
   )
   {
     return server.getActionOnSegment(segment) == SegmentAction.REPLICATE
-           && Objects.equals(profile, server.getProjectedProfile(segment))
+           && Objects.equals(fingerprintOf(profile), fingerprintOf(server.getProjectedProfile(segment)))
            && server.cancelOperation(SegmentAction.REPLICATE, segment)
            && loadQueueManager.loadSegment(segment, server, SegmentAction.LOAD, profile);
+  }
+
+  @Nullable
+  private static String fingerprintOf(@Nullable PartialLoadProfile profile)
+  {
+    return profile == null ? null : profile.fingerprint();
   }
 
   private boolean loadSegment(DataSegment segment, ServerHolder server, @Nullable PartialLoadProfile profile)

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
@@ -593,7 +593,8 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
       if (canceledOut.size() >= numToCancel) {
         break;
       }
-      // Try LOAD then REPLICATE; the queued action depends on whether this was a primary or a replica.
+      // Try to cancel the load operation
+      // (either LOAD or REPLICATE, depending on whether this was a primary or a replica).
       if (server.cancelLoad(segment)) {
         canceledOut.add(server);
       }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/RunRulesTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/RunRulesTest.java
@@ -492,7 +492,7 @@ public class RunRulesTest
         )
     );
 
-    EasyMock.expect(mockPeon.getSegmentsInQueue()).andReturn(Collections.emptySet()).anyTimes();
+    EasyMock.expect(mockPeon.getSegmentsInQueue()).andReturn(Collections.emptyList()).anyTimes();
     EasyMock.expect(mockPeon.getSegmentsMarkedToDrop()).andReturn(Collections.emptySet()).anyTimes();
     EasyMock.replay(mockPeon);
 
@@ -715,7 +715,7 @@ public class RunRulesTest
 
     LoadQueuePeon anotherMockPeon = EasyMock.createMock(LoadQueuePeon.class);
     EasyMock.expect(anotherMockPeon.getSegmentsMarkedToDrop()).andReturn(Collections.emptySet()).anyTimes();
-    EasyMock.expect(anotherMockPeon.getSegmentsInQueue()).andReturn(Collections.emptySet()).anyTimes();
+    EasyMock.expect(anotherMockPeon.getSegmentsInQueue()).andReturn(Collections.emptyList()).anyTimes();
     EasyMock.expect(anotherMockPeon.getSegmentsToLoad()).andReturn(Collections.emptySet()).anyTimes();
 
     EasyMock.replay(anotherMockPeon);
@@ -1227,7 +1227,7 @@ public class RunRulesTest
   {
     EasyMock.expect(mockPeon.getSegmentsToLoad()).andReturn(Collections.emptySet()).anyTimes();
     EasyMock.expect(mockPeon.getSegmentsMarkedToDrop()).andReturn(Collections.emptySet()).anyTimes();
-    EasyMock.expect(mockPeon.getSegmentsInQueue()).andReturn(Collections.emptySet()).anyTimes();
+    EasyMock.expect(mockPeon.getSegmentsInQueue()).andReturn(Collections.emptyList()).anyTimes();
     EasyMock.replay(mockPeon);
   }
 

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/TestLoadQueuePeon.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/TestLoadQueuePeon.java
@@ -23,7 +23,9 @@ import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.timeline.DataSegment;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -138,9 +140,9 @@ public class TestLoadQueuePeon implements LoadQueuePeon
   }
 
   @Override
-  public Set<SegmentHolder> getSegmentsInQueue()
+  public List<SegmentHolder> getSegmentsInQueue()
   {
-    return queuedHolders;
+    return new ArrayList<>(queuedHolders);
   }
 
   @Override

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulation.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulation.java
@@ -22,6 +22,7 @@ package org.apache.druid.server.coordinator.simulate;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.java.util.metrics.MetricsVerifier;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
+import org.apache.druid.server.coordinator.loading.SegmentHolder;
 import org.apache.druid.server.coordinator.rules.Rule;
 import org.apache.druid.timeline.DataSegment;
 
@@ -106,6 +107,11 @@ public interface CoordinatorSimulation
      * callbacks on the coordinator.
      */
     void loadQueuedSegments();
+
+    /**
+     * Gets the segments currently in the load queue of the given server.
+     */
+    List<SegmentHolder> getQueuedSegments(DruidServer server);
 
     /**
      * Finishes load of all the segments that were queued in the previous

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBaseTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBaseTest.java
@@ -26,6 +26,7 @@ import org.apache.druid.segment.TestDataSource;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.apache.druid.server.coordinator.CreateDataSegments;
+import org.apache.druid.server.coordinator.loading.SegmentHolder;
 import org.apache.druid.server.coordinator.rules.ForeverBroadcastDistributionRule;
 import org.apache.druid.server.coordinator.rules.ForeverDropRule;
 import org.apache.druid.server.coordinator.rules.ForeverLoadRule;
@@ -124,6 +125,12 @@ public abstract class CoordinatorSimulationBaseTest implements
   public void loadQueuedSegments()
   {
     sim.cluster().loadQueuedSegments();
+  }
+
+  @Override
+  public List<SegmentHolder> getQueuedSegments(DruidServer server)
+  {
+    return sim.cluster().getQueuedSegments(server);
   }
 
   @Override

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBuilder.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBuilder.java
@@ -61,6 +61,7 @@ import org.apache.druid.server.coordinator.config.DruidCoordinatorConfig;
 import org.apache.druid.server.coordinator.config.HttpLoadQueuePeonConfig;
 import org.apache.druid.server.coordinator.duty.CoordinatorCustomDutyGroups;
 import org.apache.druid.server.coordinator.loading.LoadQueueTaskMaster;
+import org.apache.druid.server.coordinator.loading.SegmentHolder;
 import org.apache.druid.server.coordinator.loading.SegmentLoadQueueManager;
 import org.apache.druid.server.coordinator.rules.Rule;
 import org.apache.druid.server.http.BrokerDynamicConfigSyncer;
@@ -362,6 +363,14 @@ public class CoordinatorSimulationBuilder
           env.executorFactory.loadCallbackExecutor.finishAllPendingTasks();
         }
       }
+    }
+
+    @Override
+    public List<SegmentHolder> getQueuedSegments(DruidServer server)
+    {
+      return coordinator.getLoadManagementPeons()
+                        .get(server.getName())
+                        .getSegmentsInQueue();
     }
 
     @Override

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentLoadingTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentLoadingTest.java
@@ -22,6 +22,8 @@ package org.apache.druid.server.coordinator.simulate;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.segment.TestDataSource;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
+import org.apache.druid.server.coordinator.loading.SegmentAction;
+import org.apache.druid.server.coordinator.loading.SegmentHolder;
 import org.apache.druid.timeline.DataSegment;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -544,6 +546,84 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
 
     loadQueuedSegments();
     Assertions.assertEquals(historicalT11.getCurrSize(), historicalT12.getCurrSize());
+  }
+
+  @Test
+  public void testLoadQueuePrioritizesUnavailableSegment()
+  {
+    final CoordinatorSimulation sim =
+        CoordinatorSimulation.builder()
+                             .withServers(historicalT11, historicalT12)
+                             .withDynamicConfig(withReplicationThrottleLimit(100))
+                             .withRules(datasource, Load.on(Tier.T1, 2).forever())
+                             .build();
+
+    startSimulation(sim);
+
+    // All but last wiki segments are loaded on historicalT11
+    addSegments(segments);
+    for (int i = 0; i < 9; ++i) {
+      historicalT11.addDataSegment(segments.get(i));
+    }
+    final DataSegment unavailableSegment = segments.getLast();
+
+    runCoordinatorCycle();
+
+    // Verify that the load queue of historicalT12 has the unavailable segment first
+    final List<SegmentHolder> queuedSegments = getQueuedSegments(historicalT12);
+    Assertions.assertEquals(10, queuedSegments.size());
+
+    final SegmentHolder firstItemInQueue = queuedSegments.getFirst();
+    Assertions.assertEquals(unavailableSegment, firstItemInQueue.getSegment());
+    Assertions.assertEquals(SegmentAction.LOAD, firstItemInQueue.getAction());
+
+    for (int i = 1; i < queuedSegments.size(); ++i) {
+      Assertions.assertEquals(SegmentAction.REPLICATE, queuedSegments.get(i).getAction());
+    }
+  }
+
+  @Test
+  public void testSegmentMovesUpTheLoadQueueWhenItBecomesUnavailable()
+  {
+    final CoordinatorSimulation sim =
+        CoordinatorSimulation.builder()
+                             .withServers(historicalT11, historicalT12)
+                             .withDynamicConfig(withReplicationThrottleLimit(100))
+                             .withRules(datasource, Load.on(Tier.T1, 2).forever())
+                             .build();
+
+    startSimulation(sim);
+
+    // All wiki segments are loaded on historicalT11
+    addSegments(segments);
+    segments.forEach(historicalT11::addDataSegment);
+
+    runCoordinatorCycle();
+
+    // Verify that all segments in queue are for replication
+    final List<SegmentHolder> initialQueue = getQueuedSegments(historicalT12);
+    Assertions.assertEquals(10, initialQueue.size());
+    for (SegmentHolder holder : initialQueue) {
+      Assertions.assertEquals(SegmentAction.REPLICATE, holder.getAction());
+    }
+
+    // Now remove a couple of segments from historicalT11
+    final Set<DataSegment> missingSegments = Set.of(segments.get(1), segments.get(5));
+    missingSegments.forEach(segment -> historicalT11.removeDataSegment(segment.getId()));
+
+    runCoordinatorCycle();
+
+    // Verify that the missing segments have been moved up the queue
+    final List<SegmentHolder> updatedQueue = getQueuedSegments(historicalT12);
+    Assertions.assertEquals(10, updatedQueue.size());
+    for (int i = 0; i < 2; ++i) {
+      final SegmentHolder holder = updatedQueue.get(i);
+      Assertions.assertEquals(SegmentAction.LOAD, holder.getAction());
+      Assertions.assertTrue(missingSegments.contains(holder.getSegment()));
+    }
+    for (int i = 2; i < segments.size(); ++i) {
+      Assertions.assertEquals(SegmentAction.REPLICATE, updatedQueue.get(i).getAction());
+    }
   }
 
   @Test


### PR DESCRIPTION
### Description

If a segment becomes unavailable after it has been added to the load queue of a historical, it might remain stuck in the queue while other segments are being loaded. Ideally, all unavailable segments should be prioritized.

### Changes
- Simplify book-keeping in `ServerHolder` by getting rid of method `simplify()` and treat REPLICATE and LOAD actions as distinct
- In `StrategicSegmentAssigner.updateReplicasInTier()`, check if an unavailable segment needs to be prioritized and change all in-flight REPLICATE actions on that segment to LOAD.
- Update `LoadQueuePeon.getSegmentsInQueue` to return a List instead of a Set and verify the result in Coordinator simulations

### Pending

Handle the same change for `updateReplicasInTierPartial`.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.