### PR TITLE
ci: do not fail unit test jobs when the JFR profiler agent cannot be downloaded

### DIFF
--- a/.github/scripts/setup_test_profiling_env.sh
+++ b/.github/scripts/setup_test_profiling_env.sh
@@ -28,24 +28,34 @@ fi
 
 if [[ "$1" -ge "17" ]];
 then
-  curl https://static.imply.io/cp/$JAR_INPUT_FILE -s -o $JAR_OUTPUT_FILE
+  # The profiler agent is observability only. If it cannot be downloaded, run the tests without it
+  # instead of failing the job or pointing -javaagent at a missing or partial jar.
+  TMP_JAR="$JAR_OUTPUT_FILE.tmp"
+  if curl -sSf --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 15 --max-time 120 --retry-max-time 300 \
+       "https://static.imply.io/cp/$JAR_INPUT_FILE" -o "$TMP_JAR"; then
+    mv -f "$TMP_JAR" "$JAR_OUTPUT_FILE"
 
-  # Run 'java -version' and capture the output
-  output=$(java -version 2>&1)
+    # Run 'java -version' and capture the output
+    output=$(java -version 2>&1)
 
-  # Extract the version number using grep and awk
-  jvm_version=$(echo "$output" | grep "version" | awk -F '"' '{print $2}')
+    # Extract the version number using grep and awk
+    jvm_version=$(echo "$output" | grep "version" | awk -F '"' '{print $2}')
 
-  shift
-  tags="${@/#/-Djfr.profiler.tags.}"
+    shift
+    tags="${@/#/-Djfr.profiler.tags.}"
 
-  echo $ENV_VAR=-javaagent:"$PWD"/$JAR_OUTPUT_FILE \
-  -Djfr.profiler.http.username=druid-ci \
-  -Djfr.profiler.http.password=w3Fb6PW8LIo849mViEkbgA== \
-  -Djfr.profiler.tags.project=druid \
-  -Djfr.profiler.tags.jvm_version=$jvm_version \
-  "${tags[@]}"
+    echo $ENV_VAR=-javaagent:"$PWD"/$JAR_OUTPUT_FILE \
+    -Djfr.profiler.http.username=druid-ci \
+    -Djfr.profiler.http.password=w3Fb6PW8LIo849mViEkbgA== \
+    -Djfr.profiler.tags.project=druid \
+    -Djfr.profiler.tags.jvm_version=$jvm_version \
+    "${tags[@]}"
+  else
+    # stdout is appended to $GITHUB_ENV by the caller, so diagnostics must go to stderr.
+    echo "::warning::Failed to download the JFR profiler agent ($JAR_INPUT_FILE); running tests without profiling" >&2
+    rm -f "$TMP_JAR" "$JAR_OUTPUT_FILE"
+    echo $ENV_VAR=\"\"
+  fi
 else
   echo $ENV_VAR=\"\"
 fi
-

--- a/.github/scripts/setup_test_profiling_env.sh
+++ b/.github/scripts/setup_test_profiling_env.sh
@@ -54,8 +54,8 @@ then
     # stdout is appended to $GITHUB_ENV by the caller, so diagnostics must go to stderr.
     echo "::warning::Failed to download the JFR profiler agent ($JAR_INPUT_FILE); running tests without profiling" >&2
     rm -f "$TMP_JAR" "$JAR_OUTPUT_FILE"
-    echo $ENV_VAR=\"\"
+    echo "$ENV_VAR="
   fi
 else
-  echo $ENV_VAR=\"\"
+  echo "$ENV_VAR="
 fi


### PR DESCRIPTION
Related to #20312 (item 6).

### Description

The `unit tests (25, S*)` shard on master failed before Maven even started:

```
+ ./.github/scripts/setup_test_profiling_env.sh 25 run_id=... key=test-jdk25-[S*] ...
##[error]Process completed with exit code 35.
```

Example: https://github.com/apache/druid/actions/runs/34426655504/job/102713226586. Exit code 35 is curl's TLS connect error while downloading `jfr-profiler-1.0.0.jar` from `static.imply.io`. The script runs under `set -e`, so the whole test shard was aborted by an observability-only download.

#### Changes to `setup_test_profiling_env.sh`

* Download with `curl -sSf --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 15 --max-time 120 --retry-max-time 300`. `-f` fails on HTTP error pages instead of saving them as the jar, and `--retry-all-errors` is required because curl does not retry TLS errors by default.
* Download to a temporary file and only move it into place on success, so a partial jar is never passed to `-javaagent`.
* On failure, emit an empty `JFR_PROFILER_ARG_LINE` so surefire adds nothing to the JVM, remove any partial output, and print a `::warning::` annotation to stderr (stdout is appended to `$GITHUB_ENV` by the caller).

The success path is unchanged.

<hr>

##### Key changed/added files in this PR
 * `.github/scripts/setup_test_profiling_env.sh`

<hr>

This PR has:

- [x] been self-reviewed.
