### PR TITLE
test: use a long taskDuration for bounded Kafka supervisor tests

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
@@ -179,10 +179,14 @@ public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
    * its own when it reaches its end offset. With the short duration, a bounded task that
    * has not consumed its whole range within one supervisor cycle is rolled over at its
    * current offset, and each successor task is rolled over again before the Kafka consumer
-   * finishes starting, so the supervisor never reaches the end offset. Use a duration that
-   * no bounded task in this class can exceed.
+   * finishes starting, so the supervisor never reaches the end offset.
+   * <p>
+   * 10 seconds is an order of magnitude above the time a bounded task in this class needs
+   * to start and consume its range. It is deliberately not longer: a task that pauses for a
+   * checkpoint and is not resumed by the supervisor only recovers at the next rollover, so
+   * the duration also caps how long such a stall can hold a test.
    */
-  private static final Period BOUNDED_TASK_DURATION = Period.seconds(60);
+  private static final Period BOUNDED_TASK_DURATION = Period.seconds(10);
 
   private KafkaSupervisorSpec createBoundedKafkaSupervisor(
       KafkaResource kafkaServer,

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaBoundedSupervisorTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.indexing.seekablestream.supervisor.BoundedStreamConfig;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
 import org.apache.druid.testing.embedded.StreamIngestResource;
+import org.joda.time.Period;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -172,6 +173,17 @@ public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
     Assertions.assertEquals("UNHEALTHY_SUPERVISOR", status.getState());
   }
 
+  /**
+   * Task duration for bounded supervisors in this test. The shared fixture uses a 500ms
+   * taskDuration so that unbounded tasks publish quickly, but a bounded task publishes on
+   * its own when it reaches its end offset. With the short duration, a bounded task that
+   * has not consumed its whole range within one supervisor cycle is rolled over at its
+   * current offset, and each successor task is rolled over again before the Kafka consumer
+   * finishes starting, so the supervisor never reaches the end offset. Use a duration that
+   * no bounded task in this class can exceed.
+   */
+  private static final Period BOUNDED_TASK_DURATION = Period.seconds(60);
+
   private KafkaSupervisorSpec createBoundedKafkaSupervisor(
       KafkaResource kafkaServer,
       String topic,
@@ -181,6 +193,7 @@ public class KafkaBoundedSupervisorTest extends StreamIndexTestBase
     return createKafkaSupervisor(kafkaServer)
         .withIoConfig(io -> io
             .withKafkaInputFormat(new JsonInputFormat(null, null, null, null, null))
+            .withTaskDuration(BOUNDED_TASK_DURATION)
             .withBoundedStreamConfig(boundedConfig)
         )
         .build(dataSource, topic);


### PR DESCRIPTION
### Description

Fixes the recurring flake in `KafkaBoundedSupervisorTest` (previously #19542, #19543, #20124) by giving the bounded supervisors in that class a 10s `taskDuration` instead of the 500ms inherited from the shared Kafka fixture in `MoreResources.Supervisor.KAFKA_JSON`.

#### What the failure looks like

`test_boundedSupervisor_withMismatchedMetadata_is_unhealthy` times out waiting for 200 published rows, e.g. [job 102719409989](https://github.com/apache/druid/actions/runs/34428720842/job/102719409989):

```
ISE: Timed out waiting for event after [120,000]ms
  at StreamIndexTestBase.waitUntilPublishedRecordsAreIngested(StreamIndexTestBase.java:186)
  at KafkaBoundedSupervisorTest.test_boundedSupervisor_withMismatchedMetadata_is_unhealthy(KafkaBoundedSupervisorTest.java:221)
```

#### Root cause (from the captured test output of that job)

1. The bounded task for partition 1 had consumed 96 of its 100 records when the supervisor's task-duration check fired:
   `Stopping taskGroup[1] as it has already run for duration[PT0.898S], configured task duration[PT0.500S].`
   The task was paused and its end offset set to 96. Partition 0 finished its 100 records within the cycle and was fine.
2. The supervisor created a new bounded task for offsets 96 to 100. Kafka consumer startup takes longer than 500ms, so on the next cycle the new task had read nothing, was rolled over with `Checkpoint[96] is same as the start sequences`, published zero segments, and the cycle repeated: 116 rollovers and 115 zero-row tasks in 120 seconds, never reaching offset 100.
3. In passing runs both tasks finish their 100 records inside the first cycle, so no rollover happens. The test therefore fails whenever the first read takes longer than about one supervisor cycle, which is a matter of runner timing.

The earlier fixes (#19543, #20124) raised the wait to 120s on the theory of a slow cold start. That cannot help here because no progress is made once the rollover loop starts.

#### Why 500ms is in the fixture

Unbounded Kafka tasks only publish when `taskDuration` elapses, so the shared fixture uses 500ms to make ingested rows queryable within seconds. Bounded tasks publish on their own at their end offset and gain nothing from a short duration, so this change overrides it only in `createBoundedKafkaSupervisor` and leaves the fixture untouched for the unbounded tests.

#### Second finding, exposed by this change (not fixed here)

With the rollover no longer masking it, the first CI run of this PR (with a 60s duration) showed `test_boundedSupervisor_ingestsDataAndCompletes` taking 63.8s instead of ~4s. The partition-1 task hit `maxRowsPerSegment` at 500 rows, sent a checkpoint request and paused itself, and the supervisor answered:

```
All tasks in taskGroup [1] have failed, tasks will be re-created
New checkpoint is null for taskGroup [1]
```

although the task was running. `checkpointTaskGroup` saw an empty task set for the group, returned null, and never resumed the task, which stayed paused until the `taskDuration` rollover forced it to publish at offset 500; a successor task then ingested the remaining 20 records. Under the old 500ms duration this stall was invisible because the rollover arrived almost immediately. The 10s value chosen here keeps the livelock fix while capping the cost of that stall.

#### Possible follow-ups (not in this PR)

1. The supervisor rolling over a bounded task that has made no progress can livelock a bounded supervisor with a short `taskDuration`. A guard against rolling over a bounded task at its start offset would fix that for users too.
2. A bounded task's checkpoint request can be answered with a null checkpoint while the task is running, leaving the task paused until the next rollover (up to `taskDuration`, one hour by default). This needs a look at how bounded task groups are populated relative to task start.

The supervisor rolling over a bounded task that has made no progress is a product behavior that can livelock a bounded supervisor with a short `taskDuration`. A guard against rolling over a bounded task at its start offset would fix that for users too.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
