### PR TITLE
fix: validate size in FixedIndexed header

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/data/FixedIndexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/FixedIndexed.java
@@ -63,6 +63,14 @@ public class FixedIndexed<T> implements Indexed<T>
     final boolean isSorted = (flags & IS_SORTED_MASK) == IS_SORTED_MASK ? true : false;
     Preconditions.checkState(!(hasNull && !isSorted), "cannot have null values if not sorted");
     final int size = buffer.getInt() + (hasNull ? 1 : 0);
+    Preconditions.checkArgument(size >= 0, "size[%s] must be non-negative", size);
+    final int valuesCount = hasNull ? size - 1 : size;
+    Preconditions.checkArgument(
+        (long) width * valuesCount <= buffer.remaining(),
+        "size[%s] with width[%s] exceeds the available buffer",
+        size,
+        width
+    );
     final int valuesOffset = buffer.position();
     final Supplier<FixedIndexed<T>> fixedIndexed = () -> new FixedIndexed<>(
         bb,
@@ -75,7 +83,7 @@ public class FixedIndexed<T> implements Indexed<T>
         valuesOffset
     );
 
-    bb.position(buffer.position() + (width * (hasNull ? size - 1 : size)));
+    bb.position(buffer.position() + (width * valuesCount));
     return fixedIndexed;
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/data/FixedIndexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/FixedIndexed.java
@@ -63,8 +63,8 @@ public class FixedIndexed<T> implements Indexed<T>
     final boolean isSorted = (flags & IS_SORTED_MASK) == IS_SORTED_MASK ? true : false;
     Preconditions.checkState(!(hasNull && !isSorted), "cannot have null values if not sorted");
     final int size = buffer.getInt() + (hasNull ? 1 : 0);
-    Preconditions.checkArgument(size >= 0, "size[%s] must be non-negative", size);
     final int valuesCount = hasNull ? size - 1 : size;
+    Preconditions.checkArgument(valuesCount >= 0, "valuesCount[%s] must be non-negative", valuesCount);
     Preconditions.checkArgument(
         (long) width * valuesCount <= buffer.remaining(),
         "size[%s] with width[%s] exceeds the available buffer",

--- a/processing/src/test/java/org/apache/druid/segment/data/FixedIndexedTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/FixedIndexedTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.segment.data;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.TypeStrategies;
 import org.apache.druid.segment.writeout.OnHeapMemorySegmentWriteOutMedium;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.jupiter.api.Assertions;
@@ -228,5 +229,23 @@ public class FixedIndexedTest extends InitializedNullHandlingTest
         () -> FixedIndexed.read(buffer, ColumnType.LONG.getStrategy(), order, Long.BYTES)
     );
     Assertions.assertTrue(e.getMessage().contains("exceeds the available buffer"), e.getMessage());
+  }
+
+  @Test
+  public void testNegativeCountWithNullFlagRejected()
+  {
+    // With the null flag set the serialized count is incremented before validation: a raw
+    // count of -1 yields size == 0 but valuesCount == -1, which must still be rejected.
+    final ByteBuffer buffer = ByteBuffer.allocate(16).order(order);
+    buffer.put((byte) 0);
+    buffer.put((byte) (TypeStrategies.IS_NULL_BYTE | FixedIndexed.IS_SORTED_MASK));
+    buffer.putInt(-1);
+    buffer.flip();
+
+    final IllegalArgumentException e = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> FixedIndexed.read(buffer, ColumnType.LONG.getStrategy(), order, Long.BYTES)
+    );
+    Assertions.assertTrue(e.getMessage().contains("must be non-negative"), e.getMessage());
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/data/FixedIndexedTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/FixedIndexedTest.java
@@ -197,4 +197,36 @@ public class FixedIndexedTest extends InitializedNullHandlingTest
     Assertions.assertEquals(size, buffer.position());
     buffer.position(0);
   }
+
+  @Test
+  public void testNegativeSizeRejected()
+  {
+    final ByteBuffer buffer = ByteBuffer.allocate(16).order(order);
+    buffer.put((byte) 0);
+    buffer.put((byte) 0);
+    buffer.putInt(-5);
+    buffer.flip();
+
+    final IllegalArgumentException e = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> FixedIndexed.read(buffer, ColumnType.LONG.getStrategy(), order, Long.BYTES)
+    );
+    Assertions.assertTrue(e.getMessage().contains("must be non-negative"), e.getMessage());
+  }
+
+  @Test
+  public void testSizeExceedingBufferRejected()
+  {
+    final ByteBuffer buffer = ByteBuffer.allocate(20).order(order);
+    buffer.put((byte) 0);
+    buffer.put((byte) 0);
+    buffer.putInt(4); // 4 * Long.BYTES = 32 bytes claimed, but the buffer only holds 8 value bytes
+    buffer.flip();
+
+    final IllegalArgumentException e = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> FixedIndexed.read(buffer, ColumnType.LONG.getStrategy(), order, Long.BYTES)
+    );
+    Assertions.assertTrue(e.getMessage().contains("exceeds the available buffer"), e.getMessage());
+  }
 }


### PR DESCRIPTION
### Description

`FixedIndexed.read()` trusts the `size` header field. A negative value surfaces as a raw JVM exception at load (`IllegalArgumentException: newPosition < 0`), and a crafted size whose `width * size` arithmetic wraps is **silently accepted**: e.g. `size = 0x40000002` with `width = 8` claims 1073741826 elements while the buffer holds two longs, and `get(1073741824)` / `get(1073741825)` return the values of slot 0 / slot 1 because `valuesOffset + index * width` wraps — duplicated/shifted reads with no error.

#### Fixed the bug ...

Validate the header before any offset arithmetic: `size >= 0`, and `width * valuesCount <= buffer.remaining()` (computed in long to avoid the same wrap). Malformed headers now fail fast with a descriptive `IllegalArgumentException` (`"size[%s] must be non-negative"` / `"size[%s] with width[%s] exceeds the available buffer"`).

Added `testNegativeSizeRejected` and `testSizeExceedingBufferRejected` to `FixedIndexedTest`. I verified both tests fail without the fix (reproducing the raw `newPosition < 0` / `newPosition > limit` exceptions) and pass with it; `mvn validate` (checkstyle) and `mvn -DstrictCompile test-compile` (Error Prone) also pass locally.

#### Release note

- Reject malformed `FixedIndexed` headers (negative size, or size exceeding the available buffer) with a descriptive error instead of failing later with an unrelated JVM exception or silently returning wrong values.

<hr>

##### Key changed/added classes in this PR
 * `FixedIndexed`
 * `FixedIndexedTest`

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.