### PR TITLE
fix: Avoid collisions in CacheKeyBuilder.

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/cache/CacheKeyBuilder.java
+++ b/processing/src/main/java/org/apache/druid/query/cache/CacheKeyBuilder.java
@@ -30,13 +30,10 @@ import org.apache.druid.java.util.common.Cacheable;
 import org.apache.druid.java.util.common.StringUtils;
 
 import javax.annotation.Nullable;
-
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -44,12 +41,12 @@ import java.util.List;
  *
  * The layout of the serialized cache key is like below.
  *
- * +--------------------------------------------------------+
- * | ID (1 byte)                                            |
- * | type key (1 byte) | serialized value (variable length) |
- * | type key (1 byte) | serialized value (variable length) |
- * | ...                                                    |
- * +--------------------------------------------------------+
+ * +--------------------------------------------------+
+ * | ID (1 byte)                                      |
+ * | type key (1 byte) | length (4 bytes) | value     |
+ * | type key (1 byte) | length (4 bytes) | value     |
+ * | ...                                              |
+ * +--------------------------------------------------+
  *
  */
 @PublicApi
@@ -72,20 +69,11 @@ public class CacheKeyBuilder
   static final byte[] STRING_SEPARATOR = new byte[]{(byte) 0xFF};
   static final byte[] EMPTY_BYTES = StringUtils.EMPTY_BYTES;
 
-  private static class Item
+  private record Item(byte typeKey, byte[] item)
   {
-    private final byte typeKey;
-    private final byte[] item;
-
-    Item(byte typeKey, byte[] item)
-    {
-      this.typeKey = typeKey;
-      this.item = item;
-    }
-
     int byteSize()
     {
-      return 1 + item.length;
+      return 1 + Integer.BYTES + item.length;
     }
   }
 
@@ -127,17 +115,23 @@ public class CacheKeyBuilder
       boolean preserveOrder
   )
   {
-    return collectionToByteArray(input, CacheKeyBuilder::cacheableToByteArray, EMPTY_BYTES, preserveOrder);
+    return collectionToByteArray(input, CacheKeyBuilder::cacheableToByteArray, null, preserveOrder);
   }
 
+  /**
+   * Serializes a collection as an element count followed by the elements.
+   *
+   * <p>Elements are joined with {@code separator} when one is given. When {@code separator} is null, each element
+   * is preceded by its own length.
+   */
   private static <T> byte[] collectionToByteArray(
       @Nullable Collection<? extends T> collection,
       Function<T, byte[]> serializeFunction,
-      byte[] separator,
+      @Nullable byte[] separator,
       boolean preserveOrder
   )
   {
-    if (collection != null && collection.size() > 0) {
+    if (collection != null && !collection.isEmpty()) {
       List<byte[]> byteArrayList = Lists.newArrayListWithCapacity(collection.size());
       int totalByteLength = 0;
       for (T eachItem : collection) {
@@ -148,17 +142,27 @@ public class CacheKeyBuilder
 
       if (!preserveOrder) {
         // Sort the byte array list to guarantee that collections of same items but in different orders make the same result
-        Collections.sort(byteArrayList, UnsignedBytes.lexicographicalComparator());
+        byteArrayList.sort(UnsignedBytes.lexicographicalComparator());
       }
 
-      final Iterator<byte[]> iterator = byteArrayList.iterator();
-      final int bufSize = Integer.BYTES + separator.length * (byteArrayList.size() - 1) + totalByteLength;
-      final ByteBuffer buffer = ByteBuffer.allocate(bufSize)
-                                          .putInt(byteArrayList.size())
-                                          .put(iterator.next());
+      final int bufSize;
+      if (separator == null) {
+        bufSize = Integer.BYTES * (byteArrayList.size() + 1) + totalByteLength;
+      } else {
+        bufSize = Integer.BYTES + separator.length * (byteArrayList.size() - 1) + totalByteLength;
+      }
 
-      while (iterator.hasNext()) {
-        buffer.put(separator).put(iterator.next());
+      final ByteBuffer buffer = ByteBuffer.allocate(bufSize).putInt(byteArrayList.size());
+
+      boolean first = true;
+      for (final byte[] byteArray : byteArrayList) {
+        if (separator == null) {
+          buffer.putInt(byteArray.length);
+        } else if (!first) {
+          buffer.put(separator);
+        }
+        buffer.put(byteArray);
+        first = false;
       }
 
       return buffer.array();
@@ -280,7 +284,7 @@ public class CacheKeyBuilder
 
   /**
    * Add a collection of Cacheables to the cache key.
-   * Cacheables in the collection are concatenated without any separator,
+   * Cacheables in the collection each appear preceded by their length,
    * and they appear in the cache key in their input order.
    *
    * @param input a collection of Cacheables to be included in the cache key
@@ -295,7 +299,7 @@ public class CacheKeyBuilder
   /**
    * Add a collection of Cacheables to the cache key.
    * Cacheables in the collection are sorted by their byte representation and
-   * concatenated without any separator.
+   * each appears preceded by their length.
    *
    * @param input a collection of Cacheables to be included in the cache key
    * @return this instance
@@ -323,7 +327,7 @@ public class CacheKeyBuilder
     buffer.put(id);
 
     for (Item item : items) {
-      buffer.put(item.typeKey).put(item.item);
+      buffer.put(item.typeKey).putInt(item.item.length).put(item.item);
     }
 
     return buffer.array();

--- a/processing/src/test/java/org/apache/druid/query/cache/CacheKeyBuilderTest.java
+++ b/processing/src/test/java/org/apache/druid/query/cache/CacheKeyBuilderTest.java
@@ -38,6 +38,7 @@ public class CacheKeyBuilderTest
   public void testCacheKeyBuilder()
   {
     final Cacheable cacheable = () -> new byte[]{10, 20};
+    final byte[] separatorLikeBytes = new byte[]{(byte) 0xFF};
 
     final byte[] actual = new CacheKeyBuilder((byte) 10)
         .appendBoolean(false)
@@ -46,7 +47,7 @@ public class CacheKeyBuilderTest
         .appendLong(Long.MAX_VALUE)
         .appendFloat(0.1f)
         .appendDouble(2.3)
-        .appendByteArray(CacheKeyBuilder.STRING_SEPARATOR) // test when an item is same with the separator
+        .appendByteArray(separatorLikeBytes)
         .appendFloatArray(new float[]{10.0f, 11.0f})
         .appendStrings(Lists.newArrayList("test1", "test2"))
         .appendCacheable(cacheable)
@@ -54,51 +55,70 @@ public class CacheKeyBuilderTest
         .appendCacheables(Lists.newArrayList(cacheable, null, cacheable))
         .build();
 
-    final int expectedSize = 1                                           // id
-                             + 1                                         // bool
-                             + 4                                         // 'test'
-                             + Integer.BYTES                             // 10
-                             + Long.BYTES                                // Long.MAX_VALUE
-                             + Float.BYTES                               // 0.1f
-                             + Double.BYTES                              // 2.3
-                             + CacheKeyBuilder.STRING_SEPARATOR.length   // byte array
-                             + Float.BYTES * 2                           // 10.0f, 11.0f
-                             + Integer.BYTES + 5 * 2 + 1                 // 'test1' 'test2'
-                             + cacheable.getCacheKey().length            // cacheable
-                             + Integer.BYTES + 4                         // cacheable list
-                             + 12;                                       // type keys
+    // Every item is a type key, then the length of its value, then the value; every element of a collection is
+    // likewise preceded by its own length.
+    final int itemHeader = 1 + Integer.BYTES;
+    final int expectedSize =
+        1                                                            // id
+        + itemHeader + 1                                             // bool
+        + itemHeader + 4                                             // 'test'
+        + itemHeader + Integer.BYTES                                 // 10
+        + itemHeader + Long.BYTES                                    // Long.MAX_VALUE
+        + itemHeader + Float.BYTES                                   // 0.1f
+        + itemHeader + Double.BYTES                                  // 2.3
+        + itemHeader + 1                                             // byte array
+        + itemHeader + Float.BYTES * 2                               // 10.0f, 11.0f
+        + itemHeader + (Integer.BYTES + 5 * 2 + 1)                   // 'test1' 0xFF 'test2'
+        + itemHeader + 2                                             // cacheable
+        + itemHeader                                                 // null cacheable
+        + itemHeader + (Integer.BYTES + (Integer.BYTES + 2) + Integer.BYTES + (Integer.BYTES + 2)); // cacheable list
     Assertions.assertEquals(expectedSize, actual.length);
 
     final byte[] expected = ByteBuffer.allocate(expectedSize)
                                       .put((byte) 10)
                                       .put(CacheKeyBuilder.BOOLEAN_KEY)
+                                      .putInt(1)
                                       .put((byte) 0)
                                       .put(CacheKeyBuilder.STRING_KEY)
+                                      .putInt(4)
                                       .put(StringUtils.toUtf8("test"))
                                       .put(CacheKeyBuilder.INT_KEY)
+                                      .putInt(Integer.BYTES)
                                       .putInt(10)
                                       .put(CacheKeyBuilder.LONG_KEY)
+                                      .putInt(Long.BYTES)
                                       .putLong(Long.MAX_VALUE)
                                       .put(CacheKeyBuilder.FLOAT_KEY)
+                                      .putInt(Float.BYTES)
                                       .putFloat(0.1f)
                                       .put(CacheKeyBuilder.DOUBLE_KEY)
+                                      .putInt(Double.BYTES)
                                       .putDouble(2.3)
                                       .put(CacheKeyBuilder.BYTE_ARRAY_KEY)
-                                      .put(CacheKeyBuilder.STRING_SEPARATOR)
+                                      .putInt(separatorLikeBytes.length)
+                                      .put(separatorLikeBytes)
                                       .put(CacheKeyBuilder.FLOAT_ARRAY_KEY)
+                                      .putInt(Float.BYTES * 2)
                                       .putFloat(10.0f)
                                       .putFloat(11.0f)
                                       .put(CacheKeyBuilder.STRING_LIST_KEY)
+                                      .putInt(Integer.BYTES + 5 * 2 + 1)
                                       .putInt(2)
                                       .put(StringUtils.toUtf8("test1"))
                                       .put(CacheKeyBuilder.STRING_SEPARATOR)
                                       .put(StringUtils.toUtf8("test2"))
                                       .put(CacheKeyBuilder.CACHEABLE_KEY)
+                                      .putInt(2)
                                       .put(cacheable.getCacheKey())
                                       .put(CacheKeyBuilder.CACHEABLE_KEY)
+                                      .putInt(0)
                                       .put(CacheKeyBuilder.CACHEABLE_LIST_KEY)
+                                      .putInt(Integer.BYTES + (Integer.BYTES + 2) + Integer.BYTES + (Integer.BYTES + 2))
                                       .putInt(3)
+                                      .putInt(2)
                                       .put(cacheable.getCacheKey())
+                                      .putInt(0)
+                                      .putInt(2)
                                       .put(cacheable.getCacheKey())
                                       .array();
 
@@ -299,13 +319,17 @@ public class CacheKeyBuilderTest
   @Test
   public void testIgnoringOrder()
   {
+    final int stringListSize = Integer.BYTES + (2 + 5 + 5) + CacheKeyBuilder.STRING_SEPARATOR.length * 2;
+    final int cacheableListSize = Integer.BYTES + (Integer.BYTES + 2) + (Integer.BYTES + 5) * 2;
+
     byte[] actual = new CacheKeyBuilder((byte) 10)
         .appendStringsIgnoringOrder(Lists.newArrayList("test2", "test1", "te"))
         .build();
 
-    byte[] expected = ByteBuffer.allocate(20)
+    byte[] expected = ByteBuffer.allocate(1 + 1 + Integer.BYTES + stringListSize)
                                 .put((byte) 10)
                                 .put(CacheKeyBuilder.STRING_LIST_KEY)
+                                .putInt(stringListSize)
                                 .putInt(3)
                                 .put(StringUtils.toUtf8("te"))
                                 .put(CacheKeyBuilder.STRING_SEPARATOR)
@@ -326,12 +350,16 @@ public class CacheKeyBuilderTest
         .appendCacheablesIgnoringOrder(Lists.newArrayList(c3, c2, c1))
         .build();
 
-    expected = ByteBuffer.allocate(18)
+    expected = ByteBuffer.allocate(1 + 1 + Integer.BYTES + cacheableListSize)
                          .put((byte) 10)
                          .put(CacheKeyBuilder.CACHEABLE_LIST_KEY)
+                         .putInt(cacheableListSize)
                          .putInt(3)
+                         .putInt(2)
                          .put(c1.getCacheKey())
+                         .putInt(5)
                          .put(c2.getCacheKey())
+                         .putInt(5)
                          .put(c3.getCacheKey())
                          .array();
 

--- a/processing/src/test/java/org/apache/druid/query/dimension/DefaultDimensionSpecTest.java
+++ b/processing/src/test/java/org/apache/druid/query/dimension/DefaultDimensionSpecTest.java
@@ -60,7 +60,11 @@ public class DefaultDimensionSpecTest
   public void testCacheKey()
   {
     final DimensionSpec spec = new DefaultDimensionSpec("foo", "foo", ColumnType.FLOAT);
-    final byte[] expected = new byte[] {0, 7, 102, 111, 111, 7, 70, 76, 79, 65, 84};
+    final byte[] expected = new byte[]{
+        0,                                  // cache type id
+        7, 0, 0, 0, 3, 102, 111, 111,       // STRING_KEY, length 3, "foo"
+        7, 0, 0, 0, 5, 70, 76, 79, 65, 84   // STRING_KEY, length 5, "FLOAT"
+    };
     Assertions.assertArrayEquals(expected, spec.getCacheKey());
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/dimension/ExtractionDimensionSpecTest.java
+++ b/processing/src/test/java/org/apache/druid/query/dimension/ExtractionDimensionSpecTest.java
@@ -155,7 +155,12 @@ public class ExtractionDimensionSpecTest
         ColumnType.LONG,
         StrlenExtractionFn.instance()
     );
-    final byte[] expected = new byte[]{1, 7, 102, 111, 111, 9, 14, 7, 76, 79, 78, 71};
+    final byte[] expected = new byte[]{
+        1,                                 // cache type id
+        7, 0, 0, 0, 3, 102, 111, 111,      // STRING_KEY, length 3, "foo"
+        9, 0, 0, 0, 1, 14,                 // CACHEABLE_KEY, length 1, StrlenExtractionFn
+        7, 0, 0, 0, 4, 76, 79, 78, 71      // STRING_KEY, length 4, "LONG"
+    };
     Assertions.assertArrayEquals(expected, dimensionSpec.getCacheKey());
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
@@ -112,7 +112,15 @@ public class SegmentMetadataQueryQueryToolChestTest
         new SegmentMetadataQueryQueryToolChest(new SegmentMetadataQueryConfig()).getCacheStrategy(query);
 
     // Test cache key generation
-    byte[] expectedKey = {0x04, 0x09, 0x01, 0x0A, 0x00, 0x00, 0x00, 0x03, 0x00, 0x02, 0x04};
+    byte[] expectedKey = {
+        0x04,                                // cache type id
+        0x09, 0x00, 0x00, 0x00, 0x01, 0x01,  // CACHEABLE_KEY, length 1, "toInclude"
+        0x0A, 0x00, 0x00, 0x00, 0x13,        // CACHEABLE_LIST_KEY, length 19
+        0x00, 0x00, 0x00, 0x03,              // 3 analysis types, each length-prefixed
+        0x00, 0x00, 0x00, 0x01, 0x00,
+        0x00, 0x00, 0x00, 0x01, 0x02,
+        0x00, 0x00, 0x00, 0x01, 0x04
+    };
     byte[] actualKey = strategy.computeCacheKey(query);
     Assertions.assertArrayEquals(expectedKey, actualKey);
 

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
@@ -3053,7 +3053,7 @@ public class CachingClusteredClientTest
     final ResponseContext responseContext = initializeResponseContext();
 
     getDefaultQueryRunner().run(QueryPlus.wrap(query), responseContext);
-    Assertions.assertEquals("RsQmZHYstvXNeGf86z3pgpk+Wsg=", responseContext.getEntityTag());
+    Assertions.assertEquals("oT5Zc1xWdiAOg0C4HgTrAmci7tk=", responseContext.getEntityTag());
   }
 
   @Test


### PR DESCRIPTION
This patch adds a length prefix before each item when building cache keys. This avoids ambiguity in situations where a cache key itself contains a valid type code.