### PR TITLE
test: poll sys.segments in verifyNumVisibleSegmentsIs to fix flaky compaction tests

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/CompactionTestBase.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/CompactionTestBase.java
@@ -97,8 +97,8 @@ public abstract class CompactionTestBase extends EmbeddedClusterTestBase
 
   protected void verifySegmentsCount(int numExpectedSegments)
   {
-    // Ensure that Broker has synced latest segments from the Coordinator
-    broker.latchableEmitter().waitForNextEvent(event -> event.hasMetricName("segment/metadataCache/sync/time"));
+    // The Overlord state is verified immediately; the Broker-side sys.segments view is polled
+    // until it matches, since a single metadata cache sync may still observe the previous state.
     cluster.callApi().verifyNumVisibleSegmentsIs(numExpectedSegments, dataSource, overlord);
   }
 

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedClusterApis.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedClusterApis.java
@@ -287,15 +287,28 @@ public class EmbeddedClusterApis implements EmbeddedResource
         segmentCount,
         "Segment count mismatch"
     );
-    Assertions.assertEquals(
-        String.valueOf(segmentCount),
-        runSql(
-            "SELECT COUNT(*) FROM sys.segments WHERE datasource='%s'"
-            + " AND is_overshadowed = 0 AND is_available = 1",
-            dataSource
-        ),
-        "Segment count mismatch in sys.segments table"
-    );
+
+    // The Broker learns about segment changes asynchronously from the Coordinator, so the
+    // sys.segments table may briefly lag behind the metadata store. Poll instead of asserting once.
+    final String expectedCount = String.valueOf(segmentCount);
+    final String sql = "SELECT COUNT(*) FROM sys.segments WHERE datasource='%s'"
+                       + " AND is_overshadowed = 0 AND is_available = 1";
+    try {
+      waitForResult(() -> runSql(sql, dataSource), expectedCount::equals)
+          .withTimeoutMillis(60_000)
+          .go();
+    }
+    catch (ISE e) {
+      throw new AssertionError(
+          StringUtils.format(
+              "Segment count mismatch in sys.segments table: expected[%s] segments for datasource[%s]. %s",
+              expectedCount,
+              dataSource,
+              e.getMessage()
+          ),
+          e
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
Related to #20312 (item 7).

### Description

`CompactionTaskTest.testCompactionWithTimestampDimension` failed on master with:

```
Segment count mismatch in sys.segments table ==> expected: <2> but was: <>
  at EmbeddedClusterApis.verifyNumVisibleSegmentsIs(EmbeddedClusterApis.java:290)
  at CompactionTestBase.verifySegmentsCount(CompactionTestBase.java:102)
```

Example: https://github.com/apache/druid/actions/runs/34443807042/job/102764139085.

The Overlord-side assertion passed (2 visible used segments). `verifySegmentsCount` then waited for a single `segment/metadataCache/sync/time` event on the Broker and asserted the `sys.segments` count once. A sync that was already in flight when the compaction finished can complete while still reflecting the previous state, so one sync event does not guarantee the Broker has caught up.

#### Changes

* `EmbeddedClusterApis.verifyNumVisibleSegmentsIs` keeps the immediate Overlord assertion and polls the Broker-side `sys.segments` count using the existing `ResultWaiter` (60 s deadline). On timeout it throws an `AssertionError` that includes the expected count, the datasource and the last observed result.
* `CompactionTestBase.verifySegmentsCount` no longer waits for the single sync event, since the poll covers it.

`verifyNumVisibleSegmentsIs` has a single caller (`CompactionTestBase`).

Verified locally with `mvn -pl services,embedded-tests -am test-compile`. The embedded compaction tests were not run locally.

<hr>

##### Key changed/added classes in this PR
 * `EmbeddedClusterApis`
 * `CompactionTestBase`

<hr>

This PR has:

- [x] been self-reviewed.
