### PR TITLE
fix: update PullDependencies to exclude netty-4 jars

### DIFF
--- a/services/src/main/java/org/apache/druid/cli/PullDependencies.java
+++ b/services/src/main/java/org/apache/druid/cli/PullDependencies.java
@@ -86,6 +86,28 @@ public class PullDependencies implements Runnable
                   .put("com.fasterxml.jackson.core", "jackson-databind")
                   .put("com.fasterxml.jackson.core", "jackson-core")
                   .put("com.fasterxml.jackson.core", "jackson-annotations")
+                  // Netty 4 is bundled in lib/ (used by the core Druid HTTP client). The netty-bom import
+                  // at the root pom appears to defeat scope=provided on transitive netty jars in some
+                  // extensions, so hard-exclude them here to keep them from being duplicated.
+                  .put("io.netty", "netty-buffer")
+                  .put("io.netty", "netty-codec")
+                  .put("io.netty", "netty-codec-base")
+                  .put("io.netty", "netty-codec-compression")
+                  .put("io.netty", "netty-codec-dns")
+                  .put("io.netty", "netty-codec-http")
+                  .put("io.netty", "netty-codec-http2")
+                  .put("io.netty", "netty-codec-marshalling")
+                  .put("io.netty", "netty-codec-protobuf")
+                  .put("io.netty", "netty-codec-socks")
+                  .put("io.netty", "netty-common")
+                  .put("io.netty", "netty-handler")
+                  .put("io.netty", "netty-handler-proxy")
+                  .put("io.netty", "netty-resolver")
+                  .put("io.netty", "netty-resolver-dns")
+                  .put("io.netty", "netty-transport")
+                  .put("io.netty", "netty-transport-classes-epoll")
+                  .put("io.netty", "netty-transport-native-unix-common")
+                  .put("software.amazon.awssdk", "netty-nio-client")
                   .build();
 
   private static final Dependencies SECURITY_VULNERABILITY_EXCLUSIONS =


### PR DESCRIPTION
### Description
Follow up to #19567 where i noticed i forgot to add 'provided' scope for the updated netty dependencies to the extension poms and only removed the old entries, so a fair number of jars were duplicated in the extension directories of binary distribution. It would appear that `netty-bom` we are using in the root pom.xml must be interfering in some way with pull-deps, resulting in them still being included in the extension directories even when 'provided' scope was set, so instead this PR updates `PullDependencies` to explicitly exclude them as built-ins to prevent duplication.