### PR TITLE
perf: avoid rebuilding the eligible-worker snapshot per pending task in HttpRemoteTaskRunner

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
@@ -289,6 +289,14 @@ public class HttpRemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer, 
 
   private ImmutableWorkerInfo findWorkerToRunTask(Task task)
   {
+    return findWorkerToRunTask(task, ImmutableMap.copyOf(getWorkersEligibleToRunTasks()));
+  }
+
+  private ImmutableWorkerInfo findWorkerToRunTask(
+      Task task,
+      ImmutableMap<String, ImmutableWorkerInfo> eligibleWorkers
+  )
+  {
     WorkerBehaviorConfig workerConfig = workerConfigRef.get();
     WorkerSelectStrategy strategy;
     if (workerConfig == null || workerConfig.getSelectStrategy() == null) {
@@ -300,7 +308,7 @@ public class HttpRemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer, 
 
     return strategy.findWorkerForTask(
         config,
-        ImmutableMap.copyOf(getWorkersEligibleToRunTasks()),
+        eligibleWorkers,
         task
     );
   }
@@ -1097,6 +1105,14 @@ public class HttpRemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer, 
         ImmutableWorkerInfo immutableWorker = null;
 
         synchronized (statusLock) {
+          // Compute the eligible-worker snapshot ONCE per pass instead of rebuilding it for every
+          // pending task. Within a single synchronized(statusLock) pass no worker reservation is made
+          // until the break below, so getWorkersEligibleToRunTasks() is invariant across the inner
+          // loop. Rebuilding it per pending task made this loop O(pendingTasks x workers x
+          // tasksPerWorker) and held statusLock for long periods under a large pending backlog,
+          // which stalled TaskQueue.add/manage and task submission cluster-wide.
+          final ImmutableMap<String, ImmutableWorkerInfo> eligibleWorkers =
+              ImmutableMap.copyOf(getWorkersEligibleToRunTasks());
           Iterator<String> iter = pendingTaskIds.iterator();
           while (iter.hasNext()) {
             String taskId = iter.next();
@@ -1123,7 +1139,7 @@ public class HttpRemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer, 
               break;
             }
 
-            immutableWorker = findWorkerToRunTask(ti.getTask());
+            immutableWorker = findWorkerToRunTask(ti.getTask(), eligibleWorkers);
             if (immutableWorker == null) {
               continue;
             }


### PR DESCRIPTION
Fixes #20295.

### Description

Under a large pending-task backlog with saturated workers, the Overlord's `httpRemote`
task runner stalls: one pending-task-runner thread holds `statusLock` while deep in
worker-snapshot reconstruction, blocking new task submission, status updates, and
worker-sync operations cluster-wide. Restarting doesn't help because the active task set is
reloaded from metadata, the backlog reappears, and the loop re-enters the same
lock-holding scan.

#### Fixed the Overlord stall on a large pending-task backlog

In `HttpRemoteTaskRunner.pendingTasksExecutionLoop()`, the loop holds the single
`statusLock` while iterating every pending task, and for each task calls
`findWorkerToRunTask(Task)`, which rebuilds a full immutable snapshot of all workers via
`getWorkersEligibleToRunTasks()`. This makes the loop cost
`O(pendingTasks × workers × tasksAnnouncedPerWorker)`, while it holds the lock.

This change computes the snapshot **once per pass**,
inside `synchronized (statusLock)` before iterating, and passes it into a new overload
`findWorkerToRunTask(Task, ImmutableMap<String, ImmutableWorkerInfo> eligibleWorkers)`.
The existing `findWorkerToRunTask(Task)` is retained and now delegates to the overload,
so no other call site changes behavior.

This reduces per-pass cost to `O(workers × tasksPerWorker)` with no behavioral change:
worker selection within a pass is identical because the input snapshot is identical to
what each per-task call would have recomputed.

#### Release note

Fixed an issue where the Overlord using the `httpRemote` task runner could stall for
extended periods (holding `statusLock`) when a large backlog of pending tasks
accumulated while workers were saturated, blocking task submission and status updates.

<hr>

##### Key changed/added classes in this PR
 * `HttpRemoteTaskRunner`

<hr>

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md).
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
