### PR TITLE
test: poll Broker state instead of schema refresh metrics in QueryTestBase

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryTestBase.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryTestBase.java
@@ -128,7 +128,9 @@ public abstract class QueryTestBase extends EmbeddedClusterTestBase
     final IndexTask task = MoreResources.Task.BASIC_INDEX.get().dataSource(datasourceName).withId(taskId);
     cluster.callApi().onLeaderOverlord(o -> o.runTask(taskId, task));
     cluster.callApi().waitForTaskToSucceed(taskId, overlord);
-    cluster.callApi().waitForAllSegmentsToBeAvailable(datasourceName, coordinator, broker);
+    // Poll the state observed by SQL queries rather than waiting for Broker schema refresh metrics,
+    // which has been observed to time out intermittently in CI.
+    cluster.callApi().waitForAllSegmentsToBeQueryable(datasourceName, coordinator, 100_000L);
     return datasourceName;
   }
 

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedClusterApis.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedClusterApis.java
@@ -362,7 +362,7 @@ public class EmbeddedClusterApis implements EmbeddedResource
             "SELECT COUNT(*) FROM sys.segments WHERE datasource='%s' AND is_available = 1",
             dataSource
         ),
-        result -> Integer.parseInt(result.trim()) >= numSegments
+        result -> parseCountOrZero(result) >= numSegments
     ).withTimeoutMillis(timeoutMillis).go();
 
     waitForResult(
@@ -372,6 +372,20 @@ public class EmbeddedClusterApis implements EmbeddedResource
         ),
         result -> "1".equals(result.trim())
     ).withTimeoutMillis(timeoutMillis).go();
+  }
+
+  /**
+   * Parses a {@code COUNT(*)} result, treating an empty or non-numeric result
+   * (e.g. while the Broker is still initializing) as zero so that polling continues.
+   */
+  private static long parseCountOrZero(String result)
+  {
+    try {
+      return Long.parseLong(result.trim());
+    }
+    catch (NumberFormatException e) {
+      return 0L;
+    }
   }
 
   /**

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedClusterApis.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedClusterApis.java
@@ -333,6 +333,48 @@ public class EmbeddedClusterApis implements EmbeddedResource
   }
 
   /**
+   * Waits for all non-tombstone used segments of the given datasource to be
+   * reported as available in {@code sys.segments} and for the datasource to be
+   * present in the Broker SQL schema, by polling the Broker.
+   * <p>
+   * Unlike {@link #waitForAllSegmentsToBeAvailable}, this method does not depend
+   * on schema refresh metrics being emitted by the Broker and verifies the state
+   * that SQL queries actually observe.
+   *
+   * @param timeoutMillis maximum time to wait
+   */
+  public void waitForAllSegmentsToBeQueryable(
+      String dataSource,
+      EmbeddedCoordinator coordinator,
+      long timeoutMillis
+  )
+  {
+    final int numSegments = (int) coordinator
+        .bindings()
+        .segmentsMetadataStorage()
+        .retrieveAllUsedSegments(dataSource, Segments.INCLUDING_OVERSHADOWED)
+        .stream()
+        .filter(segment -> !segment.isTombstone())
+        .count();
+
+    waitForResult(
+        () -> runSql(
+            "SELECT COUNT(*) FROM sys.segments WHERE datasource='%s' AND is_available = 1",
+            dataSource
+        ),
+        result -> Integer.parseInt(result.trim()) >= numSegments
+    ).withTimeoutMillis(timeoutMillis).go();
+
+    waitForResult(
+        () -> runSql(
+            "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'druid' AND TABLE_NAME = '%s'",
+            dataSource
+        ),
+        result -> "1".equals(result.trim())
+    ).withTimeoutMillis(timeoutMillis).go();
+  }
+
+  /**
    * Waits for all used segments (including overshadowed) of the given datasource
    * to be queryable by Brokers when centralized schema is enabled.
    */


### PR DESCRIPTION
Related to #20312 (item 3, `QueryLaningTest`).

### Description

`QueryLaningTest.test_queryUsesLaneInQueryContext_inManualStrategy` failed on master with:

```
ISE: Timed out waiting for event after [100,000]ms
  at LatchableEmitter.waitForEventAggregate
  at EmbeddedClusterApis.waitForAllSegmentsToBeAvailable(EmbeddedClusterApis.java:316)
  at QueryTestBase.ingestBasicData(QueryTestBase.java:131)
```

Example: https://github.com/apache/druid/actions/runs/34432737655/job/102731457738.

`waitForAllSegmentsToBeAvailable` waits for the aggregate `segment/schemaCache/refresh/count` emitted by the Broker to reach the number of used segments. That is an indirect signal for what the query tests actually need: the segments being available and the datasource being present in the SQL schema.

#### Changes

* Add `EmbeddedClusterApis.waitForAllSegmentsToBeQueryable(dataSource, coordinator, timeoutMillis)`, which polls the Broker for the state SQL queries observe: the number of `is_available = 1` rows in `sys.segments` for the datasource reaching the number of non-tombstone used segments, and the datasource appearing in `INFORMATION_SCHEMA.TABLES`. It uses the existing `ResultWaiter` and reports the last observed value on timeout.
* Use it from `QueryTestBase.ingestBasicData()`, which is the only call site changed. `waitForAllSegmentsToBeAvailable` and its other callers are untouched.

Verified locally with `mvn -pl services,embedded-tests -am test-compile`. The embedded query tests were not run locally.

<hr>

##### Key changed/added classes in this PR
 * `EmbeddedClusterApis`
 * `QueryTestBase`

<hr>

This PR has:

- [x] been self-reviewed.
