### PR TITLE
fix: Encode queryId in DirectDruidClient cancelUrl.

### DIFF
--- a/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
@@ -160,7 +160,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
 
     final ListenableFuture<InputStream> future;
     final String url = scheme + "://" + host + "/druid/v2/";
-    final String cancelUrl = url + query.getId();
+    final String cancelUrl = url + StringUtils.urlEncode(query.getId());
 
     try {
       log.debug("Querying queryId [%s] url [%s]", query.getId(), url);

--- a/server/src/main/java/org/apache/druid/discovery/DataServerClient.java
+++ b/server/src/main/java/org/apache/druid/discovery/DataServerClient.java
@@ -28,6 +28,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.client.JsonParserIterator;
 import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.error.DruidException;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.guava.BaseSequence;
 import org.apache.druid.java.util.common.guava.Sequence;
@@ -164,7 +165,7 @@ public class DataServerClient
       throw DruidException.defensive("Null queryId");
     }
 
-    final String cancelPath = BASE_PATH + queryId;
+    final String cancelPath = BASE_PATH + StringUtils.urlEncode(queryId);
 
     final ListenableFuture<Void> cancelFuture = serviceClient.asyncRequest(
         new RequestBuilder(HttpMethod.DELETE, cancelPath).timeout(CANCELLATION_TIMEOUT),


### PR DESCRIPTION
queryId needs to be URI-encoded, or else queryIds containing path-unsafe characters will not be handled properly.