### PR TITLE
feat: add support to push/pull/kill segments in azure deep storage without zip compression

### DIFF
--- a/docs/development/extensions-core/azure.md
+++ b/docs/development/extensions-core/azure.md
@@ -60,6 +60,7 @@ Configure where to store segments using the following properties:
 | `druid.azure.maxTries` | Number of tries before canceling an Azure operation. | 3 |
 | `druid.azure.protocol` | The protocol to use to connect to the Azure Storage account. Either `http` or `https`. | `https` |
 | `druid.azure.storageAccountEndpointSuffix` | The Storage account endpoint to use. Override the default value to connect to [Azure Government](https://learn.microsoft.com/en-us/azure/azure-government/documentation-government-get-started-connect-to-storage#getting-started-with-storage-api) or storage accounts with [Azure DNS zone endpoints](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview#azure-dns-zone-endpoints-preview).<br/><br/>Do _not_ include the storage account name prefix in this config value.<br/><br/>Examples: `ABCD1234.blob.storage.azure.net`, `blob.core.usgovcloudapi.net`. | `blob.core.windows.net` |
+| `druid.storage.zip` | Whether segments are written as directories of blobs (`false`) or as a single `index.zip` blob (`true`). | `true` |
 
 #### Configure authentication
 

--- a/docs/development/extensions-core/s3.md
+++ b/docs/development/extensions-core/s3.md
@@ -53,7 +53,7 @@ To use S3 for Deep Storage, you must supply [connection information](#configurat
 |`druid.storage.baseKey`|A prefix string that will be prepended to the object names for the segments published to S3 deep storage|Must be set.|
 |`druid.storage.type`|Global deep storage provider. Must be set to `s3` to make use of this extension.|Must be set (likely `s3`).|
 |`druid.storage.disableAcl`|Boolean flag for how object permissions are handled. To use ACLs, set this property to `false`. To use Object Ownership, set it to `true`. The permission requirements for ACLs and Object Ownership are different. For more information, see [S3 permissions settings](#s3-permissions-settings).|false|
-|`druid.storage.zip`|`true`, `false`|Whether segments in `s3` are written as directories (`false`) or zip files (`true`).|`false`|
+|`druid.storage.zip`|`true`, `false`|Whether segments in `s3` are written as directories (`false`) or zip files (`true`).|`true`|
 |`druid.storage.transfer.useTransferManager`| If true, use AWS S3 Transfer Manager to upload segments to S3.|true|
 |`druid.storage.transfer.minimumUploadPartSize`| Minimum size (in bytes) of each part in a multipart upload. Must be between 5242880 (5 MiB) and 5368709120 (5 GiB), the range S3 permits for every part except the last. Larger parts mean fewer requests per upload, which matters when many tasks write concurrently under one key prefix.|20971520 (20 MB)|
 |`druid.storage.transfer.multipartUploadThreshold`| The file size threshold (in bytes) above which a file upload is converted into a multipart upload instead of a single PUT request.| 20971520 (20 MB)|

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentKiller.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentKiller.java
@@ -87,7 +87,12 @@ public class AzureDataSegmentKiller implements DataSegmentKiller
           containerName,
           k -> new ArrayList<>()
       );
-      keysToDelete.add(blobPath);
+      if (blobPath.endsWith("/")) {
+        // segment was pushed unzipped, so the path names a directory of blobs; list them all to delete them
+        keysToDelete.addAll(azureStorage.listBlobs(containerName, blobPath, null, accountConfig.getMaxTries()));
+      } else {
+        keysToDelete.add(blobPath);
+      }
     }
 
     boolean shouldThrowException = false;
@@ -119,7 +124,9 @@ public class AzureDataSegmentKiller implements DataSegmentKiller
     Map<String, Object> loadSpec = segment.getLoadSpec();
     final String containerName = MapUtils.getString(loadSpec, "containerName");
     final String blobPath = MapUtils.getString(loadSpec, "blobPath");
-    final String dirPath = Paths.get(blobPath).getParent().toString();
+    final String dirPath = blobPath.endsWith("/")
+                           ? blobPath
+                           : Paths.get(blobPath).getParent() + "/";
 
     try {
       azureStorage.emptyCloudBlobDirectory(containerName, dirPath);

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentPuller.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentPuller.java
@@ -116,7 +116,7 @@ public class AzureDataSegmentPuller
       final String containerName,
       final String blobPathPrefix,
       final File outDir
-  ) throws IOException
+  )
   {
     final int maxTries = azureAccountConfig.getMaxTries();
     final List<String> blobPaths = azureStorage.listBlobs(containerName, blobPathPrefix, null, maxTries);

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentPuller.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentPuller.java
@@ -29,6 +29,8 @@ import org.apache.druid.utils.CompressionUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
 
 /**
  * Used for Reading segment files stored in Azure based deep storage
@@ -70,13 +72,11 @@ public class AzureDataSegmentPuller
 
       final String actualBlobPath = AzureUtils.maybeRemoveAzurePathPrefix(blobPath, azureAccountConfig.getBlobStorageEndpoint());
 
-      final ByteSource byteSource = byteSourceFactory.create(containerName, actualBlobPath, azureStorage);
-      final FileUtils.FileCopyResult result = CompressionUtils.unzip(
-          byteSource,
-          outDir,
-          AzureUtils.AZURE_RETRY,
-          false
-      );
+      // A trailing slash means the segment was pushed unzipped (druid.storage.zip=false), so the path names a
+      // directory of blobs to pull individually rather than a single zip to unpack.
+      final FileUtils.FileCopyResult result = actualBlobPath.endsWith("/")
+                                              ? getSegmentFilesFromDirectory(containerName, actualBlobPath, outDir)
+                                              : unzipSegmentFiles(containerName, actualBlobPath, outDir);
 
       log.info("Loaded %d bytes from [%s] to [%s]", result.size(), actualBlobPath, outDir.getAbsolutePath());
       return result;
@@ -95,5 +95,41 @@ public class AzureDataSegmentPuller
       }
       throw new SegmentLoadingException(e, e.getMessage());
     }
+  }
+
+  private FileUtils.FileCopyResult unzipSegmentFiles(
+      final String containerName,
+      final String blobPath,
+      final File outDir
+  ) throws IOException
+  {
+    final ByteSource byteSource = byteSourceFactory.create(containerName, blobPath, azureStorage);
+    return CompressionUtils.unzip(
+        byteSource,
+        outDir,
+        AzureUtils.AZURE_RETRY,
+        false
+    );
+  }
+
+  private FileUtils.FileCopyResult getSegmentFilesFromDirectory(
+      final String containerName,
+      final String blobPathPrefix,
+      final File outDir
+  ) throws IOException
+  {
+    final int maxTries = azureAccountConfig.getMaxTries();
+    final List<String> blobPaths = azureStorage.listBlobs(containerName, blobPathPrefix, null, maxTries);
+    final FileUtils.FileCopyResult copyResult = new FileUtils.FileCopyResult();
+
+    for (final String blobPath : blobPaths) {
+      final ByteSource byteSource = byteSourceFactory.create(containerName, blobPath, azureStorage);
+      final File outFile = new File(outDir, Paths.get(blobPath).getFileName().toString());
+      copyResult.addFiles(
+          FileUtils.retryCopy(byteSource, outFile, AzureUtils.AZURE_RETRY, maxTries).getFiles()
+      );
+    }
+
+    return copyResult;
   }
 }

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentPusher.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentPusher.java
@@ -24,10 +24,12 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import org.apache.druid.guice.annotations.Global;
+import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.segment.loading.DataSegmentPusher;
+import org.apache.druid.segment.loading.DeepStorageSegmentConfig;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.utils.CompressionUtils;
 import org.joda.time.format.ISODateTimeFormat;
@@ -44,20 +46,29 @@ import java.util.Map;
 public class AzureDataSegmentPusher implements DataSegmentPusher
 {
   private static final Logger log = new Logger(AzureDataSegmentPusher.class);
+
+  /**
+   * Originally Azure always wrote segments zipped, so that is what {@code druid.storage.zip} falls back to.
+   */
+  private static final boolean DEFAULT_ZIP = true;
+
   private final AzureStorage azureStorage;
   private final AzureAccountConfig accountConfig;
   private final AzureDataSegmentConfig segmentConfig;
+  private final boolean zip;
 
   @Inject
   public AzureDataSegmentPusher(
       @Global AzureStorage azureStorage,
       AzureAccountConfig accountConfig,
-      AzureDataSegmentConfig segmentConfig
+      AzureDataSegmentConfig segmentConfig,
+      DeepStorageSegmentConfig deepStorageConfig
   )
   {
     this.azureStorage = azureStorage;
     this.accountConfig = accountConfig;
     this.segmentConfig = segmentConfig;
+    this.zip = deepStorageConfig.isZip(DEFAULT_ZIP);
   }
 
   @Override
@@ -87,8 +98,7 @@ public class AzureDataSegmentPusher implements DataSegmentPusher
       throws IOException
   {
     log.info("Uploading [%s] to Azure.", indexFilesDir);
-    final String azurePathSuffix = getAzurePath(segment, useUniquePath);
-    return pushToPath(indexFilesDir, segment, azurePathSuffix);
+    return pushToPath(indexFilesDir, segment, getStorageDir(segment, useUniquePath));
   }
 
   @Override
@@ -96,22 +106,39 @@ public class AzureDataSegmentPusher implements DataSegmentPusher
   {
     String prefix = segmentConfig.getPrefix();
     boolean prefixIsNullOrEmpty = org.apache.commons.lang3.StringUtils.isEmpty(prefix);
-    final String azurePath = JOINER.join(
+    final String azureBasePath = JOINER.join(
         prefixIsNullOrEmpty ? null : StringUtils.maybeRemoveTrailingSlash(prefix),
         storageDirSuffix
     );
 
     final int binaryVersion = SegmentUtils.getVersionFromDir(indexFilesDir);
+
+    try {
+      if (zip) {
+        return pushZip(indexFilesDir, segment, binaryVersion, azureBasePath);
+      } else {
+        return pushNoZip(indexFilesDir, segment, binaryVersion, azureBasePath);
+      }
+    }
+    catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private DataSegment pushZip(
+      File indexFilesDir,
+      DataSegment segment,
+      int binaryVersion,
+      String azureBasePath
+  ) throws IOException
+  {
     File zipOutFile = null;
 
     try {
       final File outFile = zipOutFile = Files.createTempFile("index", ".zip").toFile();
       final long size = CompressionUtils.zip(indexFilesDir, zipOutFile);
 
-      return uploadDataSegment(segment, binaryVersion, size, outFile, azurePath);
-    }
-    catch (Exception e) {
-      throw new RuntimeException(e);
+      return uploadDataSegment(segment, binaryVersion, size, outFile, getZipBlobPath(azureBasePath));
     }
     finally {
       if (zipOutFile != null) {
@@ -121,19 +148,62 @@ public class AzureDataSegmentPusher implements DataSegmentPusher
     }
   }
 
+  /**
+   * Uploads the segment files as they are, one blob per file, under {@code azureBasePath}. The resulting loadSpec
+   * blobPath is the directory itself, with a trailing slash to tell {@link AzureDataSegmentPuller} and
+   * {@link AzureDataSegmentKiller} that it names a directory of files rather than a single blob.
+   */
+  private DataSegment pushNoZip(
+      File indexFilesDir,
+      DataSegment segment,
+      int binaryVersion,
+      String azureBasePath
+  ) throws IOException
+  {
+    final File[] files = indexFilesDir.listFiles();
+    if (files == null) {
+      throw new IOE("Cannot list directory [%s]", indexFilesDir);
+    }
+
+    long size = 0;
+    for (final File file : files) {
+      if (file.isFile()) {
+        size += file.length();
+        azureStorage.uploadBlockBlob(
+            file,
+            segmentConfig.getContainer(),
+            StringUtils.format("%s/%s", azureBasePath, file.getName()),
+            accountConfig.getMaxTries()
+        );
+      } else {
+        // Segment directories are expected to be flat.
+        throw new IOE("Unexpected subdirectory [%s]", file.getName());
+      }
+    }
+
+    return segment.withSize(size)
+                  .withLoadSpec(makeLoadSpec(azureBasePath + "/"))
+                  .withBinaryVersion(binaryVersion);
+  }
+
   @Override
   public Map<String, Object> makeLoadSpec(URI uri)
   {
     return makeLoadSpec(uri.toString());
   }
 
+  /**
+   * Path of the {@code index.zip} blob for a segment, relative to {@link AzureDataSegmentConfig#getPrefix()}.
+   */
   @VisibleForTesting
   String getAzurePath(final DataSegment segment, final boolean useUniquePath)
   {
-    final String storageDir = this.getStorageDir(segment, useUniquePath);
+    return getZipBlobPath(this.getStorageDir(segment, useUniquePath));
+  }
 
-    return StringUtils.format("%s/%s", storageDir, AzureStorageDruidModule.INDEX_ZIP_FILE_NAME);
-
+  private static String getZipBlobPath(final String azureBasePath)
+  {
+    return StringUtils.format("%s/%s", azureBasePath, AzureStorageDruidModule.INDEX_ZIP_FILE_NAME);
   }
 
   @VisibleForTesting

--- a/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureDataSegmentKillerTest.java
+++ b/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureDataSegmentKillerTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.loading.SegmentLoadingException;
 import org.apache.druid.storage.azure.blob.CloudBlobHolder;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
@@ -67,43 +68,31 @@ public class AzureDataSegmentKillerTest extends EasyMockSupport
   // BlobStorageException is not recoverable since the client attempts retries on it internally
   private static final Exception NON_RECOVERABLE_EXCEPTION = new BlobStorageException("", null, null);
 
-  private static final DataSegment DATA_SEGMENT = new DataSegment(
-      "test",
-      Intervals.of("2015-04-12/2015-04-13"),
-      "1",
-      ImmutableMap.of("containerName", CONTAINER_NAME, "blobPath", BLOB_PATH),
-      null,
-      null,
-      new LinearShardSpec(0),
-      0,
-      1
-  );
+  private static final DataSegment DATA_SEGMENT =
+      DataSegment.builder(SegmentId.of("test", Intervals.of("2015-04-12/2015-04-13"), "1", 0))
+                 .loadSpec(ImmutableMap.of("containerName", CONTAINER_NAME, "blobPath", BLOB_PATH))
+                 .shardSpec(new LinearShardSpec(0))
+                 .binaryVersion(0)
+                 .size(1)
+                 .build();
 
-  private static final DataSegment DATA_SEGMENT_2 = new DataSegment(
-      "test",
-      Intervals.of("2015-04-12/2015-04-13"),
-      "1",
-      ImmutableMap.of("containerName", CONTAINER_NAME, "blobPath", BLOB_PATH_2),
-      null,
-      null,
-      new LinearShardSpec(0),
-      0,
-      1
-  );
+  private static final DataSegment DATA_SEGMENT_2 =
+      DataSegment.builder(SegmentId.of("test", Intervals.of("2015-04-12/2015-04-13"), "1", 0))
+                 .loadSpec(ImmutableMap.of("containerName", CONTAINER_NAME, "blobPath", BLOB_PATH_2))
+                 .shardSpec(new LinearShardSpec(0))
+                 .binaryVersion(0)
+                 .size(1)
+                 .build();
 
   // pushed with druid.storage.zip=false, so blobPath is the directory holding the segment files
   private static final String UNZIPPED_BLOB_PATH = "test/2015-04-12T00:00:00.000Z_2015-04-13T00:00:00.000Z/1/0/";
-  private static final DataSegment UNZIPPED_DATA_SEGMENT = new DataSegment(
-      "test",
-      Intervals.of("2015-04-12/2015-04-13"),
-      "1",
-      ImmutableMap.of("containerName", CONTAINER_NAME, "blobPath", UNZIPPED_BLOB_PATH),
-      null,
-      null,
-      new LinearShardSpec(0),
-      0,
-      1
-  );
+  private static final DataSegment UNZIPPED_DATA_SEGMENT =
+      DataSegment.builder(SegmentId.of("test", Intervals.of("2015-04-12/2015-04-13"), "1", 0))
+                 .loadSpec(ImmutableMap.of("containerName", CONTAINER_NAME, "blobPath", UNZIPPED_BLOB_PATH))
+                 .shardSpec(new LinearShardSpec(0))
+                 .binaryVersion(0)
+                 .size(1)
+                 .build();
 
   private AzureDataSegmentConfig segmentConfig;
   private AzureInputDataConfig inputDataConfig;

--- a/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureDataSegmentKillerTest.java
+++ b/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureDataSegmentKillerTest.java
@@ -44,6 +44,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -90,6 +91,20 @@ public class AzureDataSegmentKillerTest extends EasyMockSupport
       1
   );
 
+  // pushed with druid.storage.zip=false, so blobPath is the directory holding the segment files
+  private static final String UNZIPPED_BLOB_PATH = "test/2015-04-12T00:00:00.000Z_2015-04-13T00:00:00.000Z/1/0/";
+  private static final DataSegment UNZIPPED_DATA_SEGMENT = new DataSegment(
+      "test",
+      Intervals.of("2015-04-12/2015-04-13"),
+      "1",
+      ImmutableMap.of("containerName", CONTAINER_NAME, "blobPath", UNZIPPED_BLOB_PATH),
+      null,
+      null,
+      new LinearShardSpec(0),
+      0,
+      1
+  );
+
   private AzureDataSegmentConfig segmentConfig;
   private AzureInputDataConfig inputDataConfig;
   private AzureAccountConfig accountConfig;
@@ -110,7 +125,7 @@ public class AzureDataSegmentKillerTest extends EasyMockSupport
   public void killTest() throws SegmentLoadingException, BlobStorageException
   {
     List<String> deletedFiles = new ArrayList<>();
-    final String dirPath = Paths.get(BLOB_PATH).getParent().toString();
+    final String dirPath = Paths.get(BLOB_PATH).getParent() + "/";
 
     EasyMock.expect(azureStorage.emptyCloudBlobDirectory(CONTAINER_NAME, dirPath)).andReturn(deletedFiles);
 
@@ -130,9 +145,68 @@ public class AzureDataSegmentKillerTest extends EasyMockSupport
   }
 
   @Test
+  public void test_kill_prefixEndsAtPartitionDirectory_cannotMatchSiblingPartition()
+      throws SegmentLoadingException, BlobStorageException
+  {
+    // emptyCloudBlobDirectory matches its prefix textually rather than by path segment, so the prefix has to end at the
+    // partition directory boundary: without the trailing slash, killing partition 1 would also match partition 10.
+    final String versionDir = "test/2015-04-12T00:00:00.000Z_2015-04-13T00:00:00.000Z/1";
+    final String partition1 = versionDir + "/1/index.zip";
+    final String partition10 = versionDir + "/10/index.zip";
+
+    final Capture<String> prefixCapture = Capture.newInstance();
+    EasyMock.expect(azureStorage.emptyCloudBlobDirectory(
+        EasyMock.eq(CONTAINER_NAME),
+        EasyMock.capture(prefixCapture)
+    )).andReturn(ImmutableList.of(partition1));
+
+    replayAll();
+
+    final AzureDataSegmentKiller killer = new AzureDataSegmentKiller(
+        segmentConfig,
+        inputDataConfig,
+        accountConfig,
+        azureStorage,
+        azureCloudBlobIterableFactory
+    );
+
+    killer.kill(
+        DATA_SEGMENT.withLoadSpec(ImmutableMap.of("containerName", CONTAINER_NAME, "blobPath", partition1))
+    );
+
+    verifyAll();
+
+    assertEquals(versionDir + "/1/", prefixCapture.getValue());
+    assertFalse(partition10.startsWith(prefixCapture.getValue()));
+  }
+
+  @Test
+  public void test_kill_unzippedSegment_emptiesItsOwnDirectory() throws SegmentLoadingException, BlobStorageException
+  {
+    // The blobPath is already the segment's directory, so it is emptied as it stands. Taking its parent, as is done
+    // for a zipped segment's index.zip, would reach up into the version directory and take out sibling partitions.
+    EasyMock.expect(azureStorage.emptyCloudBlobDirectory(CONTAINER_NAME, UNZIPPED_BLOB_PATH))
+            .andReturn(ImmutableList.of(UNZIPPED_BLOB_PATH + "version.bin"));
+
+    replayAll();
+
+    final AzureDataSegmentKiller killer = new AzureDataSegmentKiller(
+        segmentConfig,
+        inputDataConfig,
+        accountConfig,
+        azureStorage,
+        azureCloudBlobIterableFactory
+    );
+
+    killer.kill(UNZIPPED_DATA_SEGMENT);
+
+    verifyAll();
+  }
+
+  @Test
   public void test_kill_StorageExceptionExtendedErrorInformationNull_throwsException()
   {
-    String dirPath = Paths.get(BLOB_PATH).getParent().toString();
+    String dirPath = Paths.get(BLOB_PATH).getParent() + "/";
 
     EasyMock.expect(azureStorage.emptyCloudBlobDirectory(CONTAINER_NAME, dirPath))
             .andThrow(new BlobStorageException("", null, null));
@@ -158,7 +232,7 @@ public class AzureDataSegmentKillerTest extends EasyMockSupport
   @Test
   public void test_kill_runtimeException_throwsException()
   {
-    final String dirPath = Paths.get(BLOB_PATH).getParent().toString();
+    final String dirPath = Paths.get(BLOB_PATH).getParent() + "/";
 
     EasyMock.expect(azureStorage.emptyCloudBlobDirectory(CONTAINER_NAME, dirPath))
             .andThrow(new RuntimeException(""));
@@ -325,6 +399,39 @@ public class AzureDataSegmentKillerTest extends EasyMockSupport
   }
 
   @Test
+  public void test_killBatch_unzippedSegment_deletesEveryBlobInTheDirectory()
+      throws SegmentLoadingException, BlobStorageException
+  {
+    final String versionBlob = UNZIPPED_BLOB_PATH + "version.bin";
+    final String smooshBlob = UNZIPPED_BLOB_PATH + "meta.smoosh";
+
+    // an unzipped segment is a directory rather than a single blob, so its files have to be listed to be deleted
+    EasyMock.expect(accountConfig.getMaxTries()).andReturn(MAX_TRIES);
+    EasyMock.expect(azureStorage.listBlobs(CONTAINER_NAME, UNZIPPED_BLOB_PATH, null, MAX_TRIES))
+            .andReturn(ImmutableList.of(versionBlob, smooshBlob));
+
+    Capture<List<String>> deletedFilesCapture = Capture.newInstance();
+    EasyMock.expect(azureStorage.batchDeleteFiles(
+        EasyMock.eq(CONTAINER_NAME),
+        EasyMock.capture(deletedFilesCapture),
+        EasyMock.eq(null)
+    )).andReturn(true);
+
+    replayAll();
+
+    AzureDataSegmentKiller killer = new AzureDataSegmentKiller(segmentConfig, inputDataConfig, accountConfig, azureStorage, azureCloudBlobIterableFactory);
+
+    killer.kill(ImmutableList.of(UNZIPPED_DATA_SEGMENT, DATA_SEGMENT_2));
+
+    verifyAll();
+
+    assertEquals(
+        ImmutableSet.of(versionBlob, smooshBlob, BLOB_PATH_2),
+        new HashSet<>(deletedFilesCapture.getValue())
+    );
+  }
+
+  @Test
   public void test_killBatch_runtimeException()
   {
     EasyMock.expect(azureStorage.batchDeleteFiles(CONTAINER_NAME, ImmutableList.of(BLOB_PATH, BLOB_PATH_2), null))
@@ -383,7 +490,7 @@ public class AzureDataSegmentKillerTest extends EasyMockSupport
   public void killBatch_singleSegment() throws SegmentLoadingException, BlobStorageException
   {
     List<String> deletedFiles = new ArrayList<>();
-    final String dirPath = Paths.get(BLOB_PATH).getParent().toString();
+    final String dirPath = Paths.get(BLOB_PATH).getParent() + "/";
 
     // For a single segment, fall back to regular kill(DataSegment) logic
     EasyMock.expect(azureStorage.emptyCloudBlobDirectory(CONTAINER_NAME, dirPath)).andReturn(deletedFiles);

--- a/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureDataSegmentPullerTest.java
+++ b/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureDataSegmentPullerTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.storage.azure;
 
 import com.azure.core.http.HttpResponse;
 import com.azure.storage.blob.models.BlobStorageException;
+import com.google.common.collect.ImmutableList;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.segment.loading.SegmentLoadingException;
 import org.easymock.EasyMock;
@@ -35,6 +36,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -47,6 +49,7 @@ public class AzureDataSegmentPullerTest extends EasyMockSupport
 {
   private static final String CONTAINER_NAME = "container";
   private static final String BLOB_PATH = "path/to/storage/index.zip";
+  private static final String UNZIPPED_BLOB_PATH = "path/to/storage/";
   private AzureStorage azureStorage;
   private AzureByteSourceFactory byteSourceFactory;
 
@@ -119,6 +122,39 @@ public class AzureDataSegmentPullerTest extends EasyMockSupport
   }
 
   @Test
+  public void test_getSegmentFiles_unzippedSegment_pullsEachBlob(@TempDir Path sourcePath, @TempDir Path targetPath)
+      throws IOException, SegmentLoadingException
+  {
+    final AzureAccountConfig config = new AzureAccountConfig();
+    final String versionBlob = UNZIPPED_BLOB_PATH + "version.bin";
+    final String smooshBlob = UNZIPPED_BLOB_PATH + "meta.smoosh";
+    final String versionValue = "version";
+    final String smooshValue = "smoosh";
+
+    EasyMock.expect(azureStorage.listBlobs(CONTAINER_NAME, UNZIPPED_BLOB_PATH, null, config.getMaxTries()))
+            .andReturn(ImmutableList.of(versionBlob, smooshBlob));
+    expectBlobContents(sourcePath, versionBlob, versionValue);
+    expectBlobContents(sourcePath, smooshBlob, smooshValue);
+
+    replayAll();
+
+    AzureDataSegmentPuller puller = new AzureDataSegmentPuller(byteSourceFactory, azureStorage, config);
+
+    FileUtils.FileCopyResult result = puller.getSegmentFiles(CONTAINER_NAME, UNZIPPED_BLOB_PATH, targetPath.toFile());
+
+    // the blobs land in outDir under their own names, not unpacked from a zip
+    final File version = new File(targetPath.toFile(), "version.bin");
+    final File smoosh = new File(targetPath.toFile(), "meta.smoosh");
+    assertTrue(version.exists());
+    assertTrue(smoosh.exists());
+    assertEquals(versionValue.length(), version.length());
+    assertEquals(smooshValue.length(), smoosh.length());
+    assertEquals(versionValue.length() + smooshValue.length(), result.size());
+
+    verifyAll();
+  }
+
+  @Test
   public void test_getSegmentFiles_nonRecoverableErrorRaisedWhenPullingSegmentFiles_doNotDeleteOutputDirectory(
       @TempDir Path tempPath
   )
@@ -171,6 +207,22 @@ public class AzureDataSegmentPullerTest extends EasyMockSupport
 
     assertFalse(tempPath.toFile().exists());
     verifyAll();
+  }
+
+  /**
+   * Sets up {@link #byteSourceFactory} and {@link #azureStorage} to serve {@code value} as the contents of
+   * {@code blobPath}, backed by a real file so that the copy has something to read.
+   */
+  private void expectBlobContents(final Path sourcePath, final String blobPath, final String value)
+      throws IOException
+  {
+    final File blobFile = Files.createFile(sourcePath.resolve(Paths.get(blobPath).getFileName().toString())).toFile();
+    Files.write(blobFile.toPath(), value.getBytes(StandardCharsets.UTF_8));
+
+    EasyMock.expect(byteSourceFactory.create(CONTAINER_NAME, blobPath, azureStorage))
+            .andReturn(new AzureByteSource(azureStorage, CONTAINER_NAME, blobPath));
+    EasyMock.expect(azureStorage.getBlockBlobInputStream(0L, CONTAINER_NAME, blobPath))
+            .andReturn(Files.newInputStream(blobFile.toPath()));
   }
 
   @SuppressWarnings("SameParameterValue")

--- a/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureDataSegmentPusherTest.java
+++ b/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureDataSegmentPusherTest.java
@@ -25,6 +25,7 @@ import com.google.common.io.Files;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.MapUtils;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.loading.DeepStorageSegmentConfig;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.easymock.EasyMock;
@@ -63,6 +64,8 @@ public class AzureDataSegmentPusherTest extends EasyMockSupport
       0,
       1
   );
+  private static final DeepStorageSegmentConfig ZIP_CONFIG = new DeepStorageSegmentConfig(true);
+  private static final DeepStorageSegmentConfig NO_ZIP_CONFIG = new DeepStorageSegmentConfig(false);
   private static final byte[] DATA = new byte[]{0x0, 0x0, 0x0, 0x1};
   private static final String UNIQUE_MATCHER_NO_PREFIX = "foo/20150101T000000\\.000Z_20160101T000000\\.000Z/0/0/[A-Za-z0-9-]{36}/index\\.zip";
   private static final String UNIQUE_MATCHER_PREFIX = PREFIX + "/" + UNIQUE_MATCHER_NO_PREFIX;
@@ -107,8 +110,7 @@ public class AzureDataSegmentPusherTest extends EasyMockSupport
   public void test_push_nonUniquePathNoPrefix_succeeds(@TempDir Path tempPath) throws Exception
   {
     boolean useUniquePath = false;
-    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithoutPrefix
-    );
+    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithoutPrefix, ZIP_CONFIG);
 
     // Create a mock segment on disk
     File tmp = tempPath.resolve("version.bin").toFile();
@@ -138,8 +140,7 @@ public class AzureDataSegmentPusherTest extends EasyMockSupport
   public void test_push_nonUniquePathWithPrefix_succeeds(@TempDir Path tempPath) throws Exception
   {
     boolean useUniquePath = false;
-    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithPrefix
-    );
+    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithPrefix, ZIP_CONFIG);
 
     // Create a mock segment on disk
     File tmp = tempPath.resolve("version.bin").toFile();
@@ -170,7 +171,7 @@ public class AzureDataSegmentPusherTest extends EasyMockSupport
   public void test_push_uniquePathNoPrefix_succeeds(@TempDir Path tempPath) throws Exception
   {
     boolean useUniquePath = true;
-    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithoutPrefix);
+    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithoutPrefix, ZIP_CONFIG);
 
     // Create a mock segment on disk
     File tmp = tempPath.resolve("version.bin").toFile();
@@ -205,7 +206,7 @@ public class AzureDataSegmentPusherTest extends EasyMockSupport
   public void test_push_uniquePath_succeeds(@TempDir Path tempPath) throws Exception
   {
     boolean useUniquePath = true;
-    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithPrefix);
+    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithPrefix, ZIP_CONFIG);
 
     // Create a mock segment on disk
     File tmp = tempPath.resolve("version.bin").toFile();
@@ -238,10 +239,104 @@ public class AzureDataSegmentPusherTest extends EasyMockSupport
   }
 
   @Test
+  public void test_pushNoZip_uploadsEachFile_succeeds(@TempDir Path tempPath) throws Exception
+  {
+    AzureDataSegmentPusher pusher =
+        new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithPrefix, NO_ZIP_CONFIG);
+
+    // Create a mock segment on disk, of more than one file, since the point of not zipping is to keep them separate
+    Files.write(DATA, tempPath.resolve("version.bin").toFile());
+    Files.write(DATA, tempPath.resolve("meta.smoosh").toFile());
+
+    final String expectedDir = PREFIX + "/" + pusher.getStorageDir(SEGMENT_TO_PUSH, false);
+    azureStorage.uploadBlockBlob(
+        EasyMock.anyObject(File.class),
+        EasyMock.eq(CONTAINER_NAME),
+        EasyMock.eq(expectedDir + "/version.bin"),
+        EasyMock.eq(MAX_TRIES)
+    );
+    EasyMock.expectLastCall();
+    azureStorage.uploadBlockBlob(
+        EasyMock.anyObject(File.class),
+        EasyMock.eq(CONTAINER_NAME),
+        EasyMock.eq(expectedDir + "/meta.smoosh"),
+        EasyMock.eq(MAX_TRIES)
+    );
+    EasyMock.expectLastCall();
+
+    replayAll();
+
+    DataSegment segment = pusher.push(tempPath.toFile(), SEGMENT_TO_PUSH, false);
+
+    // the trailing slash is what marks the blobPath as a directory of files rather than a single blob
+    assertEquals(expectedDir + "/", segment.getLoadSpec().get("blobPath"));
+    assertEquals(CONTAINER_NAME, segment.getLoadSpec().get("containerName"));
+    assertEquals(AzureStorageDruidModule.SCHEME, segment.getLoadSpec().get("type"));
+    assertEquals(2 * DATA.length, segment.getSize());
+
+    verifyAll();
+  }
+
+  @Test
+  public void test_pushNoZip_subdirectory_throwsException(@TempDir Path tempPath) throws Exception
+  {
+    AzureDataSegmentPusher pusher =
+        new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithPrefix, NO_ZIP_CONFIG);
+
+    Files.write(DATA, tempPath.resolve("version.bin").toFile());
+    // Segment directories are expected to be flat.
+    java.nio.file.Files.createDirectory(tempPath.resolve("nested"));
+
+    // version.bin may be uploaded first or not at all, depending on the order the directory lists in
+    azureStorage.uploadBlockBlob(
+        EasyMock.anyObject(File.class),
+        EasyMock.anyString(),
+        EasyMock.anyString(),
+        EasyMock.anyInt()
+    );
+    EasyMock.expectLastCall().anyTimes();
+
+    replayAll();
+
+    assertThrows(
+        RuntimeException.class,
+        () -> pusher.push(tempPath.toFile(), SEGMENT_TO_PUSH, false)
+    );
+
+    verifyAll();
+  }
+
+  @Test
+  public void test_pushToPath_nonSegmentDirSuffix_appendsIndexZip(@TempDir Path tempPath) throws Exception
+  {
+    // The shuffle intermediary data manager pushes to a path of its own choosing, which is a directory like any other
+    AzureDataSegmentPusher pusher =
+        new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithoutPrefix, ZIP_CONFIG);
+
+    Files.write(DATA, tempPath.resolve("version.bin").toFile());
+
+    azureStorage.uploadBlockBlob(
+        EasyMock.anyObject(File.class),
+        EasyMock.eq(CONTAINER_NAME),
+        EasyMock.eq("shuffle-data/supervisorId/partition/index.zip"),
+        EasyMock.eq(MAX_TRIES)
+    );
+    EasyMock.expectLastCall();
+
+    replayAll();
+
+    DataSegment segment = pusher.pushToPath(tempPath.toFile(), SEGMENT_TO_PUSH, "shuffle-data/supervisorId/partition");
+
+    assertEquals("shuffle-data/supervisorId/partition/index.zip", segment.getLoadSpec().get("blobPath"));
+
+    verifyAll();
+  }
+
+  @Test
   public void test_push_exception_throwsException(@TempDir Path tempPath) throws Exception
   {
     boolean useUniquePath = true;
-    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithPrefix);
+    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithPrefix, ZIP_CONFIG);
 
     // Create a mock segment on disk
     File tmp = tempPath.resolve("version.bin").toFile();
@@ -264,7 +359,7 @@ public class AzureDataSegmentPusherTest extends EasyMockSupport
   @Test
   public void getAzurePathsTest()
   {
-    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithPrefix);
+    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithPrefix, ZIP_CONFIG);
     final String storageDir = pusher.getStorageDir(DATA_SEGMENT, false);
     final String azurePath = pusher.getAzurePath(DATA_SEGMENT, false);
 
@@ -277,7 +372,7 @@ public class AzureDataSegmentPusherTest extends EasyMockSupport
   @Test
   public void uploadDataSegmentTest() throws BlobStorageException, IOException
   {
-    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithPrefix);
+    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithPrefix, ZIP_CONFIG);
     final int binaryVersion = 9;
     final File compressedSegmentData = new File("index.zip");
     final String azurePath = pusher.getAzurePath(DATA_SEGMENT, false);
@@ -307,7 +402,7 @@ public class AzureDataSegmentPusherTest extends EasyMockSupport
   @Test
   public void storageDirContainsNoColonsTest()
   {
-    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithPrefix);
+    AzureDataSegmentPusher pusher = new AzureDataSegmentPusher(azureStorage, azureAccountConfig, segmentConfigWithPrefix, ZIP_CONFIG);
     DataSegment withColons = DATA_SEGMENT.withVersion("2018-01-05T14:54:09.295Z");
     String segmentPath = pusher.getStorageDir(withColons, false);
     assertFalse(segmentPath.contains(":"), "Path should not contain any columns");

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentPusher.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentPusher.java
@@ -27,6 +27,7 @@ import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.segment.loading.DataSegmentPusher;
+import org.apache.druid.segment.loading.DeepStorageSegmentConfig;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.utils.CompressionUtils;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -41,17 +42,25 @@ public class S3DataSegmentPusher implements DataSegmentPusher
 {
   private static final EmittingLogger log = new EmittingLogger(S3DataSegmentPusher.class);
 
+  /**
+   * Originally S3 always wrote segments zipped, so that is what {@code druid.storage.zip} falls back to.
+   */
+  private static final boolean DEFAULT_ZIP = true;
+
   private final ServerSideEncryptingAmazonS3 s3Client;
   private final S3DataSegmentPusherConfig config;
+  private final boolean zip;
 
   @Inject
   public S3DataSegmentPusher(
       ServerSideEncryptingAmazonS3 s3Client,
-      S3DataSegmentPusherConfig config
+      S3DataSegmentPusherConfig config,
+      DeepStorageSegmentConfig deepStorageConfig
   )
   {
     this.s3Client = s3Client;
     this.config = config;
+    this.zip = deepStorageConfig.isZip(DEFAULT_ZIP);
   }
 
   @Override
@@ -64,7 +73,7 @@ public class S3DataSegmentPusher implements DataSegmentPusher
   @Override
   public DataSegment pushToPath(File indexFilesDir, DataSegment inSegment, String storageDirSuffix) throws IOException
   {
-    if (config.isZip()) {
+    if (zip) {
       final String s3Path = S3Utils.constructSegmentPath(config.getBaseKey(), storageDirSuffix);
       log.debug("Copying segment[%s] to S3 at location[%s]", inSegment.getId(), s3Path);
       return pushZip(indexFilesDir, inSegment, s3Path);

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfig.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfig.java
@@ -39,9 +39,6 @@ public class S3DataSegmentPusherConfig
   @Min(1)
   private int maxListingLength = 1024;
 
-  @JsonProperty
-  private boolean zip = true;
-
   public void setBucket(String bucket)
   {
     this.bucket = bucket;
@@ -80,10 +77,5 @@ public class S3DataSegmentPusherConfig
   public int getMaxListingLength()
   {
     return maxListingLength;
-  }
-
-  public boolean isZip()
-  {
-    return zip;
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfigTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfigTest.java
@@ -40,7 +40,7 @@ public class S3DataSegmentPusherConfigTest
   public void testSerialization() throws IOException
   {
     String jsonConfig = "{\"bucket\":\"bucket1\",\"baseKey\":\"dataSource1\","
-                        + "\"disableAcl\":false,\"maxListingLength\":2000,\"zip\":true}";
+                        + "\"disableAcl\":false,\"maxListingLength\":2000}";
 
     S3DataSegmentPusherConfig config = JSON_MAPPER.readValue(jsonConfig, S3DataSegmentPusherConfig.class);
     Map<String, String> expected = JSON_MAPPER.readValue(jsonConfig, Map.class);
@@ -53,7 +53,7 @@ public class S3DataSegmentPusherConfigTest
   {
     String jsonConfig = "{\"bucket\":\"bucket1\",\"baseKey\":\"dataSource1\"}";
     String expectedJsonConfig = "{\"bucket\":\"bucket1\",\"baseKey\":\"dataSource1\","
-                                + "\"disableAcl\":false,\"maxListingLength\":1024,\"zip\":true}";
+                                + "\"disableAcl\":false,\"maxListingLength\":1024}";
     S3DataSegmentPusherConfig config = JSON_MAPPER.readValue(jsonConfig, S3DataSegmentPusherConfig.class);
     Map<String, String> expected = JSON_MAPPER.readValue(expectedJsonConfig, Map.class);
     Map<String, String> actual = JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(config), Map.class);
@@ -64,7 +64,7 @@ public class S3DataSegmentPusherConfigTest
   public void testSerializationValidatingMaxListingLength() throws IOException
   {
     String jsonConfig = "{\"bucket\":\"bucket1\",\"baseKey\":\"dataSource1\","
-                        + "\"disableAcl\":false,\"maxListingLength\":-1,\"zip\":true}";
+                        + "\"disableAcl\":false,\"maxListingLength\":-1}";
     Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
     S3DataSegmentPusherConfig config = JSON_MAPPER.readValue(jsonConfig, S3DataSegmentPusherConfig.class);

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.storage.s3;
 import com.google.common.io.Files;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.segment.loading.DeepStorageSegmentConfig;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.easymock.EasyMock;
@@ -98,14 +99,7 @@ public class S3DataSegmentPusherTest
 
     EasyMock.replay(s3Client);
 
-    S3DataSegmentPusherConfig config = new S3DataSegmentPusherConfig()
-    {
-      @Override
-      public boolean isZip()
-      {
-        return false;
-      }
-    };
+    S3DataSegmentPusherConfig config = new S3DataSegmentPusherConfig();
     config.setBucket("bucket");
     config.setBaseKey("key");
     DataSegment segment = validate(
@@ -113,6 +107,7 @@ public class S3DataSegmentPusherTest
         "key/foo/2015-01-01T00:00:00\\.000Z_2016-01-01T00:00:00\\.000Z/0/0/",
         s3Client,
         config,
+        false,
         new byte[]{0x0, 0x0, 0x0, 0x1}
     );
     // V1 (test fixture) → not V10 → rangeable stamped as false (skips legacy HEAD probe).
@@ -135,14 +130,7 @@ public class S3DataSegmentPusherTest
 
     EasyMock.replay(s3Client);
 
-    S3DataSegmentPusherConfig config = new S3DataSegmentPusherConfig()
-    {
-      @Override
-      public boolean isZip()
-      {
-        return false;
-      }
-    };
+    S3DataSegmentPusherConfig config = new S3DataSegmentPusherConfig();
     config.setBucket("bucket");
     config.setBaseKey("key");
 
@@ -152,6 +140,7 @@ public class S3DataSegmentPusherTest
         "key/foo/2015-01-01T00:00:00\\.000Z_2016-01-01T00:00:00\\.000Z/0/0/",
         s3Client,
         config,
+        false,
         new byte[]{0x0, 0x0, 0x0, 0x0A}
     );
     Assertions.assertEquals(10, (int) segment.getBinaryVersion());
@@ -234,7 +223,7 @@ public class S3DataSegmentPusherTest
     config.setBucket("bucket");
     config.setBaseKey("key");
     // Default version.bin is V1 for historical reasons.
-    DataSegment segment = validate(useUniquePath, matcher, s3Client, config, new byte[]{0x0, 0x0, 0x0, 0x1});
+    DataSegment segment = validate(useUniquePath, matcher, s3Client, config, true, new byte[]{0x0, 0x0, 0x0, 0x1});
     Assertions.assertEquals(1, (int) segment.getBinaryVersion());
     return segment;
   }
@@ -244,10 +233,11 @@ public class S3DataSegmentPusherTest
       String matcher,
       ServerSideEncryptingAmazonS3 s3Client,
       S3DataSegmentPusherConfig config,
+      boolean zip,
       byte[] versionBytes
   ) throws IOException
   {
-    S3DataSegmentPusher pusher = new S3DataSegmentPusher(s3Client, config);
+    S3DataSegmentPusher pusher = new S3DataSegmentPusher(s3Client, config, new DeepStorageSegmentConfig(zip));
 
     // Create a mock segment on disk
     File tmp = new File(tempFolder, "version.bin");

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunBase.java
@@ -92,6 +92,7 @@ import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.handoff.NoopSegmentHandoffNotifierFactory;
 import org.apache.druid.segment.join.NoopJoinableFactory;
+import org.apache.druid.segment.loading.DeepStorageSegmentConfig;
 import org.apache.druid.segment.loading.LeastBytesUsedStorageLocationSelectorStrategy;
 import org.apache.druid.segment.loading.LocalDataSegmentPuller;
 import org.apache.druid.segment.loading.LocalDataSegmentPusher;
@@ -1685,7 +1686,7 @@ public abstract class CompactionTaskRunBase
         .config(new TaskConfigBuilder().build())
         .emitter(NoopServiceEmitter.instance())
         .taskActionClient(taskActionClient)
-        .segmentPusher(new LocalDataSegmentPusher(new LocalDataSegmentPusherConfig()))
+        .segmentPusher(new LocalDataSegmentPusher(new LocalDataSegmentPusherConfig(), new DeepStorageSegmentConfig()))
         .dataSegmentKiller(new NoopDataSegmentKiller())
         .joinableFactory(NoopJoinableFactory.INSTANCE)
         .segmentCacheManager(cacheManager)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
@@ -72,6 +72,7 @@ import org.apache.druid.segment.SegmentSchemaMapping;
 import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.incremental.RowIngestionMetersFactory;
 import org.apache.druid.segment.join.NoopJoinableFactory;
+import org.apache.druid.segment.loading.DeepStorageSegmentConfig;
 import org.apache.druid.segment.loading.LocalDataSegmentPusher;
 import org.apache.druid.segment.loading.LocalDataSegmentPusherConfig;
 import org.apache.druid.segment.loading.SegmentCacheManager;
@@ -300,7 +301,7 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
         .config(config)
         .taskExecutorNode(new DruidNode("druid/middlemanager", "localhost", false, 8091, null, true, false))
         .taskActionClient(createActionClient(task))
-        .segmentPusher(new LocalDataSegmentPusher(new LocalDataSegmentPusherConfig()))
+        .segmentPusher(new LocalDataSegmentPusher(new LocalDataSegmentPusherConfig(), new DeepStorageSegmentConfig()))
         .dataSegmentKiller(dataSegmentKiller)
         .joinableFactory(NoopJoinableFactory.INSTANCE)
         .jsonMapper(objectMapper)
@@ -482,7 +483,7 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
             .config(config)
             .taskExecutorNode(new DruidNode("druid/middlemanager", "localhost", false, 8091, null, true, false))
             .taskActionClient(taskActionClient)
-            .segmentPusher(new LocalDataSegmentPusher(new LocalDataSegmentPusherConfig()))
+            .segmentPusher(new LocalDataSegmentPusher(new LocalDataSegmentPusherConfig(), new DeepStorageSegmentConfig()))
             .dataSegmentKiller(dataSegmentKiller)
             .joinableFactory(NoopJoinableFactory.INSTANCE)
             .jsonMapper(objectMapper)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -89,6 +89,7 @@ import org.apache.druid.segment.incremental.ParseExceptionReport;
 import org.apache.druid.segment.incremental.RowIngestionMetersFactory;
 import org.apache.druid.segment.incremental.RowIngestionMetersTotals;
 import org.apache.druid.segment.join.NoopJoinableFactory;
+import org.apache.druid.segment.loading.DeepStorageSegmentConfig;
 import org.apache.druid.segment.loading.LocalDataSegmentPuller;
 import org.apache.druid.segment.loading.LocalDataSegmentPusher;
 import org.apache.druid.segment.loading.LocalDataSegmentPusherConfig;
@@ -684,7 +685,8 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
                   {
                     return localDeepStorage;
                   }
-                }
+                },
+                new DeepStorageSegmentConfig()
             )
         )
         .dataSegmentKiller(new NoopDataSegmentKiller())

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTestBase.java
@@ -114,6 +114,7 @@ import org.apache.druid.segment.incremental.RowIngestionMetersTotals;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.join.NoopJoinableFactory;
 import org.apache.druid.segment.loading.DataSegmentPusher;
+import org.apache.druid.segment.loading.DeepStorageSegmentConfig;
 import org.apache.druid.segment.loading.LocalDataSegmentPusher;
 import org.apache.druid.segment.loading.LocalDataSegmentPusherConfig;
 import org.apache.druid.segment.metadata.CentralizedDatasourceSchemaConfig;
@@ -664,8 +665,8 @@ public abstract class SeekableStreamIndexTaskTestBase extends EasyMockSupport
     };
     final LocalDataSegmentPusherConfig dataSegmentPusherConfig = new LocalDataSegmentPusherConfig();
     dataSegmentPusherConfig.storageDirectory = getSegmentDirectory();
-    dataSegmentPusherConfig.zip = true;
-    final DataSegmentPusher dataSegmentPusher = new LocalDataSegmentPusher(dataSegmentPusherConfig);
+    final DataSegmentPusher dataSegmentPusher =
+        new LocalDataSegmentPusher(dataSegmentPusherConfig, new DeepStorageSegmentConfig(true));
 
     toolboxFactory = new TaskToolboxFactory(
         null,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleDataSegmentPusherTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleDataSegmentPusherTest.java
@@ -38,6 +38,7 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.rpc.indexing.NoopOverlordClient;
 import org.apache.druid.rpc.indexing.OverlordClient;
+import org.apache.druid.segment.loading.DeepStorageSegmentConfig;
 import org.apache.druid.segment.loading.LoadSpec;
 import org.apache.druid.segment.loading.LocalDataSegmentPuller;
 import org.apache.druid.segment.loading.LocalDataSegmentPusher;
@@ -116,7 +117,9 @@ public class ShuffleDataSegmentPusherTest
                 {
                   return localDeepStore;
                 }
-              }));
+              },
+              new DeepStorageSegmentConfig()
+          ));
     }
     intermediaryDataManager.start();
     segmentPusher = new ShuffleDataSegmentPusher("supervisorTaskId", "subTaskId", intermediaryDataManager);

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQCompactionTaskRunTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQCompactionTaskRunTest.java
@@ -91,6 +91,7 @@ import org.apache.druid.segment.indexing.TuningConfig;
 import org.apache.druid.segment.loading.AcquireSegmentAction;
 import org.apache.druid.segment.loading.AcquireSegmentResult;
 import org.apache.druid.segment.loading.DataSegmentPusher;
+import org.apache.druid.segment.loading.DeepStorageSegmentConfig;
 import org.apache.druid.segment.loading.LocalDataSegmentPusher;
 import org.apache.druid.segment.loading.LocalDataSegmentPusherConfig;
 import org.apache.druid.segment.loading.SegmentCacheManager;
@@ -245,7 +246,7 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
         binder -> binder.bind(PolicyEnforcer.class).toInstance(NoopPolicyEnforcer.instance()),
         binder -> binder.bind(WireTransferableContext.class).toInstance(new WireTransferableContext(null, null, true)),
         binder -> binder.bind(DataSegmentPusher.class)
-                        .toInstance(new LocalDataSegmentPusher(new LocalDataSegmentPusherConfig())),
+                        .toInstance(new LocalDataSegmentPusher(new LocalDataSegmentPusherConfig(), new DeepStorageSegmentConfig())),
         binder -> binder.bind(DataServerQueryHandlerFactory.class).toProvider(Providers.of(null)),
         binder -> binder.bind(Escalator.class).toProvider(Providers.of(null)),
         binder -> binder.bind(QueryProcessingPool.class)

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteMSQTestsHelper.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteMSQTestsHelper.java
@@ -50,6 +50,7 @@ import org.apache.druid.query.QueryProcessingPool;
 import org.apache.druid.query.groupby.TestGroupByBuffers;
 import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.loading.DataSegmentPusher;
+import org.apache.druid.segment.loading.DeepStorageSegmentConfig;
 import org.apache.druid.segment.loading.LocalDataSegmentPusher;
 import org.apache.druid.segment.loading.LocalDataSegmentPusherConfig;
 import org.apache.druid.segment.loading.SegmentCacheManager;
@@ -121,7 +122,10 @@ public class CalciteMSQTestsHelper
         TestSegmentManager testSegmentManager
     )
     {
-      return new MSQTestDelegateDataSegmentPusher(new LocalDataSegmentPusher(config), testSegmentManager);
+      return new MSQTestDelegateDataSegmentPusher(
+          new LocalDataSegmentPusher(config, new DeepStorageSegmentConfig()),
+          testSegmentManager
+      );
     }
 
     @Provides

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -160,6 +160,7 @@ import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.loading.AcquireMode;
 import org.apache.druid.segment.loading.DataSegmentPusher;
+import org.apache.druid.segment.loading.DeepStorageSegmentConfig;
 import org.apache.druid.segment.loading.LeastBytesUsedStorageLocationSelectorStrategy;
 import org.apache.druid.segment.loading.LocalDataSegmentPusher;
 import org.apache.druid.segment.loading.LocalDataSegmentPusherConfig;
@@ -534,7 +535,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
           LocalDataSegmentPusherConfig config = new LocalDataSegmentPusherConfig();
           config.storageDirectory = newTempFolder("storageDir");
           binder.bind(DataSegmentPusher.class).toInstance(new MSQTestDelegateDataSegmentPusher(
-              new LocalDataSegmentPusher(config),
+              new LocalDataSegmentPusher(config, new DeepStorageSegmentConfig()),
               testSegmentManager
           ));
           binder.bind(DataSegmentAnnouncer.class).toInstance(new NoopDataSegmentAnnouncer());

--- a/processing/src/main/java/org/apache/druid/segment/loading/DeepStorageSegmentConfig.java
+++ b/processing/src/main/java/org/apache/druid/segment/loading/DeepStorageSegmentConfig.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.loading;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+/**
+ * The {@code druid.storage} properties that describe how segments are laid out in deep storage rather than how to
+ * reach it, and so are shared by every {@link DataSegmentPusher} instead of belonging to any one of them. Currently
+ * that is only {@code druid.storage.zip}, but anything else that is a property of the layout rather than of a
+ * particular deep storage belongs here too.
+ * <p>
+ * This is bound once in core, by {@code LocalDataStorageDruidModule}, instead of once per deep storage
+ * implementation, so that these properties mean the same thing whatever {@code druid.storage.type} is set to, and so
+ * that each implementation does not have to redeclare them in its own config class. Any single-implementation
+ * property still belongs in that implementation's own config, next to its bucket and credentials.
+ * <p>
+ * Values here are deliberately tri-state: when a property is unset, the getter falls back to the default the calling
+ * implementation passes in, since those defaults differ per implementation.
+ */
+public class DeepStorageSegmentConfig
+{
+  @JsonProperty
+  @Nullable
+  private final Boolean zip;
+
+  @JsonCreator
+  public DeepStorageSegmentConfig(@JsonProperty("zip") @Nullable Boolean zip)
+  {
+    this.zip = zip;
+  }
+
+  public DeepStorageSegmentConfig()
+  {
+    this(null);
+  }
+
+  /**
+   * Whether segments should be written as a zip file, falling back to {@code defaultZip} when
+   * {@code druid.storage.zip} has not been set.
+   */
+  public boolean isZip(boolean defaultZip)
+  {
+    return zip == null ? defaultZip : zip;
+  }
+
+  @JsonProperty("zip")
+  @Nullable
+  public Boolean getZip()
+  {
+    return zip;
+  }
+}

--- a/processing/src/test/java/org/apache/druid/segment/loading/DeepStorageSegmentConfigTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/loading/DeepStorageSegmentConfigTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.loading;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.apache.druid.guice.JsonConfigurator;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DeepStorageSegmentConfigTest
+{
+  private static final String PROP_PREFIX = "druid.storage";
+
+  private final ObjectMapper jsonMapper = new DefaultObjectMapper();
+  private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  @Test
+  public void testUnsetFallsBackToCallerDefault()
+  {
+    final DeepStorageSegmentConfig config = new DeepStorageSegmentConfig();
+    assertNull(config.getZip());
+    // each DataSegmentPusher keeps its own default when druid.storage.zip is not set
+    assertTrue(config.isZip(true));
+    assertFalse(config.isZip(false));
+  }
+
+  @Test
+  public void testSetOverridesCallerDefault()
+  {
+    assertTrue(new DeepStorageSegmentConfig(true).isZip(false));
+    assertFalse(new DeepStorageSegmentConfig(false).isZip(true));
+  }
+
+  @Test
+  public void testConfigurateFromProperties()
+  {
+    final Properties properties = new Properties();
+    properties.setProperty("druid.storage.zip", "false");
+
+    final DeepStorageSegmentConfig config = configurate(properties);
+    assertEquals(Boolean.FALSE, config.getZip());
+    assertFalse(config.isZip(true));
+  }
+
+  @Test
+  public void testConfigurateIgnoresOtherStorageProperties()
+  {
+    // druid.storage is shared with the deep storage implementation's own config, so the properties belonging to it
+    // must not upset this one
+    final Properties properties = new Properties();
+    properties.setProperty("druid.storage.type", "s3");
+    properties.setProperty("druid.storage.bucket", "bucket");
+    properties.setProperty("druid.storage.baseKey", "baseKey");
+
+    final DeepStorageSegmentConfig config = configurate(properties);
+    assertNull(config.getZip());
+    assertTrue(config.isZip(true));
+  }
+
+  @Test
+  public void testSerde() throws IOException
+  {
+    assertEquals(
+        Boolean.TRUE,
+        jsonMapper.readValue(jsonMapper.writeValueAsBytes(new DeepStorageSegmentConfig(true)), DeepStorageSegmentConfig.class)
+                  .getZip()
+    );
+    assertNull(
+        jsonMapper.readValue(jsonMapper.writeValueAsBytes(new DeepStorageSegmentConfig()), DeepStorageSegmentConfig.class)
+                  .getZip()
+    );
+  }
+
+  private DeepStorageSegmentConfig configurate(Properties properties)
+  {
+    return new JsonConfigurator(jsonMapper, validator).configurate(properties, PROP_PREFIX, DeepStorageSegmentConfig.class);
+  }
+}

--- a/server/src/main/java/org/apache/druid/guice/LocalDataStorageDruidModule.java
+++ b/server/src/main/java/org/apache/druid/guice/LocalDataStorageDruidModule.java
@@ -29,6 +29,7 @@ import org.apache.druid.data.SearchableVersionedDataFinder;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.segment.loading.DataSegmentKiller;
 import org.apache.druid.segment.loading.DataSegmentPusher;
+import org.apache.druid.segment.loading.DeepStorageSegmentConfig;
 import org.apache.druid.segment.loading.LocalDataSegmentKiller;
 import org.apache.druid.segment.loading.LocalDataSegmentPusher;
 import org.apache.druid.segment.loading.LocalDataSegmentPusherConfig;
@@ -47,6 +48,11 @@ public class LocalDataStorageDruidModule implements DruidModule
   public void configure(Binder binder)
   {
     bindDeepStorageLocal(binder);
+
+    // The segment layout properties are not specific to local deep storage: they are bound here, next to the
+    // DataSegmentPusher choice, because this module is always installed, so every deep storage implementation can read
+    // the same config object instead of declaring the properties itself.
+    JsonConfigProvider.bind(binder, "druid.storage", DeepStorageSegmentConfig.class);
 
     PolyBind.createChoice(
         binder,

--- a/server/src/main/java/org/apache/druid/segment/loading/LocalDataSegmentPusher.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/LocalDataSegmentPusher.java
@@ -44,12 +44,19 @@ public class LocalDataSegmentPusher implements DataSegmentPusher
   public static final String INDEX_DIR = "index";
   public static final String INDEX_ZIP_FILENAME = "index.zip";
 
+  /**
+   * Local deep storage writes segments as a directory of files unless {@code druid.storage.zip} says otherwise.
+   */
+  private static final boolean DEFAULT_ZIP = false;
+
   private final LocalDataSegmentPusherConfig config;
+  private final boolean zip;
 
   @Inject
-  public LocalDataSegmentPusher(LocalDataSegmentPusherConfig config)
+  public LocalDataSegmentPusher(LocalDataSegmentPusherConfig config, DeepStorageSegmentConfig deepStorageConfig)
   {
     this.config = config;
+    this.zip = deepStorageConfig.isZip(DEFAULT_ZIP);
   }
 
   @Override
@@ -80,7 +87,7 @@ public class LocalDataSegmentPusher implements DataSegmentPusher
       return segment.withLoadSpec(makeLoadSpec(outDir.toURI()))
                     .withSize(size)
                     .withBinaryVersion(SegmentUtils.getVersionFromDir(dataSegmentFile));
-    } else if (config.isZip()) {
+    } else if (zip) {
       return pushZip(dataSegmentFile, outDir, segment);
     } else {
       return pushNoZip(dataSegmentFile, outDir, segment);

--- a/server/src/main/java/org/apache/druid/segment/loading/LocalDataSegmentPusherConfig.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/LocalDataSegmentPusherConfig.java
@@ -30,16 +30,8 @@ public class LocalDataSegmentPusherConfig
   @JsonProperty
   public File storageDirectory = new File("/tmp/druid/localStorage");
 
-  @JsonProperty
-  public boolean zip = false;
-
   public File getStorageDirectory()
   {
     return storageDirectory;
-  }
-
-  public boolean isZip()
-  {
-    return zip;
   }
 }

--- a/server/src/test/java/org/apache/druid/guice/LocalDataStorageDruidModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/LocalDataStorageDruidModuleTest.java
@@ -34,7 +34,7 @@ import org.apache.druid.segment.loading.RandomStorageLocationSelectorStrategy;
 import org.apache.druid.segment.loading.StorageLocation;
 import org.apache.druid.segment.loading.StorageLocationSelectorStrategy;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.partition.NoneShardSpec;
+import org.apache.druid.timeline.SegmentId;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -97,17 +97,7 @@ public class LocalDataStorageDruidModuleTest
     }
 
     final DataSegmentPusher pusher = injector.getInstance(DataSegmentPusher.class);
-    final DataSegment segment = new DataSegment(
-        "ds",
-        Intervals.utc(0, 1),
-        "v1",
-        null,
-        null,
-        null,
-        NoneShardSpec.instance(),
-        null,
-        0
-    );
+    final DataSegment segment = DataSegment.builder(SegmentId.of("ds", Intervals.utc(0, 1), "v1", 0)).build();
 
     return new File(storageDir, pusher.getStorageDir(pusher.push(segmentDir, segment, false), false));
   }

--- a/server/src/test/java/org/apache/druid/guice/LocalDataStorageDruidModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/LocalDataStorageDruidModuleTest.java
@@ -20,18 +20,30 @@
 package org.apache.druid.guice;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.Files;
+import com.google.common.primitives.Ints;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.TypeLiteral;
+import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.segment.column.ColumnConfig;
+import org.apache.druid.segment.loading.DataSegmentPusher;
 import org.apache.druid.segment.loading.OmniDataSegmentKiller;
 import org.apache.druid.segment.loading.RandomStorageLocationSelectorStrategy;
 import org.apache.druid.segment.loading.StorageLocation;
 import org.apache.druid.segment.loading.StorageLocationSelectorStrategy;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
 import java.util.List;
+import java.util.Properties;
 
 public class LocalDataStorageDruidModuleTest
 {
@@ -45,6 +57,59 @@ public class LocalDataStorageDruidModuleTest
         killer.getKillers().get(LocalDataStorageDruidModule.SCHEME).get(),
         killer.getKillers().get(LocalDataStorageDruidModule.SCHEME).get()
     );
+  }
+
+  /**
+   * {@code druid.storage.zip} is bound by this module for every deep storage implementation to read, so check that it
+   * actually reaches the pusher the module provisions, rather than only that it parses.
+   */
+  @Test
+  public void testDataSegmentPusherHonorsStorageZip(@TempDir File tempDir) throws IOException
+  {
+    Assertions.assertTrue(new File(pushSegment(tempDir, "true"), "index.zip").isFile());
+  }
+
+  @Test
+  public void testDataSegmentPusherDefaultsToUnzipped(@TempDir File tempDir) throws IOException
+  {
+    // local deep storage writes a directory of files when the property is unset, which is the default the tri-state
+    // DeepStorageSegmentConfig exists to preserve
+    Assertions.assertTrue(new File(pushSegment(tempDir, null), "index").isDirectory());
+  }
+
+  /**
+   * Pushes a one-file segment through a {@link DataSegmentPusher} provisioned by this module, and returns the
+   * directory it was pushed to.
+   */
+  private static File pushSegment(File tempDir, @Nullable String zip) throws IOException
+  {
+    final File storageDir = new File(tempDir, "deepStorage");
+    final File segmentDir = new File(tempDir, "segment");
+    FileUtils.mkdirp(segmentDir);
+    Files.asByteSink(new File(segmentDir, "version.bin")).write(Ints.toByteArray(0x9));
+
+    final Injector injector = createInjector();
+    // JsonConfigProvider reads these lazily, on the first getInstance below
+    final Properties properties = injector.getInstance(Properties.class);
+    properties.setProperty("druid.storage.storageDirectory", storageDir.getAbsolutePath());
+    if (zip != null) {
+      properties.setProperty("druid.storage.zip", zip);
+    }
+
+    final DataSegmentPusher pusher = injector.getInstance(DataSegmentPusher.class);
+    final DataSegment segment = new DataSegment(
+        "ds",
+        Intervals.utc(0, 1),
+        "v1",
+        null,
+        null,
+        null,
+        NoneShardSpec.instance(),
+        null,
+        0
+    );
+
+    return new File(storageDir, pusher.getStorageDir(pusher.push(segmentDir, segment, false), false));
   }
 
   private static Injector createInjector()

--- a/server/src/test/java/org/apache/druid/segment/loading/LocalDataSegmentPusherTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/LocalDataSegmentPusherTest.java
@@ -75,14 +75,12 @@ public class LocalDataSegmentPusherTest
   public void setUp() throws IOException
   {
     config = new LocalDataSegmentPusherConfig();
-    config.zip = false;
     config.storageDirectory = temporaryFolder.newFolder();
-    localDataSegmentPusher = new LocalDataSegmentPusher(config);
+    localDataSegmentPusher = new LocalDataSegmentPusher(config, new DeepStorageSegmentConfig(false));
 
     configZip = new LocalDataSegmentPusherConfig();
-    configZip.zip = true;
     configZip.storageDirectory = temporaryFolder.newFolder();
-    localDataSegmentPusherZip = new LocalDataSegmentPusher(configZip);
+    localDataSegmentPusherZip = new LocalDataSegmentPusher(configZip, new DeepStorageSegmentConfig(true));
 
     dataSegmentFiles = temporaryFolder.newFolder();
     Files.asByteSink(new File(dataSegmentFiles, "version.bin")).write(Ints.toByteArray(0x9));


### PR DESCRIPTION
### Description
Updates Azure deep storage extension to support pushing/pulling/killing segments without zip compression (`druid.storage.zip`). In the process, I refactored the other deep storage implementations that support `druid.storage.zip` (local and s3) to move the config to a new `DeepStorageSegmentConfig` class to be shared by all deep storage implementations that is bound to `druid.storage` and available to inject to all the pushers/pullers/killers. Currently it only has the zip property, but anything else that is specific to how segments are laid out in deep storage can live here eventually as well.

I plan to wire up google cloud storage as a follow-up PR.