### PR TITLE
perf(test): Reduce PartialCompactionTest run time from 42s to 7s

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -251,10 +251,19 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
                               .withPartitionsSpec(partitionsSpec)
                               .withForceGuaranteedRollup(forceGuaranteedRollup)
                               .withMaxNumConcurrentSubTasks(maxNumConcurrentSubTasks)
-                              // Serial tests need only a short poll interval; concurrent tests retain the default.
-                              .withTaskStatusCheckPeriodMs(maxNumConcurrentSubTasks == 1 ? 100L : null)
+                              .withTaskStatusCheckPeriodMs(getTaskStatusCheckPeriodMs(maxNumConcurrentSubTasks))
                               .withMaxParseExceptions(5)
                               .build();
+  }
+
+  /**
+   * Task-status poll interval used by {@link #newTuningConfig}. Serial tests need only a short poll interval;
+   * concurrent tests retain the production default (null). Subclasses whose assertions do not depend on poll
+   * cadence can override this to cut wall-clock time without duplicating the rest of the tuning config.
+   */
+  protected Long getTaskStatusCheckPeriodMs(int maxNumConcurrentSubTasks)
+  {
+    return maxNumConcurrentSubTasks == 1 ? 100L : null;
   }
 
   protected LocalOverlordClient getIndexingServiceClient()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -162,6 +162,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
 
   protected static final double DEFAULT_TRANSIENT_TASK_FAILURE_RATE = 0.2;
   protected static final double DEFAULT_TRANSIENT_API_FAILURE_RATE = 0.2;
+  protected static final long SHORT_TASK_STATUS_CHECK_PERIOD_MS = 100L;
 
   private static final Logger LOG = new Logger(AbstractParallelIndexSupervisorTaskTest.class);
 
@@ -258,12 +259,15 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
 
   /**
    * Task-status poll interval used by {@link #newTuningConfig}. Serial tests need only a short poll interval;
-   * concurrent tests retain the production default (null). Subclasses whose assertions do not depend on poll
-   * cadence can override this to cut wall-clock time without duplicating the rest of the tuning config.
+   * concurrent tests retain the production default. Subclasses whose assertions do not depend on poll cadence
+   * can override this to cut wall-clock time without duplicating the rest of the tuning config.
+   *
+   * @return the poll interval in millis, or null to use the production default
    */
+  @Nullable
   protected Long getTaskStatusCheckPeriodMs(int maxNumConcurrentSubTasks)
   {
-    return maxNumConcurrentSubTasks == 1 ? 100L : null;
+    return maxNumConcurrentSubTasks == 1 ? SHORT_TASK_STATUS_CHECK_PERIOD_MS : null;
   }
 
   protected LocalOverlordClient getIndexingServiceClient()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialCompactionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialCompactionTest.java
@@ -20,7 +20,6 @@
 package org.apache.druid.indexing.common.task.batch.parallel;
 
 import org.apache.druid.data.input.InputFormat;
-import org.apache.druid.data.input.MaxSizeSplitHintSpec;
 import org.apache.druid.data.input.impl.CsvInputFormat;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
@@ -34,7 +33,6 @@ import org.apache.druid.indexing.common.task.CompactionTask;
 import org.apache.druid.indexing.common.task.CompactionTask.Builder;
 import org.apache.druid.indexing.common.task.MinorCompactionInputSpec;
 import org.apache.druid.indexing.common.task.Tasks;
-import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.DataSegmentsWithSchemas;
@@ -74,6 +72,7 @@ public class PartialCompactionTest extends AbstractMultiPhaseParallelIndexingTes
       null
   );
   private static final Interval INTERVAL_TO_INDEX = Intervals.of("2017-12/P1M");
+  private static final long TASK_STATUS_CHECK_PERIOD_MS = 100L;
 
   private File inputDir;
 
@@ -84,28 +83,14 @@ public class PartialCompactionTest extends AbstractMultiPhaseParallelIndexingTes
 
   /**
    * This test drives several rounds of parallel indexing/compaction (each with its own
-   * determine-partitions/generate/merge phases) back-to-back. The base implementation only
-   * shortens {@link ParallelIndexTuningConfig#getTaskStatusCheckPeriodMs()} for serial runs
-   * (maxNumConcurrentSubTasks == 1) and otherwise falls back to the 1-second production default,
-   * which is production-realistic but adds several seconds of avoidable polling latency per phase
-   * transition in this test. None of the assertions here depend on the poll cadence, so use a
-   * short interval unconditionally to cut wall-clock time without changing what is being tested.
+   * determine-partitions/generate/merge phases) back-to-back, always with concurrent sub-tasks, so the
+   * base implementation would poll task status at the 1-second production default and pay up to a full
+   * period per phase transition. None of the assertions here depend on the poll cadence, so poll quickly.
    */
   @Override
-  protected ParallelIndexTuningConfig newTuningConfig(
-      PartitionsSpec partitionsSpec,
-      int maxNumConcurrentSubTasks,
-      boolean forceGuaranteedRollup
-  )
+  protected Long getTaskStatusCheckPeriodMs(int maxNumConcurrentSubTasks)
   {
-    return TuningConfigBuilder.forParallelIndexTask()
-                              .withSplitHintSpec(new MaxSizeSplitHintSpec(null, 1))
-                              .withPartitionsSpec(partitionsSpec)
-                              .withForceGuaranteedRollup(forceGuaranteedRollup)
-                              .withMaxNumConcurrentSubTasks(maxNumConcurrentSubTasks)
-                              .withTaskStatusCheckPeriodMs(100L)
-                              .withMaxParseExceptions(5)
-                              .build();
+    return TASK_STATUS_CHECK_PERIOD_MS;
   }
 
   @BeforeEach

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialCompactionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialCompactionTest.java
@@ -72,7 +72,6 @@ public class PartialCompactionTest extends AbstractMultiPhaseParallelIndexingTes
       null
   );
   private static final Interval INTERVAL_TO_INDEX = Intervals.of("2017-12/P1M");
-  private static final long TASK_STATUS_CHECK_PERIOD_MS = 100L;
 
   private File inputDir;
 
@@ -88,9 +87,9 @@ public class PartialCompactionTest extends AbstractMultiPhaseParallelIndexingTes
    * period per phase transition. None of the assertions here depend on the poll cadence, so poll quickly.
    */
   @Override
-  protected Long getTaskStatusCheckPeriodMs(int maxNumConcurrentSubTasks)
+  protected Long getTaskStatusCheckPeriodMs(int ignoredMaxNumConcurrentSubTasks)
   {
-    return TASK_STATUS_CHECK_PERIOD_MS;
+    return SHORT_TASK_STATUS_CHECK_PERIOD_MS;
   }
 
   @BeforeEach

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialCompactionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialCompactionTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.indexing.common.task.batch.parallel;
 
 import org.apache.druid.data.input.InputFormat;
+import org.apache.druid.data.input.MaxSizeSplitHintSpec;
 import org.apache.druid.data.input.impl.CsvInputFormat;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
@@ -33,6 +34,7 @@ import org.apache.druid.indexing.common.task.CompactionTask;
 import org.apache.druid.indexing.common.task.CompactionTask.Builder;
 import org.apache.druid.indexing.common.task.MinorCompactionInputSpec;
 import org.apache.druid.indexing.common.task.Tasks;
+import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.DataSegmentsWithSchemas;
@@ -78,6 +80,32 @@ public class PartialCompactionTest extends AbstractMultiPhaseParallelIndexingTes
   public PartialCompactionTest()
   {
     super(LockGranularity.TIME_CHUNK, DEFAULT_TRANSIENT_TASK_FAILURE_RATE, DEFAULT_TRANSIENT_API_FAILURE_RATE);
+  }
+
+  /**
+   * This test drives several rounds of parallel indexing/compaction (each with its own
+   * determine-partitions/generate/merge phases) back-to-back. The base implementation only
+   * shortens {@link ParallelIndexTuningConfig#getTaskStatusCheckPeriodMs()} for serial runs
+   * (maxNumConcurrentSubTasks == 1) and otherwise falls back to the 1-second production default,
+   * which is production-realistic but adds several seconds of avoidable polling latency per phase
+   * transition in this test. None of the assertions here depend on the poll cadence, so use a
+   * short interval unconditionally to cut wall-clock time without changing what is being tested.
+   */
+  @Override
+  protected ParallelIndexTuningConfig newTuningConfig(
+      PartitionsSpec partitionsSpec,
+      int maxNumConcurrentSubTasks,
+      boolean forceGuaranteedRollup
+  )
+  {
+    return TuningConfigBuilder.forParallelIndexTask()
+                              .withSplitHintSpec(new MaxSizeSplitHintSpec(null, 1))
+                              .withPartitionsSpec(partitionsSpec)
+                              .withForceGuaranteedRollup(forceGuaranteedRollup)
+                              .withMaxNumConcurrentSubTasks(maxNumConcurrentSubTasks)
+                              .withTaskStatusCheckPeriodMs(100L)
+                              .withMaxParseExceptions(5)
+                              .build();
   }
 
   @BeforeEach


### PR DESCRIPTION
### Description (Cause)

`PartialCompactionTest` runs three rounds of parallel indexing/compaction back-to-back (a hash- or range-partitioned load, a dynamic-partitioned append, then a `MinorCompactionInputSpec` compaction task), each going through its own determine-partitions/generate/merge phases. Every phase transition is detected by `TaskMonitor`'s fixed-rate poll (`ParallelIndexPhaseRunner` → `TaskMonitor#start(taskStatusCheckPeriodMs)`), so each transition costs up to one full poll period.

`AbstractParallelIndexSupervisorTaskTest#newTuningConfig` only shortens that period to 100ms for serial runs (`maxNumConcurrentSubTasks == 1`). `PartialCompactionTest` always uses `maxNumConcurrentSubTasks = 2`, so it falls back to the **1000ms production default**. Across the repeated multi-phase rounds, that polling latency dominates the test's wall-clock time (~42s for the slowest method in CI) without contributing to what is being asserted.

### Fix

- `AbstractParallelIndexSupervisorTaskTest`: extract the poll interval into a `@Nullable protected Long getTaskStatusCheckPeriodMs(int maxNumConcurrentSubTasks)` hook (null = production default) and a shared `SHORT_TASK_STATUS_CHECK_PERIOD_MS = 100L` constant. The default implementation keeps today's behavior exactly (short poll for serial runs, production default otherwise), so the other subclasses are unaffected.
- `PartialCompactionTest`: override only that hook to return `SHORT_TASK_STATUS_CHECK_PERIOD_MS` unconditionally. Nothing else in the tuning config is duplicated or changed.

### Why this is safe

- The base helper's behavior for every other subclass is unchanged; only `PartialCompactionTest` opts into the fast poll.
- No assertion in this class depends on poll cadence; they check final segment sets, atomic-update-group sizes, and upgraded-segment-id mappings.
- The test injects 20% random subtask kills and API failures (`DEFAULT_TRANSIENT_TASK_FAILURE_RATE`/`DEFAULT_TRANSIENT_API_FAILURE_RATE`). Polling faster does not change that behavior: subtask retries are **count-based** (`TaskMonitor#maxRetry`, `numTries() < maxRetry`) and API retries are capped by `MAX_TRANSIENT_API_FAILURES`, not by elapsed time. A shorter poll only detects a kill sooner.
- Task payloads, partitioning strategies, and expected results are unchanged.

### Benchmark

Baseline: surefire report from the latest successful `apache/druid` master CI run ([34215287115](https://github.com/apache/druid/actions/runs/34215287115), 2026-09-08). After: CI run of this change on a fork ([34353490634](https://github.com/FrankChen021/druid/actions/runs/34353490634), JDK 25); the follow-up commits are refactors that keep the effective poll interval identical. Surefire `<testcase time>`:

| Test | Before | After | Change |
|---|---:|---:|---:|
| `testPartialCompactRangeAndDynamicPartitionedSegments` | 42.00s | **7.31s** | −83% |
| `testPartialCompactHashAndDynamicPartitionedSegments` | 35.54s | **5.71s** | −84% |
| `testMinorCompactionUpgradesNonCompactedSegments` | 24.13s | **3.85s** | −84% |

All tests in the class pass with unchanged assertions.

<hr>

##### Key changed/added classes in this PR
 * `AbstractParallelIndexSupervisorTaskTest`
 * `PartialCompactionTest`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added or modified existing tests to cover new code paths (test-only change; no production code touched).
