### PR TITLE
ci: fix CI failures by switching MinIO test image from Docker Hub to Quay

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -93,7 +93,7 @@ jobs:
           images=(
             apache/kafka:4.2.0
             postgres:16-alpine
-            minio/minio:latest
+            quay.io/minio/minio:latest
             hashicorp/consul:1.18
             tabulario/iceberg-rest:1.6.0
             localstack/localstack:4.13.1

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/minio/MinIOStorageResource.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/minio/MinIOStorageResource.java
@@ -27,6 +27,7 @@ import org.apache.druid.storage.s3.S3StorageDruidModule;
 import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
 import org.apache.druid.testing.embedded.TestcontainerResource;
 import org.testcontainers.containers.MinIOContainer;
+import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -45,7 +46,8 @@ import java.net.URI;
  */
 public class MinIOStorageResource extends TestcontainerResource<MinIOContainer>
 {
-  private static final String MINIO_IMAGE = "minio/minio:latest";
+  private static final DockerImageName MINIO_IMAGE =
+      DockerImageName.parse("quay.io/minio/minio:latest").asCompatibleSubstituteFor("minio/minio");
   private static final String DEFAULT_BUCKET = "druid-deep-storage";
   private static final String DEFAULT_BASE_KEY = "druid/segments";
   private static final String ACCESS_KEY = "minioadmin";

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3MultipartUploadTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3MultipartUploadTest.java
@@ -67,7 +67,9 @@ public class ServerSideEncryptingAmazonS3MultipartUploadTest
 
   @Container
   private static final MinIOContainer MINIO =
-      new MinIOContainer(DockerImageName.parse("minio/minio:latest")).withEnv("MINIO_DOMAIN", "localhost");
+      new MinIOContainer(
+          DockerImageName.parse("quay.io/minio/minio:latest").asCompatibleSubstituteFor("minio/minio")
+      ).withEnv("MINIO_DOMAIN", "localhost");
 
   @TempDir
   public File temporaryFolder;

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3StorageConnectorTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3StorageConnectorTest.java
@@ -353,7 +353,9 @@ public class S3StorageConnectorTest
 
     public static MinIOContainer createContainer(AwsCredentials credentials)
     {
-      MinIOContainer container = new MinIOContainer(DockerImageName.parse("minio/minio:latest"));
+      MinIOContainer container = new MinIOContainer(
+          DockerImageName.parse("quay.io/minio/minio:latest").asCompatibleSubstituteFor("minio/minio")
+      );
 
       // this enables virtual-host-style requests. see
       // https://github.com/minio/minio/tree/master/docs/config#domain


### PR DESCRIPTION
## Description

The `minio/minio:latest` image is no longer publicly pullable from Docker Hub. Testcontainers therefore fails to create MinIO containers with errors such as:

```
ContainerFetchException
404: pull access denied for minio/minio
repository does not exist or may require docker login
```

This failure was observed in the CI runs for [PR #20329](https://github.com/apache/druid/pull/20329) and [PR #20330](https://github.com/apache/druid/pull/20330).

This change switches Druid's MinIO test image from:

```
minio/minio:latest
```

to:

```
quay.io/minio/minio:latest
```

The reference is updated in the shared GitHub Actions pre-pull step and the three S3/embedded test container definitions.

Testcontainers validates that `MinIOContainer` receives a compatible image name, so the Quay image is explicitly declared as a compatible substitute for `minio/minio`.

## Licensing

The registry change does not change the image license. This remains the official MinIO Community Edition image; MinIO server source is licensed under [AGPLv3](https://github.com/minio/minio/blob/master/LICENSE). The image is used only as an external test service and is not packaged into Druid artifacts.

## Testing

- `MinIOStorageResourceTest` and `MinIOStorageTest`: 6 tests passed.
- `ServerSideEncryptingAmazonS3MultipartUploadTest` and `S3StorageConnectorTest`: 14 tests passed with the `ci` profile.
- `git diff --check` passed.
