### PR TITLE
fix(sql): classify invalid timestamp constants

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidRexExecutor.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidRexExecutor.java
@@ -118,7 +118,10 @@ public class DruidRexExecutor implements RexExecutor
               // There can be implicit casts of VARCHAR to TIMESTAMP where the VARCHAR is an invalid timestamp, but the
               // TIMESTAMP type is not nullable. In this case it's best to throw an error, since it likely means the
               // user's SQL query contains an invalid literal.
-              throw InvalidSqlInput.exception("Invalid TIMESTAMP value [%s]", getTimestampValue(constExp));
+              throw InvalidSqlInput.exception(
+                  "Invalid TIMESTAMP value [%s]",
+                  getInputValueOrExpression(constExp)
+              );
             }
           } else {
             try {
@@ -130,7 +133,11 @@ public class DruidRexExecutor implements RexExecutor
               );
             }
             catch (IllegalArgumentException e) {
-              throw InvalidSqlInput.exception(e, "Invalid TIMESTAMP value [%s]", getTimestampValue(constExp));
+              throw InvalidSqlInput.exception(
+                  e,
+                  "Invalid TIMESTAMP value [%s]",
+                  getInputValueOrExpression(constExp)
+              );
             }
           }
         } else if (SqlTypeName.NUMERIC_TYPES.contains(sqlTypeName)) {
@@ -229,7 +236,7 @@ public class DruidRexExecutor implements RexExecutor
     }
   }
 
-  private static String getTimestampValue(final RexNode constExp)
+  private static String getInputValueOrExpression(final RexNode constExp)
   {
     if (constExp.isA(SqlKind.CAST)) {
       final RexNode operand = ((RexCall) constExp).getOperands().get(0);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidRexExecutor.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidRexExecutor.java
@@ -115,15 +115,20 @@ public class DruidRexExecutor implements RexExecutor
               // There can be implicit casts of VARCHAR to TIMESTAMP where the VARCHAR is an invalid timestamp, but the
               // TIMESTAMP type is not nullable. In this case it's best to throw an error, since it likely means the
               // user's SQL query contains an invalid literal.
-              throw InvalidSqlInput.exception("Illegal TIMESTAMP constant [%s]", constExp);
+              throw InvalidSqlInput.exception("Invalid TIMESTAMP constant [%s]", constExp);
             }
           } else {
-            literal = Calcites.jodaToCalciteTimestampLiteral(
-                rexBuilder,
-                DateTimes.utc(exprResult.asLong()),
-                plannerContext.getTimeZone(),
-                constExp.getType().getPrecision()
-            );
+            try {
+              literal = Calcites.jodaToCalciteTimestampLiteral(
+                  rexBuilder,
+                  DateTimes.utc(exprResult.asLong()),
+                  plannerContext.getTimeZone(),
+                  constExp.getType().getPrecision()
+              );
+            }
+            catch (IllegalArgumentException e) {
+              throw InvalidSqlInput.exception(e, "Invalid TIMESTAMP constant [%s]", constExp);
+            }
           }
         } else if (SqlTypeName.NUMERIC_TYPES.contains(sqlTypeName)) {
           final BigDecimal bigDecimal;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidRexExecutor.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidRexExecutor.java
@@ -20,8 +20,11 @@
 package org.apache.druid.sql.calcite.planner;
 
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexExecutor;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.error.InvalidSqlInput;
 import org.apache.druid.java.util.common.DateTimes;
@@ -115,7 +118,7 @@ public class DruidRexExecutor implements RexExecutor
               // There can be implicit casts of VARCHAR to TIMESTAMP where the VARCHAR is an invalid timestamp, but the
               // TIMESTAMP type is not nullable. In this case it's best to throw an error, since it likely means the
               // user's SQL query contains an invalid literal.
-              throw InvalidSqlInput.exception("Invalid TIMESTAMP constant [%s]", constExp);
+              throw InvalidSqlInput.exception("Invalid TIMESTAMP value [%s]", getTimestampValue(constExp));
             }
           } else {
             try {
@@ -127,7 +130,7 @@ public class DruidRexExecutor implements RexExecutor
               );
             }
             catch (IllegalArgumentException e) {
-              throw InvalidSqlInput.exception(e, "Invalid TIMESTAMP constant [%s]", constExp);
+              throw InvalidSqlInput.exception(e, "Invalid TIMESTAMP value [%s]", getTimestampValue(constExp));
             }
           }
         } else if (SqlTypeName.NUMERIC_TYPES.contains(sqlTypeName)) {
@@ -224,5 +227,16 @@ public class DruidRexExecutor implements RexExecutor
         reducedValues.add(literal);
       }
     }
+  }
+
+  private static String getTimestampValue(final RexNode constExp)
+  {
+    if (constExp.isA(SqlKind.CAST)) {
+      final RexNode operand = ((RexCall) constExp).getOperands().get(0);
+      if (operand instanceof RexLiteral && SqlTypeName.STRING_TYPES.contains(operand.getType().getSqlTypeName())) {
+        return RexLiteral.stringValue(operand);
+      }
+    }
+    return constExp.toString();
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -6693,7 +6693,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     catch (DruidException e) {
       assertDruidException(
           e,
-          invalidSqlIs("Invalid TIMESTAMP constant [CAST('z2000-01-01 00:00:00'):TIMESTAMP(3) NOT NULL]")
+          invalidSqlIs("Invalid TIMESTAMP value [z2000-01-01 00:00:00]")
       );
     }
     catch (Exception e) {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -6693,7 +6693,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     catch (DruidException e) {
       assertDruidException(
           e,
-          invalidSqlIs("Illegal TIMESTAMP constant [CAST('z2000-01-01 00:00:00'):TIMESTAMP(3) NOT NULL]")
+          invalidSqlIs("Invalid TIMESTAMP constant [CAST('z2000-01-01 00:00:00'):TIMESTAMP(3) NOT NULL]")
       );
     }
     catch (Exception e) {

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -1620,6 +1620,46 @@ public class SqlResourceTest extends CalciteTestBase
   }
 
   @Test
+  public void testInvalidTimestampExpressionWithoutCast() throws Exception
+  {
+    final ErrorResponse errorResponse = postSyncForException(
+        "SELECT MILLIS_TO_TIMESTAMP(253402300800000)",
+        Status.BAD_REQUEST.getStatusCode()
+    );
+
+    validateInvalidSqlError(
+        errorResponse,
+        "Invalid TIMESTAMP value [MILLIS_TO_TIMESTAMP(253402300800000:BIGINT)]"
+    );
+    Assertions.assertTrue(lifecycleManager.getAll("id").isEmpty());
+    stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
+    Assertions.assertEquals(
+        Status.BAD_REQUEST.getStatusCode(),
+        stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
+    );
+  }
+
+  @Test
+  public void testInvalidTimestampLiteralWithExplicitCast() throws Exception
+  {
+    final ErrorResponse errorResponse = postSyncForException(
+        "SELECT CAST('20260-09-11 00:00:00' AS TIMESTAMP)",
+        Status.BAD_REQUEST.getStatusCode()
+    );
+
+    validateInvalidSqlError(
+        errorResponse,
+        "Invalid TIMESTAMP value [20260-09-11 00:00:00]"
+    );
+    Assertions.assertTrue(lifecycleManager.getAll("id").isEmpty());
+    stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
+    Assertions.assertEquals(
+        Status.BAD_REQUEST.getStatusCode(),
+        stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
+    );
+  }
+
+  @Test
   public void testResourceLimitExceeded() throws Exception
   {
     final ErrorResponse errorResponse = doPost(

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -1600,6 +1600,26 @@ public class SqlResourceTest extends CalciteTestBase
   }
 
   @Test
+  public void testInvalidTimestampLiteral() throws Exception
+  {
+    final ErrorResponse errorResponse = postSyncForException(
+        "SELECT * FROM druid.foo WHERE __time BETWEEN '2026-09-10 00:00:00' AND '20260-09-11 00:00:00' LIMIT 1",
+        Status.BAD_REQUEST.getStatusCode()
+    );
+
+    validateInvalidSqlError(
+        errorResponse,
+        "Invalid TIMESTAMP constant [CAST('20260-09-11 00:00:00'):TIMESTAMP(3) NOT NULL]"
+    );
+    Assertions.assertTrue(lifecycleManager.getAll("id").isEmpty());
+    stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
+    Assertions.assertEquals(
+        Status.BAD_REQUEST.getStatusCode(),
+        stubServiceEmitter.getMetricEvents("sqlQuery/time").get(0).toMap().get(DruidMetrics.STATUS_CODE)
+    );
+  }
+
+  @Test
   public void testResourceLimitExceeded() throws Exception
   {
     final ErrorResponse errorResponse = doPost(

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -1609,7 +1609,7 @@ public class SqlResourceTest extends CalciteTestBase
 
     validateInvalidSqlError(
         errorResponse,
-        "Invalid TIMESTAMP constant [CAST('20260-09-11 00:00:00'):TIMESTAMP(3) NOT NULL]"
+        "Invalid TIMESTAMP value [20260-09-11 00:00:00]"
     );
     Assertions.assertTrue(lifecycleManager.getAll("id").isEmpty());
     stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);


### PR DESCRIPTION
### Description

Malformed timestamp strings can sometimes be evaluated to a Joda timestamp but fail when converted back to Calcite's timestamp representation. The resulting `IllegalArgumentException` was classified as an uncategorized server error and returned as HTTP 500.

This PR catches conversion failures only while reducing TIMESTAMP constants and maps them to the existing `InvalidSqlInput` contract. Invalid constants now return HTTP 400 with an error such as:

```
Invalid TIMESTAMP value [20260-09-11 00:00:00]
```

Coverage includes implicit string conversion, an explicit user-provided `CAST`, and a timestamp-producing expression with no cast. Other planner and runtime exceptions retain their existing classification.

<hr>

##### Key changed/added classes in this PR

* `DruidRexExecutor`
* `CalciteQueryTest`
* `SqlResourceTest`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added or updated unit tests to cover new code paths.

Tests:

```
mvn test -pl sql -am -Dtest="org.apache.druid.sql.http.SqlResourceTest#testInvalidTimestampLiteral+testInvalidTimestampExpressionWithoutCast+testInvalidTimestampLiteralWithExplicitCast,org.apache.druid.sql.calcite.CalciteQueryTest#testCountStarWithTimeFilterUsingStringLiteralsInvalid_isUnplannable,org.apache.druid.sql.calcite.planner.DruidRexExecutorTest" -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks -Dweb.console.skip=true -T1C
```
