### PR TITLE
perf: Use Charset in StringUtils to/fromUtf8.

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/StreamChunkReaderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/StreamChunkReaderTest.java
@@ -34,7 +34,6 @@ import org.apache.druid.error.DruidException;
 import org.apache.druid.indexing.common.task.InputRowFilter;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.RE;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.query.filter.AndDimFilter;
@@ -58,6 +57,7 @@ import org.mockito.MockitoAnnotations;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -203,11 +203,11 @@ public class StreamChunkReaderTest
         Arrays.asList(
             new ByteEntity(
                 "{\"timestamp\": \"2020-01-01\", \"column_a\": \"y\", \"column_b\": \"other\"}"
-                    .getBytes(StringUtils.UTF8_STRING)
+                    .getBytes(StandardCharsets.UTF_8)
             ),
             new ByteEntity(
                 "{\"timestamp\": \"2020-01-01\", \"column_a\": \"y\", \"column_b\": \"title1\"}"
-                    .getBytes(StringUtils.UTF8_STRING)
+                    .getBytes(StandardCharsets.UTF_8)
             )
         ),
         false
@@ -264,19 +264,19 @@ public class StreamChunkReaderTest
         Arrays.asList(
             new ByteEntity(
                 "{\"timestamp\": \"2020-01-01\", \"column_a\": \"y\", \"column_b\": \"other\"}"
-                    .getBytes(StringUtils.UTF8_STRING)
+                    .getBytes(StandardCharsets.UTF_8)
             ),
             new ByteEntity(
                 "{\"timestamp\": \"2020-01-01\", \"column_a\": \"y\", \"column_b\": \"late\"}"
-                    .getBytes(StringUtils.UTF8_STRING)
+                    .getBytes(StandardCharsets.UTF_8)
             ),
             new ByteEntity(
                 "{\"timestamp\": \"2020-01-01\", \"column_a\": \"y\", \"column_b\": \"early\"}"
-                    .getBytes(StringUtils.UTF8_STRING)
+                    .getBytes(StandardCharsets.UTF_8)
             ),
             new ByteEntity(
                 "{\"timestamp\": \"2020-01-01\", \"column_a\": \"y\", \"column_b\": \"title1\"}"
-                    .getBytes(StringUtils.UTF8_STRING)
+                    .getBytes(StandardCharsets.UTF_8)
             )
         ),
         false
@@ -314,7 +314,7 @@ public class StreamChunkReaderTest
 
     List<InputRow> parsedRows = chunkParser.parse(
         Collections.singletonList(
-            new ByteEntity(json.getBytes(StringUtils.UTF8_STRING))), false
+            new ByteEntity(json.getBytes(StandardCharsets.UTF_8))), false
     );
     // no exception and no parsed rows
     Assertions.assertEquals(0, parsedRows.size());
@@ -334,11 +334,11 @@ public class StreamChunkReaderTest
     Mockito.when(mockedByteEntityReader.read()).thenThrow(new ParseException(null, "error parsing malformed data"));
     final String json = "malformedJson";
     List<ByteEntity> byteEntities = Arrays.asList(
-        new ByteEntity(json.getBytes(StringUtils.UTF8_STRING)),
-        new ByteEntity(json.getBytes(StringUtils.UTF8_STRING)),
-        new ByteEntity(json.getBytes(StringUtils.UTF8_STRING)),
-        new ByteEntity(json.getBytes(StringUtils.UTF8_STRING)),
-        new ByteEntity(json.getBytes(StringUtils.UTF8_STRING))
+        new ByteEntity(json.getBytes(StandardCharsets.UTF_8)),
+        new ByteEntity(json.getBytes(StandardCharsets.UTF_8)),
+        new ByteEntity(json.getBytes(StandardCharsets.UTF_8)),
+        new ByteEntity(json.getBytes(StandardCharsets.UTF_8)),
+        new ByteEntity(json.getBytes(StandardCharsets.UTF_8))
     );
     Assertions.assertThrows(
         RE.class,
@@ -367,11 +367,11 @@ public class StreamChunkReaderTest
     final String json = "malformedJson";
 
     List<ByteEntity> byteEntities = Arrays.asList(
-        new ByteEntity(json.getBytes(StringUtils.UTF8_STRING)),
-        new ByteEntity(json.getBytes(StringUtils.UTF8_STRING)),
-        new ByteEntity(json.getBytes(StringUtils.UTF8_STRING)),
-        new ByteEntity(json.getBytes(StringUtils.UTF8_STRING)),
-        new ByteEntity(json.getBytes(StringUtils.UTF8_STRING))
+        new ByteEntity(json.getBytes(StandardCharsets.UTF_8)),
+        new ByteEntity(json.getBytes(StandardCharsets.UTF_8)),
+        new ByteEntity(json.getBytes(StandardCharsets.UTF_8)),
+        new ByteEntity(json.getBytes(StandardCharsets.UTF_8)),
+        new ByteEntity(json.getBytes(StandardCharsets.UTF_8))
     );
 
     List<InputRow> parsedRows = chunkParser.parse(byteEntities, false);
@@ -398,7 +398,7 @@ public class StreamChunkReaderTest
   private void parseAndAssertResult(StreamChunkReader<ByteEntity> chunkParser) throws IOException
   {
     final String json = "{\"timestamp\": \"2020-01-01\", \"dim\": \"val\", \"met\": \"val2\"}";
-    List<InputRow> parsedRows = chunkParser.parse(Collections.singletonList(new ByteEntity(json.getBytes(StringUtils.UTF8_STRING))), false);
+    List<InputRow> parsedRows = chunkParser.parse(Collections.singletonList(new ByteEntity(json.getBytes(StandardCharsets.UTF_8))), false);
     Assertions.assertEquals(1, parsedRows.size());
     InputRow row = parsedRows.get(0);
     Assertions.assertEquals(DateTimes.of("2020-01-01"), row.getTimestamp());

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQExportTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQExportTest.java
@@ -36,6 +36,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -368,7 +369,7 @@ public class MSQExportTest extends MSQTestBase
   private List<String> readResultsFromFile(File resultFile) throws IOException
   {
     List<String> results = new ArrayList<>();
-    try (BufferedReader br = new BufferedReader(new InputStreamReader(Files.newInputStream(resultFile.toPath()), StringUtils.UTF8_STRING))) {
+    try (BufferedReader br = new BufferedReader(new InputStreamReader(Files.newInputStream(resultFile.toPath()), StandardCharsets.UTF_8))) {
       String line;
       while (!(line = br.readLine()).isEmpty()) {
         results.add(line);
@@ -430,7 +431,7 @@ public class MSQExportTest extends MSQTestBase
     final File manifestFile = new File(exportDir, ExportMetadataManager.MANIFEST_FILE);
     try (
         BufferedReader bufferedReader = new BufferedReader(
-            new InputStreamReader(Files.newInputStream(manifestFile.toPath()), StringUtils.UTF8_STRING)
+            new InputStreamReader(Files.newInputStream(manifestFile.toPath()), StandardCharsets.UTF_8)
         )
     ) {
       for (File file : resultFiles) {
@@ -445,7 +446,7 @@ public class MSQExportTest extends MSQTestBase
     final File metaFile = new File(exportDir, ExportMetadataManager.META_FILE);
     try (
         BufferedReader bufferedReader = new BufferedReader(
-            new InputStreamReader(Files.newInputStream(metaFile.toPath()), StringUtils.UTF8_STRING)
+            new InputStreamReader(Files.newInputStream(metaFile.toPath()), StandardCharsets.UTF_8)
         )
     ) {
       Assertions.assertEquals(

--- a/processing/src/main/java/org/apache/druid/java/util/common/StringUtils.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/StringUtils.java
@@ -28,12 +28,10 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
@@ -43,15 +41,11 @@ import java.util.IllegalFormatException;
 import java.util.Locale;
 
 /**
- * As of OpenJDK / Oracle JDK 8, the JVM is optimized around String charset variable instead of Charset passing, that
- * is exploited in {@link #toUtf8(String)} and {@link #fromUtf8(byte[])}.
+ * Utilities for working with strings, including UTF-8 encoding and decoding.
  */
 public class StringUtils
 {
   public static final byte[] EMPTY_BYTES = new byte[0];
-  @Deprecated // Charset parameters to String are currently slower than the charset's string name
-  public static final Charset UTF8_CHARSET = StandardCharsets.UTF_8;
-  public static final String UTF8_STRING = StandardCharsets.UTF_8.toString();
   private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder();
   private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
 
@@ -231,13 +225,7 @@ public class StringUtils
 
   public static String fromUtf8(final byte[] bytes, int offset, int length)
   {
-    try {
-      return new String(bytes, offset, length, UTF8_STRING);
-    }
-    catch (UnsupportedEncodingException e) {
-      // Should never happen
-      throw new RuntimeException(e);
-    }
+    return new String(bytes, offset, length, StandardCharsets.UTF_8);
   }
 
   /**
@@ -299,13 +287,7 @@ public class StringUtils
    */
   public static byte[] toUtf8(final String string)
   {
-    try {
-      return string.getBytes(UTF8_STRING);
-    }
-    catch (UnsupportedEncodingException e) {
-      // Should never happen
-      throw new RuntimeException(e);
-    }
+    return string.getBytes(StandardCharsets.UTF_8);
   }
 
   /**

--- a/processing/src/test/java/org/apache/druid/java/util/common/StringUtilsTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/StringUtilsTest.java
@@ -24,9 +24,9 @@ import org.apache.druid.collections.ResourceHolder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -53,13 +53,13 @@ public class StringUtilsTest
   );
 
   @Test
-  public void fromUtf8ConversionTest() throws UnsupportedEncodingException
+  public void fromUtf8ConversionTest()
   {
     byte[] bytes = new byte[]{'a', 'b', 'c', 'd'};
     Assertions.assertEquals("abcd", StringUtils.fromUtf8(bytes));
 
     String abcd = "abcd";
-    Assertions.assertEquals(abcd, StringUtils.fromUtf8(abcd.getBytes(StringUtils.UTF8_STRING)));
+    Assertions.assertEquals(abcd, StringUtils.fromUtf8(abcd.getBytes(StandardCharsets.UTF_8)));
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/java/util/http/client/response/InputStreamFullResponseHandlerTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/http/client/response/InputStreamFullResponseHandlerTest.java
@@ -20,7 +20,6 @@
 package org.apache.druid.java.util.http.client.response;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.druid.java.util.common.StringUtils;
 import org.jboss.netty.buffer.BigEndianHeapChannelBuffer;
 import org.jboss.netty.handler.codec.http.DefaultHttpChunk;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
@@ -39,12 +38,12 @@ public class InputStreamFullResponseHandlerTest
   {
     HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
     response.setChunked(false);
-    response.setContent(new BigEndianHeapChannelBuffer("abcd".getBytes(StringUtils.UTF8_STRING)));
+    response.setContent(new BigEndianHeapChannelBuffer("abcd".getBytes(StandardCharsets.UTF_8)));
 
     InputStreamFullResponseHandler responseHandler = new InputStreamFullResponseHandler();
     ClientResponse<InputStreamFullResponseHolder> clientResp = responseHandler.handleResponse(response, null);
 
-    DefaultHttpChunk chunk = new DefaultHttpChunk(new BigEndianHeapChannelBuffer("efg".getBytes(StringUtils.UTF8_STRING)));
+    DefaultHttpChunk chunk = new DefaultHttpChunk(new BigEndianHeapChannelBuffer("efg".getBytes(StandardCharsets.UTF_8)));
     clientResp = responseHandler.handleChunk(clientResp, chunk, 0);
 
     clientResp = responseHandler.done(clientResp);
@@ -58,7 +57,7 @@ public class InputStreamFullResponseHandlerTest
   {
     HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
     response.setChunked(false);
-    response.setContent(new BigEndianHeapChannelBuffer("abcd".getBytes(StringUtils.UTF8_STRING)));
+    response.setContent(new BigEndianHeapChannelBuffer("abcd".getBytes(StandardCharsets.UTF_8)));
 
     InputStreamFullResponseHandler responseHandler = new InputStreamFullResponseHandler();
     ClientResponse<InputStreamFullResponseHolder> clientResp = responseHandler.handleResponse(response, null);

--- a/processing/src/test/java/org/apache/druid/java/util/http/client/response/ObjectOrErrorResponseHandlerTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/http/client/response/ObjectOrErrorResponseHandlerTest.java
@@ -21,7 +21,6 @@ package org.apache.druid.java.util.http.client.response;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.druid.java.util.common.Either;
-import org.apache.druid.java.util.common.StringUtils;
 import org.jboss.netty.buffer.BigEndianHeapChannelBuffer;
 import org.jboss.netty.handler.codec.http.DefaultHttpChunk;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
@@ -42,7 +41,7 @@ public class ObjectOrErrorResponseHandlerTest
   {
     HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
     response.setChunked(false);
-    response.setContent(new BigEndianHeapChannelBuffer("abcd".getBytes(StringUtils.UTF8_STRING)));
+    response.setContent(new BigEndianHeapChannelBuffer("abcd".getBytes(StandardCharsets.UTF_8)));
 
     final ObjectOrErrorResponseHandler<InputStreamFullResponseHolder, InputStreamFullResponseHolder> responseHandler =
         new ObjectOrErrorResponseHandler<>(new InputStreamFullResponseHandler());
@@ -51,7 +50,7 @@ public class ObjectOrErrorResponseHandlerTest
         responseHandler.handleResponse(response, null);
 
     DefaultHttpChunk chunk =
-        new DefaultHttpChunk(new BigEndianHeapChannelBuffer("efg".getBytes(StringUtils.UTF8_STRING)));
+        new DefaultHttpChunk(new BigEndianHeapChannelBuffer("efg".getBytes(StandardCharsets.UTF_8)));
     clientResp = responseHandler.handleChunk(clientResp, chunk, 0);
     clientResp = responseHandler.done(clientResp);
 
@@ -67,7 +66,7 @@ public class ObjectOrErrorResponseHandlerTest
   {
     HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
     response.setChunked(false);
-    response.setContent(new BigEndianHeapChannelBuffer("abcd".getBytes(StringUtils.UTF8_STRING)));
+    response.setContent(new BigEndianHeapChannelBuffer("abcd".getBytes(StandardCharsets.UTF_8)));
 
     final ObjectOrErrorResponseHandler<InputStreamFullResponseHolder, InputStreamFullResponseHolder> responseHandler =
         new ObjectOrErrorResponseHandler<>(new InputStreamFullResponseHandler());
@@ -96,7 +95,7 @@ public class ObjectOrErrorResponseHandlerTest
   {
     HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR);
     response.setChunked(false);
-    response.setContent(new BigEndianHeapChannelBuffer("abcd".getBytes(StringUtils.UTF8_STRING)));
+    response.setContent(new BigEndianHeapChannelBuffer("abcd".getBytes(StandardCharsets.UTF_8)));
 
     final ObjectOrErrorResponseHandler<InputStreamFullResponseHolder, InputStreamFullResponseHolder> responseHandler =
         new ObjectOrErrorResponseHandler<>(new InputStreamFullResponseHandler());
@@ -105,7 +104,7 @@ public class ObjectOrErrorResponseHandlerTest
         responseHandler.handleResponse(response, null);
 
     DefaultHttpChunk chunk =
-        new DefaultHttpChunk(new BigEndianHeapChannelBuffer("efg".getBytes(StringUtils.UTF8_STRING)));
+        new DefaultHttpChunk(new BigEndianHeapChannelBuffer("efg".getBytes(StandardCharsets.UTF_8)));
     clientResp = responseHandler.handleChunk(clientResp, chunk, 0);
     clientResp = responseHandler.done(clientResp);
 


### PR DESCRIPTION
There is an old optimization in StringUtils#fromUtf8 and toUtf8 that has outlived its usefulness. Apparently it used to be faster to pass the String charset name rather than a Charset object, but that is no longer the case.