### PR TITLE
perf(test): reduce MergingRowIteratorTest from 24s to 5s

### DIFF
--- a/processing/src/test/java/org/apache/druid/segment/MergingRowIteratorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/MergingRowIteratorTest.java
@@ -200,21 +200,33 @@ public class MergingRowIteratorTest extends InitializedNullHandlingTest
           Stream.of(timestampSequences).map(List::iterator).collect(Collectors.toList()),
           Comparator.naturalOrder()
       );
+      long currentTimestamp = 0;
+      boolean iterated = false;
       while (expectedTimestamps.hasNext()) {
+        final long expectedTimestamp = expectedTimestamps.next();
         Assertions.assertTrue(
             mergingRowIterator.moveToNext(),
             failureMessage
         );
         Assertions.assertEquals(
-            expectedTimestamps.next(),
+            expectedTimestamp,
             mergingRowIterator.getPointer().timestampSelector.getLong(),
             failureMessage
         );
+        currentTimestamp = expectedTimestamp;
+        iterated = true;
       }
       Assertions.assertFalse(
           mergingRowIterator.moveToNext(),
           failureMessage
       );
+      if (iterated) {
+        Assertions.assertEquals(
+            currentTimestamp,
+            mergingRowIterator.getPointer().timestampSelector.getLong(),
+            failureMessage
+        );
+      }
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/MergingRowIteratorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/MergingRowIteratorTest.java
@@ -84,12 +84,18 @@ public class MergingRowIteratorTest extends InitializedNullHandlingTest
   }
 
   @Test
-  public void testMarkHandlingAcrossEqualAndChangingTimestamps()
+  public void testMarkHandlingAcrossAllPossible4ElementSequences()
   {
-    // These inputs merge to [1, 1, 2, 2, 2, 3, 3, 4, 4, 5], covering equal timestamps from both
-    // the same iterator and different iterators, as well as transitions to a new timestamp. testMerge()
-    // places the mark at every output position, exercising mark handling without the exhaustive cross-product above.
-    testMerge(Longs.asList(1, 2, 2, 4), Longs.asList(1, 3, 4), Longs.asList(2, 3, 5));
+    // Keep systematic coverage of mark handling across different heap layouts while limiting its cross-product.
+    List<List<Long>> possibleSequences = new ArrayList<>();
+    populateSequences(possibleSequences, new ArrayDeque<>(), 1, 6, 4);
+    for (int i1 = 0; i1 < possibleSequences.size(); i1++) {
+      for (int i2 = i1; i2 < possibleSequences.size(); i2++) {
+        for (int i3 = i2; i3 < possibleSequences.size(); i3++) {
+          testMerge(possibleSequences.get(i1), possibleSequences.get(i2), possibleSequences.get(i3));
+        }
+      }
+    }
   }
 
   private static void populateSequences(

--- a/processing/src/test/java/org/apache/druid/segment/MergingRowIteratorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/MergingRowIteratorTest.java
@@ -33,6 +33,7 @@ import java.util.Comparator;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -76,10 +77,19 @@ public class MergingRowIteratorTest extends InitializedNullHandlingTest
     for (int i1 = 0; i1 < possibleSequences.size(); i1++) {
       for (int i2 = i1; i2 < possibleSequences.size(); i2++) {
         for (int i3 = i2; i3 < possibleSequences.size(); i3++) {
-          testMerge(possibleSequences.get(i1), possibleSequences.get(i2), possibleSequences.get(i3));
+          testMergeOrder(possibleSequences.get(i1), possibleSequences.get(i2), possibleSequences.get(i3));
         }
       }
     }
+  }
+
+  @Test
+  public void testMarkHandlingAcrossEqualAndChangingTimestamps()
+  {
+    // These inputs merge to [1, 1, 2, 2, 2, 3, 3, 4, 4, 5], covering equal timestamps from both
+    // the same iterator and different iterators, as well as transitions to a new timestamp. testMerge()
+    // places the mark at every output position, exercising mark handling without the exhaustive cross-product above.
+    testMerge(Longs.asList(1, 2, 2, 4), Longs.asList(1, 3, 4), Longs.asList(2, 3, 5));
   }
 
   private static void populateSequences(
@@ -104,8 +114,9 @@ public class MergingRowIteratorTest extends InitializedNullHandlingTest
   @SafeVarargs
   private static void testMerge(List<Long>... timestampSequences)
   {
-    String message = Stream.of(timestampSequences).map(List::toString).collect(Collectors.joining(" "));
-    int totalLength = Stream.of(timestampSequences).mapToInt(List::size).sum();
+    final Supplier<String> failureMessage
+        = () -> Stream.of(timestampSequences).map(List::toString).collect(Collectors.joining(" "));
+    final int totalLength = Stream.of(timestampSequences).mapToInt(List::size).sum();
     // The expected merge order does not depend on markIteration. Materialize it once per sequence
     // triple so each mark iteration can focus on rebuilding the production iterator and testing mark handling.
     List<Long> expectedTimestamps = new ArrayList<>();
@@ -117,13 +128,13 @@ public class MergingRowIteratorTest extends InitializedNullHandlingTest
       expectedTimestamps.add(expectedTimestampIterator.next());
     }
     for (int markIteration = 0; markIteration < totalLength; markIteration++) {
-      testMerge(message, markIteration, expectedTimestamps, timestampSequences);
+      testMerge(failureMessage, markIteration, expectedTimestamps, timestampSequences);
     }
   }
 
   @SafeVarargs
   private static void testMerge(
-      String message,
+      Supplier<String> failureMessage,
       int markIteration,
       List<Long> expectedTimestamps,
       List<Long>... timestampSequences
@@ -139,14 +150,18 @@ public class MergingRowIteratorTest extends InitializedNullHandlingTest
       boolean iterated = false;
       for (Long expectedTimestamp : expectedTimestamps) {
         currentTimestamp = expectedTimestamp;
-        Assertions.assertTrue(mergingRowIterator.moveToNext(), message);
+        Assertions.assertTrue(mergingRowIterator.moveToNext(), failureMessage);
         iterated = true;
-        Assertions.assertEquals(currentTimestamp, mergingRowIterator.getPointer().timestampSelector.getLong(), message);
+        Assertions.assertEquals(
+            currentTimestamp,
+            mergingRowIterator.getPointer().timestampSelector.getLong(),
+            failureMessage
+        );
         if (marked) {
           Assertions.assertEquals(
               markedTimestamp != currentTimestamp,
               mergingRowIterator.hasTimeAndDimsChangedSinceMark(),
-              message
+              failureMessage
           );
         }
         if (i == markIteration) {
@@ -156,10 +171,44 @@ public class MergingRowIteratorTest extends InitializedNullHandlingTest
         }
         i++;
       }
-      Assertions.assertFalse(mergingRowIterator.moveToNext(), message);
+      Assertions.assertFalse(mergingRowIterator.moveToNext(), failureMessage);
       if (iterated) {
-        Assertions.assertEquals(currentTimestamp, mergingRowIterator.getPointer().timestampSelector.getLong(), message);
+        Assertions.assertEquals(
+            currentTimestamp,
+            mergingRowIterator.getPointer().timestampSelector.getLong(),
+            failureMessage
+        );
       }
+    }
+  }
+
+  @SafeVarargs
+  private static void testMergeOrder(List<Long>... timestampSequences)
+  {
+    final Supplier<String> failureMessage
+        = () -> Stream.of(timestampSequences).map(List::toString).collect(Collectors.joining(" "));
+    try (MergingRowIterator mergingRowIterator = new MergingRowIterator(
+        Stream.of(timestampSequences).map(TestRowIterator::new).collect(Collectors.toList())
+    )) {
+      final Iterator<Long> expectedTimestamps = Utils.mergeSorted(
+          Stream.of(timestampSequences).map(List::iterator).collect(Collectors.toList()),
+          Comparator.naturalOrder()
+      );
+      while (expectedTimestamps.hasNext()) {
+        Assertions.assertTrue(
+            mergingRowIterator.moveToNext(),
+            failureMessage
+        );
+        Assertions.assertEquals(
+            expectedTimestamps.next(),
+            mergingRowIterator.getPointer().timestampSelector.getLong(),
+            failureMessage
+        );
+      }
+      Assertions.assertFalse(
+          mergingRowIterator.moveToNext(),
+          failureMessage
+      );
     }
   }
 


### PR DESCRIPTION
### Description

This PR reduces the local runtime of `MergingRowIteratorTest` from approximately 24 seconds to 5 seconds while retaining systematic coverage of merge ordering and mark semantics.

The exhaustive 5-element sequence test now verifies merge order once for each sequence combination. Mark behavior is tested separately across all possible 4-element sequence combinations and every output mark position. This reduces mark-verification combinations from 2,699,004 to 341,376 (87% fewer), while still exercising different heap layouts, equal and changing timestamps, and iterator exhaustion. Assertion failure messages are supplied lazily so expensive diagnostics are constructed only when an assertion fails.

### Benchmark

| Version | Run 1 | Run 2 | Average |
| --- | ---: | ---: | ---: |
| Current `master` | 23.942s | 23.941s | 23.942s |
| Revised test | 4.890s | 5.356s | 5.123s |

This is approximately a 78.6% reduction in test runtime.

### Verification

```
mvn test -pl processing -Dtest=org.apache.druid.segment.MergingRowIteratorTest -Pskip-static-checks -Dweb.console.skip=true -T1C
```

All 7 tests pass in both benchmark runs.
