### PR TITLE
test: fix flaky ReferenceCountingResourceHolderTest cleaner checks

### DIFF
--- a/processing/src/test/java/org/apache/druid/collections/ReferenceCountingResourceHolderTest.java
+++ b/processing/src/test/java/org/apache/druid/collections/ReferenceCountingResourceHolderTest.java
@@ -116,15 +116,21 @@ public class ReferenceCountingResourceHolderTest
 
   private void verifyCleanerRun(AtomicBoolean released, long initialLeakedResources) throws InterruptedException
   {
-    // Wait until Closer runs
-    for (int i = 0; i < 6000 && ReferenceCountingResourceHolder.leakedResources() == initialLeakedResources; i++) {
+    // Wait until the Cleaner has run the closer of the holder leaked by this test. The leaked resource counter is
+    // global to the JVM and is incremented before the closer runs, so it cannot be used to detect completion: holders
+    // leaked by other tests sharing this JVM may be collected by the forced GC as well.
+    for (int i = 0; i < 6000 && !released.get(); i++) {
       System.gc();
       @SuppressWarnings("unused")
       byte[] garbage = new byte[10_000_000];
       Thread.sleep(10);
     }
-    Assertions.assertEquals(initialLeakedResources + 1, ReferenceCountingResourceHolder.leakedResources());
-    // Cleaner also runs the closer
+    // Cleaner runs the closer
     Assertions.assertTrue(released.get());
+    // At least the holder leaked by this test must have been counted; other leaked holders may have been counted too.
+    Assertions.assertTrue(
+        ReferenceCountingResourceHolder.leakedResources() >= initialLeakedResources + 1,
+        "leakedResources should have been incremented at least once"
+    );
   }
 }


### PR DESCRIPTION
Related to #20312 (item 2).

### Description

`ReferenceCountingResourceHolderTest.testResourceHandlerClearedByJVM` fails intermittently on master with:

```
expected: <1> but was: <3>
  at ReferenceCountingResourceHolderTest.verifyCleanerRun(ReferenceCountingResourceHolderTest.java:126)
```

Example: https://github.com/apache/druid/actions/runs/34432737655/job/102731457738.

`ReferenceCountingResourceHolder.LEAKED_RESOURCES` is a JVM-global counter, and surefire runs with `reuseForks=true`. `verifyCleanerRun` loops on `System.gc()` until the counter changes and then asserts an exact `+1`. Holders leaked by other test classes in the same fork are collected by the same forced GC, so the delta can be larger than 1. Because the counter is incremented *before* the closer runs, the loop can also exit before this test's own closer has executed, which would make the `released` assertion fail too.

#### Changes

* Loop until this test's own `released` flag is set, which is the completion signal that belongs to this test.
* Assert `released`, and only assert a lower bound (`>= initial + 1`) on the global counter.

Verified locally with `mvn -pl processing test -Dtest=ReferenceCountingResourceHolderTest` (3 tests pass).

<hr>

##### Key changed/added classes in this PR
 * `ReferenceCountingResourceHolderTest`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added or updated unit tests.


#### Additional CI evidence

The same global-counter/cleaner race reappeared as a recovered flaky failure in both dependency-update PRs:

* [PR #20329](https://github.com/apache/druid/pull/20329), [unit-test job](https://github.com/apache/druid/actions/runs/34650557010/job/103431562664): `expected: <1> but was: <3>`.
* [PR #20330](https://github.com/apache/druid/pull/20330), [unit-test job](https://github.com/apache/druid/actions/runs/34659832633/job/103459832194): `expected: <1> but was: <3>`.

These occurrences were recorded as flaky failures; they are independent of the dependency changes in those PRs.
