### PR TITLE
fix: stabilize task queue and ingestion CI tests

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/IngestionSmokeTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/IngestionSmokeTest.java
@@ -24,6 +24,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.druid.common.utils.IdUtils;
 import org.apache.druid.data.input.impl.CsvInputFormat;
 import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.indexer.TaskStatusPlus;
 import org.apache.druid.indexing.common.task.CompactionTask;
 import org.apache.druid.indexing.common.task.IndexTask;
 import org.apache.druid.indexing.common.task.NoopTask;
@@ -33,6 +34,9 @@ import org.apache.druid.indexing.kafka.KafkaIndexTaskModule;
 import org.apache.druid.indexing.kafka.simulate.KafkaResource;
 import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorSpec;
 import org.apache.druid.indexing.overlord.Segments;
+import org.apache.druid.indexing.overlord.TaskMaster;
+import org.apache.druid.indexing.overlord.TaskRunner;
+import org.apache.druid.indexing.overlord.TaskRunnerWorkItem;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorStatus;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
@@ -40,6 +44,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.metadata.storage.postgresql.PostgreSQLMetadataStorageModule;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.http.SqlTaskStatus;
+import org.apache.druid.rpc.indexing.OverlordClient;
 import org.apache.druid.segment.metadata.Metric;
 import org.apache.druid.tasklogs.TaskLogStreamer;
 import org.apache.druid.testing.embedded.EmbeddedBroker;
@@ -67,6 +72,7 @@ import org.junit.jupiter.api.Test;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -145,7 +151,51 @@ public class IngestionSmokeTest extends EmbeddedClusterTestBase
   @AfterEach
   public void cleanUp()
   {
-    markSegmentsAsUnused(dataSource);
+    try {
+      final List<SupervisorStatus> supervisors = new ArrayList<>();
+      cluster.callApi().onLeaderOverlord(OverlordClient::supervisorStatuses).forEachRemaining(supervisors::add);
+      for (final SupervisorStatus supervisor : supervisors) {
+        if (dataSource.equals(supervisor.getId())) {
+          cluster.callApi().onLeaderOverlord(o -> o.terminateSupervisor(supervisor.getId()));
+        }
+      }
+
+      cluster.callApi()
+             .waitForResult(this::cancelTasksForCurrentTest, Set::isEmpty)
+             .withTimeoutMillis(60_000)
+             .go();
+    }
+    finally {
+      markSegmentsAsUnused(dataSource);
+    }
+  }
+
+  private Set<String> cancelTasksForCurrentTest()
+  {
+    final Set<String> taskIds = new HashSet<>();
+    for (final String state : List.of("running", "pending", "waiting")) {
+      for (final TaskStatusPlus task : cluster.callApi().getTasks(dataSource, state)) {
+        taskIds.add(task.getId());
+      }
+    }
+
+    // A task can be complete in storage while still occupying a worker slot.
+    // Docker subclasses may use an external leader, so its runner is not available here.
+    final Optional<TaskRunner> taskRunner = overlord.bindings().getInstance(TaskMaster.class).getTaskRunner();
+    if (taskRunner.isPresent()) {
+      final List<TaskRunnerWorkItem> runnerTasks = new ArrayList<>(taskRunner.get().getPendingTasks());
+      runnerTasks.addAll(taskRunner.get().getRunningTasks());
+      for (final TaskRunnerWorkItem task : runnerTasks) {
+        if (dataSource.equals(task.getDataSource())) {
+          taskIds.add(task.getTaskId());
+        }
+      }
+    }
+
+    for (final String taskId : taskIds) {
+      cluster.callApi().onLeaderOverlord(o -> o.cancelTask(taskId));
+    }
+    return taskIds;
   }
 
   protected int markSegmentsAsUnused(String dataSource)
@@ -363,7 +413,7 @@ public class IngestionSmokeTest extends EmbeddedClusterTestBase
     final String taskId = IdUtils.getRandomId();
     final long runDurationMillis = 100_000L;
     cluster.callApi().onLeaderOverlord(
-        o -> o.runTask(taskId, new NoopTask(taskId, null, null, runDurationMillis, 0L, null))
+        o -> o.runTask(taskId, new NoopTask(taskId, null, dataSource, runDurationMillis, 0L, null))
     );
 
     eventCollector.latchableEmitter().waitForEvent(

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
@@ -29,10 +29,17 @@ import org.apache.druid.indexing.seekablestream.supervisor.BoundedStreamConfig;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
 import org.apache.druid.testing.embedded.StreamIngestResource;
+import org.apache.druid.testing.embedded.tools.EventSerializer;
+import org.apache.druid.testing.embedded.tools.JsonEventSerializer;
+import org.apache.druid.testing.embedded.tools.StreamGenerator;
+import org.apache.druid.testing.embedded.tools.WikipediaStreamEventStreamGenerator;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -186,12 +193,26 @@ public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
         .build(dataSource, topic);
   }
 
+  private void publishRecordsToBothPartitions(String topic)
+  {
+    final EventSerializer serializer = new JsonEventSerializer(overlord.bindings().jsonMapper());
+    final StreamGenerator generator = new WikipediaStreamEventStreamGenerator(serializer, 100, 100);
+    final List<byte[]> records = generator.generateEvents(10);
+    final List<ProducerRecord<byte[], byte[]>> producerRecords = new ArrayList<>();
+    // Fixed per-partition end offsets require data in both partitions; Kafka's default partitioner need not balance it.
+    for (int i = 0; i < records.size(); i++) {
+      producerRecords.add(new ProducerRecord<>(topic, i % 2, null, records.get(i)));
+    }
+    kafkaServer.produceRecordsWithoutTransaction(producerRecords);
+    Assertions.assertEquals(Map.of("0", 500L, "1", 500L), kafkaServer.getPartitionOffsets(topic));
+  }
+
   @Test
   public void test_boundedSupervisor_withMismatchedMetadata_is_unhealthy()
   {
     final String topic = IdUtils.getRandomId();
     kafkaServer.createTopicWithPartitions(topic, 2);
-    publish1kRecords(topic, false);
+    publishRecordsToBothPartitions(topic);
 
     // Get the current end offsets for all partitions
     Map<String, Long> currentOffsets = kafkaServer.getPartitionOffsets(topic);
@@ -265,7 +286,7 @@ public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
   {
     final String topic = IdUtils.getRandomId();
     kafkaServer.createTopicWithPartitions(topic, 2);
-    publish1kRecords(topic, false);
+    publishRecordsToBothPartitions(topic);
 
     // Run 1: ingest up to offset 100 on each partition and complete.
     Map<String, Long> startOffsets1 = new HashMap<>();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueScaleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueScaleTest.java
@@ -179,12 +179,8 @@ public class TaskQueueScaleTest
       taskQueue.add(testTask);
     }
 
-    // in theory we can get a race here, since we fetch the counts at separate times
+    // The running, pending, and waiting counters are separate snapshots and cannot be summed while tasks transition.
     Assertions.assertEquals(numTasks, taskQueue.getTasks().size(), "all tasks should be known");
-    long runningTasks = taskQueue.getRunningTaskCount().values().stream().mapToLong(Long::longValue).sum();
-    long pendingTasks = taskQueue.getPendingTaskCount().values().stream().mapToLong(Long::longValue).sum();
-    long waitingTasks = taskQueue.getWaitingTaskCount().values().stream().mapToLong(Long::longValue).sum();
-    Assertions.assertEquals(numTasks, (runningTasks + pendingTasks + waitingTasks), "all tasks should be known");
 
     // Wait for all tasks to finish.
     final TaskLookup.CompleteTaskLookup completeTaskLookup =
@@ -194,12 +190,18 @@ public class TaskQueueScaleTest
       Thread.sleep(100);
     }
 
-    Thread.sleep(100);
+    // Completion is persisted before cleanup finishes. The test timeout bounds this wait.
+    while (!taskStorage.getActiveTasks().isEmpty()
+           || taskQueue.getRunningTaskCount().values().stream().anyMatch(count -> count != 0)
+           || taskQueue.getPendingTaskCount().values().stream().anyMatch(count -> count != 0)
+           || taskQueue.getWaitingTaskCount().values().stream().anyMatch(count -> count != 0)) {
+      Thread.sleep(100);
+    }
 
     Assertions.assertEquals(0, taskStorage.getActiveTasks().size(), "no tasks should be active");
-    runningTasks = taskQueue.getRunningTaskCount().values().stream().mapToLong(Long::longValue).sum();
-    pendingTasks = taskQueue.getPendingTaskCount().values().stream().mapToLong(Long::longValue).sum();
-    waitingTasks = taskQueue.getWaitingTaskCount().values().stream().mapToLong(Long::longValue).sum();
+    final long runningTasks = taskQueue.getRunningTaskCount().values().stream().mapToLong(Long::longValue).sum();
+    final long pendingTasks = taskQueue.getPendingTaskCount().values().stream().mapToLong(Long::longValue).sum();
+    final long waitingTasks = taskQueue.getWaitingTaskCount().values().stream().mapToLong(Long::longValue).sum();
     Assertions.assertEquals(0, runningTasks, "no tasks should be running");
     Assertions.assertEquals(0, pendingTasks, "no tasks should be pending");
     Assertions.assertEquals(0, waitingTasks, "no tasks should be waiting");

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
@@ -32,6 +32,7 @@ import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.error.DruidException;
+import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.indexing.common.TaskLockType;
 import org.apache.druid.indexing.common.task.Tasks;
@@ -654,15 +655,15 @@ public class SupervisorManagerTest extends EasyMockSupport
     );
 
     final Object[] data = (Object[]) result.get("data");
-    Assert.assertEquals(200, data.length);
-    Assert.assertTrue(data[0] instanceof Map);
+    Assertions.assertEquals(200, data.length);
+    Assertions.assertTrue(data[0] instanceof Map);
     final Map<?, ?> firstDataPoint = (Map<?, ?>) data[0];
-    Assert.assertTrue(firstDataPoint.containsKey("lag"));
-    Assert.assertTrue(firstDataPoint.containsKey("taskCount"));
+    Assertions.assertTrue(firstDataPoint.containsKey("lag"));
+    Assertions.assertTrue(firstDataPoint.containsKey("taskCount"));
     for (Object dataPoint : data) {
-      Assert.assertTrue(dataPoint instanceof Map);
+      Assertions.assertTrue(dataPoint instanceof Map);
       final Number taskCount = (Number) ((Map<?, ?>) dataPoint).get("taskCount");
-      Assert.assertTrue(taskCount.intValue() >= 1 && taskCount.intValue() <= 10);
+      Assertions.assertTrue(taskCount.intValue() >= 1 && taskCount.intValue() <= 10);
     }
     EasyMock.verify(supervisor);
   }
@@ -684,8 +685,8 @@ public class SupervisorManagerTest extends EasyMockSupport
         Pair.of(supervisor, new TestBackfillSupervisorSpec(supervisorId, ingestionSpec))
     );
 
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    DruidExceptionMatcher.assertThat(
+        Assertions.assertThrows(
             DruidException.class,
             () -> manager.simulateAutoscaling(
                 supervisorId,

--- a/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
@@ -605,6 +605,7 @@ public abstract class AbstractSegmentMetadataCache<T extends DataSourceInformati
               }
               removeSegmentAction(segment.getId());
               if (segmentsMap.isEmpty()) {
+                dataSourcesNeedingRebuild.remove(segment.getDataSource());
                 tables.remove(segment.getDataSource());
                 removeDataSourceAction(segment.getDataSource());
                 log.info("dataSource [%s] no longer exists, all metadata removed.", segment.getDataSource());

--- a/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
@@ -591,7 +591,7 @@ public abstract class AbstractSegmentMetadataCache<T extends DataSourceInformati
       segmentsNeedingRefresh.remove(segment.getId());
       unmarkSegmentAsMutable(segment.getId());
 
-      segmentMetadataInfo.compute(
+      final ConcurrentSkipListMap<SegmentId, AvailableSegmentMetadata> remainingSegments = segmentMetadataInfo.compute(
           segment.getDataSource(),
           (dataSource, segmentsMap) -> {
             if (segmentsMap == null) {
@@ -605,7 +605,6 @@ public abstract class AbstractSegmentMetadataCache<T extends DataSourceInformati
               }
               removeSegmentAction(segment.getId());
               if (segmentsMap.isEmpty()) {
-                dataSourcesNeedingRebuild.remove(segment.getDataSource());
                 tables.remove(segment.getDataSource());
                 removeDataSourceAction(segment.getDataSource());
                 log.info("dataSource [%s] no longer exists, all metadata removed.", segment.getDataSource());
@@ -617,6 +616,9 @@ public abstract class AbstractSegmentMetadataCache<T extends DataSourceInformati
             }
           }
       );
+      if (remainingSegments == null) {
+        dataSourcesNeedingRebuild.remove(segment.getDataSource());
+      }
 
       lock.notifyAll();
     }

--- a/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
@@ -606,6 +606,7 @@ public abstract class AbstractSegmentMetadataCache<T extends DataSourceInformati
               removeSegmentAction(segment.getId());
               if (segmentsMap.isEmpty()) {
                 tables.remove(segment.getDataSource());
+                removeDataSourceAction(segment.getDataSource());
                 log.info("dataSource [%s] no longer exists, all metadata removed.", segment.getDataSource());
                 return null;
               } else {
@@ -624,6 +625,14 @@ public abstract class AbstractSegmentMetadataCache<T extends DataSourceInformati
    * This method should be overridden by child classes to execute any action on segment removal.
    */
   protected abstract void removeSegmentAction(SegmentId segmentId);
+
+  /**
+   * Called under the cache lock after the last segment and its datasource table have been removed.
+   */
+  protected void removeDataSourceAction(String dataSource)
+  {
+    // No additional action by default.
+  }
 
   @VisibleForTesting
   public void removeServerSegment(final DruidServerMetadata server, final DataSegment segment)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/BrokerSegmentMetadataCache.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/BrokerSegmentMetadataCache.java
@@ -307,6 +307,17 @@ public class BrokerSegmentMetadataCache extends AbstractSegmentMetadataCache<Phy
     // noop, no additional action needed when segment is removed.
   }
 
+  @Override
+  protected void removeDataSourceAction(String dataSource)
+  {
+    // The last-segment callback can remove the table without another schema refresh.
+    emitMetric(
+        Metric.DATASOURCE_REMOVED,
+        1,
+        ServiceMetricEvent.builder().setDimension(DruidMetrics.DATASOURCE, dataSource)
+    );
+  }
+
   private Set<String> queryDataSources()
   {
     Set<String> dataSources = new HashSet<>();

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/BrokerSegmentMetadataCacheTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/BrokerSegmentMetadataCacheTest.java
@@ -722,7 +722,7 @@ public class BrokerSegmentMetadataCacheTest extends BrokerSegmentMetadataCacheTe
   }
 
   @Test
-  public void testLastSegmentRemovalEmitsMetricWithoutRefresh() throws IOException
+  public void testLastSegmentRemovalClearsRebuildState() throws IOException
   {
     final BrokerSegmentMetadataCache schema = new BrokerSegmentMetadataCache(
         CalciteTests.createMockQueryLifecycleFactory(walker, conglomerate),
@@ -736,21 +736,24 @@ public class BrokerSegmentMetadataCacheTest extends BrokerSegmentMetadataCacheTe
         CentralizedDatasourceSchemaConfig.create()
     );
     runningSchema = schema;
-    final DataSegment segment = walker.getSegments().stream()
-                                      .filter(s -> s.getDataSource().equals("foo2"))
-                                      .findFirst().orElseThrow();
-    schema.addSegment(druidServers.get(0).getMetadata(), segment);
-    schema.refresh(new HashSet<>(Set.of(segment.getId())), new HashSet<>(Set.of("foo2")));
-    Assertions.assertNotNull(schema.getDatasource("foo2"));
+    final List<DataSegment> segments = ImmutableList.of(segment1, segment2);
+    segments.forEach(segment -> schema.addSegment(druidServers.get(0).getMetadata(), segment));
+    schema.refresh(
+        segments.stream().map(DataSegment::getId).collect(Collectors.toSet()),
+        new HashSet<>(Set.of("foo"))
+    );
+    Assertions.assertNotNull(schema.getDatasource("foo"));
     emitter.flush();
 
-    // No background refresh is started: the callback itself must report successful removal.
-    schema.removeSegment(segment);
-    Assertions.assertNull(schema.getDatasource("foo2"));
-    emitter.verifyEmitted(Metric.DATASOURCE_REMOVED, Map.of(DruidMetrics.DATASOURCE, "foo2"), 1);
+    // Removing a non-last segment marks the datasource for rebuild before the last segment is removed.
+    schema.removeSegment(segments.get(0));
+    schema.removeSegment(segments.get(1));
+    Assertions.assertNull(schema.getDatasource("foo"));
+    emitter.verifyEmitted(Metric.DATASOURCE_REMOVED, Map.of(DruidMetrics.DATASOURCE, "foo"), 1);
 
-    schema.removeSegment(segment);
-    emitter.verifyEmitted(Metric.DATASOURCE_REMOVED, Map.of(DruidMetrics.DATASOURCE, "foo2"), 1);
+    // A later refresh must not process stale rebuild state and emit the removal metric again.
+    schema.refresh(new HashSet<>(), new HashSet<>());
+    emitter.verifyEmitted(Metric.DATASOURCE_REMOVED, Map.of(DruidMetrics.DATASOURCE, "foo"), 1);
   }
 
   @Test

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/BrokerSegmentMetadataCacheTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/BrokerSegmentMetadataCacheTest.java
@@ -34,6 +34,7 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.client.ImmutableDruidServer;
 import org.apache.druid.client.InternalQueryConfig;
+import org.apache.druid.client.TimelineServerView;
 import org.apache.druid.client.coordinator.CoordinatorClient;
 import org.apache.druid.client.coordinator.NoopCoordinatorClient;
 import org.apache.druid.data.input.InputRow;
@@ -718,6 +719,38 @@ public class BrokerSegmentMetadataCacheTest extends BrokerSegmentMetadataCacheTe
     // SegmentMetadataCache#refreshSegmentsForDataSource
     schema.refreshSegments(segments.stream().map(DataSegment::getId).collect(Collectors.toSet()));
     Assertions.assertEquals(5, schema.getSegmentMetadataSnapshot().size());
+  }
+
+  @Test
+  public void testLastSegmentRemovalEmitsMetricWithoutRefresh() throws IOException
+  {
+    final BrokerSegmentMetadataCache schema = new BrokerSegmentMetadataCache(
+        CalciteTests.createMockQueryLifecycleFactory(walker, conglomerate),
+        Mockito.mock(TimelineServerView.class),
+        SEGMENT_CACHE_CONFIG_DEFAULT,
+        new NoopEscalator(),
+        new InternalQueryConfig(),
+        emitter,
+        new PhysicalDatasourceMetadataFactory(globalTableJoinable, segmentManager),
+        new NoopCoordinatorClient(),
+        CentralizedDatasourceSchemaConfig.create()
+    );
+    runningSchema = schema;
+    final DataSegment segment = walker.getSegments().stream()
+                                      .filter(s -> s.getDataSource().equals("foo2"))
+                                      .findFirst().orElseThrow();
+    schema.addSegment(druidServers.get(0).getMetadata(), segment);
+    schema.refresh(new HashSet<>(Set.of(segment.getId())), new HashSet<>(Set.of("foo2")));
+    Assertions.assertNotNull(schema.getDatasource("foo2"));
+    emitter.flush();
+
+    // No background refresh is started: the callback itself must report successful removal.
+    schema.removeSegment(segment);
+    Assertions.assertNull(schema.getDatasource("foo2"));
+    emitter.verifyEmitted(Metric.DATASOURCE_REMOVED, Map.of(DruidMetrics.DATASOURCE, "foo2"), 1);
+
+    schema.removeSegment(segment);
+    emitter.verifyEmitted(Metric.DATASOURCE_REMOVED, Map.of(DruidMetrics.DATASOURCE, "foo2"), 1);
   }
 
   @Test


### PR DESCRIPTION
### Description

Fix three CI failures observed in Dependabot PRs:

- [#20281](https://github.com/apache/druid/actions/runs/34172126132/job/101894303636): remove the task-count assertion across independent snapshots (986 vs 1000), and wait for cleanup instead of sleeping a fixed 100 ms.
- [#20285](https://github.com/apache/druid/actions/runs/34172355861/job/101894956385): explicitly publish 500 records to each Kafka partition. The failed run reached offsets 100/96 while the test required 100/100.
- [#20289](https://github.com/apache/druid/actions/runs/34172600905/job/101902922377): emit the Broker datasource-removal metric from the last-segment callback. The log recorded removal at 01:20:12 UTC, but the test timed out waiting for the refresh-only metric. Add coverage without a background refresh.

### Validation

- TaskQueueScaleTest: 2 tests passed.
- BrokerSegmentMetadataCacheTest: 23 tests passed, including the new regression test.
- Checkstyle passed for all four affected modules.
- KafkaBoundedSupervisorTest: compiled; local execution blocked during Testcontainers startup by a Colima Docker socket mount error. CI validation pending.
- Follow-up smoke-test cleanup: all 6 `IngestionSmokeTest` methods passed locally (retries disabled), plus Checkstyle. Terminate the owned supervisor and drain/cancel datasource-scoped tasks between methods so leftover Kafka tasks cannot occupy the two worker slots; keep assertion timeouts unchanged.

### Release note

Emit the Broker datasource-removal metric when the last segment is removed directly from the cache.

### Review

- [x] Self-reviewed, including concurrency behavior.
- [x] Added or updated tests.
