### PR TITLE
ci: reduce CI duration from 1h15m to 43m

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -35,3 +35,8 @@ target
 *.DS_Store
 _site
 dependency-reduced-pom.xml
+
+# Allow the host-built distribution to pass its binary tarball into
+# the Docker build while continuing to exclude all other build output.
+!distribution/target/
+!distribution/target/apache-druid-*-bin.tar.gz

--- a/.dockerignore
+++ b/.dockerignore
@@ -39,4 +39,5 @@ dependency-reduced-pom.xml
 # Allow the host-built distribution to pass its binary tarball into
 # the Docker build while continuing to exclude all other build output.
 !distribution/target/
+distribution/target/*
 !distribution/target/apache-druid-*-bin.tar.gz

--- a/.github/scripts/build-dist
+++ b/.github/scripts/build-dist
@@ -18,4 +18,4 @@
 set -e
 set -x
 
-mvn -B clean install -Papache-release,dist,rat -DskipTests -Ddependency-check.skip -Dgpg.skip
+mvn -B -T1C clean install -Papache-release,dist,rat,bundle-contrib-exts -DskipTests -Ddependency-check.skip -Dgpg.skip

--- a/.github/scripts/run_docker-tests
+++ b/.github/scripts/run_docker-tests
@@ -35,4 +35,4 @@ fi
 
 # No snapshot updates
 OPTS+=" -nsu"
-mvn -B $OPTS verify -Pdocker-tests,skip-static-checks -DskipUTs -D$DRUID_IMAGE_SYS_PROPERTY=$DRUID_IMAGE_NAME "-DjfrProfilerArgLine=$JFR_PROFILER_ARG_LINE" "$@"
+mvn -B -pl embedded-tests -am $OPTS verify -Pdocker-tests,skip-static-checks -DskipUTs -D$DRUID_IMAGE_SYS_PROPERTY=$DRUID_IMAGE_NAME "-DjfrProfilerArgLine=$JFR_PROFILER_ARG_LINE" "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,6 @@ jobs:
       key: "test-jdk${{ matrix.jdk }}-[${{ matrix.pattern }}]"
       execute: ${{ matrix.jdk == '25' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test-jdk21') }}
 
-  validate-dist:
-    uses: ./.github/workflows/worker.yml
-    with:
-      script: .github/scripts/validate-dist
-      key: "validate-dist"
-
   reporting-jacoco-coverage-failures:
     name: "coverage-jacoco"
     needs: [run-unit-tests, run-separated-tests]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - uses: actions/setup-java@v5
+    # JavaScript/TypeScript and Python are analyzed directly from source and do
+    # not need a Java runtime or Maven build.
+    - name: Set up Java
+      if: ${{ matrix.language == 'java' }}
+      uses: actions/setup-java@v5
       with:
         distribution: 'zulu'
         java-version: '25'
@@ -60,7 +64,9 @@ jobs:
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         queries: +security-and-quality
 
-    - run: |
+    - name: Build Java sources
+      if: ${{ matrix.language == 'java' }}
+      run: |
         echo "Building using custom commands"
         mvn clean package -f "pom.xml" -B -V -e -Dfindbugs.skip -Dcheckstyle.skip -Dpmd.skip=true -Denforcer.skip -Dmaven.javadoc.skip -DskipTests -Dmaven.test.skip.exec -Dlicense.skip=true -Dweb.console.skip=true -Dcyclonedx.skip=true
 

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -25,27 +25,20 @@ jobs:
       - uses: actions/checkout@v6
       - name: Set Docker image env var
         run: echo "DRUID_DIST_IMAGE_NAME=apache/druid:docker-tests" >> $GITHUB_ENV
-      - name: Build the Docker image
-        run: DOCKER_BUILDKIT=1 docker build -t $DRUID_DIST_IMAGE_NAME -f distribution/docker/Dockerfile .
-      - name: Save Docker image to archive
-        run: |
-          echo "Saving image $DRUID_DIST_IMAGE_NAME in archive druid-dist-container.tar.gz"
-          docker save "$DRUID_DIST_IMAGE_NAME" | gzip > druid-dist-container.tar.gz
-      - name: Stop and remove Druid Docker containers
-        run: |
-          echo "Force stopping all Druid containers and pruning"
-          docker ps -aq --filter "ancestor=apache/druid" | xargs -r docker rm -f
-          docker system prune -af --volumes
-      - name: Load Docker image
-        run: |
-          docker load --input druid-dist-container.tar.gz
-          docker images
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 25
           cache: 'maven'
+      - name: Build the Druid distribution
+        run: .github/scripts/build-dist
+      - name: Build the Docker image
+        run: |
+          DOCKER_BUILDKIT=1 docker build \
+            --build-arg BUILD_FROM_SOURCE=false \
+            -t "$DRUID_DIST_IMAGE_NAME" \
+            -f distribution/docker/Dockerfile .
       - name: Run Docker tests
         id: run-it
         run: .github/scripts/run_docker-tests

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -56,7 +56,6 @@ jobs:
     uses: ./.github/workflows/ci.yml
 
   docker-tests:
-    needs: [unit-tests]
     uses: ./.github/workflows/docker-tests.yml
 
   actions-timeline:


### PR DESCRIPTION
## Summary

Re-orchestrate the CI jobs and remove redundant build work to reduce the time
required to validate a change.

## Current job dependencies

Before this change, the workflow was effectively:

```text
unit-tests (including validate-dist) -> docker-tests -> actions-timeline
```

The `docker-tests` job had `needs: [unit-tests]`, so it waited for the complete
unit-test reusable workflow, including distribution validation, before it could
start.

After this change:

```text
unit-tests ─┐
            ├─ actions-timeline
docker-tests ┘
```

The unit-test and Docker-test workflows run independently. The timeline job
remains reporting-only and waits for both workflows.

## Key problems

- Docker tests were unnecessarily gated by all unit-test shards.
- The distribution was built in a separate `validate-dist` job and transferred
  through an artifact before Docker testing.
- The Docker workflow performed unnecessary image save/load/prune operations.
- The Docker image could rebuild the application from source.
- Docker-test Maven execution verified the entire reactor instead of the
  required `embedded-tests` module and its dependencies.
- JavaScript and Python CodeQL jobs performed unnecessary Java setup and Maven
  compilation.
- The distribution build was single-threaded.

## Changes

- Remove the separate distribution-validation job from the unit-test workflow.
- Rename `.github/scripts/validate-dist` to `.github/scripts/build-dist` and run
  it in the Docker job.
- Use Maven `-T1C` for the distribution build.
- Build the Docker image from the host-built distribution with
  `BUILD_FROM_SOURCE=false`.
- Remove the Docker image save/load/prune cycle and distribution artifact
  handoff.
- Allow the host-built distribution tarball into the Docker build context.
- Limit Docker-test Maven execution to `embedded-tests` and its dependencies
  with `-pl embedded-tests -am`.
- Remove the Docker job dependency on the unit-test workflow.
- Skip Java setup and Maven compilation for JavaScript and Python CodeQL jobs.

## Measured outcome

### Successful upstream master baseline

The baseline is commit `e9db64b6e97c974975321f51085936f9c27e13f9` on the
Apache Druid `master` branch. All three relevant workflows completed
successfully:

- [Unit & Integration tests CI](https://github.com/apache/druid/actions/runs/34004622921)
- [Static Checks CI](https://github.com/apache/druid/actions/runs/34004622770)
- [CodeQL](https://github.com/apache/druid/actions/runs/34004622568)

The complete upstream CI window was **1h15m55s**. The Docker job started
**40m18s after** the Unit & Integration workflow began because of the existing
dependency.

### Current branch benchmark

The current branch benchmark is the successful run for commit
`3361d2d50b8024b8cbf72bd53b18b9f5c7b07ac6`:

- [Unit & Integration tests CI](https://github.com/apache/druid/actions/runs/34025232910)
- [Static Checks CI](https://github.com/apache/druid/actions/runs/34025232753)
- [CodeQL](https://github.com/apache/druid/actions/runs/34025232556)

The complete CI window was **43m15s**. The Docker job started **3s after** the
Unit & Integration workflow and completed successfully. All relevant checks
were green.

| Metric | Successful upstream `master` | Current branch benchmark | Difference |
| --- | ---: | ---: | ---: |
| Complete CI window | 1h15m55s | 43m15s | 32m40s faster |
| Docker job runtime | 35m27s | 34m40s | 47s faster |
| Docker job start delay | 40m18s | 3s | 40m15s earlier |
| CodeQL workflow | 30m41s | 23m04s | 7m37s faster |

For the current Docker job, the key steps were:

| Docker step | Duration |
| --- | ---: |
| Build the Druid distribution | 12m34s |
| Build the Docker image | 2m25s |
| Run Docker tests | 19m01s |

The Docker job is slightly longer because it now performs the host distribution
build, but the job becomes available immediately instead of waiting for the
unit-test workflow.

### CodeQL breakdown

| CodeQL job | Successful upstream `master` | Current branch benchmark | Difference |
| --- | ---: | ---: | ---: |
| Analyze (JavaScript) | 6m46s | 1m39s | 5m07s faster |
| Analyze (Python) | 6m41s | 1m08s | 5m33s faster |
| Analyze (Java) | 30m37s | 23m00s | Not attributed to this change |

The JavaScript and Python improvements result from skipping Java setup and
Maven compilation for interpreted-language analysis. The Java timing
difference is not an intended optimization.

### Same-workflow `-T1C` comparison

Compared with the preceding no-`-T1C` benchmark:

| Metric | No `-T1C` | Current branch | Improvement |
| --- | ---: | ---: | ---: |
| Distribution build | 29m25s | 12m34s | 16m51s faster |
| Docker job | 50m15s | 34m40s | 15m35s faster |
| End-to-end workflow | 55m43s | 43m15s | 12m28s faster |

These are single-run measurements and can vary with GitHub Actions runner
scheduling.

## CI duration visualization

![Master branch - Critical execution path](https://github.com/user-attachments/assets/2b204a4d-7d51-426e-9428-c5ea12d86cf7)

![PR #20270 - Critical execution path](https://github.com/user-attachments/assets/2aa6cfc4-0f12-40d8-ae9a-8213eefd0a06)

## Validation

- `git diff --check`
- Shell syntax validation for `build-dist` and `run_docker-tests`
- Unit & Integration tests, Static Checks, CodeQL, and PR checks completed successfully for the current head

