### PR TITLE
test: fix flaky KubernetesTaskRunnerTest start tests

### DIFF
--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
@@ -161,14 +161,20 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
         settableFuture
     );
 
+    expectCleanupOfCompletedJobs();
     replayAll();
 
-    runner.start();
+    try {
+      runner.start();
 
-    verifyAll();
+      verifyAll();
 
-    Assertions.assertNotNull(runner.tasks);
-    Assertions.assertEquals(1, runner.tasks.size());
+      Assertions.assertNotNull(runner.tasks);
+      Assertions.assertEquals(1, runner.tasks.size());
+    }
+    finally {
+      runner.stop();
+    }
   }
 
   @Test
@@ -247,14 +253,20 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
         settableFuture
     );
 
+    expectCleanupOfCompletedJobs();
     replayAll();
 
-    runner.start();
+    try {
+      runner.start();
 
-    verifyAll();
+      verifyAll();
 
-    Assertions.assertNotNull(runner.tasks);
-    Assertions.assertEquals(1, runner.tasks.size());
+      Assertions.assertNotNull(runner.tasks);
+      Assertions.assertEquals(1, runner.tasks.size());
+    }
+    finally {
+      runner.stop();
+    }
   }
 
   @Test
@@ -286,14 +298,32 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
     EasyMock.expect(peonClient.getPeonJobs()).andReturn(ImmutableList.of(job));
     EasyMock.expect(taskAdapter.toTask(job)).andThrow(new IOException());
 
+    expectCleanupOfCompletedJobs();
     replayAll();
 
-    runner.start();
+    try {
+      runner.start();
 
-    verifyAll();
+      verifyAll();
 
-    Assertions.assertNotNull(runner.tasks);
-    Assertions.assertEquals(0, runner.tasks.size());
+      Assertions.assertNotNull(runner.tasks);
+      Assertions.assertEquals(0, runner.tasks.size());
+    }
+    finally {
+      runner.stop();
+    }
+  }
+
+  /**
+   * {@link KubernetesTaskRunner#start()} schedules the cleanup of completed peon jobs on a background executor with
+   * an initial delay of 1 ms. Whether the first cleanup runs before {@link #verifyAll()} depends on thread scheduling,
+   * so the call must be allowed any number of times to keep the tests deterministic.
+   */
+  private void expectCleanupOfCompletedJobs()
+  {
+    EasyMock.expect(peonClient.deleteCompletedPeonJobsOlderThan(EasyMock.anyLong(), EasyMock.eq(TimeUnit.MILLISECONDS)))
+            .andReturn(0)
+            .anyTimes();
   }
 
   @Test


### PR DESCRIPTION
Related to #20312 (item 1).

### Description

`KubernetesTaskRunnerTest.test_start_whenDeserializationExceptionThrown_isIgnored` fails intermittently on master with:

```
Unexpected method calls:
  EasyMock for field KubernetesTaskRunnerTest.peonClient -> KubernetesPeonClient.deleteCompletedPeonJobsOlderThan(172800000 (long), MILLISECONDS)
```

Example: https://github.com/apache/druid/actions/runs/34431507380/job/102727804299 (failed all 4 surefire attempts).

`KubernetesTaskRunner.start()` schedules `deleteCompletedPeonJobsOlderThan` on a real `ScheduledExecutorService` with an initial delay of 1 ms. Whether the first cleanup runs before the test's `verifyAll()` depends on thread scheduling, so the strict mock sometimes sees a call it was not told to expect.

#### Changes

* In the three tests that call `runner.start()` on a locally created runner, expect `deleteCompletedPeonJobsOlderThan(anyLong(), MILLISECONDS)` any number of times via a small helper. Only this one call is relaxed; the rest of `peonClient` stays strictly verified.
* Stop each locally created runner in a `finally` block so the cleanup executor does not outlive the test.

Verified locally with `mvn -pl extensions-core/kubernetes-overlord-extensions test -Dtest=KubernetesTaskRunnerTest`.

<hr>

##### Key changed/added classes in this PR
 * `KubernetesTaskRunnerTest`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added or updated unit tests.


#### Additional CI evidence

This same scheduled-cleanup race reappeared as a recovered flaky failure in [PR #20330](https://github.com/apache/druid/pull/20330), [unit-test job](https://github.com/apache/druid/actions/runs/34659832633/job/103459832068):

```
Unexpected method calls:
  KubernetesPeonClient.deleteCompletedPeonJobsOlderThan(172800000 (long), MILLISECONDS)
```

The corresponding [PR #20329 unit run](https://github.com/apache/druid/actions/runs/34650557010) did not reach this assertion: its embedded tests failed earlier with `NoClassDefFoundError: org/apache/curator/test/TestingServer` after the `curator-test` dependency was removed.
