### PR TITLE
fix: safely publish granularity interval lookups

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
@@ -32,6 +32,7 @@ import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.error.DruidException;
+import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.indexing.common.TaskLockType;
 import org.apache.druid.indexing.common.task.Tasks;
@@ -654,15 +655,15 @@ public class SupervisorManagerTest extends EasyMockSupport
     );
 
     final Object[] data = (Object[]) result.get("data");
-    Assert.assertEquals(200, data.length);
-    Assert.assertTrue(data[0] instanceof Map);
+    Assertions.assertEquals(200, data.length);
+    Assertions.assertTrue(data[0] instanceof Map);
     final Map<?, ?> firstDataPoint = (Map<?, ?>) data[0];
-    Assert.assertTrue(firstDataPoint.containsKey("lag"));
-    Assert.assertTrue(firstDataPoint.containsKey("taskCount"));
+    Assertions.assertTrue(firstDataPoint.containsKey("lag"));
+    Assertions.assertTrue(firstDataPoint.containsKey("taskCount"));
     for (Object dataPoint : data) {
-      Assert.assertTrue(dataPoint instanceof Map);
+      Assertions.assertTrue(dataPoint instanceof Map);
       final Number taskCount = (Number) ((Map<?, ?>) dataPoint).get("taskCount");
-      Assert.assertTrue(taskCount.intValue() >= 1 && taskCount.intValue() <= 10);
+      Assertions.assertTrue(taskCount.intValue() >= 1 && taskCount.intValue() <= 10);
     }
     EasyMock.verify(supervisor);
   }
@@ -684,8 +685,8 @@ public class SupervisorManagerTest extends EasyMockSupport
         Pair.of(supervisor, new TestBackfillSupervisorSpec(supervisorId, ingestionSpec))
     );
 
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    DruidExceptionMatcher.assertThat(
+        Assertions.assertThrows(
             DruidException.class,
             () -> manager.simulateAutoscaling(
                 supervisorId,

--- a/processing/src/main/java/org/apache/druid/indexer/granularity/BaseGranularitySpec.java
+++ b/processing/src/main/java/org/apache/druid/indexer/granularity/BaseGranularitySpec.java
@@ -21,6 +21,8 @@ package org.apache.druid.indexer.granularity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Iterators;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -84,19 +86,24 @@ public abstract class BaseGranularitySpec implements GranularitySpec
    */
   protected static class LookupIntervalBuckets
   {
-    private final Iterable<Interval> intervalIterable;
-    private final TreeSet<Interval> intervals;
+    private final Supplier<TreeSet<Interval>> intervals;
 
     /**
      * @param intervalIterable The intervals to materialize
      */
     public LookupIntervalBuckets(Iterable<Interval> intervalIterable)
     {
-      this.intervalIterable = intervalIterable;
       // The tree set will be materialized on demand (see below) to avoid client code
       // blowing up when constructing this data structure and when the
       // number of intervals is very large...
-      this.intervals = new TreeSet<>(Comparators.intervalsByStartThenEnd());
+      // Memoization serializes initialization and safely publishes only the complete tree to concurrent readers.
+      this.intervals = Suppliers.memoize(() -> {
+        final TreeSet<Interval> materialized = new TreeSet<>(Comparators.intervalsByStartThenEnd());
+        if (intervalIterable != null) {
+          Iterators.addAll(materialized, intervalIterable.iterator());
+        }
+        return materialized;
+      });
     }
 
     /**
@@ -132,10 +139,7 @@ public abstract class BaseGranularitySpec implements GranularitySpec
      */
     public TreeSet<Interval> materializedIntervals()
     {
-      if (intervalIterable != null && intervalIterable.iterator().hasNext() && intervals.isEmpty()) {
-        Iterators.addAll(intervals, intervalIterable.iterator());
-      }
-      return intervals;
+      return intervals.get();
     }
   }
 }

--- a/processing/src/test/java/org/apache/druid/indexer/granularity/BaseGranularitySpecTest.java
+++ b/processing/src/test/java/org/apache/druid/indexer/granularity/BaseGranularitySpecTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexer.granularity;
+
+import com.google.common.base.Optional;
+import org.apache.druid.java.util.common.Intervals;
+import org.joda.time.Interval;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class BaseGranularitySpecTest
+{
+  @Test
+  public void testConcurrentLookupDuringMaterialization() throws Exception
+  {
+    final Interval first = Intervals.of("2026-01-01/2026-01-02");
+    final Interval second = Intervals.of("2026-01-02/2026-01-03");
+    final CountDownLatch partiallyMaterialized = new CountDownLatch(1);
+    final CountDownLatch finishMaterialization = new CountDownLatch(1);
+    final BaseGranularitySpec.LookupIntervalBuckets buckets = new BaseGranularitySpec.LookupIntervalBuckets(
+        () -> new Iterator<>()
+        {
+          private final Iterator<Interval> delegate = List.of(first, second).iterator();
+
+          @Override
+          public boolean hasNext()
+          {
+            return delegate.hasNext();
+          }
+
+          @Override
+          public Interval next()
+          {
+            final Interval interval = delegate.next();
+            if (interval.equals(second)) {
+              // The first interval has been inserted, but the second has not been returned to the builder.
+              partiallyMaterialized.countDown();
+              try {
+                Assertions.assertTrue(finishMaterialization.await(10, TimeUnit.SECONDS));
+              }
+              catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+              }
+            }
+            return interval;
+          }
+        }
+    );
+    final FutureTask<TreeSet<Interval>> materialization = new FutureTask<>(buckets::materializedIntervals);
+    final FutureTask<Optional<Interval>> lookup = new FutureTask<>(() -> buckets.bucketInterval(second.getStart()));
+    final Thread builder = new Thread(materialization, "interval-builder");
+    final Thread reader = new Thread(lookup, "interval-reader");
+    builder.setDaemon(true);
+    reader.setDaemon(true);
+
+    try {
+      builder.start();
+      Assertions.assertTrue(partiallyMaterialized.await(10, TimeUnit.SECONDS));
+      reader.start();
+
+      // Wait for the reader to either contend on initialization or return the baseline's partial lookup.
+      // This avoids relying on a sleep to assume that the second lookup has run.
+      final long startNanos = System.nanoTime();
+      while (!lookup.isDone()
+             && reader.getState() != Thread.State.BLOCKED
+             && System.nanoTime() - startNanos < TimeUnit.SECONDS.toNanos(10)) {
+        Thread.sleep(1);
+      }
+      Assertions.assertTrue(lookup.isDone() || reader.getState() == Thread.State.BLOCKED, "Reader did not reach lookup");
+      finishMaterialization.countDown();
+
+      Assertions.assertEquals(Optional.of(second), lookup.get(10, TimeUnit.SECONDS));
+      Assertions.assertEquals(List.of(first, second), List.copyOf(materialization.get(10, TimeUnit.SECONDS)));
+      Assertions.assertSame(materialization.get(), buckets.materializedIntervals());
+    }
+    finally {
+      finishMaterialization.countDown();
+      builder.join(10_000);
+      reader.join(10_000);
+    }
+  }
+
+  @Test
+  public void testLazyMaterialization()
+  {
+    final AtomicInteger iterations = new AtomicInteger();
+    final Interval interval = Intervals.of("2026-01-01/2026-01-02");
+    final BaseGranularitySpec.LookupIntervalBuckets buckets = new BaseGranularitySpec.LookupIntervalBuckets(() -> {
+      iterations.incrementAndGet();
+      return List.of(interval).iterator();
+    });
+
+    Assertions.assertEquals(0, iterations.get());
+    Assertions.assertEquals(Optional.of(interval), buckets.bucketInterval(interval.getStart()));
+    Assertions.assertEquals(List.of(interval), List.copyOf(buckets.materializedIntervals()));
+    Assertions.assertEquals(interval, buckets.iterator().next());
+    Assertions.assertEquals(1, iterations.get());
+  }
+
+  @Test
+  public void testEmptyMaterializationIsCached()
+  {
+    final AtomicInteger iterations = new AtomicInteger();
+    final BaseGranularitySpec.LookupIntervalBuckets buckets = new BaseGranularitySpec.LookupIntervalBuckets(() -> {
+      iterations.incrementAndGet();
+      return Collections.emptyIterator();
+    });
+
+    Assertions.assertEquals(0, iterations.get());
+    final TreeSet<Interval> intervals = buckets.materializedIntervals();
+    Assertions.assertTrue(intervals.isEmpty());
+    Assertions.assertSame(intervals, buckets.materializedIntervals());
+    Assertions.assertEquals(1, iterations.get());
+  }
+
+  @Test
+  public void testNullIntervals()
+  {
+    final BaseGranularitySpec.LookupIntervalBuckets buckets = new BaseGranularitySpec.LookupIntervalBuckets(null);
+    Assertions.assertTrue(buckets.materializedIntervals().isEmpty());
+    Assertions.assertFalse(buckets.iterator().hasNext());
+  }
+}


### PR DESCRIPTION
### Description

Safely publish the lazily materialized granularity interval lookup using a memoized supplier. Concurrent segment-allocation requests can otherwise read a partially populated `TreeSet` or initialize it concurrently.

Observed in [PR #20291 CI](https://github.com/apache/druid/actions/runs/34184621200/job/101930347980): `ITHttpInputSourceTest` rejected `2016-06-27T00:00:11.080Z` despite its explicit June 2016 input interval. A deterministic regression reproduces a missing valid interval on baseline code.

### Validation

- Baseline concurrent-lookup regression failed; fixed version passed.
- 57 focused processing tests passed; Checkstyle passed.
- Initialization remains lazy, including empty input; existing `TreeSet` API unchanged.

### Release note

Fix a race during granularity interval lookup initialization that could cause parallel ingestion to reject valid timestamps.

### Review

- [x] Self-reviewed, including concurrency behavior.
- [x] Added regression tests.
