### PR TITLE
fix: Do not block in ChainedProcessorManager.next().

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/ChainedProcessorManager.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/ChainedProcessorManager.java
@@ -23,16 +23,18 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.apache.druid.common.guava.FutureUtils;
+import org.apache.druid.frame.processor.FrameProcessor;
 import org.apache.druid.frame.processor.manager.ProcessorAndCallback;
 import org.apache.druid.frame.processor.manager.ProcessorManager;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.utils.CloseableUtils;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 /**
@@ -41,11 +43,14 @@ import java.util.function.Function;
  */
 public class ChainedProcessorManager<A, B, R> implements ProcessorManager<Object, R>
 {
+  private static final Logger log = new Logger(ChainedProcessorManager.class);
+
   /**
-   * First processor manager. FrameProcessors created by this runs before all the others.
-   * The reference is set to null once all the processors have been returned by the channel.
+   * First processor manager. The {@link FrameProcessor}s it creates run before all the others. The reference is
+   * set to null once this manager has returned all of its processors.
    */
   @Nullable
+  @GuardedBy("lock")
   private ProcessorManager<A, List<A>> first;
 
   /**
@@ -59,13 +64,29 @@ public class ChainedProcessorManager<A, B, R> implements ProcessorManager<Object
   private final SettableFuture<ProcessorManager<B, R>> restFuture = SettableFuture.create();
 
   /**
+   * Lock used to synchronize the things used by {@link #next()}. We need enough thread safety to allow the
+   * future returned by {@link #next()} to be resolved in a future callback handler.
+   */
+  private final Object lock = new Object();
+
+  /**
    * Whether {@link #close()} has been called.
    */
+  @GuardedBy("lock")
   private boolean closed;
 
-  private final List<A> firstProcessorResult = new CopyOnWriteArrayList<>();
+  /**
+   * Number of processors handed out by {@link #first}. {@link #firstProcessorResult} is complete once this many
+   * results have been accumulated.
+   */
+  @GuardedBy("lock")
+  private int firstProcessorCount;
 
-  private final AtomicInteger firstProcessorCount = new AtomicInteger(0);
+  /**
+   * Results of the processors created by {@link #first}. Read and written under {@link #lock}, but the list itself
+   * is handed to {@link #restFactory}, so it may be read by the resulting manager on another thread.
+   */
+  private final List<A> firstProcessorResult = new CopyOnWriteArrayList<>();
 
   public ChainedProcessorManager(
       final ProcessorManager<A, ?> firstProcessor,
@@ -77,8 +98,10 @@ public class ChainedProcessorManager<A, B, R> implements ProcessorManager<Object
     this.first = firstProcessor.withAccumulation(
         firstProcessorResult,
         (acc, a) -> {
-          acc.add(a);
-          checkFirstProcessorComplete();
+          synchronized (lock) {
+            acc.add(a);
+            checkFirstProcessorComplete();
+          }
           return acc;
         }
     );
@@ -88,32 +111,70 @@ public class ChainedProcessorManager<A, B, R> implements ProcessorManager<Object
   @Override
   public ListenableFuture<Optional<ProcessorAndCallback<Object>>> next()
   {
-    if (closed) {
-      throw new IllegalStateException();
-    } else if (first != null) {
-      Optional<ProcessorAndCallback<A>> processorAndCallbackOptional = Futures.getUnchecked(first.next());
-      if (processorAndCallbackOptional.isPresent()) {
-        // More processors left to run.
-        firstProcessorCount.incrementAndGet();
-        ProcessorAndCallback<A> aProcessorAndCallback = processorAndCallbackOptional.get();
-        //noinspection unchecked
-        return Futures.immediateFuture(Optional.of((ProcessorAndCallback<Object>) aProcessorAndCallback));
-      } else {
-        first = null;
-        checkFirstProcessorComplete();
+    final ListenableFuture<Optional<ProcessorAndCallback<A>>> nextFromFirst;
+
+    synchronized (lock) {
+      if (closed) {
+        throw new IllegalStateException();
+      } else if (first == null) {
+        return nextFromRest();
       }
+
+      nextFromFirst = first.next();
     }
 
-    //noinspection unchecked
+    return FutureUtils.transformAsync(
+        nextFromFirst,
+        processorAndCallback -> {
+          synchronized (lock) {
+            if (!closed) {
+              if (processorAndCallback.isPresent()) {
+                // More processors left to run.
+                firstProcessorCount++;
+                //noinspection unchecked
+                return Futures.immediateFuture(Optional.of((ProcessorAndCallback<Object>) processorAndCallback.get()));
+              } else {
+                first = null;
+                checkFirstProcessorComplete();
+                return nextFromRest();
+              }
+            }
+          }
+
+          // Closed while we were waiting. Clean up the processor we were handed.
+          if (processorAndCallback.isPresent()) {
+            final FrameProcessor<A> processor = processorAndCallback.get().processor();
+            CloseableUtils.closeAndSuppressExceptions(
+                processor::cleanup,
+                e -> log.noStackTrace().warn(e, "Failed to clean up processor[%s] after close", processor)
+            );
+          }
+
+          return Futures.immediateFuture(Optional.empty());
+        }
+    );
+  }
+
+  /**
+   * Returns the next processor from {@link #restFuture}, once that manager is available.
+   */
+  private ListenableFuture<Optional<ProcessorAndCallback<Object>>> nextFromRest()
+  {
+    //noinspection unchecked, rawtypes
     return FutureUtils.transformAsync(
         restFuture,
         rest -> (ListenableFuture) rest.next()
     );
   }
 
+  /**
+   * Sets {@link #restFuture} once all processors from {@link #first} have been created and have finished running.
+   * Does nothing once {@link #close()} has been called, since nothing would close the new manager.
+   */
+  @GuardedBy("lock")
   private void checkFirstProcessorComplete()
   {
-    if (first == null && (firstProcessorResult.size() == firstProcessorCount.get())) {
+    if (!closed && first == null && (firstProcessorResult.size() == firstProcessorCount)) {
       restFuture.set(restFactory.apply(firstProcessorResult));
     }
   }
@@ -127,12 +188,22 @@ public class ChainedProcessorManager<A, B, R> implements ProcessorManager<Object
   @Override
   public void close()
   {
-    if (!closed) {
+    final ProcessorManager<A, List<A>> firstToClose;
+    final ProcessorManager<B, R> restToClose;
+
+    synchronized (lock) {
+      if (closed) {
+        return;
+      }
+
       closed = true;
-      CloseableUtils.closeAndWrapExceptions(() -> CloseableUtils.closeAll(
-          first != null ? first : null,
-          restFuture.isDone() ? FutureUtils.getUnchecked(restFuture, false) : null
-      ));
+      firstToClose = first;
+      restToClose = restFuture.isDone() ? FutureUtils.getUncheckedImmediately(restFuture) : null;
     }
+
+    // Cancel in case restFuture was never set, so futures from nextFromRest() do not remain pending forever.
+    restFuture.cancel(false);
+
+    CloseableUtils.closeAndWrapExceptions(() -> CloseableUtils.closeAll(firstToClose, restToClose));
   }
 }

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/ChainedProcessorManagerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/ChainedProcessorManagerTest.java
@@ -22,7 +22,9 @@ package org.apache.druid.msq.querykit;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.frame.Frame;
@@ -30,9 +32,11 @@ import org.apache.druid.frame.channel.BlockingQueueFrameChannel;
 import org.apache.druid.frame.channel.ReadableFrameChannel;
 import org.apache.druid.frame.channel.WritableFrameChannel;
 import org.apache.druid.frame.processor.Bouncer;
+import org.apache.druid.frame.processor.FrameProcessor;
 import org.apache.druid.frame.processor.FrameProcessorExecutorTest;
 import org.apache.druid.frame.processor.FrameProcessors;
 import org.apache.druid.frame.processor.manager.NilFrameProcessor;
+import org.apache.druid.frame.processor.manager.ProcessorAndCallback;
 import org.apache.druid.frame.processor.manager.ProcessorManager;
 import org.apache.druid.frame.processor.manager.ProcessorManagers;
 import org.apache.druid.frame.processor.test.SimpleReturningFrameProcessor;
@@ -61,8 +65,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
@@ -192,6 +198,36 @@ public class ChainedProcessorManagerTest extends FrameProcessorExecutorTest.Base
   }
 
   @Test
+  public void test_asynchronously_completing_processor_manager() throws Exception
+  {
+    final ImmutableList<Long> expectedValues = ImmutableList.of(1L, 2L, 3L);
+    final BlockingQueueFrameChannel outputChannel = new BlockingQueueFrameChannel(3);
+
+    final ChainedProcessorManager<List<Long>, Long, Long> chainedProcessorManager = new ChainedProcessorManager<>(
+        new CompleteAfterProcessorRunsProcessorManager<>(new SimpleReturningFrameProcessor<>(expectedValues)),
+        (values) -> createNextProcessors(
+            outputChannel.writable(),
+            values.stream().flatMap(List::stream).collect(Collectors.toList())
+        )
+    );
+
+    exec.runAllFully(
+        chainedProcessorManager,
+        maxOutstandingProcessors,
+        bouncer,
+        null
+    ).get(1, TimeUnit.MINUTES);
+
+    final HashSet<Long> actualValues = new HashSet<>();
+    try (ReadableFrameChannel readable = outputChannel.readable()) {
+      while (readable.canRead()) {
+        actualValues.add(extractColumnValue(readable.readFrame(), 1));
+      }
+    }
+    Assertions.assertEquals(new HashSet<>(expectedValues), actualValues);
+  }
+
+  @Test
   public void test_failing_processor_manager()
   {
     final ImmutableSet<Long> expectedValues = ImmutableSet.of();
@@ -298,6 +334,47 @@ public class ChainedProcessorManagerTest extends FrameProcessorExecutorTest.Base
   {
     final Map<String, Object> event = TestHelper.makeMap(true, kv);
     return new MapBasedInputRow(0L, ImmutableList.copyOf(event.keySet()), event);
+  }
+
+  /**
+   * Processor manager that returns a single processor, and only reports that it has no more processors once that
+   * processor has completed.
+   */
+  private static class CompleteAfterProcessorRunsProcessorManager<T> implements ProcessorManager<T, Long>
+  {
+    private final FrameProcessor<T> processor;
+    private final SettableFuture<Optional<ProcessorAndCallback<T>>> doneFuture = SettableFuture.create();
+    private boolean returnedProcessor;
+
+    public CompleteAfterProcessorRunsProcessorManager(final FrameProcessor<T> processor)
+    {
+      this.processor = processor;
+    }
+
+    @Override
+    public ListenableFuture<Optional<ProcessorAndCallback<T>>> next()
+    {
+      if (returnedProcessor) {
+        return doneFuture;
+      }
+
+      returnedProcessor = true;
+      return Futures.immediateFuture(
+          Optional.of(new ProcessorAndCallback<>(processor, ignored -> doneFuture.set(Optional.empty())))
+      );
+    }
+
+    @Override
+    public Long result()
+    {
+      return 0L;
+    }
+
+    @Override
+    public void close()
+    {
+      doneFuture.cancel(false);
+    }
   }
 
   public static class PrintFirstAndReturnRestFrameProcessor extends SingleChannelFrameProcessor<List<Long>>


### PR DESCRIPTION
Previously, a blocking Future wait ran inside next(), which could cause a processing thread to block while waiting for the next processor to be ready. This patch fixes it by moving resolution to a callback.